### PR TITLE
feat: add SimulatedSubagent base class and validation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Example:
 
   // Experimental features
   "experimentalSimulateCommands": false,
-  "experimentalSimutateSubagents": false
+  "experimentalSimulateSubagents": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ rulesync supports both **generation** and **import** for All of the major AI cod
 |------------------------|:-----:|:------:|:-----:|:--------:|:---------:|
 | AGENTS.md            |  ✅   |      |       |          |           |
 | Claude Code            |  ✅   |      |  ✅    |    ✅     |    ✅      |
-| Codex CLI              |  ✅   |   ✅   |      |         |          |
+| Codex CLI              |  ✅   |   ✅   |      |    🎮     |    🎮      |
 | Gemini CLI             |  ✅   |   ✅   |      |     ✅   |          |
-| GitHub Copilot         |  ✅    |       |  ✅    |          |          |
-| Cursor                 |  ✅   |   ✅  |   ✅   |          |          |
+| GitHub Copilot         |  ✅    |       |  ✅    |    🎮      |    🎮      |
+| Cursor                 |  ✅   |   ✅  |   ✅   |     🎮    |     🎮     |
 | OpenCode               |  ✅   |       |       |         |          |
 | Cline                  |  ✅    |   ✅    |  ✅    |          |          |
 | Roo Code               |  ✅   |   ✅   |  ✅    |   ✅     |          |
@@ -73,6 +73,9 @@ rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        |  ✅   |   ✅   |      |         |          |
 | AugmentCode            |  ✅   |   ✅   |       |         |          |
 | Windsurf               |  ✅   |   ✅    |      |         |          |
+
+
+🎮: Simulated Commands/Subagents (Experimental Feature)
 
 ## Why rulesync?
 
@@ -110,6 +113,9 @@ npx rulesync generate --targets claudecode --features rules,subagents
 # Generate only rules (no MCP, ignore files, commands, or subagents)
 npx rulesync generate --targets "*" --features rules
 
+# Generate simulated commands and subagents with experimental features
+npx rulesync generate --targets copilot,cursor,codexcli --features commands,subagents --experimental-simulate-commands --experimental-simulate-subagents
+
 # Add generated files to .gitignore
 npx rulesync gitignore
 ```
@@ -136,7 +142,11 @@ Example:
   "delete": true,
 
   // Verbose output
-  "verbose": false
+  "verbose": false,
+
+  // Experimental features
+  "experimentalSimulateCommands": false,
+  "experimentalSimutateSubagents": false
 }
 ```
 

--- a/cspell.json
+++ b/cspell.json
@@ -45,6 +45,7 @@
         "ccinstall",
         "ccusage",
         "chokidar",
+        "cicheck",
         "claudecode",
         "clineignore",
         "clinerules",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"test:coverage": "vitest run --coverage --silent=true",
 		"test:watch": "vitest --silent=true",
 		"typecheck": "tsgo --noEmit",
-		"prepare": "simple-git-hooks && pnpm generate"
+		"prepare": "simple-git-hooks && pnpm generate",
+		"cicheck": "pnpm run check && pnpm run test && pnpm run cspell && pnpm run secretlint"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec lint-staged"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"bcheck:fix": "biome check --write .",
 		"build": "tsup src/cli/index.ts --format cjs,esm --dts --clean",
 		"check": "pnpm run bcheck && pnpm run oxlint && pnpm run eslint && pnpm run typecheck",
+		"cicheck": "pnpm run check && pnpm run test && pnpm run cspell && pnpm run secretlint",
 		"cspell": "cspell \"**/*\"",
 		"dev": "tsx src/cli/index.ts",
 		"eslint": "eslint . --max-warnings 0 --cache",
@@ -46,16 +47,15 @@
 		"knip": "knip",
 		"oxlint": "oxlint . --max-warnings 0",
 		"oxlint:fix": "oxlint . --fix --max-warnings 0",
+		"prepare": "simple-git-hooks && pnpm generate",
 		"prepublishOnly": "pnpm build",
 		"secretlint": "secretlint --secretlintignore .gitignore \"**/*\"",
 		"sort": "sort-package-json",
+		"task": "tsx scripts/run-tasks.ts",
 		"test": "vitest run --silent=true",
 		"test:coverage": "vitest run --coverage --silent=true",
 		"test:watch": "vitest --silent=true",
-		"typecheck": "tsgo --noEmit",
-		"prepare": "simple-git-hooks && pnpm generate",
-		"cicheck": "pnpm run check && pnpm run test && pnpm run cspell && pnpm run secretlint",
-		"task": "tsx scripts/run-tasks.ts"
+		"typecheck": "tsgo --noEmit"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec lint-staged"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"test:watch": "vitest --silent=true",
 		"typecheck": "tsgo --noEmit",
 		"prepare": "simple-git-hooks && pnpm generate",
-		"cicheck": "pnpm run check && pnpm run test && pnpm run cspell && pnpm run secretlint"
+		"cicheck": "pnpm run check && pnpm run test && pnpm run cspell && pnpm run secretlint",
+		"task": "tsx scripts/run-tasks.ts"
 	},
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec lint-staged"

--- a/scripts/run-tasks.ts
+++ b/scripts/run-tasks.ts
@@ -3,7 +3,7 @@
 import { query } from "@anthropic-ai/claude-code";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { tasks } from "../tmp/tasks/tasks.ts";
