### PR TITLE
chore(dependabot): improve configuration for better manageability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,16 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     groups:
-      # Group all development dependencies into a single PR
       dev-dependencies:
         dependency-type: "development"
         patterns:
           - "*"
-      # Production dependencies are updated individually
       production-dependencies:
         dependency-type: "production"
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -38,6 +38,11 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
## Summary
- Reduce open-pull-requests-limit from 10 to 3 for npm dependencies for better manageability
- Add new group configuration for production dependencies with pattern matching
- Set open-pull-requests-limit to 1 for GitHub Actions updates
- Add 'all-actions' group to streamline all GitHub Actions updates into single PRs

## Changes
- **Dependabot npm configuration**: Reduced concurrent PR limit to prevent overwhelming the review process
- **Production dependencies grouping**: Added explicit pattern matching for production dependencies
- **GitHub Actions optimization**: Configured to group all action updates together with single PR limit

## Test plan
- [ ] Verify Dependabot configuration syntax is valid
- [ ] Confirm reduced PR limits work as expected
- [ ] Check that dependency grouping functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)