### PR TITLE
fix: add .aiignore and .kiro/steering/ patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ test-*
 .pnpm-store
 
 .rulesync/my-instructions.md
+
+**/.aiignore
+**/.kiro/steering/


### PR DESCRIPTION
## Summary
- Add **/.aiignore pattern to ignore Gemini CLI exclude files
- Add **/.kiro/steering/ pattern to ignore Kiro steering documentation

## Test plan
- Verify that the patterns are properly added to .gitignore
- Confirm the changes don't break existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)