### PR TITLE
docs: add Warp to supported tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        |  ✅   |   ✅   |      |         |          |
 | AugmentCode            |  ✅   |   ✅   |       |         |          |
 | Windsurf               |  ✅   |   ✅    |      |         |          |
+| Warp               |  ✅   |        |      |         |          |
 
 
 🎮: Simulated Commands/Subagents (Experimental Feature)


### PR DESCRIPTION
## Summary
- Add Warp to the supported tools table in README.md
- Warp supports generation functionality but not import yet

## Test plan
- [x] Verify table formatting is correct
- [x] Confirm Warp entry shows generation support (✅) and no import support (empty cell)
- [x] Check that documentation accurately reflects current tool capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)