### PR TITLE
Release v0.71.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "0.70.0",
+	"version": "0.71.0",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,7 +33,7 @@ const getVersion = async (): Promise<string> => {
     return packageJson.version;
   } catch {
     // Fallback to a hardcoded version if reading fails
-    return "0.70.0";
+    return "0.71.0";
   }
 };
 


### PR DESCRIPTION
## Release v0.71.0

This PR bumps the version from 0.70.0 to 0.71.0 (minor version increment).

### Changes
- Updated version in `package.json` to 0.71.0
- Updated fallback version in `src/cli/index.ts` to 0.71.0

### Release Process
After merging this PR:
1. The tag `v0.71.0` has already been pushed
2. Create a GitHub release from the tag to trigger npm publication

🤖 Generated with [Claude Code](https://claude.ai/code)