### PR TITLE
fix: use full path for cargo install to resolve PATH issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,7 +55,7 @@ USER node
 
 # Rust and similarity-ts install
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN cargo install similarity-ts
+RUN ~/.cargo/bin/cargo install similarity-ts
 
 # Install global packages
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global


### PR DESCRIPTION
## Summary
- Fixed an issue where cargo command was not found during similarity-ts installation
- Updated Dockerfile to use the full path to cargo in the user's home directory (~/.cargo/bin/cargo)

## Test plan
- [ ] Verify devcontainer builds successfully
- [ ] Confirm similarity-ts is installed correctly
- [ ] Test that cargo is accessible with full path

🤖 Generated with [Claude Code](https://claude.ai/code)