### PR TITLE
chore: add DISABLE_AUTOUPDATER environment variable and bump version to 0.72.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,7 @@
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
-    "BASH_MAX_TIMEOUT_MS": "1200000"
+    "BASH_MAX_TIMEOUT_MS": "1200000",
+    "DISABLE_AUTOUPDATER": "0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "0.71.0",
+	"version": "0.72.0",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",


### PR DESCRIPTION
## Summary
- Add DISABLE_AUTOUPDATER environment variable to control auto-updater behavior in .claude/settings.json
- Bump package version from 0.71.0 to 0.72.0

## Changes
- **Settings Configuration**: Added `DISABLE_AUTOUPDATER: "0"` to the env section in `.claude/settings.json` to provide control over the auto-updater functionality
- **Version Bump**: Updated package version in `package.json` from 0.71.0 to 0.72.0

## Test plan
- [ ] Verify the new environment variable is properly loaded
- [ ] Test that auto-updater behavior respects the DISABLE_AUTOUPDATER setting
- [ ] Confirm version bump is reflected correctly

🤖 Generated with [Claude Code](https://claude.ai/code)