### PR TITLE
chore: Update Dependabot schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 3
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary
- Change Dependabot update schedule from daily to weekly for both npm and GitHub Actions ecosystems
- Reduces frequency of automated dependency updates to improve manageability
- Maintains existing cooldown periods and pull request limits

## Changes
- Updated `.github/dependabot.yml` to use `interval: "weekly"` instead of `interval: "daily"`
- Applied to both npm package ecosystem and GitHub Actions ecosystem

## Benefits
- Reduces noise from frequent dependency updates
- Allows more time for manual review and testing of updates
- Maintains security and dependency freshness with weekly cadence
- Improves team productivity by reducing interruptions from automated PRs

🤖 Generated with [Claude Code](https://claude.ai/code)