+import { model, tasks } from "../tmp/tasks/tasks.ts";
 
 const runClaudeCode = async (task: string) => {
   console.log("task", task);
@@ -12,6 +12,7 @@ const runClaudeCode = async (task: string) => {
     options: {
       abortController: new AbortController(),
       permissionMode: "bypassPermissions",
+      model: model ?? "sonnet",
     },
   })) {
     if (message.type === "assistant") {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -33,7 +33,7 @@ async function initConfig(): Promise<void> {
         delete: true,
         verbose: false,
         experimentalSimulateCommands: false,
-        experimentalSimutateSubagents: false,
+        experimentalSimulateSubagents: false,
       } satisfies ConfigParams,
       null,
       2,

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -32,6 +32,8 @@ async function initConfig(): Promise<void> {
         baseDirs: ["."],
         delete: true,
         verbose: false,
+        experimentalSimulateCommands: false,
+        experimentalSimutateSubagents: false,
       } satisfies ConfigParams,
       null,
       2,

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandsProcessor } from "../../commands/commands-processor.js";
+import { ConfigResolver } from "../../config/config-resolver.js";
+import { IgnoreProcessor } from "../../ignore/ignore-processor.js";
+import { McpProcessor } from "../../mcp/mcp-processor.js";
+import { RulesProcessor } from "../../rules/rules-processor.js";
+import { SubagentsProcessor } from "../../subagents/subagents-processor.js";
+import { logger } from "../../utils/logger.js";
+import type { ImportOptions } from "./import.js";
+import { importCommand } from "./import.js";
+
+// Mock all dependencies
+vi.mock("../../config/config-resolver.js");
+vi.mock("../../rules/rules-processor.js");
+vi.mock("../../ignore/ignore-processor.js");
+vi.mock("../../mcp/mcp-processor.js");
+vi.mock("../../subagents/subagents-processor.js");
+vi.mock("../../commands/commands-processor.js");
+vi.mock("../../utils/logger.js");
+
+describe("importCommand", () => {
+  let mockExit: any;
+  let mockConfig: any;
+
+  beforeEach(() => {
+    // Mock process.exit
+    mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("Process exit");
+    }) as any);
+
+    // Setup default mock config
+    mockConfig = {
+      getVerbose: vi.fn().mockReturnValue(false),
+      getTargets: vi.fn().mockReturnValue(["claudecode"]),
+      getFeatures: vi.fn().mockReturnValue(["rules", "ignore", "mcp", "subagents", "commands"]),
+    };
+
+    vi.mocked(ConfigResolver.resolve).mockResolvedValue(mockConfig);
+    vi.mocked(logger.setVerbose).mockImplementation(() => {});
+    vi.mocked(logger.error).mockImplementation(() => {});
+    vi.mocked(logger.success).mockImplementation(() => {});
+
+    // Setup processor mocks with default return values
+    vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "roo", "geminicli"]);
+    vi.mocked(IgnoreProcessor.getToolTargets).mockReturnValue(["claudecode", "roo", "geminicli"]);
+    vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+    vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+    vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode", "roo"]);
+
+    // Mock processor instances
+    const mockProcessorMethods = {
+      loadToolFiles: vi.fn().mockResolvedValue([]),
+      convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
+      writeAiFiles: vi.fn().mockResolvedValue(0),
+    };
+
+    vi.mocked(RulesProcessor).mockImplementation(() => mockProcessorMethods as any);
+    vi.mocked(IgnoreProcessor).mockImplementation(() => mockProcessorMethods as any);
+    vi.mocked(McpProcessor).mockImplementation(() => mockProcessorMethods as any);
+    vi.mocked(SubagentsProcessor).mockImplementation(() => mockProcessorMethods as any);
+    vi.mocked(CommandsProcessor).mockImplementation(() => mockProcessorMethods as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validation", () => {
+    it("should exit with error when no targets provided", async () => {
+      const options: ImportOptions = {};
+
+      await expect(importCommand(options)).rejects.toThrow("Process exit");
+      expect(logger.error).toHaveBeenCalledWith("No tools found in --targets");
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error when multiple targets provided", async () => {
+      const options: ImportOptions = {
+        targets: ["claudecode", "roo"],
+      };
+
+      await expect(importCommand(options)).rejects.toThrow("Process exit");
+      expect(logger.error).toHaveBeenCalledWith("Only one tool can be imported at a time");
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error when trying to import simulated-only tool copilot", async () => {
+      mockConfig.getTargets.mockReturnValue(["copilot"]);
+      const options: ImportOptions = {
+        targets: ["copilot"],
+      };
+
+      await expect(importCommand(options)).rejects.toThrow("Process exit");
+      expect(logger.error).toHaveBeenCalledWith(
+        "Cannot import copilot: it only supports generation (simulated commands/subagents)",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error when trying to import simulated-only tool cursor", async () => {
+      mockConfig.getTargets.mockReturnValue(["cursor"]);
+      const options: ImportOptions = {
+        targets: ["cursor"],
+      };
+
+      await expect(importCommand(options)).rejects.toThrow("Process exit");
+      expect(logger.error).toHaveBeenCalledWith(
+        "Cannot import cursor: it only supports generation (simulated commands/subagents)",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error when trying to import simulated-only tool codexcli", async () => {
+      mockConfig.getTargets.mockReturnValue(["codexcli"]);
+      const options: ImportOptions = {
+        targets: ["codexcli"],
+      };
+
+      await expect(importCommand(options)).rejects.toThrow("Process exit");
+      expect(logger.error).toHaveBeenCalledWith(
+        "Cannot import codexcli: it only supports generation (simulated commands/subagents)",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("successful import", () => {
+    it("should import rules when feature is enabled and tool is supported", async () => {
+      const mockRulesProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "rule1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ rule: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(RulesProcessor).mockImplementation(() => mockRulesProcessor as any);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      expect(RulesProcessor).toHaveBeenCalledWith({
+        baseDir: ".",
+        toolTarget: "claudecode",
+      });
+      expect(mockRulesProcessor.loadToolFiles).toHaveBeenCalled();
+      expect(mockRulesProcessor.convertToolFilesToRulesyncFiles).toHaveBeenCalled();
+      expect(mockRulesProcessor.writeAiFiles).toHaveBeenCalled();
+    });
+
+    it("should import ignore files when feature is enabled and tool is supported", async () => {
+      const mockIgnoreProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "ignore1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ ignore: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(IgnoreProcessor).mockImplementation(() => mockIgnoreProcessor as any);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      expect(IgnoreProcessor).toHaveBeenCalledWith({
+        baseDir: ".",
+        toolTarget: "claudecode",
+      });
+      expect(mockIgnoreProcessor.loadToolFiles).toHaveBeenCalled();
+      expect(mockIgnoreProcessor.convertToolFilesToRulesyncFiles).toHaveBeenCalled();
+      expect(mockIgnoreProcessor.writeAiFiles).toHaveBeenCalled();
+    });
+
+    it("should import MCP files when feature is enabled and tool is supported", async () => {
+      const mockMcpProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "mcp1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ mcp: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(McpProcessor).mockImplementation(() => mockMcpProcessor as any);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      expect(McpProcessor).toHaveBeenCalledWith({
+        baseDir: ".",
+        toolTarget: "claudecode",
+      });
+      expect(mockMcpProcessor.loadToolFiles).toHaveBeenCalled();
+      expect(mockMcpProcessor.convertToolFilesToRulesyncFiles).toHaveBeenCalled();
+      expect(mockMcpProcessor.writeAiFiles).toHaveBeenCalled();
+    });
+
+    it("should import subagents with excludeSimulated flag", async () => {
+      const mockSubagentsProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "subagent1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ subagent: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(SubagentsProcessor).mockImplementation(() => mockSubagentsProcessor as any);
+      vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      // Verify that getToolTargets was called with excludeSimulated: true
+      expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith({ excludeSimulated: true });
+      expect(SubagentsProcessor).toHaveBeenCalledWith({
+        baseDir: ".",
+        toolTarget: "claudecode",
+      });
+      expect(mockSubagentsProcessor.loadToolFiles).toHaveBeenCalled();
+      expect(mockSubagentsProcessor.convertToolFilesToRulesyncFiles).toHaveBeenCalled();
+      expect(mockSubagentsProcessor.writeAiFiles).toHaveBeenCalled();
+    });
+
+    it("should import commands with excludeSimulated flag", async () => {
+      const mockCommandsProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "command1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ command: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(CommandsProcessor).mockImplementation(() => mockCommandsProcessor as any);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      // Verify that getToolTargets was called with excludeSimulated: true
+      expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({ excludeSimulated: true });
+      expect(CommandsProcessor).toHaveBeenCalledWith({
+        baseDir: ".",
+        toolTarget: "claudecode",
+      });
+      expect(mockCommandsProcessor.loadToolFiles).toHaveBeenCalled();
+      expect(mockCommandsProcessor.convertToolFilesToRulesyncFiles).toHaveBeenCalled();
+      expect(mockCommandsProcessor.writeAiFiles).toHaveBeenCalled();
+    });
+
+    it("should not create processors for unsupported tools", async () => {
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue([]);
+      vi.mocked(IgnoreProcessor.getToolTargets).mockReturnValue([]);
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue([]);
+      vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue([]);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue([]);
+
+      const options: ImportOptions = {
+        targets: ["roo" as any],
+      };
+
+      mockConfig.getTargets.mockReturnValue(["roo"]);
+
+      await importCommand(options);
+
+      expect(RulesProcessor).not.toHaveBeenCalled();
+      expect(IgnoreProcessor).not.toHaveBeenCalled();
+      expect(McpProcessor).not.toHaveBeenCalled();
+      expect(SubagentsProcessor).not.toHaveBeenCalled();
+      expect(CommandsProcessor).not.toHaveBeenCalled();
+    });
+
+    it("should skip processors when feature is disabled", async () => {
+      mockConfig.getFeatures.mockReturnValue([]);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      expect(RulesProcessor).not.toHaveBeenCalled();
+      expect(IgnoreProcessor).not.toHaveBeenCalled();
+      expect(McpProcessor).not.toHaveBeenCalled();
+      expect(SubagentsProcessor).not.toHaveBeenCalled();
+      expect(CommandsProcessor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("verbose logging", () => {
+    beforeEach(() => {
+      mockConfig.getVerbose.mockReturnValue(true);
+    });
+
+    it("should log success messages in verbose mode", async () => {
+      const mockRulesProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "rule1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ rule: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(2),
+      };
+      vi.mocked(RulesProcessor).mockImplementation(() => mockRulesProcessor as any);
+
+      const mockIgnoreProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "ignore1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ ignore: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(IgnoreProcessor).mockImplementation(() => mockIgnoreProcessor as any);
+
+      const mockMcpProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "mcp1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ mcp: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(3),
+      };
+      vi.mocked(McpProcessor).mockImplementation(() => mockMcpProcessor as any);
+
+      const mockSubagentsProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "subagent1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ subagent: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(4),
+      };
+      vi.mocked(SubagentsProcessor).mockImplementation(() => mockSubagentsProcessor as any);
+
+      const mockCommandsProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([{ file: "command1" }]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ command: "converted" }]),
+        writeAiFiles: vi.fn().mockResolvedValue(5),
+      };
+      vi.mocked(CommandsProcessor).mockImplementation(() => mockCommandsProcessor as any);
+
+      vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      expect(logger.setVerbose).toHaveBeenCalledWith(true);
+      expect(logger.success).toHaveBeenCalledWith("Created 2 rule files");
+      expect(logger.success).toHaveBeenCalledWith(
+        "Created ignore files from 1 tool ignore configurations",
+      );
+      expect(logger.success).toHaveBeenCalledWith("Created 1 ignore files");
+      expect(logger.success).toHaveBeenCalledWith("Created 3 MCP files");
+      expect(logger.success).toHaveBeenCalledWith("Created 4 subagent files");
+      expect(logger.success).toHaveBeenCalledWith("Created 5 command files");
+    });
+
+    it("should not log success messages when no files are created", async () => {
+      const mockProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([]),
+        convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
+        writeAiFiles: vi.fn().mockResolvedValue(0),
+      };
+
+      vi.mocked(RulesProcessor).mockImplementation(() => mockProcessor as any);
+      vi.mocked(IgnoreProcessor).mockImplementation(() => mockProcessor as any);
+      vi.mocked(McpProcessor).mockImplementation(() => mockProcessor as any);
+      vi.mocked(SubagentsProcessor).mockImplementation(() => mockProcessor as any);
+      vi.mocked(CommandsProcessor).mockImplementation(() => mockProcessor as any);
+
+      vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      const options: ImportOptions = {
+        targets: ["claudecode"],
+      };
+
+      await importCommand(options);
+
+      // Only the setVerbose call should have been made, no success messages
+      expect(logger.setVerbose).toHaveBeenCalledWith(true);
+      expect(logger.success).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -125,7 +125,7 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   let commandsCreated = 0;
   if (config.getFeatures().includes("commands")) {
     // Use CommandsProcessor for supported tools
-    const supportedTargets = CommandsProcessor.getToolTargets();
+    const supportedTargets = CommandsProcessor.getToolTargets({ excludeSimulated: true });
     if (supportedTargets && supportedTargets.includes && supportedTargets.includes(tool)) {
       const commandsProcessor = new CommandsProcessor({
         baseDir: ".",

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -27,6 +27,15 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const tool = config.getTargets()[0]!;
 
+  // Check if tool is simulated-only and prevent import
+  const simulatedOnlyTools = ["copilot", "cursor", "codexcli"];
+  if (simulatedOnlyTools.includes(tool)) {
+    logger.error(
+      `Cannot import ${tool}: it only supports generation (simulated commands/subagents)`,
+    );
+    process.exit(1);
+  }
+
   // Import rule files using RulesProcessor if rules feature is enabled
   let rulesCreated = 0;
   if (config.getFeatures().includes("rules")) {
@@ -101,8 +110,9 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   // Create subagent files if subagents feature is enabled
   let subagentsCreated = 0;
   if (config.getFeatures().includes("subagents")) {
-    // Use SubagentsProcessor for supported tools
-    if (SubagentsProcessor.getToolTargets().includes(tool)) {
+    // Use SubagentsProcessor for supported tools, excluding simulated ones
+    const supportedTargets = SubagentsProcessor.getToolTargets({ excludeSimulated: true });
+    if (supportedTargets.includes(tool)) {
       const subagentsProcessor = new SubagentsProcessor({
         baseDir: ".",
         toolTarget: tool,
@@ -124,9 +134,9 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   // Create command files using CommandsProcessor if commands feature is enabled
   let commandsCreated = 0;
   if (config.getFeatures().includes("commands")) {
-    // Use CommandsProcessor for supported tools
+    // Use CommandsProcessor for supported tools, excluding simulated ones
     const supportedTargets = CommandsProcessor.getToolTargets({ excludeSimulated: true });
-    if (supportedTargets && supportedTargets.includes && supportedTargets.includes(tool)) {
+    if (supportedTargets.includes(tool)) {
       const commandsProcessor = new CommandsProcessor({
         baseDir: ".",
         toolTarget: tool,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -80,7 +80,7 @@ const main = async () => {
         return value.split(",").map((f) => f.trim());
       },
     )
-    .option("--verbose", "Verbose output")
+    .option("-V, --verbose", "Verbose output")
     .action(async (options) => {
       try {
         await importCommand({
@@ -118,8 +118,16 @@ const main = async () => {
       "-b, --base-dir <paths>",
       "Base directories to generate files (comma-separated for multiple paths)",
     )
-    .option("-v, --verbose", "Verbose output")
+    .option("-V, --verbose", "Verbose output")
     .option("-c, --config <path>", "Path to configuration file")
+    .option(
+      "--experimental-simulate-commands",
+      "Generate simulated commands (experimental feature). This feature is only available for copilot, cursor and codexcli.",
+    )
+    .option(
+      "--experimental-simulate-subagents",
+      "Generate simulated subagents (experimental feature). This feature is only available for copilot, cursor and codexcli.",
+    )
     .action(async (options) => {
       try {
         await generateCommand({
@@ -129,6 +137,8 @@ const main = async () => {
           delete: options.delete,
           baseDirs: options.baseDirs,
           configPath: options.config,
+          experimentalSimulateCommands: options.experimentalSimulateCommands,
+          experimentalSimutateSubagents: options.experimentalSimutateSubagents,
         });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,7 +138,7 @@ const main = async () => {
           baseDirs: options.baseDirs,
           configPath: options.config,
           experimentalSimulateCommands: options.experimentalSimulateCommands,
-          experimentalSimutateSubagents: options.experimentalSimutateSubagents,
+          experimentalSimulateSubagents: options.experimentalSimulateSubagents,
         });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));

--- a/src/commands/codexcli-command.test.ts
+++ b/src/commands/codexcli-command.test.ts
@@ -1,0 +1,529 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CodexCliCommand } from "./codexcli-command.js";
+import { RulesyncCommand } from "./rulesync-command.js";
+import {
+  SimulatedCommandFrontmatter,
+  SimulatedCommandFrontmatterSchema,
+} from "./simulated-command.js";
+
+describe("CodexCliCommand", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+description: Test codexcli command description
+---
+
+This is the body of the codexcli command.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required description field
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for codexcli commands", () => {
+      const paths = CodexCliCommand.getSettablePaths();
+      expect(paths).toEqual({
+        relativeDirPath: ".codex/commands",
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test codexcli command description",
+        },
+        body: "This is the body of the codexcli command.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CodexCliCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the codexcli command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test codexcli command description",
+      });
+    });
+
+    it("should create instance with empty description", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "",
+        },
+        body: "This is a codexcli command without description.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is a codexcli command without description.");
+      expect(command.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(command).toBeInstanceOf(CodexCliCommand);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CodexCliCommand({
+            baseDir: testDir,
+            relativeDirPath: ".codex/commands",
+            relativeFilePath: "invalid-command.md",
+            frontmatter: {
+              // Missing required description field
+            } as SimulatedCommandFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with description", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test codexcli command",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = command.getFrontmatter();
+      expect(frontmatter).toEqual({
+        description: "Test codexcli command",
+      });
+    });
+  });
+
+  describe("toRulesyncCommand", () => {
+    it("should throw error as it is a simulated file", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => command.toRulesyncCommand()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncCommand", () => {
+    it("should create CodexCliCommand from RulesyncCommand", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          description: "Test description from rulesync",
+        },
+        body: "Test command content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const codexcliCommand = CodexCliCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(codexcliCommand).toBeInstanceOf(CodexCliCommand);
+      expect(codexcliCommand.getBody()).toBe("Test command content");
+      expect(codexcliCommand.getFrontmatter()).toEqual({
+        description: "Test description from rulesync",
+      });
+      expect(codexcliCommand.getRelativeFilePath()).toBe("test-command.md");
+      expect(codexcliCommand.getRelativeDirPath()).toBe(".codex/commands");
+    });
+
+    it("should handle RulesyncCommand with different file extensions", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "complex-command.txt",
+        frontmatter: {
+          targets: ["codexcli"],
+          description: "Complex command",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const codexcliCommand = CodexCliCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(codexcliCommand.getRelativeFilePath()).toBe("complex-command.txt");
+    });
+
+    it("should handle empty description", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const codexcliCommand = CodexCliCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(codexcliCommand.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CodexCliCommand from file", async () => {
+      const commandsDir = join(testDir, ".codex", "commands");
+      const filePath = join(commandsDir, "test-file-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CodexCliCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-command.md",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CodexCliCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the codexcli command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test codexcli command description",
+      });
+      expect(command.getRelativeFilePath()).toBe("test-file-command.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const commandsDir = join(testDir, ".codex", "commands", "subdir");
+      const filePath = join(commandsDir, "nested-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CodexCliCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-command.md",
+        validate: true,
+      });
+
+      expect(command.getRelativeFilePath()).toBe("nested-command.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CodexCliCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const commandsDir = join(testDir, ".codex", "commands");
+      const filePath = join(commandsDir, "invalid-command.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CodexCliCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const commandsDir = join(testDir, ".codex", "commands");
+      const filePath = join(commandsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CodexCliCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "valid-command.md",
+        frontmatter: {
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = command.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "command-with-extras.md",
+        frontmatter: {
+          description: "Command with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = command.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedCommandFrontmatterSchema", () => {
+    it("should validate valid frontmatter with description", () => {
+      const validFrontmatter = {
+        description: "Test description",
+      };
+
+      const result = SimulatedCommandFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {};
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        description: 123, // Should be string
+      };
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          description: "Command with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("");
+      expect(command.getFrontmatter()).toEqual({
+        description: "Command with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(specialContent);
+      expect(command.getBody()).toContain("@#$%^&*()");
+      expect(command.getBody()).toContain("你好世界 🌍");
+      expect(command.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(longContent);
+      expect(command.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line description", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "multiline-desc.md",
+        frontmatter: {
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(command.getFrontmatter()).toEqual({
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedCommand", () => {
+      const command = new CodexCliCommand({
+        baseDir: testDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(command).toBeInstanceOf(CodexCliCommand);
+      expect(command.getRelativeDirPath()).toBe(".codex/commands");
+      expect(command.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const command = new CodexCliCommand({
+        baseDir: customBaseDir,
+        relativeDirPath: ".codex/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CodexCliCommand);
+    });
+  });
+});

--- a/src/commands/codexcli-command.ts
+++ b/src/commands/codexcli-command.ts
@@ -1,0 +1,55 @@
+import { basename, join } from "node:path";
+import { readFileContent } from "../utils/file.js";
+import { parseFrontmatter } from "../utils/frontmatter.js";
+import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
+import {
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+  ToolCommandSettablePaths,
+} from "./tool-command.js";
+
+export class CodexCliCommand extends SimulatedCommand {
+  static getSettablePaths(): ToolCommandSettablePaths {
+    return {
+      relativeDirPath: ".codex/commands",
+    };
+  }
+
+  static fromRulesyncCommand({
+    baseDir = ".",
+    rulesyncCommand,
+    validate = true,
+  }: ToolCommandFromRulesyncCommandParams): CodexCliCommand {
+    return new CodexCliCommand(
+      this.fromRulesyncCommandDefault({ baseDir, rulesyncCommand, validate }),
+    );
+  }
+
+  static async fromFile({
+    baseDir = ".",
+    relativeFilePath,
+    validate = true,
+  }: ToolCommandFromFileParams): Promise<CodexCliCommand> {
+    const filePath = join(
+      baseDir,
+      CodexCliCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = SimulatedCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${result.error.message}`);
+    }
+
+    return new CodexCliCommand({
+      baseDir: baseDir,
+      relativeDirPath: CodexCliCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    });
+  }
+}

--- a/src/commands/commands-processor.test.ts
+++ b/src/commands/commands-processor.test.ts
@@ -652,7 +652,7 @@ describe("CommandsProcessor", () => {
   describe("getToolTargets", () => {
     it("should return supported tool targets", () => {
       const targets = CommandsProcessor.getToolTargets();
-      expect(targets).toEqual(["claudecode", "geminicli", "roo"]);
+      expect(targets).toEqual(["claudecode", "geminicli", "roo", "copilot", "cursor", "codexcli"]);
     });
   });
 });

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -211,7 +211,11 @@ export class CommandsProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(excludeSimulated: boolean = true): ToolTarget[] {
+  static getToolTargets({
+    excludeSimulated = false,
+  }: {
+    excludeSimulated?: boolean;
+  } = {}): ToolTarget[] {
     if (excludeSimulated) {
       return commandsProcessorToolTargets.filter(
         (target) => !commandsProcessorToolTargetsSimulated.includes(target),

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -12,8 +12,17 @@ import { RooCommand } from "./roo-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 import { ToolCommand } from "./tool-command.js";
 
-const commandsProcessorToolTargets: ToolTarget[] = ["claudecode", "geminicli", "roo"];
+const commandsProcessorToolTargets: ToolTarget[] = [
+  "claudecode",
+  "geminicli",
+  "roo",
+  "copilot",
+  "cursor",
+  "codexcli",
+];
 export const CommandsProcessorToolTargetSchema = z.enum(commandsProcessorToolTargets);
+
+const commandsProcessorToolTargetsSimulated: ToolTarget[] = ["copilot", "cursor", "codexcli"];
 
 export type CommandsProcessorToolTarget = z.infer<typeof CommandsProcessorToolTargetSchema>;
 
@@ -184,7 +193,13 @@ export class CommandsProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(): ToolTarget[] {
+  static getToolTargets(excludeSimulated: boolean = false): ToolTarget[] {
+    if (excludeSimulated) {
+      return commandsProcessorToolTargets.filter(
+        (target) => !commandsProcessorToolTargetsSimulated.includes(target),
+      );
+    }
+
     return commandsProcessorToolTargets;
   }
 }

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -211,7 +211,7 @@ export class CommandsProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(excludeSimulated: boolean = false): ToolTarget[] {
+  static getToolTargets(excludeSimulated: boolean = true): ToolTarget[] {
     if (excludeSimulated) {
       return commandsProcessorToolTargets.filter(
         (target) => !commandsProcessorToolTargetsSimulated.includes(target),

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -7,6 +7,9 @@ import { ToolTarget } from "../types/tool-targets.js";
 import { findFilesByGlobs } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
 import { ClaudecodeCommand } from "./claudecode-command.js";
+import { CodexCliCommand } from "./codexcli-command.js";
+import { CopilotCommand } from "./copilot-command.js";
+import { CursorCommand } from "./cursor-command.js";
 import { GeminiCliCommand } from "./geminicli-command.js";
 import { RooCommand } from "./roo-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
@@ -56,6 +59,21 @@ export class CommandsProcessor extends FeatureProcessor {
           });
         case "roo":
           return RooCommand.fromRulesyncCommand({
+            baseDir: this.baseDir,
+            rulesyncCommand: rulesyncCommand,
+          });
+        case "copilot":
+          return CopilotCommand.fromRulesyncCommand({
+            baseDir: this.baseDir,
+            rulesyncCommand: rulesyncCommand,
+          });
+        case "cursor":
+          return CursorCommand.fromRulesyncCommand({
+            baseDir: this.baseDir,
+            rulesyncCommand: rulesyncCommand,
+          });
+        case "codexcli":
+          return CodexCliCommand.fromRulesyncCommand({
             baseDir: this.baseDir,
             rulesyncCommand: rulesyncCommand,
           });

--- a/src/commands/copilot-command.test.ts
+++ b/src/commands/copilot-command.test.ts
@@ -1,0 +1,529 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CopilotCommand } from "./copilot-command.js";
+import { RulesyncCommand } from "./rulesync-command.js";
+import {
+  SimulatedCommandFrontmatter,
+  SimulatedCommandFrontmatterSchema,
+} from "./simulated-command.js";
+
+describe("CopilotCommand", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+description: Test copilot command description
+---
+
+This is the body of the copilot command.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required description field
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for copilot commands", () => {
+      const paths = CopilotCommand.getSettablePaths();
+      expect(paths).toEqual({
+        relativeDirPath: ".copilot/commands",
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test copilot command description",
+        },
+        body: "This is the body of the copilot command.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CopilotCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the copilot command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test copilot command description",
+      });
+    });
+
+    it("should create instance with empty description", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "",
+        },
+        body: "This is a copilot command without description.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is a copilot command without description.");
+      expect(command.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(command).toBeInstanceOf(CopilotCommand);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CopilotCommand({
+            baseDir: testDir,
+            relativeDirPath: ".copilot/commands",
+            relativeFilePath: "invalid-command.md",
+            frontmatter: {
+              // Missing required description field
+            } as SimulatedCommandFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with description", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test copilot command",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = command.getFrontmatter();
+      expect(frontmatter).toEqual({
+        description: "Test copilot command",
+      });
+    });
+  });
+
+  describe("toRulesyncCommand", () => {
+    it("should throw error as it is a simulated file", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => command.toRulesyncCommand()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncCommand", () => {
+    it("should create CopilotCommand from RulesyncCommand", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["copilot"],
+          description: "Test description from rulesync",
+        },
+        body: "Test command content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const copilotCommand = CopilotCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(copilotCommand).toBeInstanceOf(CopilotCommand);
+      expect(copilotCommand.getBody()).toBe("Test command content");
+      expect(copilotCommand.getFrontmatter()).toEqual({
+        description: "Test description from rulesync",
+      });
+      expect(copilotCommand.getRelativeFilePath()).toBe("test-command.md");
+      expect(copilotCommand.getRelativeDirPath()).toBe(".copilot/commands");
+    });
+
+    it("should handle RulesyncCommand with different file extensions", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "complex-command.txt",
+        frontmatter: {
+          targets: ["copilot"],
+          description: "Complex command",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const copilotCommand = CopilotCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(copilotCommand.getRelativeFilePath()).toBe("complex-command.txt");
+    });
+
+    it("should handle empty description", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["copilot"],
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const copilotCommand = CopilotCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(copilotCommand.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CopilotCommand from file", async () => {
+      const commandsDir = join(testDir, ".copilot", "commands");
+      const filePath = join(commandsDir, "test-file-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CopilotCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-command.md",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CopilotCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the copilot command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test copilot command description",
+      });
+      expect(command.getRelativeFilePath()).toBe("test-file-command.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const commandsDir = join(testDir, ".copilot", "commands", "subdir");
+      const filePath = join(commandsDir, "nested-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CopilotCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-command.md",
+        validate: true,
+      });
+
+      expect(command.getRelativeFilePath()).toBe("nested-command.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CopilotCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const commandsDir = join(testDir, ".copilot", "commands");
+      const filePath = join(commandsDir, "invalid-command.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CopilotCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const commandsDir = join(testDir, ".copilot", "commands");
+      const filePath = join(commandsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CopilotCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "valid-command.md",
+        frontmatter: {
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = command.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "command-with-extras.md",
+        frontmatter: {
+          description: "Command with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = command.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedCommandFrontmatterSchema", () => {
+    it("should validate valid frontmatter with description", () => {
+      const validFrontmatter = {
+        description: "Test description",
+      };
+
+      const result = SimulatedCommandFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {};
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        description: 123, // Should be string
+      };
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          description: "Command with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("");
+      expect(command.getFrontmatter()).toEqual({
+        description: "Command with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(specialContent);
+      expect(command.getBody()).toContain("@#$%^&*()");
+      expect(command.getBody()).toContain("你好世界 🌍");
+      expect(command.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(longContent);
+      expect(command.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line description", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "multiline-desc.md",
+        frontmatter: {
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(command.getFrontmatter()).toEqual({
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedCommand", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(command).toBeInstanceOf(CopilotCommand);
+      expect(command.getRelativeDirPath()).toBe(".copilot/commands");
+      expect(command.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const command = new CopilotCommand({
+        baseDir: customBaseDir,
+        relativeDirPath: ".copilot/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CopilotCommand);
+    });
+  });
+});

--- a/src/commands/copilot-command.ts
+++ b/src/commands/copilot-command.ts
@@ -1,0 +1,55 @@
+import { basename, join } from "node:path";
+import { readFileContent } from "../utils/file.js";
+import { parseFrontmatter } from "../utils/frontmatter.js";
+import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
+import {
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+  ToolCommandSettablePaths,
+} from "./tool-command.js";
+
+export class CopilotCommand extends SimulatedCommand {
+  static getSettablePaths(): ToolCommandSettablePaths {
+    return {
+      relativeDirPath: ".copilot/commands",
+    };
+  }
+
+  static fromRulesyncCommand({
+    baseDir = ".",
+    rulesyncCommand,
+    validate = true,
+  }: ToolCommandFromRulesyncCommandParams): CopilotCommand {
+    return new CopilotCommand(
+      this.fromRulesyncCommandDefault({ baseDir, rulesyncCommand, validate }),
+    );
+  }
+
+  static async fromFile({
+    baseDir = ".",
+    relativeFilePath,
+    validate = true,
+  }: ToolCommandFromFileParams): Promise<CopilotCommand> {
+    const filePath = join(
+      baseDir,
+      CopilotCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = SimulatedCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${result.error.message}`);
+    }
+
+    return new CopilotCommand({
+      baseDir: baseDir,
+      relativeDirPath: CopilotCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    });
+  }
+}

--- a/src/commands/cursor-command.test.ts
+++ b/src/commands/cursor-command.test.ts
@@ -1,0 +1,529 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CursorCommand } from "./cursor-command.js";
+import { RulesyncCommand } from "./rulesync-command.js";
+import {
+  SimulatedCommandFrontmatter,
+  SimulatedCommandFrontmatterSchema,
+} from "./simulated-command.js";
+
+describe("CursorCommand", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+description: Test cursor command description
+---
+
+This is the body of the cursor command.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required description field
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for cursor commands", () => {
+      const paths = CursorCommand.getSettablePaths();
+      expect(paths).toEqual({
+        relativeDirPath: ".cursor/commands",
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test cursor command description",
+        },
+        body: "This is the body of the cursor command.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CursorCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the cursor command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test cursor command description",
+      });
+    });
+
+    it("should create instance with empty description", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "",
+        },
+        body: "This is a cursor command without description.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is a cursor command without description.");
+      expect(command.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(command).toBeInstanceOf(CursorCommand);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CursorCommand({
+            baseDir: testDir,
+            relativeDirPath: ".cursor/commands",
+            relativeFilePath: "invalid-command.md",
+            frontmatter: {
+              // Missing required description field
+            } as SimulatedCommandFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with description", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test cursor command",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = command.getFrontmatter();
+      expect(frontmatter).toEqual({
+        description: "Test cursor command",
+      });
+    });
+  });
+
+  describe("toRulesyncCommand", () => {
+    it("should throw error as it is a simulated file", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => command.toRulesyncCommand()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncCommand", () => {
+    it("should create CursorCommand from RulesyncCommand", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "Test description from rulesync",
+        },
+        body: "Test command content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const cursorCommand = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(cursorCommand).toBeInstanceOf(CursorCommand);
+      expect(cursorCommand.getBody()).toBe("Test command content");
+      expect(cursorCommand.getFrontmatter()).toEqual({
+        description: "Test description from rulesync",
+      });
+      expect(cursorCommand.getRelativeFilePath()).toBe("test-command.md");
+      expect(cursorCommand.getRelativeDirPath()).toBe(".cursor/commands");
+    });
+
+    it("should handle RulesyncCommand with different file extensions", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "complex-command.txt",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "Complex command",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const cursorCommand = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(cursorCommand.getRelativeFilePath()).toBe("complex-command.txt");
+    });
+
+    it("should handle empty description", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test-command.md",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const cursorCommand = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(cursorCommand.getFrontmatter()).toEqual({
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CursorCommand from file", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      const filePath = join(commandsDir, "test-file-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CursorCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-command.md",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CursorCommand);
+      expect(command.getBody()).toBe(
+        "This is the body of the cursor command.\nIt can be multiline.",
+      );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test cursor command description",
+      });
+      expect(command.getRelativeFilePath()).toBe("test-file-command.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands", "subdir");
+      const filePath = join(commandsDir, "nested-command.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const command = await CursorCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-command.md",
+        validate: true,
+      });
+
+      expect(command.getRelativeFilePath()).toBe("nested-command.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CursorCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      const filePath = join(commandsDir, "invalid-command.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CursorCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-command.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      const filePath = join(commandsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CursorCommand.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "valid-command.md",
+        frontmatter: {
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = command.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "command-with-extras.md",
+        frontmatter: {
+          description: "Command with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = command.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedCommandFrontmatterSchema", () => {
+    it("should validate valid frontmatter with description", () => {
+      const validFrontmatter = {
+        description: "Test description",
+      };
+
+      const result = SimulatedCommandFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {};
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        description: 123, // Should be string
+      };
+
+      expect(() => SimulatedCommandFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          description: "Command with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("");
+      expect(command.getFrontmatter()).toEqual({
+        description: "Command with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(specialContent);
+      expect(command.getBody()).toContain("@#$%^&*()");
+      expect(command.getBody()).toContain("你好世界 🌍");
+      expect(command.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(longContent);
+      expect(command.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line description", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "multiline-desc.md",
+        frontmatter: {
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(command.getFrontmatter()).toEqual({
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedCommand", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(command).toBeInstanceOf(CursorCommand);
+      expect(command.getRelativeDirPath()).toBe(".cursor/commands");
+      expect(command.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const command = new CursorCommand({
+        baseDir: customBaseDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(command).toBeInstanceOf(CursorCommand);
+    });
+  });
+});

--- a/src/commands/cursor-command.ts
+++ b/src/commands/cursor-command.ts
@@ -1,0 +1,55 @@
+import { basename, join } from "node:path";
+import { readFileContent } from "../utils/file.js";
+import { parseFrontmatter } from "../utils/frontmatter.js";
+import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
+import {
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+  ToolCommandSettablePaths,
+} from "./tool-command.js";
+
+export class CursorCommand extends SimulatedCommand {
+  static getSettablePaths(): ToolCommandSettablePaths {
+    return {
+      relativeDirPath: ".cursor/commands",
+    };
+  }
+
+  static fromRulesyncCommand({
+    baseDir = ".",
+    rulesyncCommand,
+    validate = true,
+  }: ToolCommandFromRulesyncCommandParams): CursorCommand {
+    return new CursorCommand(
+      this.fromRulesyncCommandDefault({ baseDir, rulesyncCommand, validate }),
+    );
+  }
+
+  static async fromFile({
+    baseDir = ".",
+    relativeFilePath,
+    validate = true,
+  }: ToolCommandFromFileParams): Promise<CursorCommand> {
+    const filePath = join(
+      baseDir,
+      CursorCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = SimulatedCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${result.error.message}`);
+    }
+
+    return new CursorCommand({
+      baseDir: baseDir,
+      relativeDirPath: CursorCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    });
+  }
+}

--- a/src/commands/simulated-command.ts
+++ b/src/commands/simulated-command.ts
@@ -1,0 +1,120 @@
+import { basename, join } from "node:path";
+import { z } from "zod/mini";
+import { AiFileParams, ValidationResult } from "../types/ai-file.js";
+import { readFileContent } from "../utils/file.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../utils/frontmatter.js";
+import { RulesyncCommand } from "./rulesync-command.js";
+import {
+  ToolCommand,
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+} from "./tool-command.js";
+
+export const SimulatedCommandFrontmatterSchema = z.object({
+  description: z.string(),
+});
+
+export type SimulatedCommandFrontmatter = z.infer<typeof SimulatedCommandFrontmatterSchema>;
+
+export type SimulatedCommandParams = {
+  frontmatter: SimulatedCommandFrontmatter;
+  body: string;
+} & Omit<AiFileParams, "fileContent">;
+
+export abstract class SimulatedCommand extends ToolCommand {
+  private readonly frontmatter: SimulatedCommandFrontmatter;
+  private readonly body: string;
+
+  constructor({ frontmatter, body, ...rest }: SimulatedCommandParams) {
+    if (rest.validate) {
+      const result = SimulatedCommandFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyFrontmatter(body, frontmatter),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
+  getBody(): string {
+    return this.body;
+  }
+
+  getFrontmatter(): Record<string, unknown> {
+    return this.frontmatter;
+  }
+
+  toRulesyncCommand(): RulesyncCommand {
+    throw new Error("Not implemented because it is a SIMULATED file.");
+  }
+
+  protected static fromRulesyncCommandDefault({
+    baseDir = ".",
+    rulesyncCommand,
+    validate = true,
+  }: ToolCommandFromRulesyncCommandParams): ConstructorParameters<typeof SimulatedCommand>[0] {
+    const rulesyncFrontmatter = rulesyncCommand.getFrontmatter();
+
+    const claudecodeFrontmatter: SimulatedCommandFrontmatter = {
+      description: rulesyncFrontmatter.description,
+    };
+
+    const body = rulesyncCommand.getBody();
+
+    return {
+      baseDir: baseDir,
+      frontmatter: claudecodeFrontmatter,
+      body,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: rulesyncCommand.getRelativeFilePath(),
+      validate,
+    };
+  }
+
+  validate(): ValidationResult {
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
+    const result = SimulatedCommandFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return { success: false, error: result.error };
+    }
+  }
+
+  protected static async fromFileDefault({
+    baseDir = ".",
+    relativeFilePath,
+    validate = true,
+  }: ToolCommandFromFileParams): Promise<ConstructorParameters<typeof SimulatedCommand>[0]> {
+    const filePath = join(
+      baseDir,
+      SimulatedCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = SimulatedCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${result.error.message}`);
+    }
+
+    return {
+      baseDir: baseDir,
+      relativeDirPath: SimulatedCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    };
+  }
+}

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -15,6 +15,8 @@ const defaults: Required<ConfigResolverResolveParams> = {
   delete: false,
   baseDirs: ["."],
   configPath: "rulesync.jsonc",
+  experimentalSimulateCommands: false,
+  experimentalSimutateSubagents: false,
 };
 
 // oxlint-disable-next-line no-extraneous-class
@@ -26,6 +28,8 @@ export class ConfigResolver {
     delete: isDelete,
     baseDirs,
     configPath = defaults.configPath,
+    experimentalSimulateCommands,
+    experimentalSimutateSubagents,
   }: ConfigResolverResolveParams): Promise<Config> {
     if (!fileExists(configPath)) {
       return new Config({
@@ -34,6 +38,10 @@ export class ConfigResolver {
         verbose: verbose ?? defaults.verbose,
         delete: isDelete ?? defaults.delete,
         baseDirs: baseDirs ?? defaults.baseDirs,
+        experimentalSimulateCommands:
+          experimentalSimulateCommands ?? defaults.experimentalSimulateCommands,
+        experimentalSimutateSubagents:
+          experimentalSimutateSubagents ?? defaults.experimentalSimutateSubagents,
       });
     }
 
@@ -56,6 +64,14 @@ export class ConfigResolver {
       verbose: verbose ?? configByFile.verbose ?? defaults.verbose,
       delete: isDelete ?? configByFile.delete ?? defaults.delete,
       baseDirs: baseDirs ?? configByFile.baseDirs ?? defaults.baseDirs,
+      experimentalSimulateCommands:
+        experimentalSimulateCommands ??
+        configByFile.experimentalSimulateCommands ??
+        defaults.experimentalSimulateCommands,
+      experimentalSimutateSubagents:
+        experimentalSimutateSubagents ??
+        configByFile.experimentalSimutateSubagents ??
+        defaults.experimentalSimutateSubagents,
     };
     return new Config(configParams);
   }

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -16,7 +16,7 @@ const defaults: Required<ConfigResolverResolveParams> = {
   baseDirs: ["."],
   configPath: "rulesync.jsonc",
   experimentalSimulateCommands: false,
-  experimentalSimutateSubagents: false,
+  experimentalSimulateSubagents: false,
 };
 
 // oxlint-disable-next-line no-extraneous-class
@@ -29,7 +29,7 @@ export class ConfigResolver {
     baseDirs,
     configPath = defaults.configPath,
     experimentalSimulateCommands,
-    experimentalSimutateSubagents,
+    experimentalSimulateSubagents,
   }: ConfigResolverResolveParams): Promise<Config> {
     if (!fileExists(configPath)) {
       return new Config({
@@ -40,8 +40,8 @@ export class ConfigResolver {
         baseDirs: baseDirs ?? defaults.baseDirs,
         experimentalSimulateCommands:
           experimentalSimulateCommands ?? defaults.experimentalSimulateCommands,
-        experimentalSimutateSubagents:
-          experimentalSimutateSubagents ?? defaults.experimentalSimutateSubagents,
+        experimentalSimulateSubagents:
+          experimentalSimulateSubagents ?? defaults.experimentalSimulateSubagents,
       });
     }
 
@@ -68,10 +68,10 @@ export class ConfigResolver {
         experimentalSimulateCommands ??
         configByFile.experimentalSimulateCommands ??
         defaults.experimentalSimulateCommands,
-      experimentalSimutateSubagents:
-        experimentalSimutateSubagents ??
-        configByFile.experimentalSimutateSubagents ??
-        defaults.experimentalSimutateSubagents,
+      experimentalSimulateSubagents:
+        experimentalSimulateSubagents ??
+        configByFile.experimentalSimulateSubagents ??
+        defaults.experimentalSimulateSubagents,
     };
     return new Config(configParams);
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,7 +8,7 @@ export type ConfigParams = {
   verbose: boolean;
   delete: boolean;
   experimentalSimulateCommands: boolean;
-  experimentalSimutateSubagents: boolean;
+  experimentalSimulateSubagents: boolean;
 };
 
 export class Config {
@@ -18,7 +18,7 @@ export class Config {
   private readonly verbose: boolean;
   private readonly delete: boolean;
   private readonly experimentalSimulateCommands: boolean;
-  private readonly experimentalSimutateSubagents: boolean;
+  private readonly experimentalSimulateSubagents: boolean;
 
   constructor({
     baseDirs,
@@ -27,7 +27,7 @@ export class Config {
     verbose,
     delete: isDelete,
     experimentalSimulateCommands,
-    experimentalSimutateSubagents,
+    experimentalSimulateSubagents,
   }: ConfigParams) {
     this.baseDirs = baseDirs;
     this.targets = targets;
@@ -35,7 +35,7 @@ export class Config {
     this.verbose = verbose;
     this.delete = isDelete;
     this.experimentalSimulateCommands = experimentalSimulateCommands;
-    this.experimentalSimutateSubagents = experimentalSimutateSubagents;
+    this.experimentalSimulateSubagents = experimentalSimulateSubagents;
   }
 
   public getBaseDirs(): string[] {
@@ -70,7 +70,7 @@ export class Config {
     return this.experimentalSimulateCommands;
   }
 
-  public getExperimentalSimutateSubagents(): boolean {
-    return this.experimentalSimutateSubagents;
+  public getExperimentalSimulateSubagents(): boolean {
+    return this.experimentalSimulateSubagents;
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -7,6 +7,8 @@ export type ConfigParams = {
   features: RulesyncFeatures;
   verbose: boolean;
   delete: boolean;
+  experimentalSimulateCommands: boolean;
+  experimentalSimutateSubagents: boolean;
 };
 
 export class Config {
@@ -15,13 +17,25 @@ export class Config {
   private readonly features: RulesyncFeatures;
   private readonly verbose: boolean;
   private readonly delete: boolean;
+  private readonly experimentalSimulateCommands: boolean;
+  private readonly experimentalSimutateSubagents: boolean;
 
-  constructor({ baseDirs, targets, features, verbose, delete: isDelete }: ConfigParams) {
+  constructor({
+    baseDirs,
+    targets,
+    features,
+    verbose,
+    delete: isDelete,
+    experimentalSimulateCommands,
+    experimentalSimutateSubagents,
+  }: ConfigParams) {
     this.baseDirs = baseDirs;
     this.targets = targets;
     this.features = features;
     this.verbose = verbose;
     this.delete = isDelete;
+    this.experimentalSimulateCommands = experimentalSimulateCommands;
+    this.experimentalSimutateSubagents = experimentalSimutateSubagents;
   }
 
   public getBaseDirs(): string[] {
@@ -50,5 +64,13 @@ export class Config {
 
   public getDelete(): boolean {
     return this.delete;
+  }
+
+  public getExperimentalSimulateCommands(): boolean {
+    return this.experimentalSimulateCommands;
+  }
+
+  public getExperimentalSimutateSubagents(): boolean {
+    return this.experimentalSimutateSubagents;
   }
 }

--- a/src/rules/qwencode-rule.test.ts
+++ b/src/rules/qwencode-rule.test.ts
@@ -20,13 +20,13 @@ describe("QwencodeRule", () => {
   describe("constructor", () => {
     it("should create instance with default parameters", () => {
       const qwencodeRule = new QwencodeRule({
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule\n\nThis is a test rule.",
       });
 
       expect(qwencodeRule).toBeInstanceOf(QwencodeRule);
-      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwencode/memories");
+      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwen/memories");
       expect(qwencodeRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(qwencodeRule.getFileContent()).toBe("# Test Rule\n\nThis is a test rule.");
       expect(qwencodeRule.isRoot()).toBe(false);
@@ -35,19 +35,19 @@ describe("QwencodeRule", () => {
     it("should create instance with custom baseDir", () => {
       const qwencodeRule = new QwencodeRule({
         baseDir: "/custom/path",
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
       });
 
-      expect(qwencodeRule.getFilePath()).toBe("/custom/path/.qwencode/memories/test-rule.md");
+      expect(qwencodeRule.getFilePath()).toBe("/custom/path/.qwen/memories/test-rule.md");
       expect(qwencodeRule.isRoot()).toBe(false);
     });
 
     it("should validate content by default", () => {
       expect(() => {
         const _instance = new QwencodeRule({
-          relativeDirPath: ".qwencode/memories",
+          relativeDirPath: ".qwen/memories",
           relativeFilePath: "test-rule.md",
           fileContent: "", // empty content should be valid since validate always returns success
         });
@@ -57,7 +57,7 @@ describe("QwencodeRule", () => {
     it("should skip validation when requested", () => {
       expect(() => {
         const _instance = new QwencodeRule({
-          relativeDirPath: ".qwencode/memories",
+          relativeDirPath: ".qwen/memories",
           relativeFilePath: "test-rule.md",
           fileContent: "",
           validate: false,
@@ -79,7 +79,7 @@ describe("QwencodeRule", () => {
 
     it("should handle non-root rule parameter", () => {
       const qwencodeRule = new QwencodeRule({
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "non-root-rule.md",
         fileContent: "# Non-Root Rule",
         root: false,
@@ -93,7 +93,7 @@ describe("QwencodeRule", () => {
   describe("fromFile", () => {
     it("should create instance from existing non-root file", async () => {
       // Setup test file
-      const memoriesDir = join(testDir, ".qwencode/memories");
+      const memoriesDir = join(testDir, ".qwen/memories");
       await ensureDir(memoriesDir);
       const testContent = "# Test Rule from File\n\nContent from file.";
       await writeFileContent(join(memoriesDir, "test.md"), testContent);
@@ -103,10 +103,10 @@ describe("QwencodeRule", () => {
         relativeFilePath: "test.md",
       });
 
-      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwencode/memories");
+      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwen/memories");
       expect(qwencodeRule.getRelativeFilePath()).toBe("test.md");
       expect(qwencodeRule.getFileContent()).toBe(testContent);
-      expect(qwencodeRule.getFilePath()).toBe(join(testDir, ".qwencode/memories/test.md"));
+      expect(qwencodeRule.getFilePath()).toBe(join(testDir, ".qwen/memories/test.md"));
       expect(qwencodeRule.isRoot()).toBe(false);
     });
 
@@ -129,7 +129,7 @@ describe("QwencodeRule", () => {
 
     it("should use default baseDir when not provided", async () => {
       // Setup test file in current directory
-      const memoriesDir = join(".", ".qwencode/memories");
+      const memoriesDir = join(".", ".qwen/memories");
       await ensureDir(memoriesDir);
       const testContent = "# Default BaseDir Test";
       const testFilePath = join(memoriesDir, "default-test.md");
@@ -140,7 +140,7 @@ describe("QwencodeRule", () => {
           relativeFilePath: "default-test.md",
         });
 
-        expect(qwencodeRule.getRelativeDirPath()).toBe(".qwencode/memories");
+        expect(qwencodeRule.getRelativeDirPath()).toBe(".qwen/memories");
         expect(qwencodeRule.getRelativeFilePath()).toBe("default-test.md");
         expect(qwencodeRule.getFileContent()).toBe(testContent);
         expect(qwencodeRule.isRoot()).toBe(false);
@@ -174,7 +174,7 @@ describe("QwencodeRule", () => {
     });
 
     it("should handle validation parameter", async () => {
-      const memoriesDir = join(testDir, ".qwencode/memories");
+      const memoriesDir = join(testDir, ".qwen/memories");
       await ensureDir(memoriesDir);
       const testContent = "# Validation Test";
       await writeFileContent(join(memoriesDir, "validation-test.md"), testContent);
@@ -233,7 +233,7 @@ describe("QwencodeRule", () => {
       });
 
       expect(qwencodeRule).toBeInstanceOf(QwencodeRule);
-      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwencode/memories");
+      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwen/memories");
       expect(qwencodeRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(qwencodeRule.getFileContent()).toBe("# Test RulesyncRule\n\nContent from rulesync.");
       expect(qwencodeRule.isRoot()).toBe(false);
@@ -283,7 +283,7 @@ describe("QwencodeRule", () => {
         rulesyncRule,
       });
 
-      expect(qwencodeRule.getFilePath()).toBe("/custom/base/.qwencode/memories/custom-base.md");
+      expect(qwencodeRule.getFilePath()).toBe("/custom/base/.qwen/memories/custom-base.md");
       expect(qwencodeRule.isRoot()).toBe(false);
     });
 
@@ -331,7 +331,7 @@ describe("QwencodeRule", () => {
       });
 
       expect(qwencodeRule.isRoot()).toBe(false);
-      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwencode/memories");
+      expect(qwencodeRule.getRelativeDirPath()).toBe(".qwen/memories");
     });
   });
 
@@ -339,7 +339,7 @@ describe("QwencodeRule", () => {
     it("should convert non-root QwencodeRule to RulesyncRule", () => {
       const qwencodeRule = new QwencodeRule({
         baseDir: testDir,
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "convert-test.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
       });
@@ -384,7 +384,7 @@ describe("QwencodeRule", () => {
     it("should preserve metadata in conversion", () => {
       const qwencodeRule = new QwencodeRule({
         baseDir: "/test/path",
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "metadata-test.md",
         fileContent: "# Metadata Test\n\nContent with metadata.",
       });
@@ -399,7 +399,7 @@ describe("QwencodeRule", () => {
   describe("validate", () => {
     it("should always return success", () => {
       const qwencodeRule = new QwencodeRule({
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "validation-test.md",
         fileContent: "# Any content is valid",
       });
@@ -412,7 +412,7 @@ describe("QwencodeRule", () => {
 
     it("should return success for empty content", () => {
       const qwencodeRule = new QwencodeRule({
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
         relativeFilePath: "empty.md",
         fileContent: "",
       });
@@ -448,7 +448,7 @@ describe("QwencodeRule", () => {
 
       for (const content of contents) {
         const qwencodeRule = new QwencodeRule({
-          relativeDirPath: ".qwencode/memories",
+          relativeDirPath: ".qwen/memories",
           relativeFilePath: "test.md",
           fileContent: content,
         });
@@ -463,7 +463,7 @@ describe("QwencodeRule", () => {
   describe("integration tests", () => {
     it("should handle complete workflow from non-root file to rulesync rule", async () => {
       // Create original file
-      const memoriesDir = join(testDir, ".qwencode/memories");
+      const memoriesDir = join(testDir, ".qwen/memories");
       await ensureDir(memoriesDir);
       const originalContent = "# Integration Test\n\nComplete workflow test.";
       await writeFileContent(join(memoriesDir, "integration.md"), originalContent);
@@ -588,7 +588,7 @@ describe("QwencodeRule", () => {
         rulesyncRule: nonRootRulesync,
       });
 
-      expect(nonRootQwencode.getRelativeDirPath()).toBe(".qwencode/memories");
+      expect(nonRootQwencode.getRelativeDirPath()).toBe(".qwen/memories");
       expect(nonRootQwencode.getRelativeFilePath()).toBe("non-root.md");
       expect(nonRootQwencode.isRoot()).toBe(false);
 

--- a/src/rules/qwencode-rule.ts
+++ b/src/rules/qwencode-rule.ts
@@ -36,7 +36,7 @@ export class QwencodeRule extends ToolRule {
         relativeFilePath: "QWEN.md",
       },
       nonRoot: {
-        relativeDirPath: ".qwencode/memories",
+        relativeDirPath: ".qwen/memories",
       },
     };
   }
@@ -47,7 +47,7 @@ export class QwencodeRule extends ToolRule {
     validate = true,
   }: ToolRuleFromFileParams): Promise<QwencodeRule> {
     const isRoot = relativeFilePath === "QWEN.md";
-    const relativePath = isRoot ? "QWEN.md" : join(".qwencode/memories", relativeFilePath);
+    const relativePath = isRoot ? "QWEN.md" : join(".qwen/memories", relativeFilePath);
     const fileContent = await readFileContent(join(baseDir, relativePath));
 
     return new QwencodeRule({

--- a/src/subagents/codexcli-subagent.test.ts
+++ b/src/subagents/codexcli-subagent.test.ts
@@ -1,0 +1,573 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CodexCliSubagent } from "./codexcli-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import {
+  SimulatedSubagentFrontmatter,
+  SimulatedSubagentFrontmatterSchema,
+} from "./simulated-subagent.js";
+
+describe("CodexCliSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+name: Test Codex Agent
+description: Test codex agent description
+---
+
+This is the body of the codex agent.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required fields
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for codex subagents", () => {
+      const paths = CodexCliSubagent.getSettablePaths();
+      expect(paths).toEqual({
+        root: {
+          relativeDirPath: ".",
+          relativeFilePath: "CODEX.md",
+        },
+        nonRoot: {
+          relativeDirPath: ".codex/subagents",
+        },
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Codex Agent",
+          description: "Test codex agent description",
+        },
+        body: "This is the body of the codex agent.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+      expect(subagent.getBody()).toBe("This is the body of the codex agent.\nIt can be multiline.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Codex Agent",
+        description: "Test codex agent description",
+      });
+    });
+
+    it("should create instance with empty name and description", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "",
+          description: "",
+        },
+        body: "This is a codex agent without name or description.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is a codex agent without name or description.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CodexCliSubagent({
+            baseDir: testDir,
+            relativeDirPath: ".codex/subagents",
+            relativeFilePath: "invalid-agent.md",
+            frontmatter: {
+              // Missing required fields
+            } as SimulatedSubagentFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with name and description", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Codex Agent",
+          description: "Test codex agent",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = subagent.getFrontmatter();
+      expect(frontmatter).toEqual({
+        name: "Test Codex Agent",
+        description: "Test codex agent",
+      });
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should throw error as it is a simulated file", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create CodexCliSubagent from RulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          name: "Test Agent",
+          description: "Test description from rulesync",
+        },
+        body: "Test agent content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CodexCliSubagent;
+
+      expect(codexSubagent).toBeInstanceOf(CodexCliSubagent);
+      expect(codexSubagent.getBody()).toBe("Test agent content");
+      expect(codexSubagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test description from rulesync",
+      });
+      expect(codexSubagent.getRelativeFilePath()).toBe("test-agent.md");
+      expect(codexSubagent.getRelativeDirPath()).toBe(".codex/subagents");
+    });
+
+    it("should handle RulesyncSubagent with different file extensions", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "complex-agent.txt",
+        frontmatter: {
+          targets: ["codexcli"],
+          name: "Complex Agent",
+          description: "Complex agent",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CodexCliSubagent;
+
+      expect(codexSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
+    });
+
+    it("should handle empty name and description", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          name: "",
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CodexCliSubagent;
+
+      expect(codexSubagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CodexCliSubagent from file", async () => {
+      const subagentsDir = join(testDir, ".codex", "subagents");
+      const filePath = join(subagentsDir, "test-file-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CodexCliSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-agent.md",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+      expect(subagent.getBody()).toBe("This is the body of the codex agent.\nIt can be multiline.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Codex Agent",
+        description: "Test codex agent description",
+      });
+      expect(subagent.getRelativeFilePath()).toBe("test-file-agent.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const subagentsDir = join(testDir, ".codex", "subagents", "subdir");
+      const filePath = join(subagentsDir, "nested-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CodexCliSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-agent.md",
+        validate: true,
+      });
+
+      expect(subagent.getRelativeFilePath()).toBe("nested-agent.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CodexCliSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const subagentsDir = join(testDir, ".codex", "subagents");
+      const filePath = join(subagentsDir, "invalid-agent.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CodexCliSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const subagentsDir = join(testDir, ".codex", "subagents");
+      const filePath = join(subagentsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CodexCliSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "valid-agent.md",
+        frontmatter: {
+          name: "Valid Agent",
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "agent-with-extras.md",
+        frontmatter: {
+          name: "Agent",
+          description: "Agent with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedSubagentFrontmatterSchema", () => {
+    it("should validate valid frontmatter with name and description", () => {
+      const validFrontmatter = {
+        name: "Test Agent",
+        description: "Test description",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without name", () => {
+      const invalidFrontmatter = {
+        description: "Test description",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {
+        name: "Test Agent",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        name: 123, // Should be string
+        description: "Test",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          name: "Empty Body Agent",
+          description: "Agent with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Empty Body Agent",
+        description: "Agent with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          name: "Special Agent",
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(specialContent);
+      expect(subagent.getBody()).toContain("@#$%^&*()");
+      expect(subagent.getBody()).toContain("你好世界 🌍");
+      expect(subagent.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          name: "Long Agent",
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(longContent);
+      expect(subagent.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line name and description", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "multiline-fields.md",
+        frontmatter: {
+          name: "Multi-line\nAgent Name",
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Multi-line\nAgent Name",
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          name: "Windows Agent",
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedSubagent", () => {
+      const subagent = new CodexCliSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+      expect(subagent.getRelativeDirPath()).toBe(".codex/subagents");
+      expect(subagent.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const subagent = new CodexCliSubagent({
+        baseDir: customBaseDir,
+        relativeDirPath: ".codex/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+    });
+  });
+});

--- a/src/subagents/codexcli-subagent.test.ts
+++ b/src/subagents/codexcli-subagent.test.ts
@@ -8,17 +8,18 @@ import {
   SimulatedSubagentFrontmatter,
   SimulatedSubagentFrontmatterSchema,
 } from "./simulated-subagent.js";
+import type { ToolSubagent } from "./tool-subagent.js";
 
 describe("CodexCliSubagent", () => {
   let testDir: string;
   let cleanup: () => Promise<void>;
 
   const validMarkdownContent = `---
-name: Test Codex Agent
-description: Test codex agent description
+name: Test CodexCli Agent
+description: Test codexcli agent description
 ---
 
-This is the body of the codex agent.
+This is the body of the codexcli agent.
 It can be multiline.`;
 
   const invalidMarkdownContent = `---
@@ -42,7 +43,7 @@ Body content`;
   });
 
   describe("getSettablePaths", () => {
-    it("should return correct paths for codex subagents", () => {
+    it("should return correct paths for codexcli subagents", () => {
       const paths = CodexCliSubagent.getSettablePaths();
       expect(paths).toEqual({
         root: {
@@ -63,18 +64,20 @@ Body content`;
         relativeDirPath: ".codex/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
-          name: "Test Codex Agent",
-          description: "Test codex agent description",
+          name: "Test CodexCli Agent",
+          description: "Test codexcli agent description",
         },
-        body: "This is the body of the codex agent.\nIt can be multiline.",
+        body: "This is the body of the codexcli agent.\nIt can be multiline.",
         validate: true,
       });
 
       expect(subagent).toBeInstanceOf(CodexCliSubagent);
-      expect(subagent.getBody()).toBe("This is the body of the codex agent.\nIt can be multiline.");
+      expect(subagent.getBody()).toBe(
+        "This is the body of the codexcli agent.\nIt can be multiline.",
+      );
       expect(subagent.getFrontmatter()).toEqual({
-        name: "Test Codex Agent",
-        description: "Test codex agent description",
+        name: "Test CodexCli Agent",
+        description: "Test codexcli agent description",
       });
     });
 
@@ -87,11 +90,11 @@ Body content`;
           name: "",
           description: "",
         },
-        body: "This is a codex agent without name or description.",
+        body: "This is a codexcli agent without name or description.",
         validate: true,
       });
 
-      expect(subagent.getBody()).toBe("This is a codex agent without name or description.");
+      expect(subagent.getBody()).toBe("This is a codexcli agent without name or description.");
       expect(subagent.getFrontmatter()).toEqual({
         name: "",
         description: "",
@@ -156,8 +159,8 @@ Body content`;
         relativeDirPath: ".codex/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
-          name: "Test Codex Agent",
-          description: "Test codex agent",
+          name: "Test CodexCli Agent",
+          description: "Test codexcli agent",
         },
         body: "Test body",
         validate: true,
@@ -165,8 +168,8 @@ Body content`;
 
       const frontmatter = subagent.getFrontmatter();
       expect(frontmatter).toEqual({
-        name: "Test Codex Agent",
-        description: "Test codex agent",
+        name: "Test CodexCli Agent",
+        description: "Test codexcli agent",
       });
     });
   });
@@ -207,21 +210,21 @@ Body content`;
         validate: true,
       });
 
-      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+      const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
         baseDir: testDir,
         relativeDirPath: ".codex/subagents",
         rulesyncSubagent,
         validate: true,
       }) as CodexCliSubagent;
 
-      expect(codexSubagent).toBeInstanceOf(CodexCliSubagent);
-      expect(codexSubagent.getBody()).toBe("Test agent content");
-      expect(codexSubagent.getFrontmatter()).toEqual({
+      expect(codexcliSubagent).toBeInstanceOf(CodexCliSubagent);
+      expect(codexcliSubagent.getBody()).toBe("Test agent content");
+      expect(codexcliSubagent.getFrontmatter()).toEqual({
         name: "Test Agent",
         description: "Test description from rulesync",
       });
-      expect(codexSubagent.getRelativeFilePath()).toBe("test-agent.md");
-      expect(codexSubagent.getRelativeDirPath()).toBe(".codex/subagents");
+      expect(codexcliSubagent.getRelativeFilePath()).toBe("test-agent.md");
+      expect(codexcliSubagent.getRelativeDirPath()).toBe(".codex/subagents");
     });
 
     it("should handle RulesyncSubagent with different file extensions", () => {
@@ -239,14 +242,14 @@ Body content`;
         validate: true,
       });
 
-      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+      const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
         baseDir: testDir,
         relativeDirPath: ".codex/subagents",
         rulesyncSubagent,
         validate: true,
       }) as CodexCliSubagent;
 
-      expect(codexSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
+      expect(codexcliSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
     });
 
     it("should handle empty name and description", () => {
@@ -264,14 +267,14 @@ Body content`;
         validate: true,
       });
 
-      const codexSubagent = CodexCliSubagent.fromRulesyncSubagent({
+      const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
         baseDir: testDir,
         relativeDirPath: ".codex/subagents",
         rulesyncSubagent,
         validate: true,
       }) as CodexCliSubagent;
 
-      expect(codexSubagent.getFrontmatter()).toEqual({
+      expect(codexcliSubagent.getFrontmatter()).toEqual({
         name: "",
         description: "",
       });
@@ -292,10 +295,12 @@ Body content`;
       });
 
       expect(subagent).toBeInstanceOf(CodexCliSubagent);
-      expect(subagent.getBody()).toBe("This is the body of the codex agent.\nIt can be multiline.");
+      expect(subagent.getBody()).toBe(
+        "This is the body of the codexcli agent.\nIt can be multiline.",
+      );
       expect(subagent.getFrontmatter()).toEqual({
-        name: "Test Codex Agent",
-        description: "Test codex agent description",
+        name: "Test CodexCli Agent",
+        description: "Test codexcli agent description",
       });
       expect(subagent.getRelativeFilePath()).toBe("test-file-agent.md");
     });
@@ -543,31 +548,32 @@ Body content`;
           name: "Test",
           description: "Test",
         },
-        body: "Body",
+        body: "Test",
         validate: true,
       });
 
-      // Check that it's an instance of parent classes
-      expect(subagent).toBeInstanceOf(CodexCliSubagent);
-      expect(subagent.getRelativeDirPath()).toBe(".codex/subagents");
-      expect(subagent.getRelativeFilePath()).toBe("test.md");
+      // Should inherit toRulesyncSubagent that throws error
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
     });
 
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
+    it("should be assignable to ToolSubagent type", () => {
       const subagent = new CodexCliSubagent({
-        baseDir: customBaseDir,
+        baseDir: testDir,
         relativeDirPath: ".codex/subagents",
         relativeFilePath: "test.md",
         frontmatter: {
           name: "Test",
           description: "Test",
         },
-        body: "Body",
-        validate: true,
+        body: "Test",
+        validate: false,
       });
 
-      expect(subagent).toBeInstanceOf(CodexCliSubagent);
+      // Type check: should be assignable to ToolSubagent
+      const toolSubagent: ToolSubagent = subagent;
+      expect(toolSubagent).toBeDefined();
     });
   });
 });

--- a/src/subagents/codexcli-subagent.ts
+++ b/src/subagents/codexcli-subagent.ts
@@ -1,0 +1,31 @@
+import { SimulatedSubagent } from "./simulated-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+  ToolSubagentSettablePaths,
+} from "./tool-subagent.js";
+
+export class CodexCliSubagent extends SimulatedSubagent {
+  static getSettablePaths(): ToolSubagentSettablePaths {
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "CODEX.md",
+      },
+      nonRoot: {
+        relativeDirPath: ".codex/subagents",
+      },
+    };
+  }
+
+  static async fromFile(params: ToolSubagentFromFileParams): Promise<CodexCliSubagent> {
+    const baseParams = await this.fromFileDefault(params);
+    return new CodexCliSubagent(baseParams);
+  }
+
+  static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    const baseParams = this.fromRulesyncSubagentDefault(params);
+    return new CodexCliSubagent(baseParams);
+  }
+}

--- a/src/subagents/copilot-subagent.test.ts
+++ b/src/subagents/copilot-subagent.test.ts
@@ -1,0 +1,577 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CopilotSubagent } from "./copilot-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import {
+  SimulatedSubagentFrontmatter,
+  SimulatedSubagentFrontmatterSchema,
+} from "./simulated-subagent.js";
+
+describe("CopilotSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+name: Test Copilot Agent
+description: Test copilot agent description
+---
+
+This is the body of the copilot agent.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required fields
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for copilot subagents", () => {
+      const paths = CopilotSubagent.getSettablePaths();
+      expect(paths).toEqual({
+        root: {
+          relativeDirPath: ".",
+          relativeFilePath: "COPILOT.md",
+        },
+        nonRoot: {
+          relativeDirPath: ".copilot/subagents",
+        },
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Copilot Agent",
+          description: "Test copilot agent description",
+        },
+        body: "This is the body of the copilot agent.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CopilotSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the copilot agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Copilot Agent",
+        description: "Test copilot agent description",
+      });
+    });
+
+    it("should create instance with empty name and description", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "",
+          description: "",
+        },
+        body: "This is a copilot agent without name or description.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is a copilot agent without name or description.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(subagent).toBeInstanceOf(CopilotSubagent);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CopilotSubagent({
+            baseDir: testDir,
+            relativeDirPath: ".copilot/subagents",
+            relativeFilePath: "invalid-agent.md",
+            frontmatter: {
+              // Missing required fields
+            } as SimulatedSubagentFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with name and description", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Copilot Agent",
+          description: "Test copilot agent",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = subagent.getFrontmatter();
+      expect(frontmatter).toEqual({
+        name: "Test Copilot Agent",
+        description: "Test copilot agent",
+      });
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should throw error as it is a simulated file", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create CopilotSubagent from RulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "Test Agent",
+          description: "Test description from rulesync",
+        },
+        body: "Test agent content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const copilotSubagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(copilotSubagent).toBeInstanceOf(CopilotSubagent);
+      expect(copilotSubagent.getBody()).toBe("Test agent content");
+      expect(copilotSubagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test description from rulesync",
+      });
+      expect(copilotSubagent.getRelativeFilePath()).toBe("test-agent.md");
+      expect(copilotSubagent.getRelativeDirPath()).toBe(".copilot/subagents");
+    });
+
+    it("should handle RulesyncSubagent with different file extensions", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "complex-agent.txt",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "Complex Agent",
+          description: "Complex agent",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const copilotSubagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(copilotSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
+    });
+
+    it("should handle empty name and description", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "",
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const copilotSubagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(copilotSubagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CopilotSubagent from file", async () => {
+      const subagentsDir = join(testDir, ".copilot", "subagents");
+      const filePath = join(subagentsDir, "test-file-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CopilotSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-agent.md",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CopilotSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the copilot agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Copilot Agent",
+        description: "Test copilot agent description",
+      });
+      expect(subagent.getRelativeFilePath()).toBe("test-file-agent.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const subagentsDir = join(testDir, ".copilot", "subagents", "subdir");
+      const filePath = join(subagentsDir, "nested-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CopilotSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-agent.md",
+        validate: true,
+      });
+
+      expect(subagent.getRelativeFilePath()).toBe("nested-agent.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CopilotSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const subagentsDir = join(testDir, ".copilot", "subagents");
+      const filePath = join(subagentsDir, "invalid-agent.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CopilotSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const subagentsDir = join(testDir, ".copilot", "subagents");
+      const filePath = join(subagentsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CopilotSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "valid-agent.md",
+        frontmatter: {
+          name: "Valid Agent",
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "agent-with-extras.md",
+        frontmatter: {
+          name: "Agent",
+          description: "Agent with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedSubagentFrontmatterSchema", () => {
+    it("should validate valid frontmatter with name and description", () => {
+      const validFrontmatter = {
+        name: "Test Agent",
+        description: "Test description",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without name", () => {
+      const invalidFrontmatter = {
+        description: "Test description",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {
+        name: "Test Agent",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        name: 123, // Should be string
+        description: "Test",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          name: "Empty Body Agent",
+          description: "Agent with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Empty Body Agent",
+        description: "Agent with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          name: "Special Agent",
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(specialContent);
+      expect(subagent.getBody()).toContain("@#$%^&*()");
+      expect(subagent.getBody()).toContain("你好世界 🌍");
+      expect(subagent.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          name: "Long Agent",
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(longContent);
+      expect(subagent.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line name and description", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "multiline-fields.md",
+        frontmatter: {
+          name: "Multi-line\nAgent Name",
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Multi-line\nAgent Name",
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          name: "Windows Agent",
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedSubagent", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(subagent).toBeInstanceOf(CopilotSubagent);
+      expect(subagent.getRelativeDirPath()).toBe(".copilot/subagents");
+      expect(subagent.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const subagent = new CopilotSubagent({
+        baseDir: customBaseDir,
+        relativeDirPath: ".copilot/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CopilotSubagent);
+    });
+  });
+});

--- a/src/subagents/copilot-subagent.ts
+++ b/src/subagents/copilot-subagent.ts
@@ -1,0 +1,31 @@
+import { SimulatedSubagent } from "./simulated-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+  ToolSubagentSettablePaths,
+} from "./tool-subagent.js";
+
+export class CopilotSubagent extends SimulatedSubagent {
+  static getSettablePaths(): ToolSubagentSettablePaths {
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "COPILOT.md",
+      },
+      nonRoot: {
+        relativeDirPath: ".copilot/subagents",
+      },
+    };
+  }
+
+  static async fromFile(params: ToolSubagentFromFileParams): Promise<CopilotSubagent> {
+    const baseParams = await this.fromFileDefault(params);
+    return new CopilotSubagent(baseParams);
+  }
+
+  static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    const baseParams = this.fromRulesyncSubagentDefault(params);
+    return new CopilotSubagent(baseParams);
+  }
+}

--- a/src/subagents/cursor-subagent.test.ts
+++ b/src/subagents/cursor-subagent.test.ts
@@ -1,0 +1,577 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { CursorSubagent } from "./cursor-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import {
+  SimulatedSubagentFrontmatter,
+  SimulatedSubagentFrontmatterSchema,
+} from "./simulated-subagent.js";
+
+describe("CursorSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+name: Test Cursor Agent
+description: Test cursor agent description
+---
+
+This is the body of the cursor agent.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required fields
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for cursor subagents", () => {
+      const paths = CursorSubagent.getSettablePaths();
+      expect(paths).toEqual({
+        root: {
+          relativeDirPath: ".",
+          relativeFilePath: "CURSOR.md",
+        },
+        nonRoot: {
+          relativeDirPath: ".cursor/subagents",
+        },
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid markdown content", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Cursor Agent",
+          description: "Test cursor agent description",
+        },
+        body: "This is the body of the cursor agent.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CursorSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the cursor agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Cursor Agent",
+        description: "Test cursor agent description",
+      });
+    });
+
+    it("should create instance with empty name and description", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "",
+          description: "",
+        },
+        body: "This is a cursor agent without name or description.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is a cursor agent without name or description.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(subagent).toBeInstanceOf(CursorSubagent);
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(
+        () =>
+          new CursorSubagent({
+            baseDir: testDir,
+            relativeDirPath: ".cursor/subagents",
+            relativeFilePath: "invalid-agent.md",
+            frontmatter: {
+              // Missing required fields
+            } as SimulatedSubagentFrontmatter,
+            body: "Body content",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
+  describe("getBody", () => {
+    it("should return the body content", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "This is the body content.\nWith multiple lines.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is the body content.\nWith multiple lines.");
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return frontmatter with name and description", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Cursor Agent",
+          description: "Test cursor agent",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const frontmatter = subagent.getFrontmatter();
+      expect(frontmatter).toEqual({
+        name: "Test Cursor Agent",
+        description: "Test cursor agent",
+      });
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should throw error as it is a simulated file", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create CursorSubagent from RulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["cursor"],
+          name: "Test Agent",
+          description: "Test description from rulesync",
+        },
+        body: "Test agent content",
+        fileContent: "", // Will be generated
+        validate: true,
+      });
+
+      const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CursorSubagent;
+
+      expect(cursorSubagent).toBeInstanceOf(CursorSubagent);
+      expect(cursorSubagent.getBody()).toBe("Test agent content");
+      expect(cursorSubagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test description from rulesync",
+      });
+      expect(cursorSubagent.getRelativeFilePath()).toBe("test-agent.md");
+      expect(cursorSubagent.getRelativeDirPath()).toBe(".cursor/subagents");
+    });
+
+    it("should handle RulesyncSubagent with different file extensions", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "complex-agent.txt",
+        frontmatter: {
+          targets: ["cursor"],
+          name: "Complex Agent",
+          description: "Complex agent",
+        },
+        body: "Complex content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CursorSubagent;
+
+      expect(cursorSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
+    });
+
+    it("should handle empty name and description", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["cursor"],
+          name: "",
+          description: "",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CursorSubagent;
+
+      expect(cursorSubagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load CursorSubagent from file", async () => {
+      const subagentsDir = join(testDir, ".cursor", "subagents");
+      const filePath = join(subagentsDir, "test-file-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CursorSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-file-agent.md",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CursorSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the cursor agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Cursor Agent",
+        description: "Test cursor agent description",
+      });
+      expect(subagent.getRelativeFilePath()).toBe("test-file-agent.md");
+    });
+
+    it("should handle file path with subdirectories", async () => {
+      const subagentsDir = join(testDir, ".cursor", "subagents", "subdir");
+      const filePath = join(subagentsDir, "nested-agent.md");
+
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await CursorSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "subdir/nested-agent.md",
+        validate: true,
+      });
+
+      expect(subagent.getRelativeFilePath()).toBe("nested-agent.md");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        CursorSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "non-existent-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should throw error when file contains invalid frontmatter", async () => {
+      const subagentsDir = join(testDir, ".cursor", "subagents");
+      const filePath = join(subagentsDir, "invalid-agent.md");
+
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        CursorSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const subagentsDir = join(testDir, ".cursor", "subagents");
+      const filePath = join(subagentsDir, "no-frontmatter.md");
+
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        CursorSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "valid-agent.md",
+        frontmatter: {
+          name: "Valid Agent",
+          description: "Valid description",
+        },
+        body: "Valid body",
+        validate: false, // Skip validation in constructor to test validate method
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle frontmatter with additional properties", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "agent-with-extras.md",
+        frontmatter: {
+          name: "Agent",
+          description: "Agent with extra properties",
+          // Additional properties should be allowed but not validated
+          extra: "property",
+        } as any,
+        body: "Body content",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      // The validation should pass as long as required fields are present
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("SimulatedSubagentFrontmatterSchema", () => {
+    it("should validate valid frontmatter with name and description", () => {
+      const validFrontmatter = {
+        name: "Test Agent",
+        description: "Test description",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.parse(validFrontmatter);
+      expect(result).toEqual(validFrontmatter);
+    });
+
+    it("should throw error for frontmatter without name", () => {
+      const invalidFrontmatter = {
+        description: "Test description",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter without description", () => {
+      const invalidFrontmatter = {
+        name: "Test Agent",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+
+    it("should throw error for frontmatter with invalid types", () => {
+      const invalidFrontmatter = {
+        name: 123, // Should be string
+        description: "Test",
+      };
+
+      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty body content", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "empty-body.md",
+        frontmatter: {
+          name: "Empty Body Agent",
+          description: "Agent with empty body",
+        },
+        body: "",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Empty Body Agent",
+        description: "Agent with empty body",
+      });
+    });
+
+    it("should handle special characters in content", () => {
+      const specialContent =
+        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
+
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "special-char.md",
+        frontmatter: {
+          name: "Special Agent",
+          description: "Special characters test",
+        },
+        body: specialContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(specialContent);
+      expect(subagent.getBody()).toContain("@#$%^&*()");
+      expect(subagent.getBody()).toContain("你好世界 🌍");
+      expect(subagent.getBody()).toContain("\"Hello 'World'\"");
+    });
+
+    it("should handle very long content", () => {
+      const longContent = "A".repeat(10000);
+
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "long-content.md",
+        frontmatter: {
+          name: "Long Agent",
+          description: "Long content test",
+        },
+        body: longContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(longContent);
+      expect(subagent.getBody().length).toBe(10000);
+    });
+
+    it("should handle multi-line name and description", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "multiline-fields.md",
+        frontmatter: {
+          name: "Multi-line\nAgent Name",
+          description: "This is a multi-line\ndescription with\nmultiple lines",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Multi-line\nAgent Name",
+        description: "This is a multi-line\ndescription with\nmultiple lines",
+      });
+    });
+
+    it("should handle Windows-style line endings", () => {
+      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
+
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "windows-lines.md",
+        frontmatter: {
+          name: "Windows Agent",
+          description: "Windows line endings test",
+        },
+        body: windowsContent,
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe(windowsContent);
+    });
+  });
+
+  describe("integration with base classes", () => {
+    it("should properly inherit from SimulatedSubagent", () => {
+      const subagent = new CursorSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      // Check that it's an instance of parent classes
+      expect(subagent).toBeInstanceOf(CursorSubagent);
+      expect(subagent.getRelativeDirPath()).toBe(".cursor/subagents");
+      expect(subagent.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should handle baseDir correctly", () => {
+      const customBaseDir = "/custom/base/dir";
+      const subagent = new CursorSubagent({
+        baseDir: customBaseDir,
+        relativeDirPath: ".cursor/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(CursorSubagent);
+    });
+  });
+});

--- a/src/subagents/cursor-subagent.test.ts
+++ b/src/subagents/cursor-subagent.test.ts
@@ -527,7 +527,7 @@ Body content`;
         relativeFilePath: "windows-lines.md",
         frontmatter: {
           name: "Windows Agent",
-          description: "Windows line endings test",
+          description: "Test with Windows line endings",
         },
         body: windowsContent,
         validate: true,
@@ -537,8 +537,8 @@ Body content`;
     });
   });
 
-  describe("integration with base classes", () => {
-    it("should properly inherit from SimulatedSubagent", () => {
+  describe("inheritance", () => {
+    it("should inherit from SimulatedSubagent", () => {
       const subagent = new CursorSubagent({
         baseDir: testDir,
         relativeDirPath: ".cursor/subagents",
@@ -547,31 +547,15 @@ Body content`;
           name: "Test",
           description: "Test",
         },
-        body: "Body",
-        validate: true,
-      });
-
-      // Check that it's an instance of parent classes
-      expect(subagent).toBeInstanceOf(CursorSubagent);
-      expect(subagent.getRelativeDirPath()).toBe(".cursor/subagents");
-      expect(subagent.getRelativeFilePath()).toBe("test.md");
-    });
-
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
-      const subagent = new CursorSubagent({
-        baseDir: customBaseDir,
-        relativeDirPath: ".cursor/subagents",
-        relativeFilePath: "test.md",
-        frontmatter: {
-          name: "Test",
-          description: "Test",
-        },
-        body: "Body",
+        body: "Test",
         validate: true,
       });
 
       expect(subagent).toBeInstanceOf(CursorSubagent);
+      // Test that it inherits methods from parent class
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
     });
   });
 });

--- a/src/subagents/cursor-subagent.ts
+++ b/src/subagents/cursor-subagent.ts
@@ -1,0 +1,31 @@
+import { SimulatedSubagent } from "./simulated-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+  ToolSubagentSettablePaths,
+} from "./tool-subagent.js";
+
+export class CursorSubagent extends SimulatedSubagent {
+  static getSettablePaths(): ToolSubagentSettablePaths {
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "CURSOR.md",
+      },
+      nonRoot: {
+        relativeDirPath: ".cursor/subagents",
+      },
+    };
+  }
+
+  static async fromFile(params: ToolSubagentFromFileParams): Promise<CursorSubagent> {
+    const baseParams = await this.fromFileDefault(params);
+    return new CursorSubagent(baseParams);
+  }
+
+  static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    const baseParams = this.fromRulesyncSubagentDefault(params);
+    return new CursorSubagent(baseParams);
+  }
+}

--- a/src/subagents/simulated-subagent.test.ts
+++ b/src/subagents/simulated-subagent.test.ts
@@ -1,0 +1,323 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import {
+  SimulatedSubagent,
+  SimulatedSubagentFrontmatter,
+  SimulatedSubagentFrontmatterSchema,
+} from "./simulated-subagent.js";
+
+// Create a concrete test implementation of SimulatedSubagent
+class TestSimulatedSubagent extends SimulatedSubagent {
+  static getSettablePaths() {
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "TEST_AGENT.md",
+      },
+      nonRoot: {
+        relativeDirPath: ".test/agents",
+      },
+    };
+  }
+
+  static async fromFile(params: any) {
+    const baseParams = await this.fromFileDefault(params);
+    return new TestSimulatedSubagent(baseParams);
+  }
+
+  static fromRulesyncSubagent(params: any) {
+    const baseParams = this.fromRulesyncSubagentDefault(params);
+    return new TestSimulatedSubagent(baseParams);
+  }
+}
+
+describe("SimulatedSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  const validMarkdownContent = `---
+name: Test Agent
+description: Test agent description
+---
+
+This is the body of the simulated agent.
+It can be multiline.`;
+
+  const invalidMarkdownContent = `---
+# Missing required fields
+invalid: true
+---
+
+Body content`;
+
+  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test agent description",
+        },
+        body: "This is the body of the simulated agent.\nIt can be multiline.",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(TestSimulatedSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the simulated agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test agent description",
+      });
+    });
+
+    it("should create instance with empty name and description", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "",
+          description: "",
+        },
+        body: "This is a simulated agent without name or description.",
+        validate: true,
+      });
+
+      expect(subagent.getBody()).toBe("This is a simulated agent without name or description.");
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+    });
+
+    it("should create instance without validation when validate is false", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      expect(subagent.getBody()).toBe("Test body");
+    });
+
+    it("should throw error for invalid frontmatter when validation is enabled", () => {
+      expect(() => {
+        new TestSimulatedSubagent({
+          baseDir: testDir,
+          relativeDirPath: ".test/agents",
+          relativeFilePath: "test-agent.md",
+          frontmatter: {
+            // Missing required fields
+            invalid: true,
+          } as any,
+          body: "Test body",
+          validate: true,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe("toRulesyncSubagent", () => {
+    it("should throw error because SimulatedSubagent is simulated", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => subagent.toRulesyncSubagent()).toThrow(
+        "Not implemented because it is a SIMULATED file.",
+      );
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should create instance from valid markdown file", async () => {
+      const filePath = join(testDir, ".test/agents", "test-agent.md");
+      await writeFileContent(filePath, validMarkdownContent);
+
+      const subagent = await TestSimulatedSubagent.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "test-agent.md",
+        validate: true,
+      });
+
+      expect(subagent).toBeInstanceOf(TestSimulatedSubagent);
+      expect(subagent.getBody()).toBe(
+        "This is the body of the simulated agent.\nIt can be multiline.",
+      );
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test agent description",
+      });
+    });
+
+    it("should throw error for invalid markdown file", async () => {
+      const filePath = join(testDir, ".test/agents", "invalid-agent.md");
+      await writeFileContent(filePath, invalidMarkdownContent);
+
+      await expect(
+        TestSimulatedSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "invalid-agent.md",
+          validate: true,
+        }),
+      ).rejects.toThrow(/Invalid frontmatter/);
+    });
+
+    it("should throw error for file without frontmatter", async () => {
+      const filePath = join(testDir, ".test/agents", "no-frontmatter.md");
+      await writeFileContent(filePath, markdownWithoutFrontmatter);
+
+      await expect(
+        TestSimulatedSubagent.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "no-frontmatter.md",
+          validate: true,
+        }),
+      ).rejects.toThrow(/Invalid frontmatter/);
+    });
+  });
+
+  describe("fromRulesyncSubagent", () => {
+    it("should create instance from RulesyncSubagent", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["claudecode"],
+          name: "Test Agent",
+          description: "Test agent description",
+        },
+        body: "Test body content",
+        fileContent: `---
+targets:
+  - claudecode
+name: Test Agent
+description: Test agent description
+---
+
+Test body content`,
+        validate: true,
+      });
+
+      const simulatedSubagent = TestSimulatedSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        rulesyncSubagent,
+        validate: true,
+      });
+
+      expect(simulatedSubagent).toBeInstanceOf(TestSimulatedSubagent);
+      expect(simulatedSubagent.getBody()).toBe("Test body content");
+      expect(simulatedSubagent.getFrontmatter()).toEqual({
+        name: "Test Agent",
+        description: "Test agent description",
+      });
+    });
+  });
+
+  describe("validate", () => {
+    it("should return success for valid frontmatter", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should return error for invalid frontmatter", () => {
+      const subagent = new TestSimulatedSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".test/agents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          // Missing required fields
+          invalid: true,
+        } as any,
+        body: "Test body",
+        validate: false,
+      });
+
+      const result = subagent.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+  });
+
+  describe("SimulatedSubagentFrontmatterSchema", () => {
+    it("should validate correct frontmatter", () => {
+      const validFrontmatter: SimulatedSubagentFrontmatter = {
+        name: "Test Agent",
+        description: "Test description",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.safeParse(validFrontmatter);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validFrontmatter);
+      }
+    });
+
+    it("should reject frontmatter without name", () => {
+      const invalidFrontmatter = {
+        description: "Test description",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.safeParse(invalidFrontmatter);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject frontmatter without description", () => {
+      const invalidFrontmatter = {
+        name: "Test Agent",
+      };
+
+      const result = SimulatedSubagentFrontmatterSchema.safeParse(invalidFrontmatter);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/subagents/simulated-subagent.ts
+++ b/src/subagents/simulated-subagent.ts
@@ -1,0 +1,122 @@
+import { basename, join } from "node:path";
+import { z } from "zod/mini";
+import { AiFileParams, ValidationResult } from "../types/ai-file.js";
+import { readFileContent } from "../utils/file.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../utils/frontmatter.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+} from "./tool-subagent.js";
+
+export const SimulatedSubagentFrontmatterSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+});
+
+export type SimulatedSubagentFrontmatter = z.infer<typeof SimulatedSubagentFrontmatterSchema>;
+
+export type SimulatedSubagentParams = {
+  frontmatter: SimulatedSubagentFrontmatter;
+  body: string;
+} & Omit<AiFileParams, "fileContent">;
+
+export abstract class SimulatedSubagent extends ToolSubagent {
+  private readonly frontmatter: SimulatedSubagentFrontmatter;
+  private readonly body: string;
+
+  constructor({ frontmatter, body, ...rest }: SimulatedSubagentParams) {
+    if (rest.validate) {
+      const result = SimulatedSubagentFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyFrontmatter(body, frontmatter),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
+  getBody(): string {
+    return this.body;
+  }
+
+  getFrontmatter(): Record<string, unknown> {
+    return this.frontmatter;
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    throw new Error("Not implemented because it is a SIMULATED file.");
+  }
+
+  protected static fromRulesyncSubagentDefault({
+    baseDir = ".",
+    rulesyncSubagent,
+    validate = true,
+  }: ToolSubagentFromRulesyncSubagentParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
+    const rulesyncFrontmatter = rulesyncSubagent.getFrontmatter();
+
+    const simulatedFrontmatter: SimulatedSubagentFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    const body = rulesyncSubagent.getBody();
+
+    return {
+      baseDir: baseDir,
+      frontmatter: simulatedFrontmatter,
+      body,
+      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
+      validate,
+    };
+  }
+
+  validate(): ValidationResult {
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
+    const result = SimulatedSubagentFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return { success: false, error: result.error };
+    }
+  }
+
+  protected static async fromFileDefault({
+    baseDir = ".",
+    relativeFilePath,
+    validate = true,
+  }: ToolSubagentFromFileParams): Promise<ConstructorParameters<typeof SimulatedSubagent>[0]> {
+    const filePath = join(
+      baseDir,
+      this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = SimulatedSubagentFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${result.error.message}`);
+    }
+
+    return {
+      baseDir: baseDir,
+      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    };
+  }
+}

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -22,7 +22,7 @@ export abstract class FeatureProcessor {
   /**
    * Return tool targets that this feature supports.
    */
-  static getToolTargets(): ToolTarget[] {
+  static getToolTargets(_excludeSimulated: boolean = false): ToolTarget[] {
     throw new Error("Not implemented");
   }
 

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -22,7 +22,7 @@ export abstract class FeatureProcessor {
   /**
    * Return tool targets that this feature supports.
    */
-  static getToolTargets(_excludeSimulated: boolean = false): ToolTarget[] {
+  static getToolTargets(_params: { excludeSimulated?: boolean } = {}): ToolTarget[] {
     throw new Error("Not implemented");
   }
 


### PR DESCRIPTION
## Summary
- Add SimulatedSubagent base class and implementations for Copilot, Cursor, and CodexCli
- Add validation to prevent importing simulated-only tools
- Add support for simulated subagents in subagents-processor
- Fix CodexCliSubagent test import and naming consistency

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Test SimulatedSubagent implementations
- [x] Verify import validation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)