### PR TITLE
chore(docs): remove outdated v0.68.0 refactoring announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 [![npm version](https://img.shields.io/npm/v/rulesync)](https://www.npmjs.com/package/rulesync)
 [![npm downloads](https://img.shields.io/npm/dt/rulesync)](https://www.npmjs.com/package/rulesync)
 
-> [!IMPORTANT]
-> Starting from v0.68.0, we have implemented a major refactoring by the maintainers. If the behavior is unstable, please specify and run v0.67.0.
-> Additionally, as a result, we have deprecated some features, support, and backward compatibility. If you wish to see any of these features restored, please create an Issue.
-> As background, this tool has been built using Vibe Coding up until now, but the codebase had become extremely complex, making future extensions difficult, so we had to discard the existing codebase. We plan to continue active development going forward.
-> Thank you for your continued support of rulesync.
-
 A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files. Features selective generation, comprehensive import/export capabilities, and supports 19+ AI development tools with rules, commands, MCP, ignore files, and subagents. Uses the recommended `.rulesync/rules/*.md` structure, with full backward compatibility for legacy `.rulesync/*.md` layouts.
 
 ## Installation

--- a/src/constants/announcements.ts
+++ b/src/constants/announcements.ts
@@ -1,2 +1,1 @@
-export const ANNOUNCEMENT =
-  "Starting from v0.68.0, we have conducted large-scale refactoring and applied breaking changes. We apologize for any inconvenience this may cause. If you encounter unstable behavior, you can downgrade to v0.67.0 to use the previous version.".trim();
+export const ANNOUNCEMENT = "".trim();


### PR DESCRIPTION
## Summary
- Remove outdated announcement regarding v0.68.0 refactoring from README.md and announcements.ts
- Streamlines documentation by removing confusing legacy messaging about version 0.68.0 changes
- Cleans up both the README important notice and the announcements constant

## Changes
- Remove the important notice block from README.md that referenced v0.68.0 refactoring and deprecation warnings
- Clear the ANNOUNCEMENT constant in announcements.ts by setting it to an empty string
- Improves user experience by removing outdated information that could confuse new users

## Test plan
- [x] Verify README.md no longer contains the outdated v0.68.0 notice
- [x] Confirm announcements.ts has empty announcement string
- [x] Check that the removal doesn't break any existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)