### PR TITLE
fix: simplify init command to generate only overview.md

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -40,18 +40,9 @@ describe("initCommand", () => {
       join(".rulesync", "overview.md"),
       expect.stringContaining("root: true"),
     );
-    expect(mockWriteFileContent).toHaveBeenCalledWith(
-      join(".rulesync", "frontend.md"),
-      expect.stringContaining("root: false"),
-    );
-    expect(mockWriteFileContent).toHaveBeenCalledWith(
-      join(".rulesync", "backend.md"),
-      expect.stringContaining("root: false"),
-    );
+    expect(mockWriteFileContent).toHaveBeenCalledTimes(1);
 
     expect(console.log).toHaveBeenCalledWith("Created .rulesync/overview.md");
-    expect(console.log).toHaveBeenCalledWith("Created .rulesync/frontend.md");
-    expect(console.log).toHaveBeenCalledWith("Created .rulesync/backend.md");
   });
 
   it("should skip existing files", async () => {
@@ -61,10 +52,8 @@ describe("initCommand", () => {
 
     await initCommand();
 
-    expect(mockWriteFileContent).toHaveBeenCalledTimes(2); // Only non-existing files
+    expect(mockWriteFileContent).not.toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith("Skipped .rulesync/overview.md (already exists)");
-    expect(console.log).toHaveBeenCalledWith("Created .rulesync/frontend.md");
-    expect(console.log).toHaveBeenCalledWith("Created .rulesync/backend.md");
   });
 
   it("should handle all files existing", async () => {
@@ -74,8 +63,6 @@ describe("initCommand", () => {
 
     expect(mockWriteFileContent).not.toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith("Skipped .rulesync/overview.md (already exists)");
-    expect(console.log).toHaveBeenCalledWith("Skipped .rulesync/frontend.md (already exists)");
-    expect(console.log).toHaveBeenCalledWith("Skipped .rulesync/backend.md (already exists)");
   });
 
   it("should create proper content for root file", async () => {
@@ -90,21 +77,17 @@ describe("initCommand", () => {
     expect(overviewCall![1]).toContain("Project overview");
   });
 
-  it("should create proper content for non-root files", async () => {
+  it("should create proper content for overview file", async () => {
     await initCommand();
 
-    const frontendCall = mockWriteFileContent.mock.calls.find((call) =>
-      call[0].includes("frontend.md"),
+    const overviewCall = mockWriteFileContent.mock.calls.find((call) =>
+      call[0].includes("overview.md"),
     );
-    expect(frontendCall).toBeDefined();
-    expect(frontendCall![1]).toContain("root: false");
-    expect(frontendCall![1]).toContain("Frontend development rules");
-
-    const backendCall = mockWriteFileContent.mock.calls.find((call) =>
-      call[0].includes("backend.md"),
-    );
-    expect(backendCall).toBeDefined();
-    expect(backendCall![1]).toContain("root: false");
-    expect(backendCall![1]).toContain("Backend development rules");
+    expect(overviewCall).toBeDefined();
+    expect(overviewCall![1]).toContain("root: true");
+    expect(overviewCall![1]).toContain("Project overview");
+    expect(overviewCall![1]).toContain("General Guidelines");
+    expect(overviewCall![1]).toContain("Code Style");
+    expect(overviewCall![1]).toContain("Architecture Principles");
   });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -19,14 +19,13 @@ export async function initCommand(): Promise<void> {
 }
 
 async function createSampleFiles(aiRulesDir: string): Promise<void> {
-  const sampleFiles = [
-    {
-      filename: "overview.md",
-      content: `---
+  const sampleFile = {
+    filename: "overview.md",
+    content: `---
 root: true
 targets: ["*"]
 description: "Project overview and general development guidelines"
-globs: ["**/*."]
+globs: ["**/*"]
 ---
 
 # Project Overview
@@ -54,96 +53,13 @@ globs: ["**/*."]
 - Implement proper error handling
 - Follow single responsibility principle
 `,
-    },
-    {
-      filename: "frontend.md",
-      content: `---
-root: false
-targets: ["*"]
-description: "Frontend development rules and best practices"
-globs: ["src/components/**/*.tsx", "src/pages/**/*.tsx", "**/*.css", "**/*.scss"]
----
+  };
 
-# Frontend Development Rules
-
-## React Components
-
-- Use functional components with hooks
-- Follow PascalCase naming for components
-- Use TypeScript interfaces for props
-- Implement proper error boundaries
-
-## Styling
-
-- Use CSS modules or styled-components
-- Follow BEM methodology for CSS classes
-- Prefer flexbox and grid for layouts
-- Use semantic HTML elements
-
-## State Management
-
-- Use React hooks for local state
-- Consider Redux or Zustand for global state
-- Avoid prop drilling with context API
-- Keep state as close to where it's used as possible
-
-## Performance
-
-- Use React.memo for expensive components
-- Implement lazy loading for routes
-- Optimize images and assets
-- Use proper key props in lists
-`,
-    },
-    {
-      filename: "backend.md",
-      content: `---
-root: false
-targets: ["*"]
-description: "Backend development rules and API guidelines"
-globs: ["src/api/**/*.ts", "src/services/**/*.ts", "src/models/**/*.ts"]
----
-
-# Backend Development Rules
-
-## API Design
-
-- Follow RESTful conventions
-- Use consistent HTTP status codes
-- Implement proper error handling with meaningful messages
-- Use API versioning when necessary
-
-## Database
-
-- Use proper indexing for performance
-- Implement database migrations
-- Follow naming conventions for tables and columns
-- Use transactions for data consistency
-
-## Security
-
-- Validate all input data
-- Use proper authentication and authorization
-- Implement rate limiting
-- Sanitize database queries to prevent SQL injection
-
-## Code Organization
-
-- Use service layer pattern
-- Implement proper logging
-- Use environment variables for configuration
-- Write comprehensive tests for business logic
-`,
-    },
-  ];
-
-  for (const file of sampleFiles) {
-    const filepath = join(aiRulesDir, file.filename);
-    if (!(await fileExists(filepath))) {
-      await writeFileContent(filepath, file.content);
-      console.log(`Created ${filepath}`);
-    } else {
-      console.log(`Skipped ${filepath} (already exists)`);
-    }
+  const filepath = join(aiRulesDir, sampleFile.filename);
+  if (!(await fileExists(filepath))) {
+    await writeFileContent(filepath, sampleFile.content);
+    console.log(`Created ${filepath}`);
+  } else {
+    console.log(`Skipped ${filepath} (already exists)`);
   }
 }


### PR DESCRIPTION
## Summary
- Remove frontend.md and backend.md generation from init command
- Focus on creating a single overview.md file with basic project guidelines
- Update tests to match the new single-file behavior

## Test plan
- [x] Run unit tests for init command
- [x] Verify only overview.md is created
- [x] Ensure existing file skip logic works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)