### PR TITLE
fix: add 'toolname' to cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -249,6 +249,7 @@
         "reinclusion",
         "Mcps",
         "junieignore",
-        "geminiignore"
+        "geminiignore",
+        "toolname"
     ]
 }


### PR DESCRIPTION
## Summary
- Add 'toolname' to cspell dictionary to resolve spell checking errors

## Changes
- Updated `cspell.json` to include 'toolname' in the custom words list

## Test plan
- [x] Verified spell check passes with the new word added
- [x] No other changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)