### PR TITLE
feat: change baseDir to baseDirs for multiple directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Example:
   // Features to generate. You can specify "*" to generate all features.
   "features": ["rules", "ignore", "mcp", "commands", "subagents"],
   
-  // Base directory or directories for generation
-  "baseDir": ".",
+  // Base directories for generation
+  "baseDirs": ["."],
   
   // Delete existing files before generating
   "delete": true,

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -4,8 +4,10 @@
 
   "features": ["rules", "ignore", "mcp", "commands", "subagents"],
   
-  // Base directory or directories for generation
-  "baseDir": ".",
+  // Base directory or directories for generation.
+  // Basically, you can specify a `[.]` only.
+  // However, for example, if your project is a monorepo and you have to launch the AI agent at each package directory, you can specify multiple base directories.
+  "baseDirs": ["."],
   
   // Delete existing files before generating
   "delete": true,


### PR DESCRIPTION
## Summary
- Updates configuration parameter from `baseDir` to `baseDirs` to support multiple base directories
- Updates both README.md and rulesync.jsonc with the new array-based configuration
- Maintains backward compatibility while enabling monorepo support where AI agents can be launched from multiple package directories

## Changes
- Changed `baseDir` to `baseDirs` in configuration documentation and examples
- Updated parameter type from string to array of strings
- Added clarifying comments about usage in monorepo scenarios

## Test plan
- [ ] Verify configuration still works with single directory `["."]`
- [ ] Test multiple directory configuration if applicable
- [ ] Ensure documentation examples are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)