### PR TITLE
fix: add claudecode to valid targets in parser validation

### DIFF
--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -209,6 +209,45 @@ globs: ["**/*.ts"]
 
       await expect(parseRuleFile(filepath)).rejects.toThrow('Invalid "targets" field');
     });
+
+    it("should accept claudecode as valid target", async () => {
+      const ruleContent = `---
+root: false
+targets: ["claudecode"]
+description: "Test rule for Claude Code"
+globs: ["**/*.ts"]
+---
+
+# Claude Code Rule
+`;
+
+      const filepath = join(testDir, "claudecode-rule.md");
+      writeFileSync(filepath, ruleContent);
+
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.targets).toEqual(["claudecode"]);
+      expect(rule.frontmatter.description).toBe("Test rule for Claude Code");
+    });
+
+    it("should accept mixed targets including claudecode", async () => {
+      const ruleContent = `---
+root: false
+targets: ["copilot", "claudecode", "cursor"]
+description: "Test rule for multiple tools including Claude Code"
+globs: ["**/*.ts"]
+---
+
+# Mixed Targets with Claude Code
+`;
+
+      const filepath = join(testDir, "mixed-claudecode-rule.md");
+      writeFileSync(filepath, ruleContent);
+
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.targets).toEqual(["copilot", "claudecode", "cursor"]);
+    });
   });
 
   describe("parseRulesFromDirectory", () => {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -93,7 +93,7 @@ function validateFrontmatter(data: unknown, filepath: string): void {
     );
   }
 
-  const validTargets = ["copilot", "cursor", "cline", "claude", "roo", "*"];
+  const validTargets = ["copilot", "cursor", "cline", "claude", "claudecode", "roo", "*"];
   for (const target of obj.targets) {
     if (typeof target !== "string" || !validTargets.includes(target)) {
       throw new Error(


### PR DESCRIPTION
## Summary

Fix validation error when importing from `CLAUDE.md` by adding `claudecode` to valid targets.

## Problem

- When using the `import` command to import from `CLAUDE.md`, the `targets` field is set to `["claudecode"]`
- However, `src/core/parser.ts` validation only allows `["copilot", "cursor", "cline", "claude", "roo", "*"]`
- This causes a validation error: `Invalid target "claudecode"` when running `rulesync validate`

## Solution

- Added `claudecode` to the `validTargets` array in `src/core/parser.ts`
- Since `claude` is already being used as a target in existing configurations, we preserve both `claude` and `claudecode` for backward compatibility
- Added comprehensive tests to ensure both single and mixed target configurations work properly

## Changes

- ✅ Updated `validTargets` array to include `claudecode`
- ✅ Added test cases for `claudecode` target validation
- ✅ Added test cases for mixed targets including `claudecode`
- ✅ All existing tests pass (159/159)

## Testing

```bash
pnpm test  # All tests pass
```

The fix resolves the validation error while maintaining backward compatibility with existing `claude` target configurations.

---

Thank you for creating such an amazing tool! 🚀
Please review when you have a chance.