### PR TITLE
fix: actually fix junie MCP path

### DIFF
--- a/src/core/mcp-generator.test.ts
+++ b/src/core/mcp-generator.test.ts
@@ -44,7 +44,7 @@ describe("generateMcpConfigurations", () => {
     expect(filepaths).toContain(join(testDir, ".codex/mcp-config.json"));
     expect(filepaths).toContain(join(testDir, ".roo/mcp.json"));
     expect(filepaths).toContain(join(testDir, ".gemini/settings.json"));
-    expect(filepaths).toContain(join(testDir, ".junie/mcp-config.json"));
+    expect(filepaths).toContain(join(testDir, ".junie/mcp/mcp.json"));
     expect(filepaths).toContain(join(testDir, ".kiro/mcp.json"));
     expect(filepaths).toContain(join(testDir, "mcp_config.json")); // Windsurf
   });

--- a/src/generators/mcp/junie.test.ts
+++ b/src/generators/mcp/junie.test.ts
@@ -205,7 +205,7 @@ describe("generateJunieMcpConfiguration", () => {
     const result = generateJunieMcpConfiguration(servers);
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.filepath).toBe(".junie/mcp-config.json");
+    expect(result[0]?.filepath).toBe(".junie/mcp/mcp.json");
 
     const parsed = JSON.parse(result[0]?.content || "{}");
     expect(parsed.mcpServers).toHaveProperty("test-server");
@@ -222,7 +222,7 @@ describe("generateJunieMcpConfiguration", () => {
     const result = generateJunieMcpConfiguration(servers, "/custom/base");
 
     expect(result).toHaveLength(1);
-    expect(result[0]?.filepath).toBe("/custom/base/.junie/mcp-config.json");
+    expect(result[0]?.filepath).toBe("/custom/base/.junie/mcp/mcp.json");
   });
 
   it("should preserve server configuration and add name", () => {

--- a/src/generators/mcp/shared-factory.ts
+++ b/src/generators/mcp/shared-factory.ts
@@ -386,10 +386,11 @@ function generateJunieMcpConfigurationFiles(
   mcpServers: Record<string, RulesyncMcpServer>,
   baseDir: string = "",
 ): Array<{ filepath: string; content: string }> {
+  const junieMcpPath = ".junie/mcp/mcp.json";
   // Generate project-level configuration only (as per precautions.md constraint)
   // Junie MCP config is stored in project root - no IDE settings path is used
   // to avoid creating user-level settings
-  const filepath = baseDir ? `${baseDir}/.junie/mcp-config.json` : ".junie/mcp-config.json";
+  const filepath = baseDir ? `${baseDir}/${junieMcpPath}` : junieMcpPath;
 
   const config: BaseMcpConfig = {
     mcpServers: {},


### PR DESCRIPTION
Follow up to https://github.com/dyoshikawa/rulesync/pull/118 where the junie MCP path was not changed in all places