### PR TITLE
refactor: migrate from zod/v4 to zod/v4-mini for reduced bundle size

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -2,14 +2,8 @@ export default {
   "*.{ts,js}": [
     "biome check --write",
     "oxlint --fix --max-warnings 0",
-    "eslint --fix --max-warnings 0 --cache",
+    "eslint --fix --max-warnings 0 --cache --no-warn-ignored",
   ],
-  "*.ts": [
-    () => "tsgo --noEmit",
-    () => "pnpm test"
-  ],
-  "**/*": [
-    "secretlint",
-    "cspell"
-  ]
+  "*.ts": [() => "tsgo --noEmit", () => "pnpm test"],
+  "**/*": ["secretlint", "cspell"],
 };

--- a/biome.json
+++ b/biome.json
@@ -28,6 +28,6 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["src/**/*", "tests/**/*"]
+    "includes": ["src/**/*", "tests/**/*", "*.js", "*.mjs"]
   }
 }

--- a/eslint-plugin-zod-import.js
+++ b/eslint-plugin-zod-import.js
@@ -1,0 +1,57 @@
+/**
+ * ESLint plugin to enforce zod/v4-mini imports
+ */
+
+const zodMiniRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce using zod/v4-mini instead of zod or zod/v4",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      useZodMini: 'Use "zod/v4-mini" instead of "{{actual}}" for reduced bundle size',
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+
+        // Check if importing from 'zod' or 'zod/v4'
+        if (source === "zod" || source === "zod/v4") {
+          context.report({
+            node: node.source,
+            messageId: "useZodMini",
+            data: {
+              actual: source,
+            },
+            fix(fixer) {
+              // Replace with zod/v4-mini
+              return fixer.replaceText(node.source, '"zod/v4-mini"');
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+const plugin = {
+  rules: {
+    "use-zod-mini": zodMiniRule,
+  },
+  configs: {
+    recommended: {
+      rules: {
+        "zod-mini/use-zod-mini": "error",
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,56 +1,67 @@
-import { defineConfig } from 'eslint/config';
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import oxlint from 'eslint-plugin-oxlint';
-import noTypeAssertion from 'eslint-plugin-no-type-assertion';
+import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
+import noTypeAssertion from "eslint-plugin-no-type-assertion";
+import oxlint from "eslint-plugin-oxlint";
+import tseslint from "typescript-eslint";
+import zodMiniPlugin from "./eslint-plugin-zod-import.js";
 
 /**
  * @type {import('eslint').Linter.Config}
  */
 export default defineConfig([
   {
-    ignores: ['node_modules/', 'dist/', 'coverage/', '*.config.js', '*.config.mjs', '.lintstagedrc.js'],
+    ignores: [
+      "node_modules/",
+      "dist/",
+      "coverage/",
+      "*.config.js",
+      "*.config.mjs",
+      ".lintstagedrc.js",
+      "eslint-plugin-*.js",
+    ],
   },
   {
-    files: ['**/*.{js,mjs,cjs,ts,mts}'],
+    files: ["**/*.{js,mjs,cjs,ts,mts}"],
   },
-  
+
   eslint.configs.recommended,
-  
+
   ...tseslint.configs.recommended,
-  
+
   {
-    files: ['**/*.ts', '**/*.mts'],
+    files: ["**/*.ts", "**/*.mts"],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: './tsconfig.json',
+        project: "./tsconfig.json",
         tsconfigRootDir: import.meta.dirname,
       },
     },
     plugins: {
-      'no-type-assertion': noTypeAssertion,
+      "no-type-assertion": noTypeAssertion,
+      "zod-mini": zodMiniPlugin,
     },
     rules: {
-      'no-type-assertion/no-type-assertion': 'warn',
+      "no-type-assertion/no-type-assertion": "warn",
+      "zod-mini/use-zod-mini": "error",
     },
   },
 
   {
-    files: ['**/*.test.ts'],
+    files: ["**/*.test.ts"],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: './tsconfig.json',
+        project: "./tsconfig.json",
         tsconfigRootDir: import.meta.dirname,
       },
     },
     rules: {
-      "no-empty": 'off', // Allow empty test cases
-      "@typescript-eslint/no-explicit-any": 'off', // Allow any in tests
-      'no-type-assertion/no-type-assertion': 'off', // Allow type assertions in tests
+      "no-empty": "off", // Allow empty test cases
+      "@typescript-eslint/no-explicit-any": "off", // Allow any in tests
+      "no-type-assertion/no-type-assertion": "off", // Allow type assertions in tests
     },
   },
 
-  ...oxlint.buildFromOxlintConfigFile('./.oxlintrc.json'),
+  ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
 ]);

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -1,7 +1,7 @@
 import { basename, join } from "node:path";
 import matter from "gray-matter";
 import { DEFAULT_SCHEMA, FAILSAFE_SCHEMA, load } from "js-yaml";
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 import type { ParsedRule, RuleFrontmatter } from "../types/index.js";
 import type { RulesyncMcpServer } from "../types/mcp.js";
 import { RulesyncMcpConfigSchema } from "../types/mcp.js";

--- a/src/types/claudecode.ts
+++ b/src/types/claudecode.ts
@@ -1,11 +1,12 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 
 export const ClaudeSettingsSchema = z.looseObject({
-  permissions: z
-    .looseObject({
-      deny: z.array(z.string()).default([]),
-    })
-    .default({ deny: [] }),
+  permissions: z._default(
+    z.looseObject({
+      deny: z._default(z.array(z.string()), []),
+    }),
+    { deny: [] },
+  ),
 });
 
 export type ClaudeSettings = z.infer<typeof ClaudeSettingsSchema>;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 import { ToolTargetSchema, ToolTargetsSchema } from "./tool-targets.js";
 
 export const ConfigSchema = z.object({

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,27 +1,27 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 import { RulesyncTargetsSchema } from "./tool-targets.js";
 
 export const McpTransportTypeSchema = z.enum(["stdio", "sse", "http"]);
 
 export const McpServerBaseSchema = z.object({
-  command: z.string().optional(),
-  args: z.array(z.string()).optional(),
-  url: z.string().optional(),
-  httpUrl: z.string().optional(),
-  env: z.record(z.string(), z.string()).optional(),
-  disabled: z.boolean().optional(),
-  networkTimeout: z.number().optional(),
-  timeout: z.number().optional(),
-  trust: z.boolean().optional(),
-  cwd: z.string().optional(),
-  transport: McpTransportTypeSchema.optional(),
-  type: z.enum(["sse", "streamable-http"]).optional(),
-  alwaysAllow: z.array(z.string()).optional(),
-  tools: z.array(z.string()).optional(),
+  command: z.optional(z.string()),
+  args: z.optional(z.array(z.string())),
+  url: z.optional(z.string()),
+  httpUrl: z.optional(z.string()),
+  env: z.optional(z.record(z.string(), z.string())),
+  disabled: z.optional(z.boolean()),
+  networkTimeout: z.optional(z.number()),
+  timeout: z.optional(z.number()),
+  trust: z.optional(z.boolean()),
+  cwd: z.optional(z.string()),
+  transport: z.optional(McpTransportTypeSchema),
+  type: z.optional(z.enum(["sse", "streamable-http"])),
+  alwaysAllow: z.optional(z.array(z.string())),
+  tools: z.optional(z.array(z.string())),
 });
 
-export const RulesyncMcpServerSchema = McpServerBaseSchema.extend({
-  targets: RulesyncTargetsSchema.optional(),
+export const RulesyncMcpServerSchema = z.extend(McpServerBaseSchema, {
+  targets: z.optional(RulesyncTargetsSchema),
 });
 
 export const McpConfigSchema = z.object({

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 import { RulesyncTargetsSchema, ToolTargetSchema, ToolTargetsSchema } from "./tool-targets.js";
 
 export const RuleFrontmatterSchema = z.object({
@@ -6,7 +6,7 @@ export const RuleFrontmatterSchema = z.object({
   targets: RulesyncTargetsSchema,
   description: z.string(),
   globs: z.array(z.string()),
-  cursorRuleType: z.enum(["always", "manual", "specificFiles", "intelligently"]).optional(),
+  cursorRuleType: z.optional(z.enum(["always", "manual", "specificFiles", "intelligently"])),
 });
 
 export const ParsedRuleSchema = z.object({
@@ -23,9 +23,9 @@ export const GeneratedOutputSchema = z.object({
 });
 
 export const GenerateOptionsSchema = z.object({
-  targetTools: ToolTargetsSchema.optional(),
-  outputDir: z.string().optional(),
-  watch: z.boolean().optional(),
+  targetTools: z.optional(ToolTargetsSchema),
+  outputDir: z.optional(z.string()),
+  watch: z.optional(z.boolean()),
 });
 
 export type RuleFrontmatter = z.infer<typeof RuleFrontmatterSchema>;

--- a/src/types/tool-targets.ts
+++ b/src/types/tool-targets.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 
 export const ToolTargetSchema = z.enum([
   "copilot",


### PR DESCRIPTION
## Summary
- Replace all zod/v4 imports with zod/v4-mini for smaller bundle size
- Update API usage from method chaining to function calls for compatibility
- Maintain full type safety and functionality

## Changes
- Replaced 6 files with zod/v4-mini imports
- Updated API calls: `.optional()` → `z.optional()`, `.default()` → `z._default()`, `.extend()` → `z.extend()`
- All tests pass and build succeeds

## Test plan
- [x] All existing tests pass
- [x] Build succeeds with smaller bundle size
- [x] Type safety maintained

🤖 Generated with [Claude Code](https://claude.ai/code)