### PR TITLE
feat: make frontmatter keys optional with default values

### DIFF
--- a/.claude/commands/to-english-all.md
+++ b/.claude/commands/to-english-all.md
@@ -5,3 +5,4 @@ Call the japanese-to-english-translator subagent in parallel as much as possible
 - .claude/commands/*.md
 - .claude/agents/*.md
 - .rulesync/*.md
+    - Except for `my-instructions.md`.

--- a/.claude/commands/to-english.md
+++ b/.claude/commands/to-english.md
@@ -5,3 +5,4 @@
     - .claude/commands/*.md
     - .claude/agents/*.md
     - .rulesync/*.md
+        - Except for `my-instructions.md`.

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -96,7 +96,7 @@ globs: ["**/*.ts"]
       await expect(parseRuleFile(filepath)).rejects.toThrow("Invalid frontmatter");
     });
 
-    it("should throw error for missing description", async () => {
+    it("should apply default value for missing description", async () => {
       const ruleContent = `---
 root: true
 targets: ["copilot"]
@@ -109,10 +109,15 @@ globs: ["**/*.ts"]
       const filepath = join(testDir, "missing-desc.md");
       writeFileSync(filepath, ruleContent);
 
-      await expect(parseRuleFile(filepath)).rejects.toThrow("Invalid frontmatter");
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.description).toBe("");
+      expect(rule.frontmatter.root).toBe(true);
+      expect(rule.frontmatter.targets).toEqual(["copilot"]);
+      expect(rule.frontmatter.globs).toEqual(["**/*.ts"]);
     });
 
-    it("should throw error for missing globs", async () => {
+    it("should apply default value for missing globs", async () => {
       const ruleContent = `---
 root: true
 targets: ["copilot"]
@@ -125,7 +130,12 @@ description: "Test rule"
       const filepath = join(testDir, "missing-globs.md");
       writeFileSync(filepath, ruleContent);
 
-      await expect(parseRuleFile(filepath)).rejects.toThrow("Invalid frontmatter");
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.globs).toEqual([]);
+      expect(rule.frontmatter.root).toBe(true);
+      expect(rule.frontmatter.targets).toEqual(["copilot"]);
+      expect(rule.frontmatter.description).toBe("Test rule");
     });
 
     it("should throw error for invalid globs type", async () => {
@@ -164,7 +174,7 @@ globs: []
       expect(rule.frontmatter.globs).toEqual([]);
     });
 
-    it("should throw error for file without frontmatter", async () => {
+    it("should apply all default values for file without frontmatter", async () => {
       const ruleContent = `# No Frontmatter
 
 This file has no frontmatter.
@@ -173,10 +183,15 @@ This file has no frontmatter.
       const filepath = join(testDir, "no-frontmatter.md");
       writeFileSync(filepath, ruleContent);
 
-      await expect(parseRuleFile(filepath)).rejects.toThrow("Invalid frontmatter");
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.root).toBe(false);
+      expect(rule.frontmatter.targets).toEqual(["*"]);
+      expect(rule.frontmatter.description).toBe("");
+      expect(rule.frontmatter.globs).toEqual([]);
     });
 
-    it("should throw error for completely empty frontmatter", async () => {
+    it("should apply all default values for completely empty frontmatter", async () => {
       const ruleContent = `---
 ---
 
@@ -186,7 +201,12 @@ This file has no frontmatter.
       const filepath = join(testDir, "empty-frontmatter.md");
       writeFileSync(filepath, ruleContent);
 
-      await expect(parseRuleFile(filepath)).rejects.toThrow("Invalid frontmatter");
+      const rule = await parseRuleFile(filepath);
+
+      expect(rule.frontmatter.root).toBe(false);
+      expect(rule.frontmatter.targets).toEqual(["*"]);
+      expect(rule.frontmatter.description).toBe("");
+      expect(rule.frontmatter.globs).toEqual([]);
     });
 
     it("should throw error for string targets", async () => {

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -2,22 +2,31 @@ import { z } from "zod/mini";
 import { RulesyncTargetsSchema, ToolTargetSchema, ToolTargetsSchema } from "./tool-targets.js";
 
 export const RuleFrontmatterSchema = z.object({
-  root: z.boolean(),
-  targets: RulesyncTargetsSchema,
-  description: z.string(),
-  globs: z.array(z.string()),
+  root: z.optional(z.boolean()),
+  targets: z.optional(RulesyncTargetsSchema),
+  description: z.optional(z.string()),
+  globs: z.optional(z.array(z.string())),
   cursorRuleType: z.optional(z.enum(["always", "manual", "specificFiles", "intelligently"])),
   windsurfActivationMode: z.optional(z.enum(["always", "manual", "model-decision", "glob"])),
   windsurfOutputFormat: z.optional(z.enum(["single-file", "directory"])),
   tags: z.optional(z.array(z.string())),
 });
 
+// Schema for parsing (with optional fields)
 export const ParsedRuleSchema = z.object({
   frontmatter: RuleFrontmatterSchema,
   content: z.string(),
   filename: z.string(),
   filepath: z.string(),
 });
+
+// Type for processed rule (with defaults applied)
+export type ProcessedRule = {
+  frontmatter: RuleFrontmatter;
+  content: string;
+  filename: string;
+  filepath: string;
+};
 
 export const GeneratedOutputSchema = z.object({
   tool: ToolTargetSchema,
@@ -31,7 +40,21 @@ export const GenerateOptionsSchema = z.object({
   watch: z.optional(z.boolean()),
 });
 
-export type RuleFrontmatter = z.infer<typeof RuleFrontmatterSchema>;
-export type ParsedRule = z.infer<typeof ParsedRuleSchema>;
+// Raw frontmatter type from the schema (with optional fields)
+export type RawRuleFrontmatter = z.infer<typeof RuleFrontmatterSchema>;
+
+// Processed frontmatter type with defaults applied (required fields)
+export type RuleFrontmatter = {
+  root: boolean;
+  targets: z.infer<typeof RulesyncTargetsSchema>;
+  description: string;
+  globs: string[];
+  cursorRuleType?: "always" | "manual" | "specificFiles" | "intelligently";
+  windsurfActivationMode?: "always" | "manual" | "model-decision" | "glob";
+  windsurfOutputFormat?: "single-file" | "directory";
+  tags?: string[];
+};
+
+export type ParsedRule = ProcessedRule;
 export type GeneratedOutput = z.infer<typeof GeneratedOutputSchema>;
 export type GenerateOptions = z.infer<typeof GenerateOptionsSchema>;


### PR DESCRIPTION
## Summary
- Made all required frontmatter keys (root, targets, description, globs) optional in the schema
- Added default value handling in the parser with sensible defaults
- Updated type definitions to properly handle optional fields
- Fixed tests to verify default value behavior instead of expecting errors

## Changes
- **Parser improvements**: Modified `parser.ts` to apply default values for missing frontmatter fields
- **Schema updates**: Changed `RuleFrontmatterSchema` to make all core fields optional
- **Type safety**: Added proper type definitions for raw vs processed frontmatter
- **Test updates**: Updated tests to verify default behavior works correctly

## Default Values
- `root`: `false`
- `targets`: `["*"]` (applies to all tools)
- `description`: `""` (empty string)
- `globs`: `[]` (empty array)

## Test Plan
- [x] All existing tests pass with new default behavior
- [x] Parser handles missing frontmatter gracefully
- [x] Type system correctly represents optional vs required fields
- [x] Default values are applied consistently

🤖 Generated with [Claude Code](https://claude.ai/code)