### PR TITLE
fix: remove tool prefix from imported rule filenames

### DIFF
--- a/src/parsers/claudecode.test.ts
+++ b/src/parsers/claudecode.test.ts
@@ -82,7 +82,7 @@ This is the real content after the table.`;
     const result = await parseClaudeConfiguration(testDir);
     expect(result.rules).toHaveLength(3);
 
-    const memoryRules = result.rules.filter((r) => r.filename.includes("memory"));
+    const memoryRules = result.rules.filter((r) => r.filename !== "main");
     expect(memoryRules).toHaveLength(2);
 
     const contents = memoryRules.map((r) => r.content);
@@ -97,9 +97,9 @@ This is the real content after the table.`;
     await writeFile(join(memoryDir, "valid.md"), "# Valid content");
 
     const result = await parseClaudeConfiguration(testDir);
-    const memoryRules = result.rules.filter((r) => r.filename.includes("memory"));
+    const memoryRules = result.rules.filter((r) => r.filename !== "main");
     expect(memoryRules).toHaveLength(1);
-    expect(memoryRules[0]?.filename).toContain("valid");
+    expect(memoryRules[0]?.filename).toBe("valid");
   });
 
   it("should parse settings.json and extract ignore patterns", async () => {

--- a/src/parsers/cline.test.ts
+++ b/src/parsers/cline.test.ts
@@ -66,8 +66,8 @@ This is a Node.js application.
     expect(result.rules).toHaveLength(2);
 
     const filenames = result.rules.map((r) => r.filename);
-    expect(filenames).toContain("cline-coding-style");
-    expect(filenames).toContain("cline-testing");
+    expect(filenames).toContain("coding-style");
+    expect(filenames).toContain("testing");
   });
 
   it("should parse both instructions and rules", async () => {
@@ -134,6 +134,6 @@ This is a Node.js application.
       description: "Cline rule: architecture",
       globs: ["**/*"],
     });
-    expect(result.rules[0]?.filename).toBe("cline-architecture");
+    expect(result.rules[0]?.filename).toBe("architecture");
   });
 });

--- a/src/parsers/copilot.test.ts
+++ b/src/parsers/copilot.test.ts
@@ -66,9 +66,9 @@ This is a TypeScript project.
     expect(result.rules).toHaveLength(2);
 
     const filenames = result.rules.map((r) => r.filename);
-    expect(filenames).toContain("copilot-typescript");
-    expect(filenames).toContain("copilot-testing");
-    expect(filenames).not.toContain("copilot-not-instructions");
+    expect(filenames).toContain("typescript");
+    expect(filenames).toContain("testing");
+    expect(filenames).not.toContain("not-instructions");
   });
 
   it("should parse both main file and instructions", async () => {
@@ -120,6 +120,6 @@ This is a TypeScript project.
       description: "Copilot instruction: api-design",
       globs: ["**/*"],
     });
-    expect(result.rules[0]!.filename).toBe("copilot-api-design");
+    expect(result.rules[0]!.filename).toBe("api-design");
   });
 });

--- a/src/parsers/geminicli.test.ts
+++ b/src/parsers/geminicli.test.ts
@@ -49,7 +49,7 @@ This is the main Gemini CLI configuration.
       globs: ["**/*"],
     });
     expect(result.rules[0]?.content).toContain("This is the main Gemini CLI configuration");
