### PR TITLE
chore: update releaser subagent model configuration

### DIFF
--- a/.rulesync/subagents/releaser.md
+++ b/.rulesync/subagents/releaser.md
@@ -5,7 +5,7 @@ description: >-
   Use this agent when the user wants to release a new version of the project.
   This agent can be called by user explicitly only.
 claudecode:
-  model: sonnet
+  model: opus
 ---
 
 First, let's work on the following steps.


### PR DESCRIPTION
## Summary
- Update model configuration in releaser subagent from sonnet to opus to reflect the latest configuration changes

## Changes
- Modified `.rulesync/subagents/releaser.md` to use `opus` model instead of `sonnet`
- This aligns the releaser subagent configuration with the latest model preferences

## Test plan
- [ ] Verify releaser subagent loads with the new model configuration
- [ ] Confirm the model change doesn't affect other functionality

🤖 Generated with [Claude Code](https://claude.ai/code)