### PR TITLE
Release v0.68.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "0.67.0",
+	"version": "0.68.0",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,7 +33,7 @@ const getVersion = async (): Promise<string> => {
     return packageJson.version;
   } catch {
     // Fallback to a hardcoded version if reading fails
-    return "0.67.0";
+    return "0.68.0";
   }
 };
 


### PR DESCRIPTION
## Summary
- Update fallback version to 0.68.0
- Bump package.json version to 0.68.0

This PR prepares for the v0.68.0 release.

## Test plan
- Version updates are correctly reflected
- Package.json version matches expected version

🤖 Generated with [Claude Code](https://claude.ai/code)