### PR TITLE
Fix subagent execution strategy in research-tool-specs command

### DIFF
--- a/.claude/commands/research-tool-specs.md
+++ b/.claude/commands/research-tool-specs.md
@@ -10,13 +10,13 @@ Please complete all of the following tasks.
 
 Important: `.rulesync/*.md` files must include the required frontmatter. Refer to @README.md for frontmatter specification details.
 
-Call the rulesync-md-creator subagent in parallel as much as possible to create the following files:
+Call the rulesync-md-creator subagent serially to create the following files:
 
-- `.rulesync/specification-{tool_name_in_rulesync}-rules.md`
+1. `.rulesync/specification-{tool_name_in_rulesync}-rules.md`
   - Research the specifications for rules or memories text files of target_tool_name.
-- `.rulesync/specification-{tool_name_in_rulesync}-mcp.md`
+2. `.rulesync/specification-{tool_name_in_rulesync}-mcp.md`
   - Research the specifications for MCP configuration text files of target_tool_name.
-- `.rulesync/specification-{tool_name_in_rulesync}-ignore.md`
+3. `.rulesync/specification-{tool_name_in_rulesync}-ignore.md`
   - Research the specifications for ignore text files of target_tool_name. Ignore files are configuration files used to specify files that should not be read or written by AI coding tools, such as files containing secret information.
 
 For all files, instruct the subagent to research and document the specifications as comprehensively and thoroughly as possible without omissions.


### PR DESCRIPTION
## Summary

This PR modifies the research-tool-specs command to change the subagent execution strategy from parallel to serial execution.

## Changes Made

- **Modified execution strategy**: Changed from calling rulesync-md-creator subagent "in parallel" to "serially"
- **Improved task structure**: Reorganized the file creation tasks into a numbered list format (1, 2, 3) for better clarity and sequential execution
- **Enhanced readability**: The numbered format makes it clearer that these tasks should be executed in order

## Files Modified

- `.claude/commands/research-tool-specs.md`

## Rationale

The change from parallel to serial execution ensures that:
1. Subagent tasks are executed in a predictable order
2. Dependencies between tasks are properly handled
3. Resource usage is more controlled during specification research
4. The numbered list format provides clearer instructions for task execution

## Test Plan

- [x] Verify the command file syntax is correct
- [x] Confirm the frontmatter requirements are still referenced properly
- [x] Ensure all three specification file types are still covered

🤖 Generated with [Claude Code](https://claude.ai/code)