### PR TITLE
feat: implement isTargetedByRulesyncCommand methods for all command types

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,6 @@
       "Edit(**)",
       "MultiEdit(**)",
       "WebFetch(domain:*)",
-      "WebSearch(domain:*)",
       "Write(**)",
       "Bash(node:*)",
       "Bash(pnpm:*)",

--- a/.rulesync/commands/add-support.md
+++ b/.rulesync/commands/add-support.md
@@ -1,7 +1,7 @@
 ---
 description: 'Add support for a new AI coding tool.'
 targets:
-  - claudecode
+  - '*'
 ---
 
 target_tool_name, tool_name_in_rulesync, overwrite, remarks = $ARGUMENTS

--- a/.rulesync/commands/check.md
+++ b/.rulesync/commands/check.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: check'
 targets:
-  - claudecode
+  - '*'
 ---
 
 Do the following actions and fix any failures if exists. Until all pass successfully, do the following actions again.

--- a/.rulesync/commands/clean-branches.md
+++ b/.rulesync/commands/clean-branches.md
@@ -1,7 +1,7 @@
 ---
 description: 'Clean branches'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Delete all local branches except for current branch and main branch.

--- a/.rulesync/commands/create-and-merge-pr.md
+++ b/.rulesync/commands/create-and-merge-pr.md
@@ -1,7 +1,7 @@
 ---
 description: 'create and merge PR'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Call the pr-handler subagent to create or update a PR.

--- a/.rulesync/commands/enhance-tests.md
+++ b/.rulesync/commands/enhance-tests.md
@@ -1,7 +1,7 @@
 ---
 description: 'Enhance the test coverage'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Add test code until coverage reaches 80% or higher.

--- a/.rulesync/commands/implement-ignore-generation.md
+++ b/.rulesync/commands/implement-ignore-generation.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: implement-ignore-generation'
 targets:
-  - claudecode
+  - '*'
 ---
 
 tool_name_in_rulesync, remarks = $ARGUMENTS

--- a/.rulesync/commands/implement-mcp-config-generation.md
+++ b/.rulesync/commands/implement-mcp-config-generation.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: implement-mcp-config-generation'
 targets:
-  - claudecode
+  - '*'
 ---
 
 tool_name_in_rulesync, remarks = $ARGUMENTS

--- a/.rulesync/commands/implement-rules-generation.md
+++ b/.rulesync/commands/implement-rules-generation.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: implement-rules-generation'
 targets:
-  - claudecode
+  - '*'
 ---
 
 tool_name_in_rulesync, remarks = $ARGUMENTS

--- a/.rulesync/commands/init-rulesync.md
+++ b/.rulesync/commands/init-rulesync.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: init-rulesync'
 targets:
-  - claudecode
+  - '*'
 ---
 
 Analyze this project's codebase and update .rulesync/rules/overview.md files as needed. Especially you should read `README.md` and `CONTRIBUTING.md`.

--- a/.rulesync/commands/instruct-for-multiple-tools.md
+++ b/.rulesync/commands/instruct-for-multiple-tools.md
@@ -1,7 +1,7 @@
 ---
 description: 'Instruct for multiple AI coding tools.'
 targets:
-  - claudecode
+  - '*'
 ---
 
 $ARGUMENTS is required.

--- a/.rulesync/commands/judge-pr.md
+++ b/.rulesync/commands/judge-pr.md
@@ -1,7 +1,7 @@
 ---
 description: 'Judge PR'
 targets:
-  - claudecode
+  - '*'
 ---
 
 target_pr = $ARGUMENTS

--- a/.rulesync/commands/refactor.md
+++ b/.rulesync/commands/refactor.md
@@ -1,7 +1,7 @@
 ---
 description: 'Refactor'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Call refactoring-planner subagent to plan refactoring tasks.

--- a/.rulesync/commands/release.md
+++ b/.rulesync/commands/release.md
@@ -1,7 +1,7 @@
 ---
 description: 'Release a new version of the project.'
 targets:
-  - claudecode
+  - '*'
 ---
 
 Call the releaser subagent. If $ARGUMENTS is not empty, pass it to the releaser subagent.

--- a/.rulesync/commands/research-tool-specs.md
+++ b/.rulesync/commands/research-tool-specs.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: research-tool-specs'
 targets:
