### PR TITLE
chore: release v0.56.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "0.55.0",
+	"version": "0.56.0",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,7 +16,7 @@ import {
 
 const program = new Command();
 
-program.name("rulesync").description("Unified AI rules management CLI tool").version("0.55.0");
+program.name("rulesync").description("Unified AI rules management CLI tool").version("0.56.0");
 
 program.command("init").description("Initialize rulesync in current directory").action(initCommand);
 


### PR DESCRIPTION
Version bump to v0.56.0

- Updated CLI version in src/cli/index.ts
- Updated package.json version

This PR contains the version updates for the v0.56.0 release.