### PR TITLE
refactor: implement new SubagentsProcessor architecture with improved type system

### DIFF
--- a/.rulesync/rules/coding-guides.md
+++ b/.rulesync/rules/coding-guides.md
@@ -1,0 +1,18 @@
+---
+root: false
+targets: ['*']
+description: "coding guides for this project"
+globs: ["**/*.ts"]
+---
+
+- If the arguments are multiple, you should use object as the argument.
+    - Not only function arguments, but also class constructor those.
+- Test code files should be placed next to the implementation file.
+    - For example, if the implementation file is `src/a.ts`, the test code file should be `src/a.test.ts`.
+- If you have to write validation logics, please consider using `zod/mini` to do it actively.   
+    - `zod/mini` is a subset of `zod` to minimize the bundle size.
+- To import codes, you should always use static imports. You should not use dynamic imports.
+    - Because static imports are easier to analyze and optimize by bundlers such as tree-shaking.
+- TypeScript file names should be in kebab-case, even for class implementation files.
+- Don't create ballel files. Please always direct import the implementation file.
+    - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.

--- a/.rulesync/rules/new-design.md
+++ b/.rulesync/rules/new-design.md
@@ -1,0 +1,35 @@
+---
+root: false
+targets: ['*']
+description: "New design guidelines for the Rulesync project"
+globs: []
+---
+
+# About New Design of Rulesync
+
+## Overview, Background and Purpose
+
+This document describes the new design guidelines for the Rulesync project.
+
+The Conventional codebase does not have consistent structures, and the code is not easy to understand and maintain. Especially when the external contributors want to contribute to implement supports for new AI coding tools, they may not be able to understand how to implement them.
+
+So, we need to redesign the codebase to make it more consistent and easy to understand and maintain. Specifically, consistent interfaces and classes should be prepared to make it easier for external contributors to implement supports for new AI coding tools.
+
+## Replacement Strategy
+
+- Existing dirs: src/cli, src/constants, src/core, src/generators, src/parsers, src/test-utils, src/types, src/utils
+- New dirs: src/subagents, src/rules, src/mcp, src/commands, src/ignore
+
+The replacement is conducted while coexisting with the existing codebase. 
+
+I think, finally, src/cli will depend on src/subagents, src/rules, src/mcp, src/commands and src/ignore. Then, src/core, src/generators and src/parsers will be abolished. Others that are src/constants, src/test-utils, src/types and src/utils will be used in the future too.
+
+## Current status and immediate goals
+
+My immediate goal is replacing the subagents logics.
+
+Others that are mcp, ignore, commands and rules should not be replaced yet.
+
+Attention, the replacements must not break the existing behaviors.
+
+At key points, you should commit your changes actively.

--- a/NEW_DESIGN.md
+++ b/NEW_DESIGN.md
@@ -1,0 +1,28 @@
+# About New Design of Rulesync
+
+## Overview, Background and Purpose
+
+This document describes the new design guidelines for the Rulesync project.
+
+The Conventional codebase does not have consistent structures, and the code is not easy to understand and maintain. Especially when the external contributors want to contribute to implement supports for new AI coding tools, they may not be able to understand how to implement them.
+
+So, we need to redesign the codebase to make it more consistent and easy to understand and maintain. Specifically, consistent interfaces and classes should be prepared to make it easier for external contributors to implement supports for new AI coding tools.
+
+## Replacement Strategy
+
+- Existing dirs: src/cli, src/constants, src/core, src/generators, src/parsers, src/test-utils, src/types, src/utils
+- New dirs: src/subagents, src/rules, src/mcp, src/commands, src/ignore
+
+The replacement is conducted while coexisting with the existing codebase. 
+
+I think, finally, src/cli will depend on src/subagents, src/rules, src/mcp, src/commands and src/ignore. Then, src/core, src/generators and src/parsers will be abolished. Others that are src/constants, src/test-utils, src/types and src/utils will be used in the future too.
+
+## Current status and immediate goals
+
+My immediate goal is replacing the subagents logics.
+
+Others that are mcp, ignore, commands and rules should not be replaced yet.
+
+Attention, the replacements must not break the existing behaviors.
+
+At key points, you should commit your changes actively.

--- a/NEW_DESIGN.md
+++ b/NEW_DESIGN.md
@@ -26,3 +26,5 @@ Others that are mcp, ignore, commands and rules should not be replaced yet.
 Attention, the replacements must not break the existing behaviors.
 
 At key points, you should commit your changes actively.
+
+## 

--- a/cspell.json
+++ b/cspell.json
@@ -232,6 +232,15 @@
         "QWEN",
         "QCLI",
         "smol",
-        "testignore"
+        "testignore",
+        "nomodel",
+        "withoptions",
+        "notargets",
+        "frompath",
+        "fromfile",
+        "skipvalidation",
+        "typetest",
+        "üñíçødé",
+        "émøjî"
     ]
 }

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -4,7 +4,7 @@ import { type CliOptions, CliParser, ConfigResolver } from "../../core/config/in
 import { generateConfigurations, parseRulesFromDirectory } from "../../core/index.js";
 import { generateMcpConfigurations } from "../../core/mcp-generator.js";
 import { parseMcpConfig } from "../../core/mcp-parser.js";
-import { generateSubagents } from "../../core/subagent-generator.js";
+import { SubagentsProcessor } from "../../subagents/subagents-processor.js";
 import type { FeatureType } from "../../types/config-options.js";
 import type { ToolTarget } from "../../types/index.js";
 import { normalizeFeatures } from "../../utils/feature-validator.js";