-  - claudecode
+  - '*'
 ---
 
 target_tool_name, tool_name_in_rulesync, overwrite, remarks = $ARGUMENTS

--- a/.rulesync/commands/review-pr.md
+++ b/.rulesync/commands/review-pr.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: review-pr'
 targets:
-  - claudecode
+  - '*'
 ---
 
 target_pr = $ARGUMENTS

--- a/.rulesync/commands/reviewprompt.md
+++ b/.rulesync/commands/reviewprompt.md
@@ -1,7 +1,7 @@
 ---
 description: 'Reviewprompt'
 targets:
-  - claudecode
+  - '*'
 ---
 
 pr_url = $ARGUMENTS

--- a/.rulesync/commands/to-english-all.md
+++ b/.rulesync/commands/to-english-all.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: to-english-all'
 targets:
-  - claudecode
+  - '*'
 ---
 
 Call the japanese-to-english-translator subagent to convert the following documents to English and overwrite them. All files should be processed at once in a single subagent execution.

--- a/.rulesync/commands/to-english.md
+++ b/.rulesync/commands/to-english.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: to-english'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Call the diff-analyzer subagent to detect the changes of docs in current branch.

--- a/.rulesync/commands/update-docs-all.md
+++ b/.rulesync/commands/update-docs-all.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: update-docs-all'
 targets:
-  - claudecode
+  - '*'
 ---
 
 Call the docs-updater subagent to update the following documents in light of the changes detected by the diff-analyzer. All files should be processed at once in a single subagent execution.

--- a/.rulesync/commands/update-docs.md
+++ b/.rulesync/commands/update-docs.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: update-docs'
 targets:
-  - claudecode
+  - '*'
 ---
 
 1. Call the diff-analyzer subagent to detect the changes in current branch.

--- a/.rulesync/commands/update-gitignore-command.md
+++ b/.rulesync/commands/update-gitignore-command.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: update-gitignore-command'
 targets:
-  - claudecode
+  - '*'
 ---
 
 tool_name_in_rulesync, remarks = $ARGUMENTS

--- a/.rulesync/commands/work-on-tons-of-errors.md
+++ b/.rulesync/commands/work-on-tons-of-errors.md
@@ -1,7 +1,7 @@
 ---
 description: 'Command: work-on-tons-of-errors'
 targets:
-  - claudecode
+  - '*'
 ---
 
 work_guidelines = $ARGUMENTS

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -440,7 +440,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(logger.success).toHaveBeenCalledWith(
-        "🎉 All done! Generated 6 file(s) total (2 rules + 3 MCPs + 1 commands)",
+        "🎉 All done! Generated 6 file(s) total (2 rules + 3 MCP files + 1 commands)",
       );
     });
 
@@ -455,7 +455,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(logger.success).toHaveBeenCalledWith(
-        "🎉 All done! Generated 5 file(s) total (1 rules + 1 ignore files + 1 MCPs + 1 commands + 1 subagents)",
+        "🎉 All done! Generated 5 file(s) total (1 rules + 1 ignore files + 1 MCP files + 1 commands + 1 subagents)",
       );
     });
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -220,7 +220,7 @@ export async function generateCommand(options: GenerateOptions): Promise<void> {
     const parts = [];
     if (totalRulesOutputs > 0) parts.push(`${totalRulesOutputs} rules`);
     if (totalIgnoreOutputs > 0) parts.push(`${totalIgnoreOutputs} ignore files`);
-    if (totalMcpOutputs > 0) parts.push(`${totalMcpOutputs} MCPs`);
+    if (totalMcpOutputs > 0) parts.push(`${totalMcpOutputs} MCP files`);
     if (totalCommandOutputs > 0) parts.push(`${totalCommandOutputs} commands`);
     if (totalSubagentOutputs > 0) parts.push(`${totalSubagentOutputs} subagents`);
 

--- a/src/commands/claudecode-command.test.ts
+++ b/src/commands/claudecode-command.test.ts
@@ -577,4 +577,71 @@ Body`;
       expect(command).toBeInstanceOf(ClaudecodeCommand);
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with claudecode target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["claudecode"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with claudecode and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "claudecode", "cline"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync command with no targets specified", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/commands/claudecode-command.ts
+++ b/src/commands/claudecode-command.ts
@@ -116,6 +116,13 @@ export class ClaudecodeCommand extends ToolCommand {
     }
   }
 
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "claudecode",
+    });
+  }
+
   static async fromFile({
     baseDir = ".",
     relativeFilePath,

--- a/src/commands/codexcli-command.test.ts
+++ b/src/commands/codexcli-command.test.ts
@@ -526,4 +526,71 @@ Body content`;
       expect(command).toBeInstanceOf(CodexCliCommand);
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with codexcli target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["codexcli"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with codexcli and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "codexcli", "claudecode"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync command with no targets specified", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/commands/codexcli-command.ts
+++ b/src/commands/codexcli-command.ts
@@ -1,6 +1,7 @@
 import { basename, join } from "node:path";
 import { readFileContent } from "../utils/file.js";
 import { parseFrontmatter } from "../utils/frontmatter.js";
+import { RulesyncCommand } from "./rulesync-command.js";
 import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
 import {
   ToolCommandFromFileParams,
@@ -50,6 +51,13 @@ export class CodexCliCommand extends SimulatedCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "codexcli",
     });
   }
 }

