### PR TITLE
refactor: simplify cursor rule frontmatter handling logic

### DIFF
--- a/src/rules/cursor-rule.ts
+++ b/src/rules/cursor-rule.ts
@@ -3,7 +3,7 @@ import { z } from "zod/mini";
 import { AiFileParams, ValidationResult } from "../types/ai-file.js";
 import type { RulesyncTargets } from "../types/tool-targets.js";
 import { readFileContent } from "../utils/file.js";
-import { parseFrontmatter, stringifyFrontmatter } from "../utils/frontmatter.js";
+import { parseFrontmatter } from "../utils/frontmatter.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -69,16 +69,7 @@ export class CursorRule extends ToolRule {
     body: string,
     frontmatter: CursorRuleFrontmatter,
   ): string {
-    // If there are no globs or they don't contain asterisk patterns, use the default stringifier
-    if (
-      !frontmatter.globs ||
-      typeof frontmatter.globs !== "string" ||
-      !frontmatter.globs.includes("*")
-    ) {
-      return stringifyFrontmatter(body, frontmatter);
-    }
-
-    // For globs with asterisk patterns, manually build the YAML frontmatter
+    // For cursor settings, manually build the YAML frontmatter
     // to ensure they are output without quotes
     const lines: string[] = ["---"];
 


### PR DESCRIPTION
## Summary
- Remove unused `stringifyFrontmatter` import from cursor-rule.ts
- Simplify frontmatter handling logic by removing conditional logic for glob patterns
- Use consistent manual YAML frontmatter building for all cursor settings

## Changes
- Removed unnecessary import of `stringifyFrontmatter` function
- Simplified the `stringifyRule` method by removing the conditional check for glob patterns containing asterisks
- Now consistently uses manual YAML frontmatter building for all cursor rule outputs

## Benefits
- Cleaner, more maintainable code
- Reduced complexity in frontmatter handling
- Consistent output formatting for all cursor rule types

🤖 Generated with [Claude Code](https://claude.ai/code)