-    expect(result.rules[0]?.filename).toBe("gemini-main");
+    expect(result.rules[0]?.filename).toBe("main");
   });
 
   it("should skip reference table when parsing main file", async () => {
@@ -84,9 +84,7 @@ This is the actual content after the table.`;
     const result = await parseGeminiConfiguration(testDir);
     expect(result.rules).toHaveLength(3); // main + 2 memory files
 
-    const memoryRules = result.rules.filter((rule: ParsedRule) =>
-      rule.filename.startsWith("gemini-memory-"),
-    );
+    const memoryRules = result.rules.filter((rule: ParsedRule) => rule.filename !== "main");
     expect(memoryRules).toHaveLength(2);
     expect(memoryRules[0]?.frontmatter.description).toContain("Memory file:");
     expect(memoryRules[0]?.content).toContain("Memory content");
@@ -179,11 +177,9 @@ dist/
     const result = await parseGeminiConfiguration(testDir);
     expect(result.rules).toHaveLength(2); // main + 1 valid memory file
 
-    const memoryRules = result.rules.filter((rule: ParsedRule) =>
-      rule.filename.startsWith("gemini-memory-"),
-    );
+    const memoryRules = result.rules.filter((rule: ParsedRule) => rule.filename !== "main");
     expect(memoryRules).toHaveLength(1);
-    expect(memoryRules[0]?.filename).toBe("gemini-memory-valid");
+    expect(memoryRules[0]?.filename).toBe("valid");
   });
 
   it("should handle file reading errors gracefully", async () => {
@@ -197,7 +193,7 @@ dist/
     const result = await parseGeminiConfiguration(testDir);
     // Should not crash and should still parse main file
     expect(result.rules).toHaveLength(1);
-    expect(result.rules[0]?.filename).toBe("gemini-main");
+    expect(result.rules[0]?.filename).toBe("main");
   });
 
   it("should use default baseDir when not provided", async () => {

--- a/src/parsers/roo.test.ts
+++ b/src/parsers/roo.test.ts
@@ -66,8 +66,8 @@ This is a React TypeScript project.
     expect(result.rules).toHaveLength(2);
 
     const filenames = result.rules.map((r) => r.filename);
-    expect(filenames).toContain("roo-react-patterns");
-    expect(filenames).toContain("roo-performance");
+    expect(filenames).toContain("react-patterns");
+    expect(filenames).toContain("performance");
   });
 
   it("should parse both instructions and rules", async () => {
@@ -134,7 +134,7 @@ This is a React TypeScript project.
       description: "Roo rule: state-management",
       globs: ["**/*"],
     });
-    expect(result.rules[0]?.filename).toBe("roo-state-management");
+    expect(result.rules[0]?.filename).toBe("state-management");
   });
 
   it("should handle special characters in filenames", async () => {
@@ -143,7 +143,7 @@ This is a React TypeScript project.
 
     const result = await parseRooConfiguration(testDir);
     expect(result.rules).toHaveLength(2);
-    expect(result.rules[0]?.filename).toBe("roo-api-integration");
-    expect(result.rules[1]?.filename).toBe("roo-ui_components");
+    expect(result.rules[0]?.filename).toBe("api-integration");
+    expect(result.rules[1]?.filename).toBe("ui_components");
   });
 });

--- a/src/parsers/shared-helpers.ts
+++ b/src/parsers/shared-helpers.ts
@@ -69,7 +69,7 @@ export async function parseConfigurationFiles(
           rules.push({
             frontmatter,
             content,
-            filename: `${config.tool}-instructions`,
+            filename: "instructions",
             filepath: mainFilePath,
           });
         }
@@ -116,7 +116,7 @@ export async function parseConfigurationFiles(
                   rules.push({
                     frontmatter,
                     content,
-                    filename: `${config.tool}-${filename}`,
+                    filename: filename,
                     filepath: filePath,
                   });
                 }
@@ -274,7 +274,7 @@ function parseMainFile(
   return {
     frontmatter,
     content: mainContent,
-    filename: `${config.filenamePrefix}-main`,
+    filename: "main",
     filepath,
   };
 }
@@ -306,7 +306,7 @@ async function parseMemoryFiles(
           rules.push({
             frontmatter,
             content: content.trim(),
-            filename: `${config.filenamePrefix}-memory-${filename}`,
+            filename: filename,
             filepath: filePath,
           });
         }


### PR DESCRIPTION
## Summary
- rulesyncのimport時に生成されるファイル名から`{tool}-*.md`のようなツールプレフィックスを削除
- 例: `.claude/memories/overview.md` → `.rulesync/overview.md` (従来: `.rulesync/claude-memory-overview.md`)

## Test plan
- [x] 全ての関連テストケースを更新
- [x] 全てのテストが正常に通ることを確認
- [x] import機能が期待通りに動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)