--- a/src/commands/commands-processor.test.ts
+++ b/src/commands/commands-processor.test.ts
@@ -44,6 +44,7 @@ vi.mocked(RulesyncCommand).getSettablePaths = vi
 // Set up static methods after mocking
 vi.mocked(ClaudecodeCommand).fromFile = vi.fn();
 vi.mocked(ClaudecodeCommand).fromRulesyncCommand = vi.fn();
+vi.mocked(ClaudecodeCommand).isTargetedByRulesyncCommand = vi.fn().mockReturnValue(true);
 vi.mocked(ClaudecodeCommand).getSettablePaths = vi
   .fn()
   .mockReturnValue({ relativeDirPath: ".claude/commands" });
@@ -51,6 +52,7 @@ vi.mocked(ClaudecodeCommand).getSettablePaths = vi
 // Set up static methods after mocking
 vi.mocked(GeminiCliCommand).fromFile = vi.fn();
 vi.mocked(GeminiCliCommand).fromRulesyncCommand = vi.fn();
+vi.mocked(GeminiCliCommand).isTargetedByRulesyncCommand = vi.fn().mockReturnValue(true);
 vi.mocked(GeminiCliCommand).getSettablePaths = vi
   .fn()
   .mockReturnValue({ relativeDirPath: ".gemini/commands" });
@@ -58,6 +60,7 @@ vi.mocked(GeminiCliCommand).getSettablePaths = vi
 // Set up static methods after mocking
 vi.mocked(RooCommand).fromFile = vi.fn();
 vi.mocked(RooCommand).fromRulesyncCommand = vi.fn();
+vi.mocked(RooCommand).isTargetedByRulesyncCommand = vi.fn().mockReturnValue(true);
 vi.mocked(RooCommand).getSettablePaths = vi
   .fn()
   .mockReturnValue({ relativeDirPath: ".roo/commands" });

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -45,42 +45,72 @@ export class CommandsProcessor extends FeatureProcessor {
       (file): file is RulesyncCommand => file instanceof RulesyncCommand,
     );
 
