### PR TITLE
fix: add final success message to generate command

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -125,6 +125,7 @@ export async function generateCommand(options: GenerateOptions = {}): Promise<vo
       console.log("\nGenerating MCP configurations...");
     }
 
+    let totalMcpOutputs = 0;
     for (const baseDir of baseDirs) {
       const mcpResults = await generateMcpConfigs(
         process.cwd(),
@@ -141,12 +142,21 @@ export async function generateCommand(options: GenerateOptions = {}): Promise<vo
       for (const result of mcpResults) {
         if (result.status === "success") {
           console.log(`✅ Generated ${result.tool} MCP configuration: ${result.path}`);
+          totalMcpOutputs++;
         } else if (result.status === "error") {
           console.error(`❌ Failed to generate ${result.tool} MCP configuration: ${result.error}`);
         } else if (options.verbose && result.status === "skipped") {
           console.log(`⏭️  Skipped ${result.tool} MCP configuration (no servers configured)`);
         }
       }
+    }
+
+    // Final success message
+    const totalGenerated = totalOutputs + totalMcpOutputs;
+    if (totalGenerated > 0) {
+      console.log(
+        `\n🎉 All done! Generated ${totalGenerated} file(s) total (${totalOutputs} configurations + ${totalMcpOutputs} MCP configurations)`,
+      );
     }
   } catch (error) {
     console.error("❌ Failed to generate configurations:", error);

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -118,8 +118,6 @@ export async function generateCommand(options: GenerateOptions = {}): Promise<vo
       return;
     }
 
-    console.log(`\n🎉 Successfully generated ${totalOutputs} configuration file(s)!`);
-
     // Generate MCP configurations
     if (options.verbose) {
       console.log("\nGenerating MCP configurations...");


### PR DESCRIPTION
## Summary
- Fixed missing final success message in `pnpm generate` command
- Added comprehensive summary showing total files generated (configurations + MCP configurations)

## Changes
- Added counter for MCP outputs in generate command
- Added final success message that shows breakdown of generated files
- Improved user experience with clear completion indication

## Test plan
- [x] Run `pnpm generate` and verify final success message appears
- [x] Verify message shows correct file count breakdown
- [x] Ensure all existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)