### PR TITLE
docs(releaser): improve versioning examples and simplify semantic versioning rules

### DIFF
--- a/.rulesync/subagents/releaser.md
+++ b/.rulesync/subagents/releaser.md
@@ -17,12 +17,9 @@ First, let's work on the following steps.
   - Sections, `What's Changed`, `Contributors` and `Full Changelog` are needed.
   - `./ai-tmp/release-notes.md` will be used as the release notes.
 
-Then, from $ARGUMENTS, get the new version without v prefix, and assign it to $new_version. For example, if $ARGUMENTS is "v0.1.0", the new version is "0.1.0".
+Then, from $ARGUMENTS, get the new version without v prefix, and assign it to $new_version. For example, if $ARGUMENTS is "v1.0.0", the new version is "1.0.0".
 
-Unless the user does not explicitly specify the new version, please judge the new version from the release description with the following rules:
-
-- For the time being, the major version is kept as `0` because the project is not yet stable.
-- If this release includes breaking changes, the minor version is incremented by 1. Otherwise, the minor version is kept as is and the patch version is incremented by 1 (For example, bug fixes, new features, refactoring and etc.).
+Unless the user does not explicitly specify the new version, please judge the new version from the release description with the following the general semantic versioning rules.
 
 Let's resume the release process.
 


### PR DESCRIPTION
## Summary
- Update versioning example from v0.1.0 to v1.0.0 for better clarity and consistency
- Simplify versioning rules explanation to align with general semantic versioning principles
- Remove project-specific versioning constraints that were overly restrictive

## Changes Made
- **Updated example**: Changed versioning example from "v0.1.0" to "v1.0.0" to demonstrate standard semantic versioning
- **Simplified rules**: Replaced complex project-specific versioning rules with reference to general semantic versioning principles
- **Improved clarity**: Made the documentation more straightforward and easier to understand

## Test plan
- [x] Review documentation changes for clarity and accuracy
- [x] Ensure examples are consistent with semantic versioning standards
- [x] Verify that the simplified rules are easier to understand

🤖 Generated with [Claude Code](https://claude.ai/code)