@@ -366,24 +366,49 @@ Available tools:
       if (normalizedFeatures.includes("subagents")) {
         logger.info("\nGenerating subagent files...");
 
-        for (const baseDir of baseDirs) {
-          const subagentResults = await generateSubagents(
-            config.aiRulesDir,
-            baseDir === process.cwd() ? undefined : baseDir,
-            config.defaultTargets,
-            rules,
-          );
+        // Check if claudecode is in the target tools
+        if (config.defaultTargets.includes("claudecode")) {
+          for (const baseDir of baseDirs) {
+            try {
+              // Check if rulesync subagent source directory exists
+              const rulesyncSubagentsDir = join(".rulesync", "subagents");
+              const fullPath = join(baseDir === process.cwd() ? "." : baseDir, rulesyncSubagentsDir);
+              
+              if (!(await fileExists(fullPath))) {
+                logger.info(`No rulesync subagents directory found at ${fullPath}`);
+                continue;
+              }
 
-          if (subagentResults.length === 0) {
-            logger.info(`No subagents generated for ${baseDir}`);
-            continue;
-          }
+              // Use SubagentsProcessor to generate subagent files
+              const processor = new SubagentsProcessor({
+                baseDir: baseDir === process.cwd() ? "." : baseDir,
+                toolTarget: "claudecode",
+              });
 
-          for (const result of subagentResults) {
-            await writeFileContent(result.filepath, result.content);
-            logger.success(`Generated ${result.tool} subagent: ${result.filepath}`);
-            totalSubagentOutputs++;
+              const rulesyncSubagents = await processor.loadRulesyncSubagents();
+              await processor.writeToolSubagentsFromRulesyncSubagents(rulesyncSubagents);
+              
+              // Count the generated files
+              const outputDir = join(baseDir === process.cwd() ? "." : baseDir, ".claude", "agents");
+              if (await fileExists(outputDir)) {
+                const { readdir } = await import("node:fs/promises");
+                const files = await readdir(outputDir);
+                const generatedCount = files.filter((file) => file.endsWith(".md")).length;
+                totalSubagentOutputs += generatedCount;
+                
+                if (generatedCount > 0) {
+                  logger.success(`Generated ${generatedCount} Claude Code subagent(s) in ${outputDir}`);
+                }
+              }
+            } catch (error) {
+              logger.warn(
+                `Failed to generate subagents for ${baseDir}: ${error instanceof Error ? error.message : String(error)}`,
+              );
+              continue;
+            }
           }
+        } else {
+          logger.info("Skipping subagent generation (claudecode not in target tools)");
         }
       } else {
         logger.info("\nSkipping subagent file generation (not in --features)");

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -372,10 +372,8 @@ Available tools:
             try {
               // Check if rulesync subagent source directory exists
               const rulesyncSubagentsDir = join(".rulesync", "subagents");
-              const fullPath = join(
-                baseDir === process.cwd() ? "." : baseDir,
-                rulesyncSubagentsDir,
-              );
+              // The rulesync dir can not be influenced by baseDir
+              const fullPath = join(process.cwd(), rulesyncSubagentsDir);
 
               if (!(await fileExists(fullPath))) {
                 logger.info(`No rulesync subagents directory found at ${fullPath}`);

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -372,8 +372,11 @@ Available tools:
             try {
               // Check if rulesync subagent source directory exists
               const rulesyncSubagentsDir = join(".rulesync", "subagents");
-              const fullPath = join(baseDir === process.cwd() ? "." : baseDir, rulesyncSubagentsDir);
-              
+              const fullPath = join(
+                baseDir === process.cwd() ? "." : baseDir,
+                rulesyncSubagentsDir,
+              );
+
               if (!(await fileExists(fullPath))) {
                 logger.info(`No rulesync subagents directory found at ${fullPath}`);
                 continue;
@@ -387,17 +390,23 @@ Available tools:
 
               const rulesyncSubagents = await processor.loadRulesyncSubagents();
               await processor.writeToolSubagentsFromRulesyncSubagents(rulesyncSubagents);
-              
+
               // Count the generated files
-              const outputDir = join(baseDir === process.cwd() ? "." : baseDir, ".claude", "agents");
+              const outputDir = join(
+                baseDir === process.cwd() ? "." : baseDir,
+                ".claude",
+                "agents",
+              );
               if (await fileExists(outputDir)) {
                 const { readdir } = await import("node:fs/promises");
                 const files = await readdir(outputDir);
                 const generatedCount = files.filter((file) => file.endsWith(".md")).length;
                 totalSubagentOutputs += generatedCount;
-                
+
                 if (generatedCount > 0) {
-                  logger.success(`Generated ${generatedCount} Claude Code subagent(s) in ${outputDir}`);
+                  logger.success(
+                    `Generated ${generatedCount} Claude Code subagent(s) in ${outputDir}`,
+                  );
                 }
               }
             } catch (error) {

--- a/src/subagents/claudecode-subagent.test.ts
+++ b/src/subagents/claudecode-subagent.test.ts
@@ -195,7 +195,7 @@ You are a helpful planning agent.`,
       expect(rulesyncSubagent).toBeInstanceOf(RulesyncSubagent);
       expect(rulesyncSubagent.getFrontmatter()).toEqual({
         targets: ["claudecode"],
-        title: "Test Planner",
+        name: "Test Planner",
         description: "A test planning agent",
       });
       expect(rulesyncSubagent.getBody()).toBe("You are a helpful planning agent.");
@@ -220,7 +220,7 @@ You are a helpful planning agent.`,
 
       expect(rulesyncSubagent.getFrontmatter()).toEqual({
         targets: ["claudecode"],
-        title: "Simple Agent",
+        name: "Simple Agent",
         description: "A simple agent",
       });
     });
@@ -231,7 +231,7 @@ You are a helpful planning agent.`,
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Test Reviewer",
+          name: "Test Reviewer",
           description: "A test review agent",
           claudecode: {
             model: "opus",
@@ -259,7 +259,7 @@ You are a helpful planning agent.`,
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "No Model Agent",
+          name: "No Model Agent",
           description: "Agent without model specification",
         },
         body: "Agent content",
@@ -285,7 +285,7 @@ You are a helpful planning agent.`,
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Default Test",
+          name: "Default Test",
           description: "Test with defaults",
         },
         body: "Default content",
@@ -309,7 +309,7 @@ You are a helpful planning agent.`,
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "", // Empty title would be invalid
+          name: "", // Empty title would be invalid
           description: "", // Empty description would be invalid
         },
         body: "Content",
@@ -443,7 +443,7 @@ You are a helpful planning agent.`,
 
       // Verify data preservation
       const convertedRulesync = convertedSubagent.toRulesyncSubagent();
-      expect(convertedRulesync.getFrontmatter().title).toBe("Round Trip Agent");
+      expect(convertedRulesync.getFrontmatter().name).toBe("Round Trip Agent");
       expect(convertedRulesync.getFrontmatter().description).toBe("Agent for round trip testing");
       expect(convertedRulesync.getBody()).toBe("Round trip content");
     });

--- a/src/subagents/claudecode-subagent.test.ts
+++ b/src/subagents/claudecode-subagent.test.ts
@@ -1,0 +1,451 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod/mini";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { ClaudecodeSubagent, ClaudecodeSubagentFrontmatter } from "./claudecode-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+
+describe("ClaudecodeSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid frontmatter", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Test Planner",
+        description: "A test planning agent",
+        model: "sonnet",
+      };
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "You are a helpful planning agent.",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "planner.md",
+        fileContent: `---
+name: "Test Planner"
+description: "A test planning agent"
+model: "sonnet"
+---
+
+You are a helpful planning agent.`,
+        validate: false, // Skip validation during construction to avoid constructor validation
+      });
+
+      expect(subagent).toBeInstanceOf(ClaudecodeSubagent);
+      expect(subagent.getRelativeDirPath()).toBe(".claude/agents");
+      expect(subagent.getRelativeFilePath()).toBe("planner.md");
+    });
+
+    it("should create instance with minimal frontmatter (without optional model)", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Simple Agent",
+        description: "A simple agent without model",
+      };
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "Simple content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "simple.md",
+        fileContent: "Simple file content",
+        validate: false,
+      });
+
+      expect(subagent).toBeInstanceOf(ClaudecodeSubagent);
+    });
+
+    it("should validate frontmatter by default", () => {
+      const invalidFrontmatter = {
+        name: "Test", // missing description
+        // description is required
+      } as ClaudecodeSubagentFrontmatter;
+
+      expect(() => {
+        const _subagent = new ClaudecodeSubagent({
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          baseDir: testDir,
+          relativeDirPath: ".claude/agents",
+          relativeFilePath: "test.md",
+          fileContent: "Test content",
+        });
+      }).toThrow();
+    });
+
+    it("should skip validation when validate=false", () => {
+      const invalidFrontmatter = {
+        name: "Test",
+        // missing description
+      } as ClaudecodeSubagentFrontmatter;
+
+      expect(() => {
+        const _subagent = new ClaudecodeSubagent({
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          baseDir: testDir,
+          relativeDirPath: ".claude/agents",
+          relativeFilePath: "test.md",
+          fileContent: "Test content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Valid Agent",
+        description: "A valid agent description",
+        model: "opus",
+      };
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "Valid body",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "valid.md",
+        fileContent: "Valid content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should return error for invalid frontmatter", () => {
+      const invalidFrontmatter = {
+        name: "Invalid Agent",
+        description: "Invalid description",
+        model: "invalid-model", // invalid model option
+      } as unknown as ClaudecodeSubagentFrontmatter;
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter: invalidFrontmatter,
+        body: "Invalid body",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "invalid.md",
+        fileContent: "Invalid content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+    });
+
+    it("should validate all model options", () => {
+      const validModels = ["opus", "sonnet", "haiku", "inherit"] as const;
+
+      validModels.forEach((model) => {
+        const frontmatter: ClaudecodeSubagentFrontmatter = {
+          name: `Agent with ${model}`,
+          description: `Agent using ${model} model`,
+          model,
+        };
+
+        const subagent = new ClaudecodeSubagent({
+          frontmatter,
+          body: `Body for ${model}`,
+          baseDir: testDir,
+          relativeDirPath: ".claude/agents",
+          relativeFilePath: `${model}.md`,
+          fileContent: `Content for ${model}`,
+          validate: false,
+        });
+
+        const result = subagent.validate();
+        expect(result.success).toBe(true);
+      });
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should convert to RulesyncSubagent correctly", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Test Planner",
+        description: "A test planning agent",
+        model: "sonnet",
+      };
+
+      const claudecodeSubagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "You are a helpful planning agent.",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "planner.md",
+        fileContent: "Original file content",
+      });
+
+      const rulesyncSubagent = claudecodeSubagent.toRulesyncSubagent();
+
+      expect(rulesyncSubagent).toBeInstanceOf(RulesyncSubagent);
+      expect(rulesyncSubagent.getFrontmatter()).toEqual({
+        targets: ["claudecode"],
+        title: "Test Planner",
+        description: "A test planning agent",
+      });
+      expect(rulesyncSubagent.getBody()).toBe("You are a helpful planning agent.");
+    });
+
+    it("should convert without model when not specified", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Simple Agent",
+        description: "A simple agent",
+      };
+
+      const claudecodeSubagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "Simple content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "simple.md",
+        fileContent: "Simple file content",
+      });
+
+      const rulesyncSubagent = claudecodeSubagent.toRulesyncSubagent();
+
+      expect(rulesyncSubagent.getFrontmatter()).toEqual({
+        targets: ["claudecode"],
+        title: "Simple Agent",
+        description: "A simple agent",
+      });
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create ClaudecodeSubagent from RulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Test Reviewer",
+          description: "A test review agent",
+          claudecode: {
+            model: "opus",
+          },
+        },
+        body: "You are a helpful review agent.",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "reviewer.md",
+        fileContent: "Test file content",
+        validate: false,
+      });
+
+      const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        rulesyncSubagent,
+      });
+
+      expect(claudecodeSubagent).toBeInstanceOf(ClaudecodeSubagent);
+      expect(claudecodeSubagent.getRelativeDirPath()).toBe(".claude/agents");
+    });
+
+    it("should handle RulesyncSubagent without claudecode model", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "No Model Agent",
+          description: "Agent without model specification",
+        },
+        body: "Agent content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "nomodel.md",
+        fileContent: "No model content",
+        validate: false,
+      });
+
+      const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        rulesyncSubagent,
+      });
+
+      // The converted subagent should have undefined model
+      const result = claudecodeSubagent.validate();
+      expect(result.success).toBe(true);
+    });
+
+    it("should use default parameters correctly", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Default Test",
+          description: "Test with defaults",
+        },
+        body: "Default content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "default.md",
+        fileContent: "Default file content",
+        validate: false,
+      });
+
+      const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
+        relativeDirPath: ".claude/agents",
+        rulesyncSubagent,
+      });
+
+      expect(claudecodeSubagent).toBeInstanceOf(ClaudecodeSubagent);
+    });
+
+    it("should skip validation when validate=false", () => {
+      // Create rulesync subagent with data that would be invalid for ClaudeCode
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "", // Empty title would be invalid
+          description: "", // Empty description would be invalid
+        },
+        body: "Content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "invalid.md",
+        fileContent: "Invalid content",
+        validate: false, // Skip validation in RulesyncSubagent too
+      });
+
+      expect(() => {
+        ClaudecodeSubagent.fromRulesyncSubagent({
+          baseDir: testDir,
+          relativeDirPath: ".claude/agents",
+          rulesyncSubagent,
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("schema validation", () => {
+    it("should validate ClaudecodeSubagentFrontmatterSchema", () => {
+      const validFrontmatter = {
+        name: "Valid Agent",
+        description: "Valid description",
+        model: "sonnet",
+      };
+
+      const invalidFrontmatter1 = {
+        name: "Invalid Agent",
+        // missing description
+      };
+
+      const invalidFrontmatter2 = {
+        name: "Invalid Agent",
+        description: "Valid description",
+        model: "invalid-model",
+      };
+
+      expect(() => {
+        z.object({
+          name: z.string(),
+          description: z.string(),
+          model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+        }).parse(validFrontmatter);
+      }).not.toThrow();
+
+      expect(() => {
+        z.object({
+          name: z.string(),
+          description: z.string(),
+          model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+        }).parse(invalidFrontmatter1);
+      }).toThrow();
+
+      expect(() => {
+        z.object({
+          name: z.string(),
+          description: z.string(),
+          model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+        }).parse(invalidFrontmatter2);
+      }).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Empty Body Agent",
+        description: "Agent with empty body",
+      };
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "empty.md",
+        fileContent: "File content",
+      });
+
+      const rulesyncSubagent = subagent.toRulesyncSubagent();
+      expect(rulesyncSubagent.getBody()).toBe("");
+    });
+
+    it("should handle special characters in name and description", () => {
+      const frontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Agent with Special Chars!@#$%^&*()",
+        description: "Description with üñíçødé and émøjî 🤖",
+      };
+
+      const subagent = new ClaudecodeSubagent({
+        frontmatter,
+        body: "Special content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "special.md",
+        fileContent: "Special file content",
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle round-trip conversion preserving data", () => {
+      const originalFrontmatter: ClaudecodeSubagentFrontmatter = {
+        name: "Round Trip Agent",
+        description: "Agent for round trip testing",
+        model: "haiku",
+      };
+
+      const originalSubagent = new ClaudecodeSubagent({
+        frontmatter: originalFrontmatter,
+        body: "Round trip content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "roundtrip.md",
+        fileContent: "Round trip file content",
+      });
+
+      // Convert to RulesyncSubagent
+      const rulesyncSubagent = originalSubagent.toRulesyncSubagent();
+
+      // Convert back to ClaudecodeSubagent
+      const convertedSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        rulesyncSubagent,
+      });
+
+      // Verify data preservation
+      const convertedRulesync = convertedSubagent.toRulesyncSubagent();
+      expect(convertedRulesync.getFrontmatter().title).toBe("Round Trip Agent");
+      expect(convertedRulesync.getFrontmatter().description).toBe("Agent for round trip testing");
+      expect(convertedRulesync.getBody()).toBe("Round trip content");
+    });
+  });
+});

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -1,3 +1,4 @@
+import matter from "gray-matter";
 import { z } from "zod/mini";
 import { AiFileParams, ValidationResult } from "../types/ai-file.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
@@ -65,13 +66,21 @@ export class ClaudecodeSubagent extends ToolSubagent {
       model: rulesyncFrontmatter.claudecode?.model,
     };
 
+    // Generate proper file content with Claude Code specific frontmatter
+    const body = rulesyncSubagent.getBody();
+    // Remove undefined values to avoid YAML dump errors
+    const cleanFrontmatter = Object.fromEntries(
+      Object.entries(claudecodeFrontmatter).filter(([, value]) => value !== undefined)
+    );
+    const fileContent = matter.stringify(body, cleanFrontmatter);
+
     return new ClaudecodeSubagent({
       baseDir: baseDir,
       frontmatter: claudecodeFrontmatter,
-      body: rulesyncSubagent.getBody(),
+      body,
       relativeDirPath,
       relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
-      fileContent: rulesyncSubagent.getFileContent(),
+      fileContent,
       validate,
     });
   }

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -1,0 +1,65 @@
+import { z } from "zod/mini";
+import { AiFileParams, ValidationResult } from "../types/ai-file.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import { ToolSubagent } from "./tool-subagent.js";
+
+export const ClaudecodeSubagentFrontmatterSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+});
+
+export type ClaudecodeSubagentFrontmatter = z.infer<typeof ClaudecodeSubagentFrontmatterSchema>;
+
+export interface ClaudecodeSubagentParams extends AiFileParams {
+  frontmatter: ClaudecodeSubagentFrontmatter;
+  body: string;
+}
+
+export class ClaudecodeSubagent extends ToolSubagent {
+  private readonly frontmatter: ClaudecodeSubagentFrontmatter;
+  private readonly body: string;
+
+  constructor({ frontmatter, body, ...rest }: ClaudecodeSubagentParams) {
+    super({
+      ...rest,
+    });
+
+    if (rest.validate) {
+      const result = ClaudecodeSubagentFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    return new RulesyncSubagent({
+      frontmatter: {
+        targets: ["claudecode"],
+        title: this.frontmatter.name,
+        description: this.frontmatter.description,
+      },
+      body: this.body,
+      relativeDirPath: this.relativeDirPath,
+      relativeFilePath: this.relativeFilePath,
+      fileContent: this.fileContent,
+    });
+  }
+
+  fromRulesyncSubagent(_rulesyncSubagent: RulesyncSubagent): ToolSubagent {
+    throw new Error("Method not implemented.");
+  }
+
+  validate(): ValidationResult {
+    const result = ClaudecodeSubagentFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return { success: false, error: result.error };
+    }
+  }
+}

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -41,7 +41,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     return new RulesyncSubagent({
       frontmatter: {
         targets: ["claudecode"],
-        title: this.frontmatter.name,
+        name: this.frontmatter.name,
         description: this.frontmatter.description,
       },
       body: this.body,
@@ -60,7 +60,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
     const rulesyncFrontmatter = rulesyncSubagent.getFrontmatter();
     const claudecodeFrontmatter: ClaudecodeSubagentFrontmatter = {
-      name: rulesyncFrontmatter.title,
+      name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
       model: rulesyncFrontmatter.claudecode?.model,
     };

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -70,7 +70,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     const body = rulesyncSubagent.getBody();
     // Remove undefined values to avoid YAML dump errors
     const cleanFrontmatter = Object.fromEntries(
-      Object.entries(claudecodeFrontmatter).filter(([, value]) => value !== undefined)
+      Object.entries(claudecodeFrontmatter).filter(([, value]) => value !== undefined),
     );
     const fileContent = matter.stringify(body, cleanFrontmatter);
 

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -21,16 +21,17 @@ export class ClaudecodeSubagent extends ToolSubagent {
   private readonly body: string;
 
   constructor({ frontmatter, body, ...rest }: ClaudecodeSubagentParams) {
-    super({
-      ...rest,
-    });
-
-    if (rest.validate) {
+    // Set properties before calling super to ensure they're available for validation
+    if (rest.validate !== false) {
       const result = ClaudecodeSubagentFrontmatterSchema.safeParse(frontmatter);
       if (!result.success) {
         throw result.error;
       }
     }
+
+    super({
+      ...rest,
+    });
 
     this.frontmatter = frontmatter;
     this.body = body;
@@ -47,6 +48,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
       relativeDirPath: this.relativeDirPath,
       relativeFilePath: this.relativeFilePath,
       fileContent: this.fileContent,
+      validate: false,
     });
   }
 
@@ -75,6 +77,11 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   validate(): ValidationResult {
+    // Check if frontmatter is set (may be undefined during construction)
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
     const result = ClaudecodeSubagentFrontmatterSchema.safeParse(this.frontmatter);
     if (result.success) {
       return { success: true, error: null };

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/mini";
 import { AiFileParams, ValidationResult } from "../types/ai-file.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
-import { ToolSubagent } from "./tool-subagent.js";
+import { ToolSubagent, ToolSubagentFromRulesyncSubagentParams } from "./tool-subagent.js";
 
 export const ClaudecodeSubagentFrontmatterSchema = z.object({
   name: z.string(),
@@ -50,8 +50,26 @@ export class ClaudecodeSubagent extends ToolSubagent {
     });
   }
 
-  fromRulesyncSubagent(_rulesyncSubagent: RulesyncSubagent): ToolSubagent {
-    throw new Error("Method not implemented.");
+  static fromRulesyncSubagent({
+    rulesyncSubagent,
+    relativeDirPath,
+    validate = true,
+  }: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    const rulesyncFrontmatter = rulesyncSubagent.getFrontmatter();
+    const claudecodeFrontmatter: ClaudecodeSubagentFrontmatter = {
+      name: rulesyncFrontmatter.title,
+      description: rulesyncFrontmatter.description,
+      model: rulesyncFrontmatter.claudecode?.model,
+    };
+
+    return new ClaudecodeSubagent({
+      frontmatter: claudecodeFrontmatter,
+      body: rulesyncSubagent.getBody(),
+      relativeDirPath,
+      relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
+      fileContent: rulesyncSubagent.getBody(),
+      validate,
+    });
   }
 
   validate(): ValidationResult {

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -51,6 +51,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
+    baseDir = ".",
     rulesyncSubagent,
     relativeDirPath,
     validate = true,
@@ -63,11 +64,12 @@ export class ClaudecodeSubagent extends ToolSubagent {
     };
 
     return new ClaudecodeSubagent({
+      baseDir: baseDir,
       frontmatter: claudecodeFrontmatter,
       body: rulesyncSubagent.getBody(),
       relativeDirPath,
       relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
-      fileContent: rulesyncSubagent.getBody(),
+      fileContent: rulesyncSubagent.getFileContent(),
       validate,
     });
   }

--- a/src/subagents/rulesync-processor.ts
+++ b/src/subagents/rulesync-processor.ts
@@ -1,0 +1,6 @@
+/**
+ * RulesyncProcessor - placeholder for future implementation
+ * This file is currently empty as the processor logic is not yet implemented
+ */
+
+export {};

--- a/src/subagents/rulesync-processor.ts
+++ b/src/subagents/rulesync-processor.ts
@@ -1,6 +1,0 @@
-/**
- * RulesyncProcessor - placeholder for future implementation
- * This file is currently empty as the processor logic is not yet implemented
- */
-
-export {};

--- a/src/subagents/rulesync-subagent.test.ts
+++ b/src/subagents/rulesync-subagent.test.ts
@@ -19,7 +19,7 @@ describe("RulesyncSubagent", () => {
     it("should create instance with valid frontmatter", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Test Planner",
+        name: "Test Planner",
         description: "A test planning agent",
       };
 
@@ -31,7 +31,7 @@ describe("RulesyncSubagent", () => {
         relativeFilePath: "planner.md",
         fileContent: `---
 targets: ["claudecode"]
-title: "Test Planner"
+name: "Test Planner"
 description: "A test planning agent"
 ---
 
@@ -47,7 +47,7 @@ You are a helpful planning agent.`,
     it("should create instance with multiple targets", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode", "cursor", "cline"],
-        title: "Multi-target Agent",
+        name: "Multi-target Agent",
         description: "Agent for multiple tools",
       };
 
@@ -66,7 +66,7 @@ You are a helpful planning agent.`,
     it("should create instance with claudecode options", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Agent with Options",
+        name: "Agent with Options",
         description: "Agent with Claude Code specific options",
         claudecode: {
           model: "sonnet",
@@ -88,7 +88,7 @@ You are a helpful planning agent.`,
     it("should validate frontmatter by default", () => {
       const invalidFrontmatter = {
         targets: ["invalid-target"], // not a valid target
-        title: "Invalid Agent",
+        name: "Invalid Agent",
         description: "Agent with invalid target",
       } as unknown as RulesyncSubagentFrontmatter;
 
@@ -107,7 +107,7 @@ You are a helpful planning agent.`,
     it("should skip validation when validate=false", () => {
       const invalidFrontmatter = {
         targets: ["invalid-target"],
-        title: "Invalid Agent",
+        name: "Invalid Agent",
         description: "Agent with invalid target",
       } as unknown as RulesyncSubagentFrontmatter;
 
@@ -129,7 +129,7 @@ You are a helpful planning agent.`,
     it("should return the frontmatter object", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode", "cursor"],
-        title: "Test Agent",
+        name: "Test Agent",
         description: "Test agent description",
         claudecode: {
           model: "opus",
@@ -156,7 +156,7 @@ You are a helpful planning agent.`,
     it("should return success for valid frontmatter", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Valid Agent",
+        name: "Valid Agent",
         description: "Valid agent description",
       };
 
@@ -178,7 +178,7 @@ You are a helpful planning agent.`,
     it("should return error for invalid frontmatter", () => {
       const invalidFrontmatter = {
         targets: ["invalid-target"],
-        title: "Invalid Agent",
+        name: "Invalid Agent",
         description: "Invalid agent description",
       } as unknown as RulesyncSubagentFrontmatter;
 
@@ -220,7 +220,7 @@ You are a helpful planning agent.`,
       validTargets.forEach((target) => {
         const frontmatter: RulesyncSubagentFrontmatter = {
           targets: [target as any],
-          title: `Agent for ${target}`,
+          name: `Agent for ${target}`,
           description: `Agent targeting ${target}`,
         };
 
@@ -245,7 +245,7 @@ You are a helpful planning agent.`,
       validModels.forEach((model) => {
         const frontmatter: RulesyncSubagentFrontmatter = {
           targets: ["claudecode"],
-          title: `Agent with ${model}`,
+          name: `Agent with ${model}`,
           description: `Agent using ${model} model`,
           claudecode: {
             model: model as any,
@@ -272,13 +272,13 @@ You are a helpful planning agent.`,
     it("should validate RulesyncSubagentFrontmatterSchema with required fields", () => {
       const validFrontmatter = {
         targets: ["claudecode"],
-        title: "Valid Agent",
+        name: "Valid Agent",
         description: "Valid description",
       };
 
       const invalidFrontmatter1 = {
         // missing targets
-        title: "Invalid Agent",
+        name: "Invalid Agent",
         description: "Invalid description",
       };
 
@@ -290,7 +290,7 @@ You are a helpful planning agent.`,
 
       const invalidFrontmatter3 = {
         targets: ["claudecode"],
-        title: "Invalid Agent",
+        name: "Invalid Agent",
         // missing description
       };
 
@@ -298,7 +298,7 @@ You are a helpful planning agent.`,
       expect(() => {
         z.object({
           targets: z.array(z.string()),
-          title: z.string(),
+          name: z.string(),
           description: z.string(),
         }).parse(validFrontmatter);
       }).not.toThrow();
@@ -309,7 +309,7 @@ You are a helpful planning agent.`,
           () => {
             z.object({
               targets: z.array(z.string()),
-              title: z.string(),
+              name: z.string(),
               description: z.string(),
             }).parse(invalid);
           },
@@ -321,7 +321,7 @@ You are a helpful planning agent.`,
     it("should validate optional claudecode field", () => {
       const validWithClaudecode = {
         targets: ["claudecode"],
-        title: "Agent",
+        name: "Agent",
         description: "Description",
         claudecode: {
           model: "sonnet",
@@ -330,13 +330,13 @@ You are a helpful planning agent.`,
 
       const validWithoutClaudecode = {
         targets: ["claudecode"],
-        title: "Agent",
+        name: "Agent",
         description: "Description",
       };
 
       const invalidClaudecode = {
         targets: ["claudecode"],
-        title: "Agent",
+        name: "Agent",
         description: "Description",
         claudecode: {
           model: "invalid-model",
@@ -346,7 +346,7 @@ You are a helpful planning agent.`,
       expect(() => {
         z.object({
           targets: z.array(z.string()),
-          title: z.string(),
+          name: z.string(),
           description: z.string(),
           claudecode: z.optional(
             z.object({
@@ -359,7 +359,7 @@ You are a helpful planning agent.`,
       expect(() => {
         z.object({
           targets: z.array(z.string()),
-          title: z.string(),
+          name: z.string(),
           description: z.string(),
           claudecode: z.optional(
             z.object({
@@ -372,7 +372,7 @@ You are a helpful planning agent.`,
       expect(() => {
         z.object({
           targets: z.array(z.string()),
-          title: z.string(),
+          name: z.string(),
           description: z.string(),
           claudecode: z.optional(
             z.object({
@@ -388,7 +388,7 @@ You are a helpful planning agent.`,
     it("should handle empty body", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Empty Body Agent",
+        name: "Empty Body Agent",
         description: "Agent with empty body",
       };
 
@@ -407,7 +407,7 @@ You are a helpful planning agent.`,
     it("should handle empty targets array", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: [],
-        title: "No Targets Agent",
+        name: "No Targets Agent",
         description: "Agent with no targets",
       };
 
@@ -427,7 +427,7 @@ You are a helpful planning agent.`,
     it("should handle special characters in title and description", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Agent with Special Chars!@#$%^&*()",
+        name: "Agent with Special Chars!@#$%^&*()",
         description: "Description with üñíçødé and émøjî 🤖",
       };
 
@@ -442,7 +442,7 @@ You are a helpful planning agent.`,
 
       const result = subagent.validate();
       expect(result.success).toBe(true);
-      expect(subagent.getFrontmatter().title).toBe("Agent with Special Chars!@#$%^&*()");
+      expect(subagent.getFrontmatter().name).toBe("Agent with Special Chars!@#$%^&*()");
       expect(subagent.getFrontmatter().description).toBe("Description with üñíçødé and émøjî 🤖");
     });
 
@@ -450,7 +450,7 @@ You are a helpful planning agent.`,
       // Test with future potential claudecode options
       const frontmatter = {
         targets: ["claudecode"],
-        title: "Future Options Agent",
+        name: "Future Options Agent",
         description: "Agent with potential future options",
         claudecode: {
           model: "sonnet",
@@ -475,7 +475,7 @@ You are a helpful planning agent.`,
       const longString = "x".repeat(1000);
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: `Long Title ${longString}`,
+        name: `Long Title ${longString}`,
         description: `Long Description ${longString}`,
       };
 
@@ -490,7 +490,7 @@ You are a helpful planning agent.`,
 
       const result = subagent.validate();
       expect(result.success).toBe(true);
-      expect(subagent.getFrontmatter().title.length).toBeGreaterThan(1000);
+      expect(subagent.getFrontmatter().name.length).toBeGreaterThan(1000);
     });
   });
 
@@ -498,7 +498,7 @@ You are a helpful planning agent.`,
     it("should properly extend RulesyncFile", () => {
       const frontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
-        title: "Inheritance Test",
+        name: "Inheritance Test",
         description: "Testing inheritance",
       };
 

--- a/src/subagents/rulesync-subagent.test.ts
+++ b/src/subagents/rulesync-subagent.test.ts
@@ -1,0 +1,521 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod/mini";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { RulesyncSubagent, RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
+
+describe("RulesyncSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid frontmatter", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Test Planner",
+        description: "A test planning agent",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "You are a helpful planning agent.",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "planner.md",
+        fileContent: `---
+targets: ["claudecode"]
+title: "Test Planner"
+description: "A test planning agent"
+---
+
+You are a helpful planning agent.`,
+      });
+
+      expect(subagent).toBeInstanceOf(RulesyncSubagent);
+      expect(subagent.getRelativeDirPath()).toBe(".rulesync/subagents");
+      expect(subagent.getRelativeFilePath()).toBe("planner.md");
+      expect(subagent.getBody()).toBe("You are a helpful planning agent.");
+    });
+
+    it("should create instance with multiple targets", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode", "cursor", "cline"],
+        title: "Multi-target Agent",
+        description: "Agent for multiple tools",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Multi-target content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "multitarget.md",
+        fileContent: "Multi-target file content",
+      });
+
+      expect(subagent.getFrontmatter().targets).toEqual(["claudecode", "cursor", "cline"]);
+    });
+
+    it("should create instance with claudecode options", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Agent with Options",
+        description: "Agent with Claude Code specific options",
+        claudecode: {
+          model: "sonnet",
+        },
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Agent content with options",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "withoptions.md",
+        fileContent: "With options file content",
+      });
+
+      expect(subagent.getFrontmatter().claudecode?.model).toBe("sonnet");
+    });
+
+    it("should validate frontmatter by default", () => {
+      const invalidFrontmatter = {
+        targets: ["invalid-target"], // not a valid target
+        title: "Invalid Agent",
+        description: "Agent with invalid target",
+      } as unknown as RulesyncSubagentFrontmatter;
+
+      expect(() => {
+        const _subagent = new RulesyncSubagent({
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          baseDir: testDir,
+          relativeDirPath: ".rulesync/subagents",
+          relativeFilePath: "invalid.md",
+          fileContent: "Invalid content",
+        });
+      }).toThrow();
+    });
+
+    it("should skip validation when validate=false", () => {
+      const invalidFrontmatter = {
+        targets: ["invalid-target"],
+        title: "Invalid Agent",
+        description: "Agent with invalid target",
+      } as unknown as RulesyncSubagentFrontmatter;
+
+      expect(() => {
+        const _subagent = new RulesyncSubagent({
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          baseDir: testDir,
+          relativeDirPath: ".rulesync/subagents",
+          relativeFilePath: "invalid.md",
+          fileContent: "Invalid content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return the frontmatter object", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode", "cursor"],
+        title: "Test Agent",
+        description: "Test agent description",
+        claudecode: {
+          model: "opus",
+        },
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+      });
+
+      const retrievedFrontmatter = subagent.getFrontmatter();
+      expect(retrievedFrontmatter).toEqual(frontmatter);
+      expect(retrievedFrontmatter.targets).toEqual(["claudecode", "cursor"]);
+      expect(retrievedFrontmatter.claudecode?.model).toBe("opus");
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Valid Agent",
+        description: "Valid agent description",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Valid body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "valid.md",
+        fileContent: "Valid content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should return error for invalid frontmatter", () => {
+      const invalidFrontmatter = {
+        targets: ["invalid-target"],
+        title: "Invalid Agent",
+        description: "Invalid agent description",
+      } as unknown as RulesyncSubagentFrontmatter;
+
+      const subagent = new RulesyncSubagent({
+        frontmatter: invalidFrontmatter,
+        body: "Invalid body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "invalid.md",
+        fileContent: "Invalid content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+    });
+
+    it("should validate all target options", () => {
+      const validTargets = [
+        "agentsmd",
+        "amazonqcli",
+        "augmentcode",
+        "augmentcode-legacy",
+        "copilot",
+        "cursor",
+        "cline",
+        "claudecode",
+        "codexcli",
+        "opencode",
+        "qwencode",
+        "roo",
+        "geminicli",
+        "kiro",
+        "junie",
+        "windsurf",
+      ];
+
+      validTargets.forEach((target) => {
+        const frontmatter: RulesyncSubagentFrontmatter = {
+          targets: [target as any],
+          title: `Agent for ${target}`,
+          description: `Agent targeting ${target}`,
+        };
+
+        const subagent = new RulesyncSubagent({
+          frontmatter,
+          body: `Body for ${target}`,
+          baseDir: testDir,
+          relativeDirPath: ".rulesync/subagents",
+          relativeFilePath: `${target}.md`,
+          fileContent: `Content for ${target}`,
+          validate: false,
+        });
+
+        const result = subagent.validate();
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("should validate claudecode model options", () => {
+      const validModels = ["opus", "sonnet", "haiku", "inherit"];
+
+      validModels.forEach((model) => {
+        const frontmatter: RulesyncSubagentFrontmatter = {
+          targets: ["claudecode"],
+          title: `Agent with ${model}`,
+          description: `Agent using ${model} model`,
+          claudecode: {
+            model: model as any,
+          },
+        };
+
+        const subagent = new RulesyncSubagent({
+          frontmatter,
+          body: `Body for ${model}`,
+          baseDir: testDir,
+          relativeDirPath: ".rulesync/subagents",
+          relativeFilePath: `${model}.md`,
+          fileContent: `Content for ${model}`,
+          validate: false,
+        });
+
+        const result = subagent.validate();
+        expect(result.success).toBe(true);
+      });
+    });
+  });
+
+  describe("schema validation", () => {
+    it("should validate RulesyncSubagentFrontmatterSchema with required fields", () => {
+      const validFrontmatter = {
+        targets: ["claudecode"],
+        title: "Valid Agent",
+        description: "Valid description",
+      };
+
+      const invalidFrontmatter1 = {
+        // missing targets
+        title: "Invalid Agent",
+        description: "Invalid description",
+      };
+
+      const invalidFrontmatter2 = {
+        targets: ["claudecode"],
+        // missing title
+        description: "Invalid description",
+      };
+
+      const invalidFrontmatter3 = {
+        targets: ["claudecode"],
+        title: "Invalid Agent",
+        // missing description
+      };
+
+      // Valid case should not throw
+      expect(() => {
+        z.object({
+          targets: z.array(z.string()),
+          title: z.string(),
+          description: z.string(),
+        }).parse(validFrontmatter);
+      }).not.toThrow();
+
+      // Invalid cases should throw
+      [invalidFrontmatter1, invalidFrontmatter2, invalidFrontmatter3].forEach((invalid, index) => {
+        expect(
+          () => {
+            z.object({
+              targets: z.array(z.string()),
+              title: z.string(),
+              description: z.string(),
+            }).parse(invalid);
+          },
+          `Invalid frontmatter ${index + 1} should throw`,
+        ).toThrow();
+      });
+    });
+
+    it("should validate optional claudecode field", () => {
+      const validWithClaudecode = {
+        targets: ["claudecode"],
+        title: "Agent",
+        description: "Description",
+        claudecode: {
+          model: "sonnet",
+        },
+      };
+
+      const validWithoutClaudecode = {
+        targets: ["claudecode"],
+        title: "Agent",
+        description: "Description",
+      };
+
+      const invalidClaudecode = {
+        targets: ["claudecode"],
+        title: "Agent",
+        description: "Description",
+        claudecode: {
+          model: "invalid-model",
+        },
+      };
+
+      expect(() => {
+        z.object({
+          targets: z.array(z.string()),
+          title: z.string(),
+          description: z.string(),
+          claudecode: z.optional(
+            z.object({
+              model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+            }),
+          ),
+        }).parse(validWithClaudecode);
+      }).not.toThrow();
+
+      expect(() => {
+        z.object({
+          targets: z.array(z.string()),
+          title: z.string(),
+          description: z.string(),
+          claudecode: z.optional(
+            z.object({
+              model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+            }),
+          ),
+        }).parse(validWithoutClaudecode);
+      }).not.toThrow();
+
+      expect(() => {
+        z.object({
+          targets: z.array(z.string()),
+          title: z.string(),
+          description: z.string(),
+          claudecode: z.optional(
+            z.object({
+              model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+            }),
+          ),
+        }).parse(invalidClaudecode);
+      }).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Empty Body Agent",
+        description: "Agent with empty body",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "empty.md",
+        fileContent: "File content",
+      });
+
+      expect(subagent.getBody()).toBe("");
+    });
+
+    it("should handle empty targets array", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: [],
+        title: "No Targets Agent",
+        description: "Agent with no targets",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "No targets content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "notargets.md",
+        fileContent: "No targets file content",
+        validate: false,
+      });
+
+      expect(subagent.getFrontmatter().targets).toEqual([]);
+    });
+
+    it("should handle special characters in title and description", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Agent with Special Chars!@#$%^&*()",
+        description: "Description with üñíçødé and émøjî 🤖",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Special content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "special.md",
+        fileContent: "Special file content",
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(subagent.getFrontmatter().title).toBe("Agent with Special Chars!@#$%^&*()");
+      expect(subagent.getFrontmatter().description).toBe("Description with üñíçødé and émøjî 🤖");
+    });
+
+    it("should handle multiple claudecode options", () => {
+      // Test with future potential claudecode options
+      const frontmatter = {
+        targets: ["claudecode"],
+        title: "Future Options Agent",
+        description: "Agent with potential future options",
+        claudecode: {
+          model: "sonnet",
+          // Future options could be added here
+        },
+      } as RulesyncSubagentFrontmatter;
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Future options content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "future.md",
+        fileContent: "Future options file content",
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle very long title and description", () => {
+      const longString = "x".repeat(1000);
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: `Long Title ${longString}`,
+        description: `Long Description ${longString}`,
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Long content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "long.md",
+        fileContent: "Long file content",
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(subagent.getFrontmatter().title.length).toBeGreaterThan(1000);
+    });
+  });
+
+  describe("inheritance from RulesyncFile", () => {
+    it("should properly extend RulesyncFile", () => {
+      const frontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["claudecode"],
+        title: "Inheritance Test",
+        description: "Testing inheritance",
+      };
+
+      const subagent = new RulesyncSubagent({
+        frontmatter,
+        body: "Inheritance body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "inheritance.md",
+        fileContent: "Inheritance file content",
+      });
+
+      // Test inherited methods
+      expect(subagent.getBody()).toBe("Inheritance body");
+      expect(subagent.getRelativeDirPath()).toBe(".rulesync/subagents");
+      expect(subagent.getRelativeFilePath()).toBe("inheritance.md");
+      expect(subagent.getFileContent()).toBe("Inheritance file content");
+    });
+  });
+});

--- a/src/subagents/rulesync-subagent.ts
+++ b/src/subagents/rulesync-subagent.ts
@@ -1,0 +1,49 @@
+import { z } from "zod/mini";
+import { ValidationResult } from "../types/ai-file.js";
+import { RulesyncFile, RulesyncFileParams } from "../types/rulesync-file.js";
+import { ToolTargetsSchema } from "../types/tool-targets.js";
+
+export const RulesyncSubagentFrontmatterSchema = z.object({
+  targets: ToolTargetsSchema,
+  title: z.string(),
+  description: z.string(),
+});
+
+export type RulesyncSubagentFrontmatter = z.infer<typeof RulesyncSubagentFrontmatterSchema>;
+
+export interface RulesyncSubagentParams extends RulesyncFileParams {
+  frontmatter: RulesyncSubagentFrontmatter;
+}
+
+export class RulesyncSubagent extends RulesyncFile {
+  private readonly frontmatter: RulesyncSubagentFrontmatter;
+
+  constructor({ frontmatter, ...rest }: RulesyncSubagentParams) {
+    super({
+      ...rest,
+    });
+
+    if (rest.validate) {
+      const result = RulesyncSubagentFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+
+    this.frontmatter = frontmatter;
+  }
+
+  getFrontmatter(): RulesyncSubagentFrontmatter {
+    return this.frontmatter;
+  }
+
+  validate(): ValidationResult {
+    const result = RulesyncSubagentFrontmatterSchema.safeParse(this.frontmatter);
+
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return { success: false, error: result.error };
+    }
+  }
+}

--- a/src/subagents/rulesync-subagent.ts
+++ b/src/subagents/rulesync-subagent.ts
@@ -24,16 +24,17 @@ export class RulesyncSubagent extends RulesyncFile {
   private readonly frontmatter: RulesyncSubagentFrontmatter;
 
   constructor({ frontmatter, ...rest }: RulesyncSubagentParams) {
-    super({
-      ...rest,
-    });
-
-    if (rest.validate) {
+    // Validate frontmatter before calling super to avoid validation order issues
+    if (rest.validate !== false) {
       const result = RulesyncSubagentFrontmatterSchema.safeParse(frontmatter);
       if (!result.success) {
         throw result.error;
       }
     }
+
+    super({
+      ...rest,
+    });
 
     this.frontmatter = frontmatter;
   }
@@ -43,6 +44,11 @@ export class RulesyncSubagent extends RulesyncFile {
   }
 
   validate(): ValidationResult {
+    // Check if frontmatter is set (may be undefined during construction)
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
     const result = RulesyncSubagentFrontmatterSchema.safeParse(this.frontmatter);
 
     if (result.success) {

--- a/src/subagents/rulesync-subagent.ts
+++ b/src/subagents/rulesync-subagent.ts
@@ -10,7 +10,7 @@ export const RulesyncSubagentModelSchema = z.enum(["opus", "sonnet", "haiku", "i
 
 export const RulesyncSubagentFrontmatterSchema = z.object({
   targets: RulesyncTargetsSchema,
-  title: z.string(),
+  name: z.string(),
   description: z.string(),
   claudecode: z.optional(
     z.object({

--- a/src/subagents/rulesync-subagent.ts
+++ b/src/subagents/rulesync-subagent.ts
@@ -7,6 +7,11 @@ export const RulesyncSubagentFrontmatterSchema = z.object({
   targets: ToolTargetsSchema,
   title: z.string(),
   description: z.string(),
+  claudecode: z.optional(
+    z.object({
+      model: z.optional(z.enum(["opus", "sonnet", "haiku", "inherit"])),
+    }),
+  ),
 });
 
 export type RulesyncSubagentFrontmatter = z.infer<typeof RulesyncSubagentFrontmatterSchema>;

--- a/src/subagents/subagents-processor.test.ts
+++ b/src/subagents/subagents-processor.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod/mini";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { ClaudecodeSubagent } from "./claudecode-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import { SubagentsProcessor, SubagentsProcessorToolTarget } from "./subagents-processor.js";
+
+// Mock the file utility to avoid actual file system operations in isolated tests
+vi.mock("../utils/file.js", () => ({
+  writeFileContent: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("SubagentsProcessor", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid tool target", () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      expect(processor).toBeInstanceOf(SubagentsProcessor);
+    });
+
+    it("should validate tool target with Zod schema", () => {
+      expect(() => {
+        const _processor = new SubagentsProcessor({
+          baseDir: testDir,
+          toolTarget: "unsupported" as SubagentsProcessorToolTarget,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe("writeToolSubagentsFromRulesyncSubagents", () => {
+    it("should convert rulesync subagents to claude code subagents", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Test Planner",
+          description: "A test planning agent",
+          claudecode: {
+            model: "sonnet",
+          },
+        },
+        body: "You are a helpful planning agent.",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "planner.md",
+        fileContent: `---
+targets: ["claudecode"]
+title: "Test Planner"
+description: "A test planning agent"
+claudecode:
+  model: "sonnet"
+---
+
+You are a helpful planning agent.`,
+        validate: false,
+      });
+
+      await processor.writeToolSubagentsFromRulesyncSubagents([rulesyncSubagent]);
+
+      // The method should complete without throwing
+      expect(true).toBe(true);
+    });
+
+    it("should handle multiple rulesync subagents", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const subagent1 = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Planner",
+          description: "Planning agent",
+        },
+        body: "Planning content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "planner.md",
+        fileContent:
+          '---\ntargets: ["claudecode"]\ntitle: "Planner"\ndescription: "Planning agent"\n---\n\nPlanning content',
+        validate: false,
+      });
+
+      const subagent2 = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Reviewer",
+          description: "Review agent",
+        },
+        body: "Review content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "reviewer.md",
+        fileContent:
+          '---\ntargets: ["claudecode"]\ntitle: "Reviewer"\ndescription: "Review agent"\n---\n\nReview content',
+        validate: false,
+      });
+
+      await processor.writeToolSubagentsFromRulesyncSubagents([subagent1, subagent2]);
+
+      expect(true).toBe(true);
+    });
+
+    it("should handle empty array", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      await processor.writeToolSubagentsFromRulesyncSubagents([]);
+
+      expect(true).toBe(true);
+    });
+
+    it("should throw error for unsupported tool target", async () => {
+      // Modify the internal toolTarget to simulate unsupported target
+      // Since toolTarget is private, we'll test by creating a modified version
+      const mockProcessor = Object.create(SubagentsProcessor.prototype);
+      mockProcessor.baseDir = testDir;
+      mockProcessor.toolTarget = "unsupported";
+      mockProcessor.writeAiFiles = vi.fn().mockResolvedValue(undefined);
+
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Test",
+          description: "Test description",
+        },
+        body: "Test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+        validate: false,
+      });
+
+      await expect(
+        SubagentsProcessor.prototype.writeToolSubagentsFromRulesyncSubagents.call(mockProcessor, [
+          rulesyncSubagent,
+        ]),
+      ).rejects.toThrow("Unsupported tool target: unsupported");
+    });
+  });
+
+  describe("writeRulesyncSubagentsFromToolSubagents", () => {
+    it("should convert tool subagents to rulesync subagents", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const claudecodeSubagent = new ClaudecodeSubagent({
+        frontmatter: {
+          name: "Test Planner",
+          description: "A test planning agent",
+          model: "sonnet",
+        },
+        body: "You are a helpful planning agent.",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "planner.md",
+        fileContent: `---
+name: "Test Planner"
+description: "A test planning agent"
+model: "sonnet"
+---
+
+You are a helpful planning agent.`,
+      });
+
+      await processor.writeRulesyncSubagentsFromToolSubagents([claudecodeSubagent]);
+
+      expect(true).toBe(true);
+    });
+
+    it("should handle multiple tool subagents", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const subagent1 = new ClaudecodeSubagent({
+        frontmatter: {
+          name: "Planner",
+          description: "Planning agent",
+        },
+        body: "Planning content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "planner.md",
+        fileContent: "Planning file content",
+      });
+
+      const subagent2 = new ClaudecodeSubagent({
+        frontmatter: {
+          name: "Reviewer",
+          description: "Review agent",
+        },
+        body: "Review content",
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "reviewer.md",
+        fileContent: "Review file content",
+      });
+
+      await processor.writeRulesyncSubagentsFromToolSubagents([subagent1, subagent2]);
+
+      expect(true).toBe(true);
+    });
+
+    it("should handle empty array", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: testDir,
+        toolTarget: "claudecode",
+      });
+
+      await processor.writeRulesyncSubagentsFromToolSubagents([]);
+
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("schema validation", () => {
+    it("should validate SubagentsProcessorToolTargetSchema", () => {
+      const validTarget = "claudecode";
+      const invalidTarget = "invalid-target";
+
+      expect(() => z.enum(["claudecode"]).parse(validTarget)).not.toThrow();
+      expect(() => z.enum(["claudecode"]).parse(invalidTarget)).toThrow();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle file write errors gracefully", async () => {
+      const processor = new SubagentsProcessor({
+        baseDir: "/invalid/path",
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Test",
+          description: "Test description",
+        },
+        body: "Test body",
+        baseDir: "/invalid/path",
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+        validate: false,
+      });
+
+      // Since we're mocking writeFileContent, this should not throw
+      // In real scenarios, it would throw due to invalid path
+      await expect(
+        processor.writeToolSubagentsFromRulesyncSubagents([rulesyncSubagent]),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("integration tests", () => {
+    it("should perform round-trip conversion rulesync -> claude code -> rulesync", async () => {
+      // Create original rulesync subagent
+      const originalRulesync = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Original Planner",
+          description: "Original planning agent",
+          claudecode: { model: "sonnet" },
+        },
+        body: "Original content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "planner.md",
+        fileContent: "Original file content",
+        validate: false,
+      });
+
+      // Convert to claude code
+      const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        rulesyncSubagent: originalRulesync,
+      });
+
+      // Convert back to rulesync
+      const convertedRulesync = claudecodeSubagent.toRulesyncSubagent();
+
+      // Verify the conversion preserves essential data
+      expect(convertedRulesync.getFrontmatter().title).toBe("Original Planner");
+      expect(convertedRulesync.getFrontmatter().description).toBe("Original planning agent");
+      expect(convertedRulesync.getBody()).toBe("Original content");
+      expect(convertedRulesync.getFrontmatter().targets).toEqual(["claudecode"]);
+    });
+  });
+});

--- a/src/subagents/subagents-processor.test.ts
+++ b/src/subagents/subagents-processor.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod/mini";
 import { setupTestDirectory } from "../test-utils/index.js";
 import { ClaudecodeSubagent } from "./claudecode-subagent.js";
@@ -56,7 +56,7 @@ describe("SubagentsProcessor", () => {
       // Create a mock rulesync subagent file
       const rulesyncDir = join(testDir, ".rulesync", "subagents");
       await mkdir(rulesyncDir, { recursive: true });
-      
+
       const fileContent = `---
 targets: ["claudecode"]
 name: "Test Planner"
@@ -66,7 +66,7 @@ claudecode:
 ---
 
 You are a helpful planning agent.`;
-      
+
       await writeFile(join(rulesyncDir, "planner.md"), fileContent);
 
       const rulesyncSubagents = await processor.loadRulesyncSubagents();
@@ -87,7 +87,7 @@ You are a helpful planning agent.`;
       await mkdir(rulesyncDir, { recursive: true });
 
       await expect(processor.loadRulesyncSubagents()).rejects.toThrow(
-        "No markdown files found in rulesync subagents directory"
+        "No markdown files found in rulesync subagents directory",
       );
     });
 
@@ -97,9 +97,7 @@ You are a helpful planning agent.`;
         toolTarget: "claudecode",
       });
 
-      await expect(processor.loadRulesyncSubagents()).rejects.toThrow(
-        "ENOENT"
-      );
+      await expect(processor.loadRulesyncSubagents()).rejects.toThrow("ENOENT");
     });
   });
 
@@ -162,7 +160,7 @@ You are a helpful planning agent.`;
       const subagent2 = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          name: "Reviewer", 
+          name: "Reviewer",
           description: "Review agent",
         },
         body: "Review content",
@@ -184,7 +182,6 @@ You are a helpful planning agent.`;
       // Verify the write was called twice (once for each subagent)
       expect(writeFileContent).toHaveBeenCalledTimes(2);
     });
-
   });
 
   describe("writeRulesyncSubagentsFromToolSubagents", () => {
@@ -274,7 +271,6 @@ You are a helpful planning agent.`,
       expect(() => z.enum(["claudecode"]).parse(invalidTarget)).toThrow();
     });
   });
-
 
   describe("integration tests", () => {
     it("should perform round-trip conversion rulesync -> claude code -> rulesync", async () => {

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -1,2 +1,53 @@
-export const generateToolSubagentsFromRulesyncSubagents = () => {};
-export const generateRulesyncSubagentsFromToolSubagents = () => {};
+import { z } from "zod/mini";
+import { Processor } from "../types/processor.js";
+import { writeFileContent } from "../utils/file.js";
+import { ClaudecodeSubagent } from "./claudecode-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import { ToolSubagent } from "./tool-subagent.js";
+
+export const SubagentsProcessorToolTargetSchema = z.enum(["claudecode"]);
+
+export type SubagentsProcessorToolTarget = z.infer<typeof SubagentsProcessorToolTargetSchema>;
+
+export class SubagentsProcessor extends Processor {
+  private readonly toolTarget: SubagentsProcessorToolTarget;
+
+  constructor({
+    baseDir,
+    toolTarget,
+  }: { baseDir: string; toolTarget: SubagentsProcessorToolTarget }) {
+    super({ baseDir });
+    this.toolTarget = toolTarget;
+  }
+
+  async writeToolSubagentsFromRulesyncSubagents(
+    rulesyncSubagents: RulesyncSubagent[],
+  ): Promise<void> {
+    const toolSubagents = rulesyncSubagents.map((rulesyncSubagent) => {
+      switch (this.toolTarget) {
+        case "claudecode":
+          return ClaudecodeSubagent.fromRulesyncSubagent({
+            ...rulesyncSubagent,
+            relativeDirPath: ".claude/agents",
+            relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
+            rulesyncSubagent: rulesyncSubagent,
+          });
+        default:
+          throw new Error(`Unsupported tool target: ${this.toolTarget}`);
+      }
+    });
+
+    writeFileContent(
+      path.join(this.baseDir, "subagents", "tool-subagents.json"),
+      JSON.stringify(toolSubagents, null, 2),
+    );
+  }
+
+  writeRulesyncSubagentsFromToolSubagents(toolSubagents: ToolSubagent[]): {
+    subagents: RulesyncSubagent[];
+  } {
+    return {
+      subagents: [],
+    };
+  }
+}

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -1,0 +1,2 @@
+export const generateToolSubagentsFromRulesyncSubagents = () => {};
+export const generateRulesyncSubagentsFromToolSubagents = () => {};

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -23,7 +23,9 @@ export class SubagentsProcessor extends Processor {
     this.toolTarget = SubagentsProcessorToolTargetSchema.parse(toolTarget);
   }
 
-  async writeToolSubagentsFromRulesyncSubagents(rulesyncSubagents: RulesyncSubagent[]): Promise<void> {
+  async writeToolSubagentsFromRulesyncSubagents(
+    rulesyncSubagents: RulesyncSubagent[],
+  ): Promise<void> {
     const toolSubagents = rulesyncSubagents.map((rulesyncSubagent) => {
       switch (this.toolTarget) {
         case "claudecode":
@@ -45,46 +47,45 @@ export class SubagentsProcessor extends Processor {
    */
   async loadRulesyncSubagents(): Promise<RulesyncSubagent[]> {
     const subagentsDir = join(this.baseDir, ".rulesync", "subagents");
-    
+
     // Check if directory exists
     if (!(await directoryExists(subagentsDir))) {
       throw new Error(`Rulesync subagents directory not found: ${subagentsDir}`);
     }
-    
+
     // Read all markdown files from the directory
     const entries = await readdir(subagentsDir);
     const mdFiles = entries.filter((file) => file.endsWith(".md"));
-    
+
     if (mdFiles.length === 0) {
       throw new Error(`No markdown files found in rulesync subagents directory: ${subagentsDir}`);
     }
-    
+
     logger.info(`Found ${mdFiles.length} subagent files in ${subagentsDir}`);
-    
+
     // Parse all files and create RulesyncSubagent instances using fromFilePath
     const rulesyncSubagents: RulesyncSubagent[] = [];
-    
+
     for (const mdFile of mdFiles) {
       const filepath = join(subagentsDir, mdFile);
-      
+
       try {
         const rulesyncSubagent = await RulesyncSubagent.fromFilePath({
           filePath: filepath,
         });
-        
+
         rulesyncSubagents.push(rulesyncSubagent);
         logger.debug(`Successfully loaded subagent: ${mdFile}`);
-        
       } catch (error) {
         logger.warn(`Failed to load subagent file ${filepath}:`, error);
         continue;
       }
     }
-    
+
     if (rulesyncSubagents.length === 0) {
       throw new Error(`No valid subagents found in ${subagentsDir}`);
     }
-    
+
     logger.info(`Successfully loaded ${rulesyncSubagents.length} rulesync subagents`);
     return rulesyncSubagents;
   }

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -23,10 +23,7 @@ export class SubagentsProcessor extends Processor {
     this.toolTarget = SubagentsProcessorToolTargetSchema.parse(toolTarget);
   }
 
-  async writeToolSubagentsFromRulesyncSubagents(): Promise<void> {
-    // Read and parse subagent files from .claude/rulesync/subagents/
-    const rulesyncSubagents = await this.loadRulesyncSubagents();
-    
+  async writeToolSubagentsFromRulesyncSubagents(rulesyncSubagents: RulesyncSubagent[]): Promise<void> {
     const toolSubagents = rulesyncSubagents.map((rulesyncSubagent) => {
       switch (this.toolTarget) {
         case "claudecode":
@@ -44,10 +41,10 @@ export class SubagentsProcessor extends Processor {
   }
 
   /**
-   * Load and parse rulesync subagent files from .claude/rulesync/subagents/ directory
+   * Load and parse rulesync subagent files from .rulesync/subagents/ directory
    */
-  private async loadRulesyncSubagents(): Promise<RulesyncSubagent[]> {
-    const subagentsDir = join(this.baseDir, ".claude", "rulesync", "subagents");
+  async loadRulesyncSubagents(): Promise<RulesyncSubagent[]> {
+    const subagentsDir = join(this.baseDir, ".rulesync", "subagents");
     
     // Check if directory exists
     if (!(await directoryExists(subagentsDir))) {

--- a/src/subagents/tool-subagent.test.ts
+++ b/src/subagents/tool-subagent.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { AiFileFromFilePathParams, ValidationResult } from "../types/ai-file.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import { ToolSubagent, ToolSubagentFromRulesyncSubagentParams } from "./tool-subagent.js";
+
+// Concrete implementation for testing the abstract ToolSubagent class
+class TestToolSubagent extends ToolSubagent {
+  static fromFilePath(params: AiFileFromFilePathParams): ToolSubagent {
+    return new TestToolSubagent({
+      baseDir: params.baseDir || ".",
+      relativeDirPath: params.relativeDirPath,
+      relativeFilePath: params.relativeFilePath,
+      fileContent: "test content from file path",
+      validate: params.validate || true,
+    });
+  }
+
+  static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    return new TestToolSubagent({
+      baseDir: params.baseDir || ".",
+      relativeDirPath: params.relativeDirPath,
+      relativeFilePath: params.rulesyncSubagent.getRelativeFilePath(),
+      fileContent: params.rulesyncSubagent.getFileContent(),
+      validate: params.validate || true,
+    });
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    return new RulesyncSubagent({
+      frontmatter: {
+        targets: ["claudecode"],
+        title: "Test Tool Subagent",
+        description: "Converted from tool subagent",
+      },
+      body: "Converted body content",
+      baseDir: this.baseDir,
+      relativeDirPath: ".rulesync/subagents",
+      relativeFilePath: "converted.md",
+      fileContent: "Converted file content",
+      validate: false,
+    });
+  }
+
+  validate(): ValidationResult {
+    if (this.fileContent.includes("invalid")) {
+      return {
+        success: false,
+        error: new Error("Content contains invalid text"),
+      };
+    }
+    return {
+      success: true,
+      error: undefined,
+    };
+  }
+}
+
+// Test implementation that throws errors for unimplemented methods
+class IncompleteToolSubagent extends ToolSubagent {
+  validate(): ValidationResult {
+    return { success: true, error: undefined };
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    throw new Error("toRulesyncSubagent not implemented");
+  }
+}
+
+describe("ToolSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("concrete implementation", () => {
+    it("should create instance through concrete subclass", () => {
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+      });
+
+      expect(toolSubagent).toBeInstanceOf(ToolSubagent);
+      expect(toolSubagent.getRelativeDirPath()).toBe(".tool/agents");
+      expect(toolSubagent.getRelativeFilePath()).toBe("test.md");
+      expect(toolSubagent.getFileContent()).toBe("Test content");
+    });
+
+    it("should validate content through concrete implementation", () => {
+      const validSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "valid.md",
+        fileContent: "Valid content",
+      });
+
+      const result = validSubagent.validate();
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle validation errors through concrete implementation", () => {
+      const invalidSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "invalid.md",
+        fileContent: "invalid content",
+        validate: false,
+      });
+
+      const result = invalidSubagent.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe("Content contains invalid text");
+    });
+  });
+
+  describe("fromFilePath", () => {
+    it("should create instance from file path through concrete implementation", () => {
+      const toolSubagent = TestToolSubagent.fromFilePath({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "frompath.md",
+        filePath: "/some/path/frompath.md",
+      });
+
+      expect(toolSubagent).toBeInstanceOf(TestToolSubagent);
+      expect(toolSubagent.getRelativeDirPath()).toBe(".tool/agents");
+      expect(toolSubagent.getRelativeFilePath()).toBe("frompath.md");
+      expect(toolSubagent.getFileContent()).toBe("test content from file path");
+    });
+
+    it("should throw error for abstract base class fromFilePath", () => {
+      expect(() => {
+        ToolSubagent.fromFilePath({
+          relativeDirPath: ".tool/agents",
+          relativeFilePath: "test.md",
+          filePath: "/some/path/test.md",
+        });
+      }).toThrow("Please implement this method in the subclass.");
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create instance from RulesyncSubagent through concrete implementation", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Source Agent",
+          description: "Source agent description",
+        },
+        body: "Source body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "source.md",
+        fileContent: "Source file content",
+        validate: false,
+      });
+
+      const toolSubagent = TestToolSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        rulesyncSubagent,
+      });
+
+      expect(toolSubagent).toBeInstanceOf(TestToolSubagent);
+      expect(toolSubagent.getRelativeDirPath()).toBe(".tool/agents");
+      expect(toolSubagent.getRelativeFilePath()).toBe("source.md");
+      expect(toolSubagent.getFileContent()).toBe("Source file content");
+    });
+
+    it("should throw error for abstract base class fromRulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+        validate: false,
+      });
+
+      expect(() => {
+        ToolSubagent.fromRulesyncSubagent({
+          baseDir: testDir,
+          relativeDirPath: ".tool/agents",
+          rulesyncSubagent,
+        });
+      }).toThrow("Please implement this method in the subclass.");
+    });
+
+    it("should handle optional parameters with defaults", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Default Test",
+          description: "Test with defaults",
+        },
+        body: "Default body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "default.md",
+        fileContent: "Default content",
+        validate: false,
+      });
+
+      const toolSubagent = TestToolSubagent.fromRulesyncSubagent({
+        relativeDirPath: ".tool/agents",
+        rulesyncSubagent,
+      });
+
+      expect(toolSubagent).toBeInstanceOf(TestToolSubagent);
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should convert to RulesyncSubagent through concrete implementation", () => {
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "convert.md",
+        fileContent: "Convert content",
+      });
+
+      const rulesyncSubagent = toolSubagent.toRulesyncSubagent();
+
+      expect(rulesyncSubagent).toBeInstanceOf(RulesyncSubagent);
+      expect(rulesyncSubagent.getFrontmatter().title).toBe("Test Tool Subagent");
+      expect(rulesyncSubagent.getFrontmatter().description).toBe("Converted from tool subagent");
+      expect(rulesyncSubagent.getBody()).toBe("Converted body content");
+    });
+
+    it("should require implementation in subclass", () => {
+      // Create an incomplete implementation that doesn't implement toRulesyncSubagent
+      const incompleteSubagent = new IncompleteToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "incomplete.md",
+        fileContent: "Incomplete content",
+      });
+
+      // TypeScript would catch this at compile time, but we can test runtime behavior
+      // by calling the method that should be abstract
+      expect(incompleteSubagent.toRulesyncSubagent).toBeDefined();
+    });
+  });
+
+  describe("abstract method contracts", () => {
+    it("should enforce toRulesyncSubagent implementation", () => {
+      // This test verifies that the abstract method contract exists
+      // Concrete implementations must provide toRulesyncSubagent
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "contract.md",
+        fileContent: "Contract content",
+      });
+
+      // Should have the method implemented
+      expect(typeof toolSubagent.toRulesyncSubagent).toBe("function");
+
+      // Should return a RulesyncSubagent
+      const result = toolSubagent.toRulesyncSubagent();
+      expect(result).toBeInstanceOf(RulesyncSubagent);
+    });
+
+    it("should enforce fromRulesyncSubagent static method implementation", () => {
+      // Verify the static method exists and works
+      expect(typeof TestToolSubagent.fromRulesyncSubagent).toBe("function");
+
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Static Test",
+          description: "Testing static method",
+        },
+        body: "Static test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "static.md",
+        fileContent: "Static test content",
+        validate: false,
+      });
+
+      const result = TestToolSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        rulesyncSubagent,
+      });
+
+      expect(result).toBeInstanceOf(TestToolSubagent);
+    });
+
+    it("should enforce fromFilePath static method implementation", () => {
+      // Verify the static method exists and works
+      expect(typeof TestToolSubagent.fromFilePath).toBe("function");
+
+      const result = TestToolSubagent.fromFilePath({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "fromfile.md",
+        filePath: "/some/path/fromfile.md",
+      });
+
+      expect(result).toBeInstanceOf(TestToolSubagent);
+    });
+  });
+
+  describe("inheritance from AiFile", () => {
+    it("should properly extend AiFile", () => {
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "inheritance.md",
+        fileContent: "Inheritance test content",
+      });
+
+      // Test inherited methods from AiFile
+      expect(toolSubagent.getRelativeDirPath()).toBe(".tool/agents");
+      expect(toolSubagent.getRelativeFilePath()).toBe("inheritance.md");
+      expect(toolSubagent.getFileContent()).toBe("Inheritance test content");
+      expect(toolSubagent.getFilePath()).toContain("inheritance.md");
+    });
+
+    it("should inherit validation behavior from AiFile", () => {
+      // Test that validation is called during construction
+      expect(() => {
+        const _toolSubagent = new TestToolSubagent({
+          baseDir: testDir,
+          relativeDirPath: ".tool/agents",
+          relativeFilePath: "invalid.md",
+          fileContent: "invalid content", // This should trigger validation error
+        });
+      }).toThrow("Content contains invalid text");
+    });
+
+    it("should support skipping validation from AiFile", () => {
+      expect(() => {
+        const _toolSubagent = new TestToolSubagent({
+          baseDir: testDir,
+          relativeDirPath: ".tool/agents",
+          relativeFilePath: "skipvalidation.md",
+          fileContent: "invalid content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("type definitions", () => {
+    it("should have correct ToolSubagentFromRulesyncSubagentParams type", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        frontmatter: {
+          targets: ["claudecode"],
+          title: "Type Test",
+          description: "Testing types",
+        },
+        body: "Type test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "typetest.md",
+        fileContent: "Type test content",
+        validate: false,
+      });
+
+      // This should compile and work correctly
+      const params: ToolSubagentFromRulesyncSubagentParams = {
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        rulesyncSubagent,
+        validate: true,
+      };
+
+      const result = TestToolSubagent.fromRulesyncSubagent(params);
+      expect(result).toBeInstanceOf(TestToolSubagent);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty content", () => {
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: "",
+        relativeFilePath: "empty.md",
+        fileContent: "",
+      });
+
+      expect(toolSubagent.getFileContent()).toBe("");
+    });
+
+    it("should handle special characters in paths", () => {
+      const toolSubagent = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: "path with spaces/special-chars_123",
+        relativeFilePath: "file-name_with-specials.md",
+        fileContent: "Special content",
+      });
+
+      expect(toolSubagent.getRelativeDirPath()).toBe("path with spaces/special-chars_123");
+      expect(toolSubagent.getRelativeFilePath()).toBe("file-name_with-specials.md");
+    });
+
+    it("should handle round-trip conversion", () => {
+      // Create tool subagent
+      const originalTool = new TestToolSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        relativeFilePath: "roundtrip.md",
+        fileContent: "Round trip content",
+      });
+
+      // Convert to rulesync
+      const rulesyncSubagent = originalTool.toRulesyncSubagent();
+
+      // Convert back to tool
+      const convertedTool = TestToolSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".tool/agents",
+        rulesyncSubagent,
+      });
+
+      // Verify the conversion worked
+      expect(convertedTool).toBeInstanceOf(TestToolSubagent);
+    });
+  });
+});

--- a/src/subagents/tool-subagent.test.ts
+++ b/src/subagents/tool-subagent.test.ts
@@ -30,7 +30,7 @@ class TestToolSubagent extends ToolSubagent {
     return new RulesyncSubagent({
       frontmatter: {
         targets: ["claudecode"],
-        title: "Test Tool Subagent",
+        name: "Test Tool Subagent",
         description: "Converted from tool subagent",
       },
       body: "Converted body content",
@@ -153,7 +153,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Source Agent",
+          name: "Source Agent",
           description: "Source agent description",
         },
         body: "Source body content",
@@ -180,7 +180,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Test Agent",
+          name: "Test Agent",
           description: "Test description",
         },
         body: "Test body",
@@ -204,7 +204,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Default Test",
+          name: "Default Test",
           description: "Test with defaults",
         },
         body: "Default body",
@@ -236,7 +236,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = toolSubagent.toRulesyncSubagent();
 
       expect(rulesyncSubagent).toBeInstanceOf(RulesyncSubagent);
-      expect(rulesyncSubagent.getFrontmatter().title).toBe("Test Tool Subagent");
+      expect(rulesyncSubagent.getFrontmatter().name).toBe("Test Tool Subagent");
       expect(rulesyncSubagent.getFrontmatter().description).toBe("Converted from tool subagent");
       expect(rulesyncSubagent.getBody()).toBe("Converted body content");
     });
@@ -282,7 +282,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Static Test",
+          name: "Static Test",
           description: "Testing static method",
         },
         body: "Static test body",
@@ -363,7 +363,7 @@ describe("ToolSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         frontmatter: {
           targets: ["claudecode"],
-          title: "Type Test",
+          name: "Type Test",
           description: "Testing types",
         },
         body: "Type test body",

--- a/src/subagents/tool-subagent.test.ts
+++ b/src/subagents/tool-subagent.test.ts
@@ -137,14 +137,14 @@ describe("ToolSubagent", () => {
       expect(toolSubagent.getFileContent()).toBe("test content from file path");
     });
 
-    it("should throw error for abstract base class fromFilePath", () => {
-      expect(() => {
+    it("should throw error for abstract base class fromFilePath", async () => {
+      await expect(
         ToolSubagent.fromFilePath({
           relativeDirPath: ".tool/agents",
           relativeFilePath: "test.md",
           filePath: "/some/path/test.md",
-        });
-      }).toThrow("Please implement this method in the subclass.");
+        }),
+      ).rejects.toThrow("Please implement this method in the subclass.");
     });
   });
 
@@ -302,11 +302,11 @@ describe("ToolSubagent", () => {
       expect(result).toBeInstanceOf(TestToolSubagent);
     });
 
-    it("should enforce fromFilePath static method implementation", () => {
+    it("should enforce fromFilePath static method implementation", async () => {
       // Verify the static method exists and works
       expect(typeof TestToolSubagent.fromFilePath).toBe("function");
 
-      const result = TestToolSubagent.fromFilePath({
+      const result = await TestToolSubagent.fromFilePath({
         baseDir: testDir,
         relativeDirPath: ".tool/agents",
         relativeFilePath: "fromfile.md",

--- a/src/subagents/tool-subagent.test.ts
+++ b/src/subagents/tool-subagent.test.ts
@@ -6,7 +6,7 @@ import { ToolSubagent, ToolSubagentFromRulesyncSubagentParams } from "./tool-sub
 
 // Concrete implementation for testing the abstract ToolSubagent class
 class TestToolSubagent extends ToolSubagent {
-  static fromFilePath(params: AiFileFromFilePathParams): ToolSubagent {
+  static async fromFilePath(params: AiFileFromFilePathParams): Promise<ToolSubagent> {
     return new TestToolSubagent({
       baseDir: params.baseDir || ".",
       relativeDirPath: params.relativeDirPath,
@@ -123,8 +123,8 @@ describe("ToolSubagent", () => {
   });
 
   describe("fromFilePath", () => {
-    it("should create instance from file path through concrete implementation", () => {
-      const toolSubagent = TestToolSubagent.fromFilePath({
+    it("should create instance from file path through concrete implementation", async () => {
+      const toolSubagent = await TestToolSubagent.fromFilePath({
         baseDir: testDir,
         relativeDirPath: ".tool/agents",
         relativeFilePath: "frompath.md",

--- a/src/subagents/tool-subagent.ts
+++ b/src/subagents/tool-subagent.ts
@@ -1,16 +1,21 @@
-import { AiFile } from "../types/ai-file.js";
+import { AiFile, AiFileFromFilePathParams, AiFileParams } from "../types/ai-file.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 
+export type ToolSubagentFromRulesyncSubagentParams = Omit<
+  AiFileParams,
+  "fileContent" | "relativeFilePath"
+> & {
+  rulesyncSubagent: RulesyncSubagent;
+};
+
 export abstract class ToolSubagent extends AiFile {
-  static fromFilePath(_params: {
-    baseDir: string;
-    relativeDirPath: string;
-    relativeFilePath: string;
-    filePath: string;
-  }): ToolSubagent {
+  static fromFilePath(_params: AiFileFromFilePathParams): ToolSubagent {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  static fromRulesyncSubagent(_params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
     throw new Error("Please implement this method in the subclass.");
   }
 
   abstract toRulesyncSubagent(): RulesyncSubagent;
-  abstract fromRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): ToolSubagent;
 }

--- a/src/subagents/tool-subagent.ts
+++ b/src/subagents/tool-subagent.ts
@@ -1,0 +1,16 @@
+import { AiFile } from "../types/ai-file.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+
+export abstract class ToolSubagent extends AiFile {
+  static fromFilePath(_params: {
+    baseDir: string;
+    relativeDirPath: string;
+    relativeFilePath: string;
+    filePath: string;
+  }): ToolSubagent {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  abstract toRulesyncSubagent(): RulesyncSubagent;
+  abstract fromRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): ToolSubagent;
+}

--- a/src/subagents/tool-subagent.ts
+++ b/src/subagents/tool-subagent.ts
@@ -9,7 +9,7 @@ export type ToolSubagentFromRulesyncSubagentParams = Omit<
 };
 
 export abstract class ToolSubagent extends AiFile {
-  static fromFilePath(_params: AiFileFromFilePathParams): ToolSubagent {
+  static async fromFilePath(_params: AiFileFromFilePathParams): Promise<ToolSubagent> {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/types/ai-file.test.ts
+++ b/src/types/ai-file.test.ts
@@ -123,14 +123,14 @@ describe("AiFile", () => {
       expect(aiFile.getFileContent()).toBe("test content from file path");
     });
 
-    it("should throw error for abstract base class", () => {
-      expect(() => {
+    it("should throw error for abstract base class", async () => {
+      await expect(
         AiFile.fromFilePath({
           relativeDirPath: ".claude",
           relativeFilePath: "test.md",
           filePath: "/some/path/test.md",
-        });
-      }).toThrow("Please implement this method in the subclass.");
+        }),
+      ).rejects.toThrow("Please implement this method in the subclass.");
     });
   });
 

--- a/src/types/ai-file.test.ts
+++ b/src/types/ai-file.test.ts
@@ -5,7 +5,7 @@ import { AiFile, AiFileFromFilePathParams, ValidationResult } from "./ai-file.js
 
 // Concrete implementation for testing the abstract AiFile class
 class TestAiFile extends AiFile {
-  static fromFilePath(params: AiFileFromFilePathParams): TestAiFile {
+  static async fromFilePath(params: AiFileFromFilePathParams): Promise<TestAiFile> {
     return new TestAiFile({
       baseDir: params.baseDir || ".",
       relativeDirPath: params.relativeDirPath,
@@ -110,8 +110,8 @@ describe("AiFile", () => {
   });
 
   describe("fromFilePath", () => {
-    it("should create instance from file path parameters", () => {
-      const aiFile = TestAiFile.fromFilePath({
+    it("should create instance from file path parameters", async () => {
+      const aiFile = await TestAiFile.fromFilePath({
         baseDir: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "test.md",

--- a/src/types/ai-file.test.ts
+++ b/src/types/ai-file.test.ts
@@ -1,0 +1,231 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { AiFile, AiFileFromFilePathParams, ValidationResult } from "./ai-file.js";
+
+// Concrete implementation for testing the abstract AiFile class
+class TestAiFile extends AiFile {
+  static fromFilePath(params: AiFileFromFilePathParams): TestAiFile {
+    return new TestAiFile({
+      baseDir: params.baseDir || ".",
+      relativeDirPath: params.relativeDirPath,
+      relativeFilePath: params.relativeFilePath,
+      fileContent: "test content from file path",
+      validate: params.validate || true,
+    });
+  }
+
+  validate(): ValidationResult {
+    if (this.fileContent.includes("invalid")) {
+      return {
+        success: false,
+        error: new Error("Content contains invalid text"),
+      };
+    }
+    return {
+      success: true,
+      error: undefined,
+    };
+  }
+}
+
+// Test implementation that always fails validation
+class InvalidTestAiFile extends AiFile {
+  validate(): ValidationResult {
+    return {
+      success: false,
+      error: new Error("Validation always fails"),
+    };
+  }
+}
+
+describe("AiFile", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with required parameters", () => {
+      const aiFile = new TestAiFile({
+        relativeDirPath: ".claude",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+      });
+
+      expect(aiFile.getRelativeDirPath()).toBe(".claude");
+      expect(aiFile.getRelativeFilePath()).toBe("test.md");
+      expect(aiFile.getFileContent()).toBe("Test content");
+      expect(aiFile.getFilePath()).toBe(join(".", ".claude", "test.md"));
+    });
+
+    it("should create instance with custom baseDir", () => {
+      const customBaseDir = join(testDir, "custom");
+      const _aiFile = new TestAiFile({
+        baseDir: customBaseDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "test.md",
+        fileContent: "Test content",
+      });
+
+      expect(_aiFile.getFilePath()).toBe(join(customBaseDir, ".claude", "test.md"));
+    });
+
+    it("should validate content by default", () => {
+      expect(() => {
+        const _aiFile = new TestAiFile({
+          relativeDirPath: ".claude",
+          relativeFilePath: "test.md",
+          fileContent: "invalid content",
+        });
+      }).toThrow("Content contains invalid text");
+    });
+
+    it("should skip validation when validate=false", () => {
+      expect(() => {
+        const _aiFile = new TestAiFile({
+          relativeDirPath: ".claude",
+          relativeFilePath: "test.md",
+          fileContent: "invalid content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("should throw error when validation fails", () => {
+      expect(() => {
+        const _aiFile = new InvalidTestAiFile({
+          relativeDirPath: ".claude",
+          relativeFilePath: "test.md",
+          fileContent: "any content",
+        });
+      }).toThrow("Validation always fails");
+    });
+  });
+
+  describe("fromFilePath", () => {
+    it("should create instance from file path parameters", () => {
+      const aiFile = TestAiFile.fromFilePath({
+        baseDir: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "test.md",
+        filePath: "/some/path/test.md",
+      });
+
+      expect(aiFile.getRelativeDirPath()).toBe(".claude");
+      expect(aiFile.getRelativeFilePath()).toBe("test.md");
+      expect(aiFile.getFileContent()).toBe("test content from file path");
+    });
+
+    it("should throw error for abstract base class", () => {
+      expect(() => {
+        AiFile.fromFilePath({
+          relativeDirPath: ".claude",
+          relativeFilePath: "test.md",
+          filePath: "/some/path/test.md",
+        });
+      }).toThrow("Please implement this method in the subclass.");
+    });
+  });
+
+  describe("getter methods", () => {
+    let aiFile: TestAiFile;
+
+    beforeEach(() => {
+      aiFile = new TestAiFile({
+        baseDir: testDir,
+        relativeDirPath: ".claude/agents",
+        relativeFilePath: "planner.md",
+        fileContent: "# Planner Agent\n\nThis is a test agent.",
+      });
+    });
+
+    it("should return correct relative directory path", () => {
+      expect(aiFile.getRelativeDirPath()).toBe(".claude/agents");
+    });
+
+    it("should return correct relative file path", () => {
+      expect(aiFile.getRelativeFilePath()).toBe("planner.md");
+    });
+
+    it("should return correct full file path", () => {
+      const expected = join(testDir, ".claude/agents", "planner.md");
+      expect(aiFile.getFilePath()).toBe(expected);
+    });
+
+    it("should return correct file content", () => {
+      expect(aiFile.getFileContent()).toBe("# Planner Agent\n\nThis is a test agent.");
+    });
+  });
+
+  describe("validation", () => {
+    it("should return success for valid content", () => {
+      const aiFile = new TestAiFile({
+        relativeDirPath: ".claude",
+        relativeFilePath: "test.md",
+        fileContent: "valid content",
+        validate: false,
+      });
+
+      const result = aiFile.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should return error for invalid content", () => {
+      const aiFile = new TestAiFile({
+        relativeDirPath: ".claude",
+        relativeFilePath: "test.md",
+        fileContent: "invalid content",
+        validate: false,
+      });
+
+      const result = aiFile.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe("Content contains invalid text");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty content", () => {
+      const aiFile = new TestAiFile({
+        relativeDirPath: "",
+        relativeFilePath: "empty.md",
+        fileContent: "",
+      });
+
+      expect(aiFile.getFileContent()).toBe("");
+      expect(aiFile.getFilePath()).toBe(join(".", "", "empty.md"));
+    });
+
+    it("should handle deep directory paths", () => {
+      const deepPath = "a/very/deep/directory/structure";
+      const aiFile = new TestAiFile({
+        relativeDirPath: deepPath,
+        relativeFilePath: "deep.md",
+        fileContent: "Deep content",
+      });
+
+      expect(aiFile.getRelativeDirPath()).toBe(deepPath);
+      expect(aiFile.getFilePath()).toBe(join(".", deepPath, "deep.md"));
+    });
+
+    it("should handle special characters in paths", () => {
+      const aiFile = new TestAiFile({
+        relativeDirPath: "path with spaces/special-chars_123",
+        relativeFilePath: "file-name_with-specials.md",
+        fileContent: "Special content",
+      });
+
+      expect(aiFile.getRelativeDirPath()).toBe("path with spaces/special-chars_123");
+      expect(aiFile.getRelativeFilePath()).toBe("file-name_with-specials.md");
+    });
+  });
+});

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -62,7 +62,7 @@ export abstract class AiFile {
     }
   }
 
-  static fromFilePath(_params: AiFileFromFilePathParams): AiFile {
+  static async fromFilePath(_params: AiFileFromFilePathParams): Promise<AiFile> {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -1,0 +1,78 @@
+import path from "node:path";
+
+export type ValidationResult =
+  | {
+      success: true;
+      error: undefined | null;
+    }
+  | {
+      success: false;
+      error: Error;
+    };
+
+export interface AiFileParams {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  fileContent: string;
+  validate?: boolean;
+}
+
+export interface AiFileFromFilePathParams {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  filePath: string;
+}
+
+export abstract class AiFile {
+  /**
+   * @example "."
+   */
+  protected readonly baseDir: string;
+
+  /**
+   * @example ".claude/agents"
+   */
+  protected readonly relativeDirPath: string;
+  /**
+   * @example "planner.md"
+   */
+  protected readonly relativeFilePath: string;
+
+  protected readonly fileContent: string;
+
+  constructor({
+    baseDir = ".",
+    relativeDirPath,
+    relativeFilePath,
+    fileContent,
+    validate = true,
+  }: AiFileParams) {
+    this.baseDir = baseDir;
+    this.relativeDirPath = relativeDirPath;
+    this.relativeFilePath = relativeFilePath;
+    this.fileContent = fileContent;
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static fromFilePath(_params: AiFileFromFilePathParams): AiFile {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  getFilePath(): string {
+    return path.join(this.baseDir, this.relativeDirPath, this.relativeFilePath);
+  }
+
+  getFileContent(): string {
+    return this.fileContent;
+  }
+
+  abstract validate(): ValidationResult;
+}

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -37,6 +37,9 @@ export abstract class AiFile {
    */
   protected readonly relativeFilePath: string;
 
+  /**
+   * Whole raw file content
+   */
   protected readonly fileContent: string;
 
   constructor({

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -18,12 +18,9 @@ export interface AiFileParams {
   validate?: boolean;
 }
 
-export interface AiFileFromFilePathParams {
-  baseDir?: string;
-  relativeDirPath: string;
-  relativeFilePath: string;
+export type AiFileFromFilePathParams = Omit<AiFileParams, "fileContent"> & {
   filePath: string;
-}
+};
 
 export abstract class AiFile {
   /**
@@ -64,6 +61,14 @@ export abstract class AiFile {
 
   static fromFilePath(_params: AiFileFromFilePathParams): AiFile {
     throw new Error("Please implement this method in the subclass.");
+  }
+
+  getRelativeDirPath(): string {
+    return this.relativeDirPath;
+  }
+
+  getRelativeFilePath(): string {
+    return this.relativeFilePath;
   }
 
   getFilePath(): string {

--- a/src/types/processor.test.ts
+++ b/src/types/processor.test.ts
@@ -1,0 +1,359 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { AiFile, ValidationResult } from "./ai-file.js";
+import { Processor } from "./processor.js";
+
+// Mock the file utility
+vi.mock("../utils/file.js", () => ({
+  writeFileContent: vi.fn(),
+}));
+
+import { writeFileContent } from "../utils/file.js";
+
+// Concrete implementation for testing the abstract Processor class
+class TestProcessor extends Processor {
+  constructor(baseDir: string) {
+    super({ baseDir });
+  }
+
+  // Expose protected method for testing
+  async testWriteAiFiles(aiFiles: AiFile[]): Promise<void> {
+    return this.writeAiFiles(aiFiles);
+  }
+}
+
+// Simple AiFile implementation for testing
+class TestAiFile extends AiFile {
+  constructor(
+    relativeDirPath: string,
+    relativeFilePath: string,
+    fileContent: string,
+    baseDir: string = ".",
+  ) {
+    super({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent,
+    });
+  }
+
+  validate(): ValidationResult {
+    if (this.fileContent.includes("invalid")) {
+      return {
+        success: false,
+        error: new Error("Content contains invalid text"),
+      };
+    }
+    return {
+      success: true,
+      error: undefined,
+    };
+  }
+}
+
+describe("Processor", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  let mockWriteFileContent: any;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    mockWriteFileContent = vi.mocked(writeFileContent);
+    mockWriteFileContent.mockClear();
+    mockWriteFileContent.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with baseDir", () => {
+      const processor = new TestProcessor(testDir);
+      expect(processor).toBeInstanceOf(Processor);
+    });
+
+    it("should store baseDir correctly", () => {
+      const customDir = join(testDir, "custom");
+      const processor = new TestProcessor(customDir);
+      expect(processor).toBeInstanceOf(Processor);
+    });
+  });
+
+  describe("writeAiFiles", () => {
+    it("should write single AI file", async () => {
+      const processor = new TestProcessor(testDir);
+      const aiFile = new TestAiFile(".test", "single.md", "Single file content");
+
+      await processor.testWriteAiFiles([aiFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledOnce();
+      expect(mockWriteFileContent).toHaveBeenCalledWith(
+        aiFile.getFilePath(),
+        "Single file content",
+      );
+    });
+
+    it("should write multiple AI files", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile(".test", "file1.md", "Content 1"),
+        new TestAiFile(".test", "file2.md", "Content 2"),
+        new TestAiFile(".test", "file3.md", "Content 3"),
+      ];
+
+      await processor.testWriteAiFiles(files);
+
+      expect(mockWriteFileContent).toHaveBeenCalledTimes(3);
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(1, files[0]!.getFilePath(), "Content 1");
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(2, files[1]!.getFilePath(), "Content 2");
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(3, files[2]!.getFilePath(), "Content 3");
+    });
+
+    it("should handle empty array", async () => {
+      const processor = new TestProcessor(testDir);
+
+      await processor.testWriteAiFiles([]);
+
+      expect(mockWriteFileContent).not.toHaveBeenCalled();
+    });
+
+    it("should write files with different paths", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile(".claude/agents", "planner.md", "Planner content", testDir),
+        new TestAiFile(".cursor/rules", "rules.md", "Rules content", testDir),
+        new TestAiFile("docs", "readme.md", "Readme content", testDir),
+      ];
+
+      await processor.testWriteAiFiles(files);
+
+      expect(mockWriteFileContent).toHaveBeenCalledTimes(3);
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(
+        1,
+        join(testDir, ".claude/agents", "planner.md"),
+        "Planner content",
+      );
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(
+        2,
+        join(testDir, ".cursor/rules", "rules.md"),
+        "Rules content",
+      );
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(
+        3,
+        join(testDir, "docs", "readme.md"),
+        "Readme content",
+      );
+    });
+
+    it("should handle file write errors", async () => {
+      const processor = new TestProcessor(testDir);
+      const aiFile = new TestAiFile(".test", "error.md", "Error content");
+
+      mockWriteFileContent.mockRejectedValueOnce(new Error("Write failed"));
+
+      await expect(processor.testWriteAiFiles([aiFile])).rejects.toThrow("Write failed");
+    });
+
+    it("should handle multiple files with some failures", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile(".test", "success1.md", "Success 1"),
+        new TestAiFile(".test", "error.md", "Error content"),
+        new TestAiFile(".test", "success2.md", "Success 2"),
+      ];
+
+      // Mock the second call to fail
+      mockWriteFileContent
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("Write failed"))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(processor.testWriteAiFiles(files)).rejects.toThrow("Write failed");
+
+      // Should have attempted all three calls before failing
+      expect(mockWriteFileContent).toHaveBeenCalledTimes(2);
+    });
+
+    it("should preserve file order during sequential writing", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile(".test", "first.md", "First content"),
+        new TestAiFile(".test", "second.md", "Second content"),
+        new TestAiFile(".test", "third.md", "Third content"),
+      ];
+
+      await processor.testWriteAiFiles(files);
+
+      expect(mockWriteFileContent).toHaveBeenCalledTimes(3);
+
+      // Verify the order of calls
+      const calls = mockWriteFileContent.mock.calls;
+      expect(calls[0]?.[1]).toBe("First content");
+      expect(calls[1]?.[1]).toBe("Second content");
+      expect(calls[2]?.[1]).toBe("Third content");
+    });
+  });
+
+  describe("integration with real file system (without mocking)", () => {
+    beforeEach(async () => {
+      // Restore the real writeFileContent function for these tests
+      vi.doUnmock("../utils/file.js");
+      const { writeFileContent: realWriteFileContent } = await import("../utils/file.js");
+      // Override the mock with the real implementation
+      mockWriteFileContent.mockImplementation(realWriteFileContent);
+    });
+
+    it("should actually write files to filesystem", async () => {
+      const processor = new TestProcessor(testDir);
+      const testFile = new TestAiFile(
+        "integration",
+        "test.md",
+        "Integration test content",
+        testDir,
+      );
+
+      // This will use the real writeFileContent function
+      await processor.testWriteAiFiles([testFile]);
+
+      // Verify the file was actually written
+      const writtenContent = await readFile(testFile.getFilePath(), "utf-8");
+      expect(writtenContent).toBe("Integration test content");
+    });
+
+    it("should create directories if they don't exist", async () => {
+      const processor = new TestProcessor(testDir);
+      const deepPath = "very/deep/nested/structure";
+      const testFile = new TestAiFile(deepPath, "deep.md", "Deep content", testDir);
+
+      await processor.testWriteAiFiles([testFile]);
+
+      // Verify the file was created in the deep path
+      const writtenContent = await readFile(testFile.getFilePath(), "utf-8");
+      expect(writtenContent).toBe("Deep content");
+    });
+
+    it("should handle multiple files with real file operations", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile("real", "file1.md", "Real content 1", testDir),
+        new TestAiFile("real", "file2.md", "Real content 2", testDir),
+        new TestAiFile("real/nested", "file3.md", "Real content 3", testDir),
+      ];
+
+      await processor.testWriteAiFiles(files);
+
+      // Verify all files were written correctly
+      for (const file of files) {
+        const content = await readFile(file.getFilePath(), "utf-8");
+        expect(content).toBe(file.getFileContent());
+      }
+    });
+
+    afterEach(() => {
+      // Clear the implementation override for subsequent tests
+      mockWriteFileContent.mockRestore();
+      mockWriteFileContent.mockResolvedValue(undefined);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle files with empty content", async () => {
+      const processor = new TestProcessor(testDir);
+      const emptyFile = new TestAiFile(".test", "empty.md", "");
+
+      await processor.testWriteAiFiles([emptyFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledWith(emptyFile.getFilePath(), "");
+    });
+
+    it("should handle files with special characters in content", async () => {
+      const processor = new TestProcessor(testDir);
+      const specialContent = "Special chars: üñíçødé 🤖 \n\t\r \\n \\t";
+      const specialFile = new TestAiFile(".test", "special.md", specialContent);
+
+      await processor.testWriteAiFiles([specialFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledWith(specialFile.getFilePath(), specialContent);
+    });
+
+    it("should handle files with very long content", async () => {
+      const processor = new TestProcessor(testDir);
+      const longContent = "x".repeat(10000);
+      const longFile = new TestAiFile(".test", "long.md", longContent);
+
+      await processor.testWriteAiFiles([longFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledWith(longFile.getFilePath(), longContent);
+    });
+
+    it("should handle files with special characters in paths", async () => {
+      const processor = new TestProcessor(testDir);
+      const specialFile = new TestAiFile(
+        "path with spaces/special-chars_123",
+        "file-name_with-specials.md",
+        "Special path content",
+      );
+
+      await processor.testWriteAiFiles([specialFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledWith(
+        specialFile.getFilePath(),
+        "Special path content",
+      );
+    });
+  });
+
+  describe("base directory handling", () => {
+    it("should use baseDir in file paths", async () => {
+      const customBase = join(testDir, "custom", "base");
+      const processor = new TestProcessor(customBase);
+      const testFile = new TestAiFile("relative", "test.md", "Base dir test content", customBase);
+
+      await processor.testWriteAiFiles([testFile]);
+
+      expect(mockWriteFileContent).toHaveBeenCalledWith(
+        join(customBase, "relative", "test.md"),
+        "Base dir test content",
+      );
+    });
+
+    it("should handle different baseDirs for different files", async () => {
+      const processor = new TestProcessor(testDir);
+      const files = [
+        new TestAiFile("dir1", "file1.md", "Content 1", testDir),
+        new TestAiFile("dir2", "file2.md", "Content 2", join(testDir, "alt")),
+      ];
+
+      await processor.testWriteAiFiles(files);
+
+      expect(mockWriteFileContent).toHaveBeenCalledTimes(2);
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(
+        1,
+        join(testDir, "dir1", "file1.md"),
+        "Content 1",
+      );
+      expect(mockWriteFileContent).toHaveBeenNthCalledWith(
+        2,
+        join(testDir, "alt", "dir2", "file2.md"),
+        "Content 2",
+      );
+    });
+  });
+
+  describe("abstract class behavior", () => {
+    it("should not be instantiable directly", () => {
+      // This is enforced at TypeScript compile time
+      // but we can verify the pattern exists
+      expect(Processor).toBeDefined();
+      expect(typeof Processor).toBe("function");
+
+      // Verify that TestProcessor extends Processor
+      const testProcessor = new TestProcessor(testDir);
+      expect(testProcessor).toBeInstanceOf(Processor);
+    });
+  });
+});

--- a/src/types/processor.ts
+++ b/src/types/processor.ts
@@ -1,0 +1,7 @@
+export abstract class Processor {
+  protected readonly baseDir: string;
+
+  constructor({ baseDir }: { baseDir: string }) {
+    this.baseDir = baseDir;
+  }
+}

--- a/src/types/processor.ts
+++ b/src/types/processor.ts
@@ -1,7 +1,16 @@
+import { writeFileContent } from "../utils/file.js";
+import { AiFile } from "./ai-file.js";
+
 export abstract class Processor {
   protected readonly baseDir: string;
 
   constructor({ baseDir }: { baseDir: string }) {
     this.baseDir = baseDir;
+  }
+
+  protected async writeAiFiles(aiFiles: AiFile[]): Promise<void> {
+    for (const aiFile of aiFiles) {
+      await writeFileContent(aiFile.getFilePath(), aiFile.getFileContent());
+    }
   }
 }

--- a/src/types/rulesync-file.test.ts
+++ b/src/types/rulesync-file.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setupTestDirectory } from "../test-utils/index.js";
+import { AiFileFromFilePathParams, ValidationResult } from "./ai-file.js";
+import { RulesyncFile, RulesyncFileParams } from "./rulesync-file.js";
+
+// Concrete implementation for testing the abstract RulesyncFile class
+class TestRulesyncFile extends RulesyncFile {
+  static fromFilePath(params: AiFileFromFilePathParams): TestRulesyncFile {
+    return new TestRulesyncFile({
+      baseDir: params.baseDir || ".",
+      relativeDirPath: params.relativeDirPath,
+      relativeFilePath: params.relativeFilePath,
+      fileContent: "test content from file path",
+      body: "test body from file path",
+      validate: params.validate || true,
+    });
+  }
+
+  getFrontmatter(): Record<string, unknown> {
+    return {
+      title: "Test Frontmatter",
+      description: "Test description",
+      targets: ["test-target"],
+    };
+  }
+
+  validate(): ValidationResult {
+    const body = this.getBody(); // Use getBody() method instead of direct property access
+    if (body && body.includes("invalid")) {
+      return {
+        success: false,
+        error: new Error("Body contains invalid text"),
+      };
+    }
+    return {
+      success: true,
+      error: undefined,
+    };
+  }
+}
+
+// Test implementation that always fails validation
+class InvalidTestRulesyncFile extends RulesyncFile {
+  getFrontmatter(): Record<string, unknown> {
+    return {
+      invalid: true,
+    };
+  }
+
+  validate(): ValidationResult {
+    return {
+      success: false,
+      error: new Error("Validation always fails"),
+    };
+  }
+}
+
+describe("RulesyncFile", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with required parameters", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Test body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "test.md",
+        fileContent: "Test file content",
+      });
+
+      expect(rulesyncFile).toBeInstanceOf(RulesyncFile);
+      expect(rulesyncFile.getBody()).toBe("Test body content");
+      expect(rulesyncFile.getRelativeDirPath()).toBe(".rulesync");
+      expect(rulesyncFile.getRelativeFilePath()).toBe("test.md");
+      expect(rulesyncFile.getFileContent()).toBe("Test file content");
+    });
+
+    it("should validate content by default (manual validation)", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "content with invalid text",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "invalid.md",
+        fileContent: "Invalid file content",
+        validate: false,
+      });
+
+      const result = rulesyncFile.validate();
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toBe("Body contains invalid text");
+    });
+
+    it("should skip validation when validate=false", () => {
+      expect(() => {
+        const _rulesyncFile = new TestRulesyncFile({
+          body: "invalid body content",
+          baseDir: testDir,
+          relativeDirPath: ".rulesync",
+          relativeFilePath: "skip.md",
+          fileContent: "Skip validation content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("should throw error when validation fails", () => {
+      expect(() => {
+        const _rulesyncFile = new InvalidTestRulesyncFile({
+          body: "Any body content",
+          baseDir: testDir,
+          relativeDirPath: ".rulesync",
+          relativeFilePath: "fails.md",
+          fileContent: "Any file content",
+        });
+      }).toThrow("Validation always fails");
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const bodyContent = "This is the body content for the rulesync file";
+      const rulesyncFile = new TestRulesyncFile({
+        body: bodyContent,
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "body.md",
+        fileContent: "File content",
+      });
+
+      expect(rulesyncFile.getBody()).toBe(bodyContent);
+    });
+
+    it("should handle empty body", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "empty.md",
+        fileContent: "File content",
+      });
+
+      expect(rulesyncFile.getBody()).toBe("");
+    });
+
+    it("should handle body with special characters", () => {
+      const specialBody = "Special chars: üñíçødé 🤖 \n\t\r \\n \\t";
+      const rulesyncFile = new TestRulesyncFile({
+        body: specialBody,
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "special.md",
+        fileContent: "Special file content",
+      });
+
+      expect(rulesyncFile.getBody()).toBe(specialBody);
+    });
+
+    it("should handle very long body content", () => {
+      const longBody = "x".repeat(10000);
+      const rulesyncFile = new TestRulesyncFile({
+        body: longBody,
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "long.md",
+        fileContent: "Long file content",
+      });
+
+      expect(rulesyncFile.getBody()).toBe(longBody);
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter from concrete implementation", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "frontmatter.md",
+        fileContent: "Frontmatter file content",
+      });
+
+      const frontmatter = rulesyncFile.getFrontmatter();
+      expect(frontmatter).toEqual({
+        title: "Test Frontmatter",
+        description: "Test description",
+        targets: ["test-target"],
+      });
+    });
+
+    it("should require implementation in subclass", () => {
+      // Abstract method should be implemented by subclass
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "abstract.md",
+        fileContent: "Abstract file content",
+      });
+
+      expect(typeof rulesyncFile.getFrontmatter).toBe("function");
+      expect(rulesyncFile.getFrontmatter()).toBeDefined();
+    });
+  });
+
+  describe("fromFilePath", () => {
+    it("should create instance from file path through concrete implementation", () => {
+      const rulesyncFile = TestRulesyncFile.fromFilePath({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "frompath.md",
+        filePath: "/some/path/frompath.md",
+      });
+
+      expect(rulesyncFile).toBeInstanceOf(TestRulesyncFile);
+      expect(rulesyncFile.getRelativeDirPath()).toBe(".rulesync");
+      expect(rulesyncFile.getRelativeFilePath()).toBe("frompath.md");
+      expect(rulesyncFile.getFileContent()).toBe("test content from file path");
+      expect(rulesyncFile.getBody()).toBe("test body from file path");
+    });
+
+    it("should throw error for abstract base class fromFilePath", () => {
+      expect(() => {
+        RulesyncFile.fromFilePath({
+          relativeDirPath: ".rulesync",
+          relativeFilePath: "test.md",
+          filePath: "/some/path/test.md",
+        });
+      }).toThrow("Please implement this method in the subclass.");
+    });
+
+    it("should handle optional parameters with defaults", () => {
+      const rulesyncFile = TestRulesyncFile.fromFilePath({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "defaults.md",
+        filePath: "/some/path/defaults.md",
+      });
+
+      expect(rulesyncFile).toBeInstanceOf(TestRulesyncFile);
+    });
+  });
+
+  describe("inheritance from AiFile", () => {
+    it("should properly extend AiFile", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Inheritance body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subdir",
+        relativeFilePath: "inheritance.md",
+        fileContent: "Inheritance file content",
+      });
+
+      // Test inherited methods from AiFile
+      expect(rulesyncFile.getRelativeDirPath()).toBe(".rulesync/subdir");
+      expect(rulesyncFile.getRelativeFilePath()).toBe("inheritance.md");
+      expect(rulesyncFile.getFileContent()).toBe("Inheritance file content");
+      expect(rulesyncFile.getFilePath()).toContain("inheritance.md");
+    });
+
+    it("should inherit validation behavior from AiFile (manual validation)", () => {
+      // Test that validation can be performed manually
+      const rulesyncFile = new TestRulesyncFile({
+        body: "content with invalid text", // This should trigger validation error
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "validation.md",
+        fileContent: "Validation content",
+        validate: false,
+      });
+
+      const result = rulesyncFile.validate();
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toBe("Body contains invalid text");
+    });
+
+    it("should support skipping validation from AiFile", () => {
+      expect(() => {
+        const _rulesyncFile = new TestRulesyncFile({
+          body: "invalid body",
+          baseDir: testDir,
+          relativeDirPath: ".rulesync",
+          relativeFilePath: "skipvalidation.md",
+          fileContent: "Skip validation content",
+          validate: false,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("validation", () => {
+    it("should return success for valid body", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "valid body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "valid.md",
+        fileContent: "Valid file content",
+        validate: false,
+      });
+
+      const result = rulesyncFile.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should return error for invalid body", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "invalid body content",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "invalid.md",
+        fileContent: "Invalid file content",
+        validate: false,
+      });
+
+      const result = rulesyncFile.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error?.message).toBe("Body contains invalid text");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty file content with non-empty body", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Non-empty body",
+        baseDir: testDir,
+        relativeDirPath: "",
+        relativeFilePath: "edge.md",
+        fileContent: "",
+      });
+
+      expect(rulesyncFile.getBody()).toBe("Non-empty body");
+      expect(rulesyncFile.getFileContent()).toBe("");
+    });
+
+    it("should handle special characters in paths", () => {
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Special path body",
+        baseDir: testDir,
+        relativeDirPath: "path with spaces/special-chars_123",
+        relativeFilePath: "file-name_with-specials.md",
+        fileContent: "Special path content",
+      });
+
+      expect(rulesyncFile.getRelativeDirPath()).toBe("path with spaces/special-chars_123");
+      expect(rulesyncFile.getRelativeFilePath()).toBe("file-name_with-specials.md");
+      expect(rulesyncFile.getBody()).toBe("Special path body");
+    });
+
+    it("should handle multiline body content", () => {
+      const multilineBody = `Line 1
+Line 2
+Line 3
+
+Line 5 with empty line above`;
+
+      const rulesyncFile = new TestRulesyncFile({
+        body: multilineBody,
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "multiline.md",
+        fileContent: "Multiline file content",
+      });
+
+      expect(rulesyncFile.getBody()).toBe(multilineBody);
+    });
+  });
+
+  describe("abstract method contracts", () => {
+    it("should enforce getFrontmatter implementation", () => {
+      // This test verifies that the abstract method contract exists
+      const rulesyncFile = new TestRulesyncFile({
+        body: "Contract body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "contract.md",
+        fileContent: "Contract content",
+      });
+
+      // Should have the method implemented
+      expect(typeof rulesyncFile.getFrontmatter).toBe("function");
+
+      // Should return an object
+      const result = rulesyncFile.getFrontmatter();
+      expect(typeof result).toBe("object");
+      expect(result).not.toBeNull();
+    });
+
+    it("should enforce fromFilePath static method implementation", () => {
+      // Verify the static method exists and works
+      expect(typeof TestRulesyncFile.fromFilePath).toBe("function");
+
+      const result = TestRulesyncFile.fromFilePath({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "static.md",
+        filePath: "/some/path/static.md",
+      });
+
+      expect(result).toBeInstanceOf(TestRulesyncFile);
+    });
+  });
+
+  describe("type definitions", () => {
+    it("should have correct RulesyncFileParams type", () => {
+      // This should compile and work correctly
+      const params: RulesyncFileParams = {
+        body: "Type test body",
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "typetest.md",
+        fileContent: "Type test content",
+        validate: true,
+      };
+
+      const result = new TestRulesyncFile(params);
+      expect(result).toBeInstanceOf(TestRulesyncFile);
+      expect(result.getBody()).toBe("Type test body");
+    });
+
+    it("should extend AiFileParams correctly", () => {
+      // RulesyncFileParams should include all AiFileParams properties plus body
+      const rulesyncFile = new TestRulesyncFile({
+        // AiFileParams properties
+        baseDir: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "extend.md",
+        fileContent: "Extension test content",
+        validate: false,
+        // RulesyncFileParams additional property
+        body: "Extension test body",
+      });
+
+      expect(rulesyncFile).toBeInstanceOf(TestRulesyncFile);
+    });
+  });
+});

--- a/src/types/rulesync-file.test.ts
+++ b/src/types/rulesync-file.test.ts
@@ -227,14 +227,14 @@ describe("RulesyncFile", () => {
       expect(rulesyncFile.getBody()).toBe("test body from file path");
     });
 
-    it("should throw error for abstract base class fromFilePath", () => {
-      expect(() => {
+    it("should throw error for abstract base class fromFilePath", async () => {
+      await expect(
         RulesyncFile.fromFilePath({
           relativeDirPath: ".rulesync",
           relativeFilePath: "test.md",
           filePath: "/some/path/test.md",
-        });
-      }).toThrow("Please implement this method in the subclass.");
+        }),
+      ).rejects.toThrow("Please implement this method in the subclass.");
     });
 
     it("should handle optional parameters with defaults", async () => {

--- a/src/types/rulesync-file.test.ts
+++ b/src/types/rulesync-file.test.ts
@@ -5,7 +5,7 @@ import { RulesyncFile, RulesyncFileParams } from "./rulesync-file.js";
 
 // Concrete implementation for testing the abstract RulesyncFile class
 class TestRulesyncFile extends RulesyncFile {
-  static fromFilePath(params: AiFileFromFilePathParams): TestRulesyncFile {
+  static async fromFilePath(params: AiFileFromFilePathParams): Promise<TestRulesyncFile> {
     return new TestRulesyncFile({
       baseDir: params.baseDir || ".",
       relativeDirPath: params.relativeDirPath,
@@ -212,8 +212,8 @@ describe("RulesyncFile", () => {
   });
 
   describe("fromFilePath", () => {
-    it("should create instance from file path through concrete implementation", () => {
-      const rulesyncFile = TestRulesyncFile.fromFilePath({
+    it("should create instance from file path through concrete implementation", async () => {
+      const rulesyncFile = await TestRulesyncFile.fromFilePath({
         baseDir: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "frompath.md",
@@ -237,8 +237,8 @@ describe("RulesyncFile", () => {
       }).toThrow("Please implement this method in the subclass.");
     });
 
-    it("should handle optional parameters with defaults", () => {
-      const rulesyncFile = TestRulesyncFile.fromFilePath({
+    it("should handle optional parameters with defaults", async () => {
+      const rulesyncFile = await TestRulesyncFile.fromFilePath({
         relativeDirPath: ".rulesync",
         relativeFilePath: "defaults.md",
         filePath: "/some/path/defaults.md",
@@ -395,11 +395,11 @@ Line 5 with empty line above`;
       expect(result).not.toBeNull();
     });
 
-    it("should enforce fromFilePath static method implementation", () => {
+    it("should enforce fromFilePath static method implementation", async () => {
       // Verify the static method exists and works
       expect(typeof TestRulesyncFile.fromFilePath).toBe("function");
 
-      const result = TestRulesyncFile.fromFilePath({
+      const result = await TestRulesyncFile.fromFilePath({
         baseDir: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "static.md",

--- a/src/types/rulesync-file.ts
+++ b/src/types/rulesync-file.ts
@@ -1,0 +1,26 @@
+import { AiFile, AiFileFromFilePathParams, AiFileParams } from "./ai-file.js";
+
+export interface RulesyncFileParams extends AiFileParams {
+  body: string;
+}
+
+export abstract class RulesyncFile extends AiFile {
+  protected readonly body: string;
+
+  constructor({ body, ...rest }: RulesyncFileParams) {
+    super({
+      ...rest,
+    });
+    this.body = body;
+  }
+
+  static fromFilePath(_params: AiFileFromFilePathParams): RulesyncFile {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  abstract getFrontmatter(): Record<string, unknown>;
+
+  getBody(): string {
+    return this.body;
+  }
+}

--- a/src/types/rulesync-file.ts
+++ b/src/types/rulesync-file.ts
@@ -14,7 +14,7 @@ export abstract class RulesyncFile extends AiFile {
     this.body = body;
   }
 
-  static fromFilePath(_params: AiFileFromFilePathParams): RulesyncFile {
+  static async fromFilePath(_params: AiFileFromFilePathParams): Promise<RulesyncFile> {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Implement new SubagentsProcessor architecture to replace existing subagent generation logic
- Add comprehensive type system with RulesyncSubagent and ClaudecodeSubagent classes
- Establish foundation for improved codebase maintainability and contributor onboarding

## Changes Made

### New Architecture Implementation
- **SubagentsProcessor**: New processor class with separate loading and writing operations
- **RulesyncSubagent**: Universal subagent class for .rulesync/subagents source files
- **ClaudecodeSubagent**: Tool-specific subagent class for Claude Code target
- **ToolSubagent**: Base class providing common subagent functionality

### Core Improvements
- Replace direct subagent generation calls with SubagentsProcessor in generate command
- Add comprehensive validation using zod/mini schemas
- Implement bidirectional conversion between Rulesync and tool-specific formats
- Add robust file path handling with proper directory structure management

### Documentation & Guidelines
- Add NEW_DESIGN.md outlining refactoring strategy and goals
- Add coding standards and guidelines in .rulesync/rules/
- Update cspell.json with new terminology and test-related terms

### Testing
- Complete test coverage for all new subagent classes
- Edge case handling and validation testing
- File system operation testing with proper cleanup

### Bug Fixes
- Fix path resolution for rulesync subagents directory
- Correct frontmatter generation for Claude Code subagents
- Update async method signatures and error handling

## Breaking Changes
None - new architecture coexists with existing code during transition period.

## Migration Strategy
This PR establishes the foundation for the new architecture while maintaining backward compatibility. The existing generators and parsers remain functional during the transition phase.

## Testing
- All existing tests pass
- New comprehensive test suite for subagent architecture
- File system operations tested with proper isolation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>