### PR TITLE
fix: reduce Node.js max-old-space-size to 4096 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
   ],
   "remoteEnv": {
-    "NODE_OPTIONS": "--max-old-space-size=6144",
+    "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
     "OPENAI_API_KEY": "${localEnv:DEVCONTAINER_OPENAI_API_KEY}",


### PR DESCRIPTION
## Summary
- Reduced NODE_OPTIONS max-old-space-size from 6144 to 4096 in devcontainer configuration
- Optimizes memory usage for development environment

## Test plan
- [ ] Devcontainer builds successfully
- [ ] Node.js processes run without memory issues
- [ ] Development workflow remains functional

🤖 Generated with [Claude Code](https://claude.ai/code)