### PR TITLE
fix: remove unnecessary restriction on importing simulated-only tools

### DIFF
--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -83,45 +83,6 @@ describe("importCommand", () => {
       expect(logger.error).toHaveBeenCalledWith("Only one tool can be imported at a time");
       expect(mockExit).toHaveBeenCalledWith(1);
     });
-
-    it("should exit with error when trying to import simulated-only tool copilot", async () => {
-      mockConfig.getTargets.mockReturnValue(["copilot"]);
-      const options: ImportOptions = {
-        targets: ["copilot"],
-      };
-
-      await expect(importCommand(options)).rejects.toThrow("Process exit");
-      expect(logger.error).toHaveBeenCalledWith(
-        "Cannot import copilot: it only supports generation (simulated commands/subagents)",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should exit with error when trying to import simulated-only tool cursor", async () => {
-      mockConfig.getTargets.mockReturnValue(["cursor"]);
-      const options: ImportOptions = {
-        targets: ["cursor"],
-      };
-
-      await expect(importCommand(options)).rejects.toThrow("Process exit");
-      expect(logger.error).toHaveBeenCalledWith(
-        "Cannot import cursor: it only supports generation (simulated commands/subagents)",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should exit with error when trying to import simulated-only tool codexcli", async () => {
-      mockConfig.getTargets.mockReturnValue(["codexcli"]);
-      const options: ImportOptions = {
-        targets: ["codexcli"],
-      };
-
-      await expect(importCommand(options)).rejects.toThrow("Process exit");
-      expect(logger.error).toHaveBeenCalledWith(
-        "Cannot import codexcli: it only supports generation (simulated commands/subagents)",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
   });
 
   describe("successful import", () => {

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -27,15 +27,6 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const tool = config.getTargets()[0]!;
 
-  // Check if tool is simulated-only and prevent import
-  const simulatedOnlyTools = ["copilot", "cursor", "codexcli"];
-  if (simulatedOnlyTools.includes(tool)) {
-    logger.error(
-      `Cannot import ${tool}: it only supports generation (simulated commands/subagents)`,
-    );
-    process.exit(1);
-  }
-
   // Import rule files using RulesProcessor if rules feature is enabled
   let rulesCreated = 0;
   if (config.getFeatures().includes("rules")) {


### PR DESCRIPTION
## Summary
- Remove validation check that prevented importing simulated-only tools (copilot, cursor, codexcli)
- Remove corresponding redundant tests for the restriction
- Simplify import logic to allow all configured tools to be imported

## Changes
- **src/cli/commands/import.ts**: Removed `simulatedOnlyTools` check that was blocking imports
- **src/cli/commands/import.test.ts**: Removed redundant test cases for the removed restriction

## Background
The previous restriction was preventing users from importing configurations for tools like copilot, cursor, and codexcli, even though these tools can have importable configurations. This fix removes the unnecessary limitation and allows the import command to work with all configured tools.

## Test plan
- [x] Verify existing tests still pass after removing redundant test cases
- [x] Confirm import command now works with previously restricted tools
- [x] Ensure no regression in import functionality for other tools

🤖 Generated with [Claude Code](https://claude.ai/code)