-    const toolCommands = rulesyncCommands.map((rulesyncCommand) => {
-      switch (this.toolTarget) {
-        case "claudecode":
-          return ClaudecodeCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        case "geminicli":
-          return GeminiCliCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        case "roo":
-          return RooCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        case "copilot":
-          return CopilotCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        case "cursor":
-          return CursorCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        case "codexcli":
-          return CodexCliCommand.fromRulesyncCommand({
-            baseDir: this.baseDir,
-            rulesyncCommand: rulesyncCommand,
-          });
-        default:
-          throw new Error(`Unsupported tool target: ${this.toolTarget}`);
-      }
-    });
+    const toolCommands = rulesyncCommands
+      .map((rulesyncCommand) => {
+        switch (this.toolTarget) {
+          case "claudecode":
+            if (!ClaudecodeCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return ClaudecodeCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          case "geminicli":
+            if (!GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return GeminiCliCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          case "roo":
+            if (!RooCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return RooCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          case "copilot":
+            if (!CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return CopilotCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          case "cursor":
+            if (!CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return CursorCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          case "codexcli":
+            if (!CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
+              return null;
+            }
+            return CodexCliCommand.fromRulesyncCommand({
+              baseDir: this.baseDir,
+              rulesyncCommand: rulesyncCommand,
+            });
+          default:
+            throw new Error(`Unsupported tool target: ${this.toolTarget}`);
+        }
+      })
+      .filter(
+        (
+          command,
+        ): command is
+          | ClaudecodeCommand
+          | GeminiCliCommand
+          | RooCommand
+          | CopilotCommand
+          | CursorCommand
+          | CodexCliCommand => command !== null,
+      );
 
     return toolCommands;
   }

--- a/src/commands/copilot-command.test.ts
+++ b/src/commands/copilot-command.test.ts
@@ -526,4 +526,71 @@ Body content`;
       expect(command).toBeInstanceOf(CopilotCommand);
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with copilot target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["copilot"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with copilot and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "copilot", "cline"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync command with no targets specified", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/commands/copilot-command.ts
+++ b/src/commands/copilot-command.ts
@@ -1,6 +1,7 @@
 import { basename, join } from "node:path";
 import { readFileContent } from "../utils/file.js";
 import { parseFrontmatter } from "../utils/frontmatter.js";
+import { RulesyncCommand } from "./rulesync-command.js";
 import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
 import {
   ToolCommandFromFileParams,
@@ -50,6 +51,13 @@ export class CopilotCommand extends SimulatedCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "copilot",
     });
   }
 }

--- a/src/commands/cursor-command.test.ts
+++ b/src/commands/cursor-command.test.ts
@@ -526,4 +526,71 @@ Body content`;
       expect(command).toBeInstanceOf(CursorCommand);
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with cursor target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with cursor and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["claudecode", "cursor", "cline"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["claudecode"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return false for rulesync command with empty targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: [], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/src/commands/cursor-command.ts
+++ b/src/commands/cursor-command.ts
@@ -1,6 +1,7 @@
 import { basename, join } from "node:path";
 import { readFileContent } from "../utils/file.js";
 import { parseFrontmatter } from "../utils/frontmatter.js";
+import { RulesyncCommand } from "./rulesync-command.js";
 import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
 import {
   ToolCommandFromFileParams,
@@ -50,6 +51,13 @@ export class CursorCommand extends SimulatedCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "cursor",
     });
   }
 }

--- a/src/commands/geminicli-command.test.ts
+++ b/src/commands/geminicli-command.test.ts
@@ -510,4 +510,71 @@ ${longPrompt}
       expect(command.getBody().length).toBe(10001);
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with geminicli target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["geminicli"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with geminicli and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "geminicli", "cline"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync command with no targets specified", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = GeminiCliCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/commands/geminicli-command.ts
+++ b/src/commands/geminicli-command.ts
@@ -145,4 +145,11 @@ ${geminiFrontmatter.prompt}
       return { success: false, error: error instanceof Error ? error : new Error(String(error)) };
     }
   }
+
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "geminicli",
+    });
+  }
 }

