### PR TITLE
feat: add JetBrains Junie MCP configuration generation

### DIFF
--- a/src/core/mcp-generator.test.ts
+++ b/src/core/mcp-generator.test.ts
@@ -31,8 +31,8 @@ describe("generateMcpConfigurations", () => {
 
     // Should generate for all supported tools by default
     // AugmentCode and AugmentCode-legacy both map to same .mcp.json (deduplicated), Copilot generates 2 files, others generate 1 each
-    // Total: augmentcode(1) + claudecode(1) + cursor(1) + cline(1) + roo(1) + copilot(2) + geminicli(1) + kiro(1) = 9
-    expect(outputs).toHaveLength(9);
+    // Total: augmentcode(1) + claudecode(1) + cursor(1) + cline(1) + roo(1) + copilot(2) + geminicli(1) + kiro(1) + junie(1) = 10
+    expect(outputs).toHaveLength(10);
 
     const filepaths = outputs.map((o) => o.filepath);
     expect(filepaths).toContain(join(testDir, ".mcp.json")); // AugmentCode
@@ -43,6 +43,7 @@ describe("generateMcpConfigurations", () => {
     expect(filepaths).toContain(join(testDir, ".cline/mcp.json"));
     expect(filepaths).toContain(join(testDir, ".roo/mcp.json"));
     expect(filepaths).toContain(join(testDir, ".gemini/settings.json"));
+    expect(filepaths).toContain(join(testDir, ".junie/mcp-config.json"));
     expect(filepaths).toContain(join(testDir, ".kiro/mcp.json"));
   });
 

--- a/src/core/mcp-generator.ts
+++ b/src/core/mcp-generator.ts
@@ -6,6 +6,7 @@ import {
   generateCopilotMcp,
   generateCursorMcp,
   generateGeminiCliMcp,
+  generateJunieMcp,
   generateKiroMcp,
   generateRooMcp,
 } from "../generators/mcp/index.js";
@@ -71,6 +72,11 @@ export async function generateMcpConfigs(
       generate: () => generateGeminiCliMcp(config),
     },
     {
+      tool: "junie-project",
+      path: path.join(targetRoot, ".junie", "mcp-config.json"),
+      generate: () => generateJunieMcp(config),
+    },
+    {
       tool: "kiro-project",
       path: path.join(targetRoot, ".kiro", "mcp.json"),
       generate: () => generateKiroMcp(config),
@@ -110,6 +116,7 @@ export async function generateMcpConfigs(
         generator.tool.includes("cline") ||
         generator.tool.includes("cursor") ||
         generator.tool.includes("gemini") ||
+        generator.tool.includes("junie") ||
         generator.tool.includes("kiro") ||
         generator.tool.includes("roo")
       ) {

--- a/src/generators/mcp/index.ts
+++ b/src/generators/mcp/index.ts
@@ -4,5 +4,6 @@ export { generateClineMcp } from "./cline.js";
 export { generateCopilotMcp } from "./copilot.js";
 export { generateCursorMcp } from "./cursor.js";
 export { generateGeminiCliMcp } from "./geminicli.js";
+export { generateJunieMcp } from "./junie.js";
 export { generateKiroMcp } from "./kiro.js";
 export { generateRooMcp } from "./roo.js";

--- a/src/generators/mcp/junie.test.ts
+++ b/src/generators/mcp/junie.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import type { RulesyncMcpConfig } from "../../types/mcp.js";
+import { generateJunieMcp, generateJunieMcpConfiguration } from "./junie.js";
+
+describe("generateJunieMcp", () => {
+  it("should generate Junie MCP config for stdio transport", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "test-server": {
+          command: "node",
+          args: ["server.js"],
+          env: { API_KEY: "test-key" },
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "test-server": {
+          name: "test-server",
+          command: "node",
+          args: ["server.js"],
+          env: { API_KEY: "test-key" },
+          transport: "stdio",
+        },
+      },
+    });
+  });
+
+  it("should generate Junie MCP config for HTTP transport with httpUrl", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "http-server": {
+          httpUrl: "http://localhost:3000",
+          env: { API_KEY: "test-key" },
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "http-server": {
+          name: "http-server",
+          httpUrl: "http://localhost:3000",
+          env: { API_KEY: "test-key" },
+        },
+      },
+    });
+  });
+
+  it("should generate Junie MCP config for SSE transport", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "sse-server": {
+          url: "http://localhost:3000",
+          transport: "sse",
+          timeout: 30000,
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "sse-server": {
+          name: "sse-server",
+          url: "http://localhost:3000",
+          transport: "sse",
+          timeout: 30000,
+        },
+      },
+    });
+  });
+
+  it("should map streamable-http transport to http", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "streamable-server": {
+          httpUrl: "http://localhost:3000",
+          transport: "streamable-http" as any, // Type assertion for test
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "streamable-server": {
+          name: "streamable-server",
+          httpUrl: "http://localhost:3000",
+          transport: "http",
+        },
+      },
+    });
+  });
+
+  it("should map cwd to workingDirectory", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "python-server": {
+          command: "python",
+          args: ["-m", "my_server"],
+          cwd: "/path/to/project",
+          env: { PROJECT_ROOT: "/path/to/project" },
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "python-server": {
+          name: "python-server",
+          command: "python",
+          args: ["-m", "my_server"],
+          workingDirectory: "/path/to/project",
+          env: { PROJECT_ROOT: "/path/to/project" },
+          transport: "stdio",
+        },
+      },
+    });
+  });
+
+  it("should include trust setting", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        "trusted-server": {
+          command: "node",
+          args: ["server.js"],
+          trust: true,
+        },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toEqual({
+      mcpServers: {
+        "trusted-server": {
+          name: "trusted-server",
+          command: "node",
+          args: ["server.js"],
+          trust: true,
+          transport: "stdio",
+        },
+      },
+    });
+  });
+
+  it("should respect targets configuration", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        server1: { command: "node", args: ["s1.js"], targets: ["cursor"] as const },
+        server2: { command: "node", args: ["s2.js"], targets: ["junie"] as const },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(Object.keys(parsed.mcpServers)).toHaveLength(1);
+    expect(parsed.mcpServers).toHaveProperty("server2");
+  });
+
+  it("should include all servers when targets are not specified", () => {
+    const config: RulesyncMcpConfig = {
+      mcpServers: {
+        server1: { command: "node", args: ["s1.js"] },
+        server2: { command: "python", args: ["s2.py"] },
+      },
+    };
+
+    const result = generateJunieMcp(config);
+    const parsed = JSON.parse(result);
+
+    expect(Object.keys(parsed.mcpServers)).toHaveLength(2);
+    expect(parsed.mcpServers).toHaveProperty("server1");
+    expect(parsed.mcpServers).toHaveProperty("server2");
+  });
+});
+
+describe("generateJunieMcpConfiguration", () => {
+  it("should generate configuration files with correct filepath", () => {
+    const servers = {
+      "test-server": {
+        command: "node",
+        args: ["server.js"],
+        env: { API_KEY: "test-key" },
+      },
+    };
+
+    const result = generateJunieMcpConfiguration(servers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.filepath).toBe(".junie/mcp-config.json");
+
+    const parsed = JSON.parse(result[0]?.content || "{}");
+    expect(parsed.mcpServers).toHaveProperty("test-server");
+  });
+
+  it("should generate configuration files with baseDir", () => {
+    const servers = {
+      "test-server": {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    const result = generateJunieMcpConfiguration(servers, "/custom/base");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.filepath).toBe("/custom/base/.junie/mcp-config.json");
+  });
+
+  it("should preserve server configuration and add name", () => {
+    const servers = {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/project/root"],
+        env: { LOG_LEVEL: "info" },
+        timeout: 15000,
+        cwd: "/project/root",
+      },
+    };
+
+    const result = generateJunieMcpConfiguration(servers);
+    const parsed = JSON.parse(result[0]?.content || "{}");
+
+    expect(parsed.mcpServers.filesystem).toEqual({
+      name: "filesystem",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/project/root"],
+      env: { LOG_LEVEL: "info" },
+      timeout: 15000,
+      workingDirectory: "/project/root",
+      transport: "stdio",
+    });
+  });
+
+  it("should filter servers by targets", () => {
+    const servers: Record<string, any> = {
+      server1: { command: "node", args: ["s1.js"], targets: ["cursor"] },
+      server2: { command: "node", args: ["s2.js"], targets: ["junie"] },
+      server3: { command: "node", args: ["s3.js"] }, // No targets specified
+    };
+
+    const result = generateJunieMcpConfiguration(servers);
+    const parsed = JSON.parse(result[0]?.content || "{}");
+
+    // Should include server2 (targets junie) and server3 (no targets = all tools)
+    expect(Object.keys(parsed.mcpServers)).toHaveLength(2);
+    expect(parsed.mcpServers).toHaveProperty("server2");
+    expect(parsed.mcpServers).toHaveProperty("server3");
+    expect(parsed.mcpServers).not.toHaveProperty("server1");
+  });
+});

