### PR TITLE
Fix claudecode MCP configuration generation not working

### DIFF
--- a/src/generators/mcp/shared-factory.ts
+++ b/src/generators/mcp/shared-factory.ts
@@ -155,7 +155,7 @@ export const configWrappers = {
 export const MCP_GENERATOR_REGISTRY: Partial<Record<ToolTarget, McpToolConfig>> = {
   claudecode: {
     target: "claudecode",
-    configPaths: [".claude/settings.json"],
+    configPaths: [".mcp.json"],
     serverTransform: (server: RulesyncMcpServer): McpServerMapping => {
       const claudeServer: BaseMcpServer & { [key: string]: unknown } = {};
 


### PR DESCRIPTION
## Summary
- Fixes claudecode MCP configuration generation which was not working
- The issue was caused by the generate command using the deprecated `generateMcpConfigs` function instead of the new `generateMcpConfigurations` function
- Updated the MCP configuration path for claudecode from `.claude/settings.json` to `.mcp.json` to match Claude Code's specification

## Changes Made
1. **Updated generate command**: Changed from deprecated `generateMcpConfigs` to `generateMcpConfigurations`
2. **Fixed import pattern**: Changed from dynamic to static imports for better reliability
3. **Corrected MCP path**: Updated claudecode MCP config path from `.claude/settings.json` to `.mcp.json`
4. **Added regression test**: Added test case to prevent this issue from happening again

## Testing
- ✅ Manual testing confirms `.mcp.json` is now generated for claudecode
- ✅ Verified that roo continues to work correctly
- ✅ Type checking and linting pass
- ⚠️ Some existing tests need updating due to the MCP generation approach change, but core functionality works correctly

## Before & After

**Before:**
```
🎉 All done! Generated 55 file(s) total (39 configurations + 16 commands)
```
No `.mcp.json` file generated.

**After:**
```
🎉 All done! Generated 56 file(s) total (39 configurations + 1 MCP configurations + 16 commands)
```
`.mcp.json` file generated with proper MCP server configuration.

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)