--- a/src/commands/roo-command.test.ts
+++ b/src/commands/roo-command.test.ts
@@ -517,4 +517,71 @@ This file has invalid frontmatter`;
       expect(command.getFilePath()).toBe("/test/base/.roo/commands/integration.md");
     });
   });
+
+  describe("isTargetedByRulesyncCommand", () => {
+    it("should return true for rulesync command with wildcard target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = RooCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with roo target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["roo"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = RooCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync command with roo and other targets", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "roo", "cline"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = RooCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync command with different target", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = RooCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync command with no targets specified", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: ".rulesync/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = RooCommand.isTargetedByRulesyncCommand(rulesyncCommand);
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/commands/roo-command.ts
+++ b/src/commands/roo-command.ts
@@ -122,6 +122,13 @@ export class RooCommand extends ToolCommand {
     }
   }
 
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "roo",
+    });
+  }
+
   static async fromFile({
     baseDir = ".",
     relativeFilePath,

--- a/src/commands/tool-command.ts
+++ b/src/commands/tool-command.ts
@@ -1,4 +1,5 @@
 import { AiFile, AiFileFromFileParams, AiFileParams } from "../types/ai-file.js";
+import type { ToolTarget } from "../types/tool-targets.js";
 import type { RulesyncCommand } from "./rulesync-command.js";
 
 export type ToolCommandFromRulesyncCommandParams = Omit<
@@ -78,4 +79,45 @@ export abstract class ToolCommand extends AiFile {
    * @returns A RulesyncCommand instance
    */
   abstract toRulesyncCommand(): RulesyncCommand;
+
+  /**
+   * Check if this tool is targeted by a RulesyncCommand based on its targets field.
+   * Subclasses should override this to provide specific targeting logic.
+   *
+   * @param rulesyncCommand - The RulesyncCommand to check
+   * @returns True if this tool is targeted by the command
+   */
+  static isTargetedByRulesyncCommand(_rulesyncCommand: RulesyncCommand): boolean {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Default implementation for checking if a tool is targeted by a RulesyncCommand.
+   * Checks if the command's targets include the tool target or a wildcard.
+   *
+   * @param params - Parameters including the RulesyncCommand and tool target
+   * @returns True if the tool target is included in the command's targets
+   */
+  protected static isTargetedByRulesyncCommandDefault({
+    rulesyncCommand,
+    toolTarget,
+  }: {
+    rulesyncCommand: RulesyncCommand;
+    toolTarget: ToolTarget;
+  }): boolean {
+    const targets = rulesyncCommand.getFrontmatter().targets;
+    if (!targets) {
+      return true;
+    }
+
+    if (targets.includes("*")) {
+      return true;
+    }
+
+    if (targets.includes(toolTarget)) {
+      return true;
+    }
+
+    return false;
+  }
 }

--- a/src/subagents/claudecode-subagent.test.ts
+++ b/src/subagents/claudecode-subagent.test.ts
@@ -458,6 +458,78 @@ describe("ClaudecodeSubagent", () => {
     });
   });
 
+  describe("isTargetedByRulesyncSubagent", () => {
+    it("should return true for rulesync subagent with wildcard target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with claudecode target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["claudecode"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with claudecode and other targets", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          targets: ["cursor", "claudecode", "cline"],
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync subagent with different target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync subagent with no targets specified", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, name: "Test", description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+        validate: false,
+      });
+
+      const result = ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+  });
+
   describe("fromFile", () => {
     it("should load subagent from file", async () => {
       const frontmatter: ClaudecodeSubagentFrontmatter = {

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -126,6 +126,13 @@ export class ClaudecodeSubagent extends ToolSubagent {
     }
   }
 
+  static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
+    return this.isTargetedByRulesyncSubagentDefault({
+      rulesyncSubagent,
+      toolTarget: "claudecode",
+    });
+  }
+
   static async fromFile({
     baseDir = ".",
     relativeFilePath,

--- a/src/subagents/codexcli-subagent.test.ts
+++ b/src/subagents/codexcli-subagent.test.ts
@@ -532,6 +532,78 @@ Body content`;
     });
   });
 
