### PR TITLE
feat: replace console logging with centralized consola logger system

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"c12": "3.2.0",
 		"chokidar": "4.0.3",
 		"commander": "14.0.0",
+		"consola": "3.4.2",
 		"gray-matter": "4.0.3",
 		"js-yaml": "4.1.0",
 		"micromatch": "4.0.8",

--- a/src/cli/commands/config.test.ts
+++ b/src/cli/commands/config.test.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockConfig } from "../../test-utils/index.js";
+import { createMockConfig, mockLogger } from "../../test-utils/index.js";
 import type { MergedConfig } from "../../types/index.js";
 import { loadConfig } from "../../utils/index.js";
 import { configCommand } from "./config.js";
@@ -14,6 +14,9 @@ vi.mock("../../utils/index.js", async () => {
     generateSampleConfig: actual.generateSampleConfig,
   };
 });
+vi.mock("../../utils/logger.js", () => ({
+  logger: mockLogger,
+}));
 vi.mock("node:fs");
 
 const mockLoadConfig = vi.mocked(loadConfig);
@@ -22,9 +25,6 @@ const mockWriteFileSync = vi.mocked(writeFileSync);
 describe("config command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   describe("showConfig", () => {
@@ -39,11 +39,11 @@ describe("config command", () => {
       await configCommand();
 
       expect(mockLoadConfig).toHaveBeenCalled();
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockLogger.log).toHaveBeenCalledWith(
         "Configuration loaded from: /path/to/rulesync.jsonc\n",
       );
-      expect(console.log).toHaveBeenCalledWith("\nAI Rules Directory: .rulesync");
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockLogger.log).toHaveBeenCalledWith("\nAI Rules Directory: .rulesync");
+      expect(mockLogger.log).toHaveBeenCalledWith(
         "\nDefault Targets: augmentcode, copilot, cursor, cline, claudecode, codexcli, roo, geminicli, kiro, junie, windsurf",
       );
     });

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { ConfigOptions, ToolTarget } from "../../types/index.js";
 import { ALL_TOOL_TARGETS, ToolTargetSchema } from "../../types/index.js";
 import { generateMinimalConfig, generateSampleConfig, loadConfig } from "../../utils/index.js";
