### PR TITLE
Fix: Rename --augmentcodeLegacy option to --augmentcode-legacy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -67,8 +67,9 @@ yarn global add rulesync
    npx rulesync import --cursor      # .cursorrulesと.cursor/rules/*.mdcから
    npx rulesync import --copilot     # .github/copilot-instructions.mdから
    npx rulesync import --cline       # .cline/instructions.mdから
-   npx rulesync import --augmentcode # .augment/rules/*.mdから
-   npx rulesync import --roo         # .roo/instructions.mdから
+   npx rulesync import --augmentcode        # .augment/rules/*.mdから
+   npx rulesync import --augmentcode-legacy # .augment-guidelines（レガシー形式）から
+   npx rulesync import --roo                # .roo/instructions.mdから
    npx rulesync import --geminicli   # GEMINI.mdと.gemini/memories/*.mdから
    ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ If you already have AI tool configurations, you can import them into rulesync fo
    npx rulesync import --cursor      # From .cursorrules and .cursor/rules/*.mdc
    npx rulesync import --copilot     # From .github/copilot-instructions.md
    npx rulesync import --cline       # From .cline/instructions.md
-   npx rulesync import --augmentcode # From .augment/rules/*.md
-   npx rulesync import --roo         # From .roo/instructions.md
+   npx rulesync import --augmentcode        # From .augment/rules/*.md
+   npx rulesync import --augmentcode-legacy # From .augment-guidelines (legacy format)
+   npx rulesync import --roo                # From .roo/instructions.md
    npx rulesync import --geminicli   # From GEMINI.md and .gemini/memories/*.md
    ```
 

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -22,7 +22,7 @@ describe("import command", () => {
   it("should require at least one tool to be specified", async () => {
     await expect(importCommand({})).rejects.toThrow("process.exit");
     expect(console.error).toHaveBeenCalledWith(
-      "❌ Please specify one tool to import from (--augmentcode, --augmentcodeLegacy, --claudecode, --cursor, --copilot, --cline, --roo, --geminicli)",
+      "❌ Please specify one tool to import from (--augmentcode, --augmentcode-legacy, --claudecode, --cursor, --copilot, --cline, --roo, --geminicli)",
     );
   });
 

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -3,7 +3,7 @@ import type { ToolTarget } from "../../types/index.js";
 
 export interface ImportOptions {
   augmentcode?: boolean;
-  augmentcodeLegacy?: boolean;
+  "augmentcode-legacy"?: boolean;
   claudecode?: boolean;
   cursor?: boolean;
   copilot?: boolean;
@@ -18,7 +18,7 @@ export async function importCommand(options: ImportOptions = {}): Promise<void> 
 
   // Collect selected tools
   if (options.augmentcode) tools.push("augmentcode");
-  if (options.augmentcodeLegacy) tools.push("augmentcode-legacy");
+  if (options["augmentcode-legacy"]) tools.push("augmentcode-legacy");
   if (options.claudecode) tools.push("claudecode");
   if (options.cursor) tools.push("cursor");
   if (options.copilot) tools.push("copilot");
@@ -29,7 +29,7 @@ export async function importCommand(options: ImportOptions = {}): Promise<void> 
   // Validate that exactly one tool is selected
   if (tools.length === 0) {
     console.error(
-      "❌ Please specify one tool to import from (--augmentcode, --augmentcodeLegacy, --claudecode, --cursor, --copilot, --cline, --roo, --geminicli)",
+      "❌ Please specify one tool to import from (--augmentcode, --augmentcode-legacy, --claudecode, --cursor, --copilot, --cline, --roo, --geminicli)",
     );
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,7 @@ program
   .command("import")
   .description("Import configurations from AI tools to rulesync format")
   .option("--augmentcode", "Import from AugmentCode (.augment/rules/)")
-  .option("--augmentcodeLegacy", "Import from AugmentCode legacy format (.augment-guidelines)")
+  .option("--augmentcode-legacy", "Import from AugmentCode legacy format (.augment-guidelines)")
   .option("--claudecode", "Import from Claude Code (CLAUDE.md)")
   .option("--cursor", "Import from Cursor (.cursorrules)")
   .option("--copilot", "Import from GitHub Copilot (.github/copilot-instructions.md)")
@@ -46,7 +46,7 @@ program
   .command("generate")
   .description("Generate configuration files for AI tools")
   .option("--augmentcode", "Generate only for AugmentCode")
-  .option("--augmentcodeLegacy", "Generate only for AugmentCode legacy format")
+  .option("--augmentcode-legacy", "Generate only for AugmentCode legacy format")
   .option("--copilot", "Generate only for GitHub Copilot")
   .option("--cursor", "Generate only for Cursor")
   .option("--cline", "Generate only for Cline")
@@ -66,7 +66,7 @@ program
   .action(async (options) => {
     const tools: ToolTarget[] = [];
     if (options.augmentcode) tools.push("augmentcode");
-    if (options.augmentcodeLegacy) tools.push("augmentcode-legacy");
+    if (options["augmentcode-legacy"]) tools.push("augmentcode-legacy");
     if (options.copilot) tools.push("copilot");
     if (options.cursor) tools.push("cursor");
     if (options.cline) tools.push("cline");


### PR DESCRIPTION
## Summary
- Rename CLI option from `--augmentcodeLegacy` to `--augmentcode-legacy` for kebab-case consistency
- Update all related interfaces, error messages, and documentation

## Changes
- Update CLI option definition and handling in `src/cli/index.ts`
- Fix TypeScript interface and option processing in `src/cli/commands/import.ts`
- Update error messages to reflect new option name
- Update test expectations in `src/cli/commands/import.test.ts`
- Add documentation for `--augmentcode-legacy` option in README.md and README.ja.md

## Test plan
- [x] All existing tests pass
- [x] CLI accepts the new `--augmentcode-legacy` option
- [x] Error messages display the correct option names
- [x] Documentation updated in both English and Japanese

🤖 Generated with [Claude Code](https://claude.ai/code)