+  describe("isTargetedByRulesyncSubagent", () => {
+    it("should return true for rulesync subagent with wildcard target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with codexcli target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["codexcli"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with codexcli and other targets", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          targets: ["cursor", "codexcli", "cline"],
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync subagent with different target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync subagent with no targets specified", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, name: "Test", description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+        validate: false,
+      });
+
+      const result = CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+  });
+
   describe("integration with base classes", () => {
     it("should properly inherit from SimulatedSubagent", () => {
       const subagent = new CodexCliSubagent({

--- a/src/subagents/codexcli-subagent.ts
+++ b/src/subagents/codexcli-subagent.ts
@@ -1,3 +1,4 @@
+import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
@@ -21,5 +22,12 @@ export class CodexCliSubagent extends SimulatedSubagent {
   static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
     const baseParams = this.fromRulesyncSubagentDefault(params);
     return new CodexCliSubagent(baseParams);
+  }
+
+  static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
+    return this.isTargetedByRulesyncSubagentDefault({
+      rulesyncSubagent,
+      toolTarget: "codexcli",
+    });
   }
 }

--- a/src/subagents/copilot-subagent.test.ts
+++ b/src/subagents/copilot-subagent.test.ts
@@ -531,6 +531,78 @@ Body content`;
     });
   });
 
+  describe("isTargetedByRulesyncSubagent", () => {
+    it("should return true for rulesync subagent with wildcard target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with copilot target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["copilot"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return true for rulesync subagent with copilot and other targets", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          targets: ["cursor", "copilot", "cline"],
+          name: "Test",
+          description: "Test",
+        },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for rulesync subagent with different target", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor"], name: "Test", description: "Test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const result = CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(false);
+    });
+
+    it("should return true for rulesync subagent with no targets specified", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: undefined, name: "Test", description: "Test" } as any,
+        body: "Body",
+        fileContent: "",
+        validate: false,
+      });
+
+      const result = CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent);
+      expect(result).toBe(true);
+    });
+  });
+
   describe("integration with base classes", () => {
     it("should properly inherit from SimulatedSubagent", () => {
       const subagent = new CopilotSubagent({

--- a/src/subagents/copilot-subagent.ts
+++ b/src/subagents/copilot-subagent.ts
@@ -1,3 +1,4 @@
+import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
@@ -21,5 +22,12 @@ export class CopilotSubagent extends SimulatedSubagent {
   static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
     const baseParams = this.fromRulesyncSubagentDefault(params);
     return new CopilotSubagent(baseParams);
+  }
+
+  static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
+    return this.isTargetedByRulesyncSubagentDefault({
+      rulesyncSubagent,
+      toolTarget: "copilot",
+    });
   }
 }

--- a/src/subagents/cursor-subagent.test.ts
+++ b/src/subagents/cursor-subagent.test.ts
@@ -552,4 +552,96 @@ Body content`;
       );
     });
   });
+
+  describe("isTargetedByRulesyncSubagent", () => {
+    it("should return true when targets includes cursor", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["cursor"],
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      expect(CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
+    });
+
+    it("should return true when targets includes asterisk", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["*"],
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      expect(CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
+    });
+
+    it("should return false when targets array is empty", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: [],
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: false, // Skip validation to allow empty targets array
+      });
+
+      expect(CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(false);
+    });
+
+    it("should return false when targets does not include cursor", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["copilot", "cline"],
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      expect(CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(false);
+    });
+
+    it("should return true when targets includes cursor among other targets", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".rulesync/subagents",
+        relativeFilePath: "test-agent.md",
+        frontmatter: {
+          targets: ["copilot", "cursor", "cline"],
+          name: "Test Agent",
+          description: "Test description",
+        },
+        body: "Test content",
+        fileContent: "",
+        validate: true,
+      });
+
+      expect(CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
+    });
+  });
 });

--- a/src/subagents/cursor-subagent.ts
+++ b/src/subagents/cursor-subagent.ts
@@ -1,3 +1,4 @@
+import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
@@ -21,5 +22,12 @@ export class CursorSubagent extends SimulatedSubagent {
   static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
     const baseParams = this.fromRulesyncSubagentDefault(params);
     return new CursorSubagent(baseParams);
+  }
+
+  static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
+    return this.isTargetedByRulesyncSubagentDefault({
+      rulesyncSubagent,
+      toolTarget: "cursor",
+    });
   }
 }

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -46,36 +46,50 @@ export class SubagentsProcessor extends FeatureProcessor {
       (file): file is RulesyncSubagent => file instanceof RulesyncSubagent,
     );
 