+import { logger } from "../../utils/logger.js";
 
 export interface ConfigCommandOptions {
   init?: boolean;
@@ -25,56 +26,56 @@ export async function configCommand(options: ConfigCommandOptions = {}): Promise
 }
 
 async function showConfig(): Promise<void> {
-  console.log("Loading configuration...\n");
+  logger.log("Loading configuration...\n");
 
   try {
     const result = await loadConfig();
 
     if (result.isEmpty) {
-      console.log("No configuration file found. Using default configuration.\n");
+      logger.log("No configuration file found. Using default configuration.\n");
     } else {
-      console.log(`Configuration loaded from: ${result.filepath}\n`);
+      logger.log(`Configuration loaded from: ${result.filepath}\n`);
     }
 
-    console.log("Current configuration:");
-    console.log("=====================");
+    logger.log("Current configuration:");
+    logger.log("=====================");
 
     const config = result.config;
 
-    console.log(`\nAI Rules Directory: ${config.aiRulesDir}`);
-    console.log(`\nDefault Targets: ${config.defaultTargets.join(", ")}`);
+    logger.log(`\nAI Rules Directory: ${config.aiRulesDir}`);
+    logger.log(`\nDefault Targets: ${config.defaultTargets.join(", ")}`);
 
     if (config.exclude && config.exclude.length > 0) {
-      console.log(`Excluded Targets: ${config.exclude.join(", ")}`);
+      logger.log(`Excluded Targets: ${config.exclude.join(", ")}`);
     }
 
-    console.log("\nOutput Paths:");
+    logger.log("\nOutput Paths:");
     for (const [tool, outputPath] of Object.entries(config.outputPaths)) {
-      console.log(`  ${tool}: ${outputPath}`);
+      logger.log(`  ${tool}: ${outputPath}`);
     }
 
     if (config.baseDir) {
       const dirs = Array.isArray(config.baseDir) ? config.baseDir : [config.baseDir];
-      console.log(`\nBase Directories: ${dirs.join(", ")}`);
+      logger.log(`\nBase Directories: ${dirs.join(", ")}`);
     }
 
-    console.log(`\nVerbose: ${config.verbose || false}`);
-    console.log(`Delete before generate: ${config.delete || false}`);
+    logger.log(`\nVerbose: ${config.verbose || false}`);
+    logger.log(`Delete before generate: ${config.delete || false}`);
 
     if (config.watch) {
-      console.log("\nWatch Configuration:");
-      console.log(`  Enabled: ${config.watch.enabled || false}`);
+      logger.log("\nWatch Configuration:");
+      logger.log(`  Enabled: ${config.watch.enabled || false}`);
       if (config.watch.interval) {
-        console.log(`  Interval: ${config.watch.interval}ms`);
+        logger.log(`  Interval: ${config.watch.interval}ms`);
       }
       if (config.watch.ignore && config.watch.ignore.length > 0) {
-        console.log(`  Ignore patterns: ${config.watch.ignore.join(", ")}`);
+        logger.log(`  Ignore patterns: ${config.watch.ignore.join(", ")}`);
       }
     }
 
-    console.log("\nTip: Use 'rulesync config init' to create a configuration file.");
+    logger.log("\nTip: Use 'rulesync config init' to create a configuration file.");
   } catch (error) {
-    console.error(
+    logger.error(
       "❌ Failed to load configuration:",
       error instanceof Error ? error.message : String(error),
     );
@@ -102,7 +103,7 @@ async function initConfig(options: ConfigCommandOptions): Promise<void> {
   const selectedFormat = options.format || "jsonc";
 
   if (!validFormats.includes(selectedFormat)) {
-    console.error(
+    logger.error(
       `❌ Invalid format: ${selectedFormat}. Valid formats are: ${validFormats.join(", ")}`,
     );
     process.exit(1);
@@ -121,7 +122,7 @@ async function initConfig(options: ConfigCommandOptions): Promise<void> {
       if (result.success) {
         validTargets.push(result.data);
       } else {
-        console.error(`❌ Invalid target: ${target}`);
+        logger.error(`❌ Invalid target: ${target}`);
         process.exit(1);
       }
     }
@@ -136,7 +137,7 @@ async function initConfig(options: ConfigCommandOptions): Promise<void> {
       if (result.success) {
         validExcludes.push(result.data);
       } else {
-        console.error(`❌ Invalid exclude target: ${exclude}`);
+        logger.error(`❌ Invalid exclude target: ${exclude}`);
         process.exit(1);
       }
     }
@@ -165,8 +166,8 @@ async function initConfig(options: ConfigCommandOptions): Promise<void> {
   try {
     const fs = await import("node:fs/promises");
     await fs.access(filepath);
-    console.error(`❌ Configuration file already exists: ${filepath}`);
-    console.log("Remove the existing file or choose a different format.");
+    logger.error(`❌ Configuration file already exists: ${filepath}`);
+    logger.log("Remove the existing file or choose a different format.");
     process.exit(1);
   } catch {
     // File doesn't exist, we can create it
@@ -174,11 +175,11 @@ async function initConfig(options: ConfigCommandOptions): Promise<void> {
 
   try {
     writeFileSync(filepath, content, "utf-8");
-    console.log(`✅ Created configuration file: ${filepath}`);
-    console.log("\nYou can now customize the configuration to fit your needs.");
-    console.log("Run 'rulesync generate' to use the new configuration.");
+    logger.success(`Created configuration file: ${filepath}`);
+    logger.log("\nYou can now customize the configuration to fit your needs.");
+    logger.log("Run 'rulesync generate' to use the new configuration.");
   } catch (error) {
-    console.error(
+    logger.error(
       `❌ Failed to create configuration file: ${error instanceof Error ? error.message : String(error)}`,
     );
     process.exit(1);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -45,3 +45,4 @@ export async function setupTestDirectory(): Promise<{
 }
 
 export * from "./mock-config.js";
+export * from "./logger-mock.js";

--- a/src/test-utils/logger-mock.ts
+++ b/src/test-utils/logger-mock.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+
+export const createLoggerMock = () => {
+  return {
+    setVerbose: vi.fn(),
+    get verbose() {
+      return false;
+    },
+    log: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+};
+
+export const mockLogger = createLoggerMock();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,54 @@
+import { consola } from "consola";
+
+// Global logger instance with configurable verbosity
+class Logger {
+  private _verbose = false;
+  private console = consola.withTag("rulesync");
+
+  setVerbose(verbose: boolean): void {
+    this._verbose = verbose;
+    // Set consola's log level based on verbose flag
+    this.console.level = verbose ? 1 : 2; // 1 = info, 2 = warn
+  }
+
+  get verbose(): boolean {
+    return this._verbose;
+  }
+
+  // Regular log (always shown, regardless of verbose)
+  log(message: string, ...args: unknown[]): void {
+    this.console.log(message, ...args);
+  }
+
+  // Info level (shown only in verbose mode)
+  info(message: string, ...args: unknown[]): void {
+    if (this._verbose) {
+      this.console.info(message, ...args);
+    }
+  }
+
+  // Success (always shown)
+  success(message: string, ...args: unknown[]): void {
+    this.console.success(message, ...args);
+  }
+
+  // Warning (always shown)
+  warn(message: string, ...args: unknown[]): void {
+    this.console.warn(message, ...args);
+  }
+
+  // Error (always shown)
+  error(message: string, ...args: unknown[]): void {
+    this.console.error(message, ...args);
+  }
+
+  // Debug level (shown only in verbose mode)
+  debug(message: string, ...args: unknown[]): void {
+    if (this._verbose) {
+      this.console.debug(message, ...args);
+    }
+  }
+}
+
+// Export singleton instance
+export const logger = new Logger();


### PR DESCRIPTION
## Summary
- 中央集権的なloggerシステムをconsolaで実装し、組み込みのconsoleを置き換え
- verboseオプションの条件分岐を削除し、loggerの設定で中央管理
- 統一されたタグ付きログ出力（[rulesync]）を実現

## Changes Made
- **新規作成**: `src/utils/logger.ts` - consola ベースの中央集権logger
- **新規作成**: `src/test-utils/logger-mock.ts` - テスト用loggerモック
- **修正**: console.log/warn/error 呼び出しをlogger.{method}に置き換え
- **修正**: `if (verbose)` の条件分岐を削除し、logger.setVerbose()で管理
- **改善**: 適切なログレベル（info, success, warn, error）の使い分け

## Technical Details
- verboseフラグはlogger.setVerbose()により中央管理
- logger.info() は verboseモードでのみ表示
- logger.log() は常に表示される重要メッセージ  
- logger.success() は成功メッセージ（緑色）
- consolaタグにより`[rulesync]`プレフィックスで統一

## Test Status
テストスイートは別のコミットで修正予定（全てのconsole.logモックをloggerモックに置き換える必要）

🤖 Generated with [Claude Code](https://claude.ai/code)