### PR TITLE
chore: update zod to v4.0.5 with zod/mini imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,8 @@ import eslint from "@eslint/js";
 import { defineConfig } from "eslint/config";
 import noTypeAssertion from "eslint-plugin-no-type-assertion";
 import oxlint from "eslint-plugin-oxlint";
+import zodImport from "eslint-plugin-zod-import";
 import tseslint from "typescript-eslint";
-import zodMiniPlugin from "./eslint-plugin-zod-import.js";
 
 /**
  * @type {import('eslint').Linter.Config}
@@ -39,11 +39,11 @@ export default defineConfig([
     },
     plugins: {
       "no-type-assertion": noTypeAssertion,
-      "zod-mini": zodMiniPlugin,
+      "zod-import": zodImport,
     },
     rules: {
       "no-type-assertion/no-type-assertion": "warn",
-      "zod-mini/use-zod-mini": "error",
+      "zod-import/zod-import": ["error", { variant: "zod-mini" }],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"eslint": "^9.30.1",
 		"eslint-plugin-no-type-assertion": "1.3.0",
 		"eslint-plugin-oxlint": "1.5.0",
-		"eslint-plugin-zod-import": "0.2.0",
+		"eslint-plugin-zod-import": "0.3.0",
 		"lint-staged": "16.1.2",
 		"o3-search-mcp": "0.0.3",
 		"oxlint": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"js-yaml": "4.1.0",
 		"marked": "15.0.12",
 		"micromatch": "4.0.8",
-		"zod": "3.25.67"
+		"zod": "4.0.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.0.0",
@@ -80,6 +80,7 @@
 		"eslint": "^9.30.1",
 		"eslint-plugin-no-type-assertion": "1.3.0",
 		"eslint-plugin-oxlint": "1.5.0",
+		"eslint-plugin-zod-import": "0.2.0",
 		"lint-staged": "16.1.2",
 		"o3-search-mcp": "0.0.3",
 		"oxlint": "1.4.0",

--- a/src/parsers/cursor.ts
+++ b/src/parsers/cursor.ts
@@ -1,7 +1,7 @@
 import { basename, join } from "node:path";
 import matter from "gray-matter";
 import { DEFAULT_SCHEMA, FAILSAFE_SCHEMA, load } from "js-yaml";
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 import type { ParsedRule, RuleFrontmatter } from "../types/index.js";
 import type { RulesyncMcpServer } from "../types/mcp.js";
 import { RulesyncMcpConfigSchema } from "../types/mcp.js";

--- a/src/types/claudecode.ts
+++ b/src/types/claudecode.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 
 export const ClaudeSettingsSchema = z.looseObject({
   permissions: z._default(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 import { ToolTargetSchema, ToolTargetsSchema } from "./tool-targets.js";
 
 export const ConfigSchema = z.object({

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 import { RulesyncTargetsSchema } from "./tool-targets.js";
 
 export const McpTransportTypeSchema = z.enum(["stdio", "sse", "http"]);

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 import { RulesyncTargetsSchema, ToolTargetSchema, ToolTargetsSchema } from "./tool-targets.js";
 
 export const RuleFrontmatterSchema = z.object({

--- a/src/types/tool-targets.ts
+++ b/src/types/tool-targets.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 
 export const ToolTargetSchema = z.enum([
   "copilot",


### PR DESCRIPTION
## Summary
- Updated zod from 3.25.67 to 4.0.5
- Migrated all imports to use the new `zod/mini` path for reduced bundle size
- Updated ESLint configuration to use eslint-plugin-zod-import for enforcing proper imports

## Test plan
- [ ] All tests pass
- [ ] ESLint runs without errors
- [ ] Build completes successfully
- [ ] Bundle size should be reduced due to zod/mini usage

🤖 Generated with [Claude Code](https://claude.ai/code)