### PR TITLE
docs: add JetBrains Junie support documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,6 +18,7 @@ rulesyncは以下のAI開発ツールの**生成**と**インポート**の両�
 - **AugmentCode Rules** (`.augment/rules/*.md`)
 - **Roo Code Rules** (`.roo/rules/*.md` + `.roo/instructions.md`)
 - **Gemini CLI** (`GEMINI.md` + `.gemini/memories/*.md`)
+- **JetBrains Junie Guidelines** (`.junie/guidelines.md`)
 - **Kiro IDE カスタムステアリングドキュメント** (`.kiro/steering/*.md`) + **AI除外ファイル** (`.aiignore`)
 
 ## インストール
@@ -71,6 +72,7 @@ yarn global add rulesync
    npx rulesync import --augmentcode-legacy # .augment-guidelines（レガシー形式）から
    npx rulesync import --roo                # .roo/instructions.mdから
    npx rulesync import --geminicli   # GEMINI.mdと.gemini/memories/*.mdから
+   npx rulesync import --junie       # .junie/guidelines.mdから
    ```
 
 2. **`.rulesync/`ディレクトリのインポートされたルールを確認・編集**
@@ -97,9 +99,10 @@ AI開発ツールは新しいツールが頻繁に登場し、急速に進化し
 - Claude Code：アーキテクチャ設計
 - Cline：デバッグ支援
 - Gemini CLI：知的コード解析
+- JetBrains Junie：自律的AIコーディング
 
 ### 🔓 **ベンダーロックインなし**
-ベンダーロックインを完全に回避できます。rulesyncの使用を停止することを決定した場合でも、生成されたルールファイル（`.github/instructions/`、`.cursor/rules/`、`.clinerules/`、`CLAUDE.md`、`GEMINI.md`など）をそのまま使い続けることができます。
+ベンダーロックインを完全に回避できます。rulesyncの使用を停止することを決定した場合でも、生成されたルールファイル（`.github/instructions/`、`.cursor/rules/`、`.clinerules/`、`CLAUDE.md`、`GEMINI.md`、`.junie/guidelines.md`など）をそのまま使い続けることができます。
 
 ### 🎯 **ツール間の一貫性**
 すべてのAIツールに一貫したルールを適用し、チーム全体のコード品質と開発体験を向上させます。
@@ -220,6 +223,7 @@ npx rulesync generate --claudecode
 npx rulesync generate --augmentcode
 npx rulesync generate --roo
 npx rulesync generate --geminicli
+npx rulesync generate --junie
 npx rulesync generate --kiro
 
 # クリーンビルド（既存ファイルを最初に削除）
@@ -242,7 +246,7 @@ npx rulesync generate --base-dir ./apps/web,./apps/api,./packages/shared
 
 - `--delete`: 新しいファイルを作成する前に既存の生成済みファイルをすべて削除
 - `--verbose`: 生成プロセス中に詳細出力を表示
-- `--copilot`, `--cursor`, `--cline`, `--claudecode`, `--augmentcode`, `--roo`, `--geminicli`, `--kiro`: 指定されたツールのみ生成
+- `--copilot`, `--cursor`, `--cline`, `--claudecode`, `--augmentcode`, `--roo`, `--geminicli`, `--junie`, `--kiro`: 指定されたツールのみ生成
 - `--base-dir <paths>`: 指定されたベースディレクトリに設定ファイルを生成（複数パスの場合はカンマ区切り）。異なるプロジェクトディレクトリにツール固有の設定を生成したいmonorepoセットアップに便利。
 
 ### 4. 既存設定のインポート
@@ -258,6 +262,7 @@ npx rulesync import --cline      # .cline/instructions.mdからインポート
 npx rulesync import --augmentcode # .augment/rules/*.mdからインポート
 npx rulesync import --roo        # .roo/instructions.mdからインポート
 npx rulesync import --geminicli  # GEMINI.mdと.gemini/memories/*.mdからインポート
+npx rulesync import --junie      # .junie/guidelines.mdからインポート
 
 # 各ツールを個別にインポート
 npx rulesync import --claudecode
@@ -434,7 +439,8 @@ globs: "**/*.ts,**/*.tsx"
 | **Claude Code**    | `./CLAUDE.md` (ルート)<br>`.claude/memories/*.md` (非ルート) | プレーンMarkdown              | ルートはCLAUDE.mdに移動<br>非ルートは別メモリファイルに移動<br>CLAUDE.mdは`@filename`参照を含む                                                                                                                 |
 | **AugmentCode**    | `.augment/rules/*.md`                                        | YAMLフロントマター + Markdown | ルート: `type: always`<br>非ルート: `type: auto` (description指定時) または `type: manual` (デフォルト)                                                                                                        |
 | **Roo Code**       | `.roo/rules/*.md`                                            | プレーンMarkdown              | 両レベルとも説明ヘッダー付きの同じフォーマットを使用                                                                                                                                                            |
-| **Gemini CLI**     | `GEMINI.md` (ルート)<br>`.gemini/memories/*.md` (非ルート)   | プレーンMarkdown              | ルートはGEMINI.mdに移動<br>非ルートは別メモリファイルに移動<br>GEMINI.mdは`@filename`参照を含む                                                                                                                 |
+| **Gemini CLI**     | `GEMINI.md` (ルート)<br>`.gemini/memories/*.md` (非ルート)   | プレーンMarkdown              | ルートはGEMINI.mdに移動<br>非ルートは別メモリファイルに移動<br>GEMINI.mdは`@filename`参照を含む                                                      |
+| **JetBrains Junie** | `.junie/guidelines.md`                                      | プレーンMarkdown              | すべてのルールを単一のガイドラインファイルに統合                                                                                                                                                                |
 | **Kiro IDE**       | `.kiro/steering/*.md` + `.aiignore`                          | プレーンMarkdown + 除外パターン | カスタムステアリングドキュメントで両レベルとも同じフォーマット使用<br>AI除外ファイルで機密パターンを除外                                                                                                       |
 
 ## バリデーション
@@ -462,6 +468,7 @@ rulesyncは、対応するAIツール用のMCPサーバー設定も管理でき�
 - **Cursor** (`.cursor/mcp.json`)
 - **Cline** (`.cline/mcp.json`)
 - **Gemini CLI** (`.gemini/settings.json`)
+- **JetBrains Junie** (`.junie/mcp.json`)
 - **Kiro IDE** (`.kiro/mcp.json`)
 - **Roo Code** (`.roo/mcp.json`)
 
@@ -533,7 +540,7 @@ MCP設定はルールファイルと一緒に生成されます：
 npx rulesync generate
 
 # 特定のツールのみ生成
-npx rulesync generate --claudecode --cursor --kiro
+npx rulesync generate --claudecode --cursor --junie --kiro
 
 # 特定のディレクトリに生成（monorepo）
 npx rulesync generate --base-dir ./packages/frontend

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ rulesync supports both **generation** and **import** for the following AI develo
 - **AugmentCode Rules** (`.augment/rules/*.md`)
 - **Roo Code Rules** (`.roo/rules/*.md` + `.roo/instructions.md`)
 - **Gemini CLI** (`GEMINI.md` + `.gemini/memories/*.md`)
+- **JetBrains Junie Guidelines** (`.junie/guidelines.md`)
 - **Kiro IDE Custom Steering Documents** (`.kiro/steering/*.md`) + **AI Ignore Files** (`.aiignore`)
 
 ## Installation
@@ -71,6 +72,7 @@ If you already have AI tool configurations, you can import them into rulesync fo
    npx rulesync import --augmentcode-legacy # From .augment-guidelines (legacy format)
    npx rulesync import --roo                # From .roo/instructions.md
    npx rulesync import --geminicli   # From GEMINI.md and .gemini/memories/*.md
+   npx rulesync import --junie       # From .junie/guidelines.md
    ```
 
 2. **Review and edit** the imported rules in `.rulesync/` directory
@@ -97,9 +99,10 @@ Enable hybrid development workflows combining multiple AI tools:
 - Claude Code for architecture design
 - Cline for debugging assistance
 - Gemini CLI for intelligent code analysis
+- JetBrains Junie for autonomous AI coding
 
 ### 🔓 **No Vendor Lock-in**
-Avoid vendor lock-in completely. If you decide to stop using rulesync, you can continue using the generated rule files (`.github/instructions/`, `.cursor/rules/`, `.clinerules/`, `CLAUDE.md`, `GEMINI.md`, etc.) as-is.
+Avoid vendor lock-in completely. If you decide to stop using rulesync, you can continue using the generated rule files (`.github/instructions/`, `.cursor/rules/`, `.clinerules/`, `CLAUDE.md`, `GEMINI.md`, `.junie/guidelines.md`, etc.) as-is.
 
 ### 🎯 **Consistency Across Tools**
 Apply consistent rules across all AI tools, improving code quality and development experience for the entire team.
@@ -220,6 +223,7 @@ npx rulesync generate --claudecode
 npx rulesync generate --augmentcode
 npx rulesync generate --roo
 npx rulesync generate --geminicli
+npx rulesync generate --junie
 npx rulesync generate --kiro
 
 # Clean build (delete existing files first)
@@ -242,7 +246,7 @@ npx rulesync generate --base-dir ./apps/web,./apps/api,./packages/shared
 
 - `--delete`: Remove all existing generated files before creating new ones
 - `--verbose`: Show detailed output during generation process
-- `--copilot`, `--cursor`, `--cline`, `--claudecode`, `--augmentcode`, `--roo`, `--geminicli`, `--kiro`: Generate only for specified tools
+- `--copilot`, `--cursor`, `--cline`, `--claudecode`, `--augmentcode`, `--roo`, `--geminicli`, `--junie`, `--kiro`: Generate only for specified tools
 - `--base-dir <paths>`: Generate configuration files in specified base directories (comma-separated for multiple paths). Useful for monorepo setups where you want to generate tool-specific configurations in different project directories.
 - `--config <path>`: Use a specific configuration file
 - `--no-config`: Disable configuration file loading
@@ -341,6 +345,7 @@ npx rulesync import --cline      # Import from .cline/instructions.md
 npx rulesync import --augmentcode # Import from .augment/rules/*.md
 npx rulesync import --roo        # Import from .roo/instructions.md
 npx rulesync import --geminicli  # Import from GEMINI.md and .gemini/memories/*.md
+npx rulesync import --junie      # Import from .junie/guidelines.md
 
 # Import each tool individually
 npx rulesync import --claudecode
@@ -524,6 +529,7 @@ globs: "**/*.ts,**/*.tsx"
 | **AugmentCode** | `.augment/rules/*.md` | Markdown with YAML frontmatter | Root: `type: always`<br>Non-root: `type: auto` (with description) or `type: manual` (default) |
 | **Roo Code** | `.roo/rules/*.md` | Plain Markdown | Both levels use same format with description header |
 | **Gemini CLI** | `GEMINI.md` (root)<br>`.gemini/memories/*.md` (non-root) | Plain Markdown | Root goes to GEMINI.md<br>Non-root go to separate memory files<br>GEMINI.md includes `@filename` references |
+| **JetBrains Junie** | `.junie/guidelines.md` | Plain Markdown | All rules combined into single guidelines file |
 | **Kiro IDE** | `.kiro/steering/*.md` + `.aiignore` | Plain Markdown + Ignore patterns | Both levels use same format for custom steering docs<br>AI ignore file excludes sensitive patterns |
 
 ## Validation
@@ -551,6 +557,7 @@ rulesync can also manage MCP server configurations for supported AI tools. This 
 - **Cursor** (`.cursor/mcp.json`)
 - **Cline** (`.cline/mcp.json`)
 - **Gemini CLI** (`.gemini/settings.json`)
+- **JetBrains Junie** (`.junie/mcp.json`)
 - **Kiro IDE** (`.kiro/mcp.json`)
 - **Roo Code** (`.roo/mcp.json`)
 
@@ -622,7 +629,7 @@ MCP configurations are generated alongside rule files:
 npx rulesync generate
 
 # Generate only for specific tools
-npx rulesync generate --claudecode --cursor --kiro
+npx rulesync generate --claudecode --cursor --junie --kiro
 
 # Generate in specific directories (monorepo)
 npx rulesync generate --base-dir ./packages/frontend


### PR DESCRIPTION
## Summary
- JetBrains Junieを対応ツール一覧に追加
- README.mdとREADME.ja.mdの両方でJunie関連の文言を追加
- インポート、生成、MCP設定などすべての関連セクションを更新

## Changes
- 対応ツール一覧にJetBrains Junie Guidelines (.junie/guidelines.md)を追加
- インポートコマンドに--junieフラグを追加
- マルチツールワークフローにJunieの説明を追加
- ベンダーロックイン回避の説明を更新
- 生成コマンドのオプションに--junieを追加
- 生成される設定ファイル表にJunieの行を追加
- MCPサポートセクションにJunieを追加

## Test plan
- [x] README.mdとREADME.ja.mdの両方が更新されている
- [x] すべての関連セクションでJunieが言及されている
- [x] 日英両言語で一貫した内容になっている

🤖 Generated with [Claude Code](https://claude.ai/code)