### PR TITLE
feat: add --targets option support to import command

### DIFF
--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -3,6 +3,8 @@ import type { ToolTarget } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
 
 export interface ImportOptions {
+  targets?: ToolTarget[];
+  all?: boolean;
   agentsmd?: boolean;
   amazonqcli?: boolean;
   augmentcode?: boolean;
@@ -13,6 +15,7 @@ export interface ImportOptions {
   cline?: boolean;
   roo?: boolean;
   geminicli?: boolean;
+  junie?: boolean;
   qwencode?: boolean;
   opencode?: boolean;
   verbose?: boolean;
@@ -23,73 +26,97 @@ export async function importCommand(options: ImportOptions = {}): Promise<void> 
   // Set logger verbosity based on options
   logger.setVerbose(options.verbose || false);
 
-  const tools: ToolTarget[] = [];
+  let tools: ToolTarget[] = [];
 
-  // Collect selected tools
-  if (options.agentsmd) tools.push("agentsmd");
-  if (options.amazonqcli) tools.push("amazonqcli");
-  if (options.augmentcode) tools.push("augmentcode");
-  if (options["augmentcode-legacy"]) tools.push("augmentcode-legacy");
-  if (options.claudecode) tools.push("claudecode");
-  if (options.cursor) tools.push("cursor");
-  if (options.copilot) tools.push("copilot");
-  if (options.cline) tools.push("cline");
-  if (options.roo) tools.push("roo");
-  if (options.geminicli) tools.push("geminicli");
-  if (options.qwencode) tools.push("qwencode");
-  if (options.opencode) tools.push("opencode");
+  // If targets are provided, use them directly
+  if (options.targets && options.targets.length > 0) {
+    tools = options.targets;
+  } else {
+    // Fallback to legacy individual flags for backwards compatibility
+    if (options.agentsmd) tools.push("agentsmd");
+    if (options.amazonqcli) tools.push("amazonqcli");
+    if (options.augmentcode) tools.push("augmentcode");
+    if (options["augmentcode-legacy"]) tools.push("augmentcode-legacy");
+    if (options.claudecode) tools.push("claudecode");
+    if (options.cursor) tools.push("cursor");
+    if (options.copilot) tools.push("copilot");
+    if (options.cline) tools.push("cline");
+    if (options.roo) tools.push("roo");
+    if (options.geminicli) tools.push("geminicli");
+    if (options.junie) tools.push("junie");
+    if (options.qwencode) tools.push("qwencode");
+    if (options.opencode) tools.push("opencode");
+  }
 
-  // Validate that exactly one tool is selected
+  // Validate that at least one tool is selected
   if (tools.length === 0) {
     logger.error(
-      "❌ Please specify one tool to import from (--agentsmd, --amazonqcli, --augmentcode, --augmentcode-legacy, --claudecode, --cursor, --copilot, --cline, --roo, --geminicli, --qwencode, --opencode)",
+      "❌ Please specify tools to import from using --targets <tool1,tool2> or --targets * for all supported tools.",
     );
+    logger.info("Example: rulesync import --targets cursor,copilot");
     process.exit(1);
   }
 
-  if (tools.length > 1) {
-    logger.error(
-      "❌ Only one tool can be specified at a time. Please run the import command separately for each tool.",
-    );
-    process.exit(1);
-  }
+  // Process each tool
+  const results: Array<{ tool: ToolTarget; success: boolean; error?: string }> = [];
 
-  const tool = tools[0];
-  if (!tool) {
-    logger.error("Error: No tool specified");
-    process.exit(1);
-  }
+  for (const tool of tools) {
+    logger.log(`Importing configuration files from ${tool}...`);
 
-  logger.log(`Importing configuration files from ${tool}...`);
+    try {
+      const result = await importConfiguration({
+        tool,
+        verbose: options.verbose ?? false,
+        useLegacyLocation: options.legacy ?? false,
+      });
 
-  try {
-    const result = await importConfiguration({
-      tool,
-      verbose: options.verbose ?? false,
-      useLegacyLocation: options.legacy ?? false,
-    });
-
-    if (result.success) {
-      logger.success(`Imported ${result.rulesCreated} rule(s) from ${tool}`);
-      if (result.ignoreFileCreated) {
-        logger.success("Created .rulesyncignore file from ignore patterns");
-      }
-      if (result.mcpFileCreated) {
-        logger.success("Created .rulesync/.mcp.json file from MCP configuration");
-      }
-      logger.log("You can now run 'rulesync generate' to create tool-specific configurations.");
-    } else if (result.errors.length > 0) {
-      logger.warn(`⚠️  Failed to import from ${tool}: ${result.errors[0]}`);
-      if (result.errors.length > 1) {
-        logger.info("\nDetailed errors:");
-        for (const error of result.errors) {
-          logger.info(`  - ${error}`);
+      if (result.success) {
+        logger.success(`✅ Imported ${result.rulesCreated} rule(s) from ${tool}`);
+        if (result.ignoreFileCreated) {
+          logger.success("  Created .rulesyncignore file from ignore patterns");
         }
+        if (result.mcpFileCreated) {
+          logger.success("  Created .rulesync/.mcp.json file from MCP configuration");
+        }
+        results.push({ tool, success: true });
+      } else if (result.errors.length > 0) {
+        logger.warn(`⚠️  Failed to import from ${tool}: ${result.errors[0]}`);
+        if (result.errors.length > 1) {
+          logger.info("  Detailed errors:");
+          for (const error of result.errors) {
+            logger.info(`    - ${error}`);
+          }
+        }
+        results.push({ tool, success: false, error: result.errors[0] || "Unknown error" });
       }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`❌ Error importing from ${tool}: ${errorMessage}`);
+      results.push({ tool, success: false, error: errorMessage });
     }
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error(`❌ Error importing from ${tool}: ${errorMessage}`);
+  }
+
+  // Summary
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  if (successful.length > 0 && failed.length === 0) {
+    logger.success(
+      `\n🎉 Successfully imported from ${successful.length} tool(s): ${successful.map((r) => r.tool).join(", ")}`,
+    );
+    logger.log("You can now run 'rulesync generate' to create tool-specific configurations.");
+  } else if (successful.length > 0 && failed.length > 0) {
+    logger.success(
+      `\n✅ Successfully imported from ${successful.length} tool(s): ${successful.map((r) => r.tool).join(", ")}`,
+    );
+    logger.warn(
+      `❌ Failed to import from ${failed.length} tool(s): ${failed.map((r) => r.tool).join(", ")}`,
+    );
+    logger.log(
+      "You can still run 'rulesync generate' to create configurations for successfully imported tools.",
+    );
+  } else {
+    logger.error(`\n❌ Failed to import from all ${failed.length} tool(s).`);
     process.exit(1);
   }
 }

--- a/src/cli/utils/targets-parser.ts
+++ b/src/cli/utils/targets-parser.ts
@@ -107,14 +107,18 @@ export function checkDeprecatedFlags(options: Record<string, unknown>): ToolTarg
 /**
  * Generate a deprecation warning message for deprecated flags
  * @param deprecatedTools - Array of tools from deprecated flags
+ * @param command - Command name (generate or import)
  * @returns Formatted warning message
  */
-export function getDeprecationWarning(deprecatedTools: ToolTarget[]): string {
+export function getDeprecationWarning(
+  deprecatedTools: ToolTarget[],
+  command: string = "generate",
+): string {
   const toolsStr = deprecatedTools.join(",");
   return [
     "⚠️  DEPRECATED: Individual tool flags are deprecated and will be removed in a future version.",
-    `   Current: rulesync generate ${deprecatedTools.map((t) => `--${t}`).join(" ")}`,
-    `   New:     rulesync generate --targets ${toolsStr}`,
+    `   Current: rulesync ${command} ${deprecatedTools.map((t) => `--${t}`).join(" ")}`,
+    `   New:     rulesync ${command} --targets ${toolsStr}`,
     "   Please update your scripts to use the new --targets flag.",
   ].join("\n");
 }


### PR DESCRIPTION
This PR adds support for the --targets option to the import command, allowing users to specify which AI tools to generate configurations for during import operations.