--- a/src/generators/mcp/junie.ts
+++ b/src/generators/mcp/junie.ts
@@ -1,9 +1,125 @@
-import type { RulesyncMcpServer } from "../../types/mcp.js";
+import type { RulesyncMcpConfig, RulesyncMcpServer } from "../../types/mcp.js";
+import type { BaseMcpConfig, BaseMcpServer } from "../../types/mcp-config.js";
+import { shouldIncludeServer } from "../../utils/mcp-helpers.js";
 
-export async function generateJunieMcpConfiguration(
-  _servers: Record<string, RulesyncMcpServer>,
-  _dir: string,
-): Promise<Array<{ filepath: string; content: string }>> {
-  // Junie doesn't support MCP configuration yet
-  return [];
+type JunieServer = BaseMcpServer & {
+  name?: string;
+  workingDirectory?: string;
+  transport?: "stdio" | "http" | "sse";
+  [key: string]: unknown;
+};
+
+export function generateJunieMcp(config: RulesyncMcpConfig): string {
+  const junieConfig: BaseMcpConfig = {
+    mcpServers: {},
+  };
+
+  for (const [serverName, server] of Object.entries(config.mcpServers)) {
+    if (!shouldIncludeServer(server, "junie")) continue;
+
+    const junieServer: JunieServer = {
+      name: serverName,
+    };
+
+    if (server.command) {
+      junieServer.command = server.command;
+      if (server.args) junieServer.args = server.args;
+    } else if (server.url || server.httpUrl) {
+      if (server.httpUrl) {
+        junieServer.httpUrl = server.httpUrl;
+      } else if (server.url) {
+        junieServer.url = server.url;
+      }
+    }
+
+    if (server.env) {
+      junieServer.env = server.env;
+    }
+
+    if (server.cwd) {
+      junieServer.workingDirectory = server.cwd;
+    }
+
+    if (server.timeout !== undefined) {
+      junieServer.timeout = server.timeout;
+    }
+
+    if (server.trust !== undefined) {
+      junieServer.trust = server.trust;
+    }
+
+    // Map transport types
+    if (server.transport) {
+      if (String(server.transport) === "streamable-http") {
+        junieServer.transport = "http";
+      } else if (
+        server.transport === "stdio" ||
+        server.transport === "http" ||
+        server.transport === "sse"
+      ) {
+        junieServer.transport = server.transport;
+      }
+    } else if (server.command) {
+      junieServer.transport = "stdio";
+    }
+
+    junieConfig.mcpServers[serverName] = junieServer;
+  }
+
+  return JSON.stringify(junieConfig, null, 2);
+}
+
+export function generateJunieMcpConfiguration(
+  mcpServers: Record<string, RulesyncMcpServer>,
+  baseDir: string = "",
+): Array<{ filepath: string; content: string }> {
+  // Generate project-level configuration only (as per precautions.md constraint)
+  // Junie MCP config is stored in project root - no IDE settings path is used
+  // to avoid creating user-level settings
+  const filepath = baseDir ? `${baseDir}/.junie/mcp-config.json` : ".junie/mcp-config.json";
+
+  const config: BaseMcpConfig = {
+    mcpServers: {},
+  };
+
+  for (const [serverName, server] of Object.entries(mcpServers)) {
+    // Check if this server should be included for junie
+    if (!shouldIncludeServer(server, "junie")) {
+      continue;
+    }
+
+    // Clone server config and remove targets
+    const { targets: _, transport, cwd, ...serverConfig } = server;
+
+    // Convert to JunieServer format preserving all properties
+    const junieServer: JunieServer = {
+      ...serverConfig,
+      name: serverName,
+    };
+
+    // Map cwd to workingDirectory
+    if (cwd) {
+      junieServer.workingDirectory = cwd;
+    }
+
+    // Map transport types for Junie compatibility
+    if (transport) {
+      if (String(transport) === "streamable-http") {
+        junieServer.transport = "http";
+      } else if (transport === "stdio" || transport === "http" || transport === "sse") {
+        junieServer.transport = transport;
+      }
+    } else if (serverConfig.command) {
+      junieServer.transport = "stdio";
+    }
+
+    config.mcpServers[serverName] = junieServer;
+  }
+
+  return [
+    {
+      filepath,
+      content: `${JSON.stringify(config, null, 2)}\n`,
+    },
+  ];
 }


### PR DESCRIPTION
## Summary
- JetBrains JunieのMCP（Model Context Protocol）設定ファイル生成機能を実装
- プロジェクトレベルの`.junie/mcp-config.json`ファイルを生成
- stdio、http、sseの各トランスポートタイプに対応
- `streamable-http`トランスポートの`http`への自動マッピング
- ターゲット指定による適切なサーバーフィルタリング

## Test plan
- [x] stdio、http、sseの各トランスポートタイプのテスト
- [x] ターゲット設定によるサーバーフィルタリングのテスト
- [x] 設定フィールドのマッピング（cwd→workingDirectory等）のテスト
- [x] 既存のMCPジェネレーターとの統合テスト
- [x] TypeScript型安全性の確認
- [x] ESLintおよびPrettierルールの適用

🤖 Generated with [Claude Code](https://claude.ai/code)