### PR TITLE
fix: update testing guidelines to use ensureDir instead of mkdir

### DIFF
--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -28,7 +28,7 @@ globs: ["**/*.test.ts"]
       it("Test Case", async () => {
         // Run test using testDir
         const subDir = join(testDir, "subdir");
-        await mkdir(subDir, { recursive: true });
+        await ensureDir(subDir);
         // ...
       });
     });


### PR DESCRIPTION
## Summary
- Updated testing guidelines to use `ensureDir` instead of `mkdir` for better directory creation handling in tests
- This change provides more robust directory creation that handles existing directories gracefully

## Changes
- Modified `.rulesync/rules/testing-guidelines.md` to replace `mkdir(subDir, { recursive: true })` with `ensureDir(subDir)`
- The `ensureDir` function is more semantic and handles edge cases better than raw `mkdir` calls

## Test plan
- [ ] Verify the testing guidelines documentation is accurate
- [ ] Ensure the updated example code follows project coding standards
- [ ] Confirm that `ensureDir` is available in the project dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)