### PR TITLE
fix: use correct path to junie mcp config

### DIFF
--- a/src/generators/mcp/shared-factory.ts
+++ b/src/generators/mcp/shared-factory.ts
@@ -252,7 +252,7 @@ export const MCP_GENERATOR_REGISTRY: Partial<Record<ToolTarget, McpToolConfig>> 
 
   junie: {
     target: "junie",
-    configPaths: [".junie/mcp-config.json"],
+    configPaths: [".junie/mcp/mcp.json"],
     serverTransform: (server: RulesyncMcpServer, serverName: string): McpServerMapping => {
       const junieServer: BaseMcpServer & {
         name?: string;


### PR DESCRIPTION
Thanks for creating this package, it's really helpful! When testing it, I noticed it was using the wrong mcp file path for junie: https://www.jetbrains.com/help/junie/model-context-protocol-mcp.html#bksdkr_21