-    const toolSubagents = rulesyncSubagents.map((rulesyncSubagent) => {
-      switch (this.toolTarget) {
-        case "claudecode":
-          return ClaudecodeSubagent.fromRulesyncSubagent({
-            baseDir: this.baseDir,
-            relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-            rulesyncSubagent: rulesyncSubagent,
-          });
-        case "copilot":
-          return CopilotSubagent.fromRulesyncSubagent({
-            baseDir: this.baseDir,
-            relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-            rulesyncSubagent: rulesyncSubagent,
-          });
-        case "cursor":
-          return CursorSubagent.fromRulesyncSubagent({
-            baseDir: this.baseDir,
-            relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-            rulesyncSubagent: rulesyncSubagent,
-          });
-        case "codexcli":
-          return CodexCliSubagent.fromRulesyncSubagent({
-            baseDir: this.baseDir,
-            relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-            rulesyncSubagent: rulesyncSubagent,
-          });
-        default:
-          throw new Error(`Unsupported tool target: ${this.toolTarget}`);
-      }
-    });
+    const toolSubagents = rulesyncSubagents
+      .map((rulesyncSubagent) => {
+        switch (this.toolTarget) {
+          case "claudecode":
+            if (!ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
+              return null;
+            }
+            return ClaudecodeSubagent.fromRulesyncSubagent({
+              baseDir: this.baseDir,
+              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+              rulesyncSubagent: rulesyncSubagent,
+            });
+          case "copilot":
+            if (!CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
+              return null;
+            }
+            return CopilotSubagent.fromRulesyncSubagent({
+              baseDir: this.baseDir,
+              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+              rulesyncSubagent: rulesyncSubagent,
+            });
+          case "cursor":
+            if (!CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
+              return null;
+            }
+            return CursorSubagent.fromRulesyncSubagent({
+              baseDir: this.baseDir,
+              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+              rulesyncSubagent: rulesyncSubagent,
+            });
+          case "codexcli":
+            if (!CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
+              return null;
+            }
+            return CodexCliSubagent.fromRulesyncSubagent({
+              baseDir: this.baseDir,
+              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+              rulesyncSubagent: rulesyncSubagent,
+            });
+          default:
+            throw new Error(`Unsupported tool target: ${this.toolTarget}`);
+        }
+      })
+      .filter((subagent): subagent is ToolSubagent => subagent !== null);
 
     return toolSubagents;
   }

--- a/src/subagents/tool-subagent.ts
+++ b/src/subagents/tool-subagent.ts
@@ -1,5 +1,6 @@
 import { AiFileFromFileParams, AiFileParams } from "../types/ai-file.js";
 import { ToolFile } from "../types/tool-file.js";
+import { ToolTarget } from "../types/tool-targets.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 
 export type ToolSubagentFromRulesyncSubagentParams = Omit<
@@ -28,4 +29,31 @@ export abstract class ToolSubagent extends ToolFile {
   }
 
   abstract toRulesyncSubagent(): RulesyncSubagent;
+
+  static isTargetedByRulesyncSubagent(_rulesyncSubagent: RulesyncSubagent): boolean {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  protected static isTargetedByRulesyncSubagentDefault({
+    rulesyncSubagent,
+    toolTarget,
+  }: {
+    rulesyncSubagent: RulesyncSubagent;
+    toolTarget: ToolTarget;
+  }): boolean {
+    const targets = rulesyncSubagent.getFrontmatter().targets;
+    if (!targets) {
+      return true;
+    }
+
+    if (targets.includes("*")) {
+      return true;
+    }
+
+    if (targets.includes(toolTarget)) {
+      return true;
+    }
+
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `isTargetedByRulesyncCommand` static method to all command classes (ClaudeCode, CodexCli, Copilot, Cursor, GeminiCli, Roo)
- Added corresponding comprehensive test coverage for targeting logic
- Enhanced ToolCommand base class with default targeting implementation
- Added helper methods to ToolSubagent for RulesyncSubagent targeting
- Removed WebSearch permission from settings.json

## Changes Made
- **ClaudeCode Command**: Implements targeting for "claudecode" identifier
- **CodexCli Command**: Implements targeting for "codexcli" identifier  
- **Copilot Command**: Implements targeting for "copilot" identifier
- **Cursor Command**: Implements targeting for "cursor" identifier
- **GeminiCli Command**: Implements targeting for "geminicli" identifier
- **Roo Command**: Implements targeting for "roo" identifier
- **ToolCommand Base**: Added abstract method and default implementation for targeting logic
- **ToolSubagent Base**: Added targeting methods for RulesyncSubagent compatibility
- **Tests**: Comprehensive test coverage for all targeting scenarios including wildcards, specific targets, mixed targets, and edge cases

## Test Plan
- [x] All existing tests pass
- [x] New tests cover wildcard targeting (`*`)
- [x] New tests cover specific tool targeting
- [x] New tests cover mixed target arrays
- [x] New tests cover edge cases (no targets, empty arrays)
- [x] All command classes properly implement the targeting interface

🤖 Generated with [Claude Code](https://claude.ai/code)