### PR TITLE
chore: improve versioning process and simplify getVersion implementation

### DIFF
--- a/.rulesync/subagents/releaser.md
+++ b/.rulesync/subagents/releaser.md
@@ -25,7 +25,7 @@ Let's resume the release process.
 
 3. Run `git pull`.
 4. Run `git checkout -b release/v${new_version}`.
-5. Update the version in `src/cli/index.ts`. Then, execute `git add` and `git commit`.
+5. Update `getVersion()` function to return the ${new_version} in `src/cli/index.ts`. Then, execute `git add` and `git commit`.
 6. Update the version with `pnpm version ${new_version} --no-git-tag-version`.
 7. Since `package.json` will be modified, execute `git commit` and `git push`.
 8. Run `gh pr create` and `gh pr merge --admin` to merge the release branch into the main branch.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { ANNOUNCEMENT } from "../constants/announcements.js";
 import { ALL_FEATURES } from "../types/features.js";
-import { readJsonFile } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
 import { configCommand } from "./commands/config.js";
 import { generateCommand } from "./commands/generate.js";
@@ -13,34 +10,12 @@ import { gitignoreCommand } from "./commands/gitignore.js";
 import { importCommand } from "./commands/import.js";
 import { initCommand } from "./commands/init.js";
 
-const getVersion = async (): Promise<string> => {
-  try {
-    // Try to read version from package.json dynamically
-    // Use different approaches for ESM and CJS
-    let packageJsonPath: string;
-
-    if (typeof import.meta !== "undefined" && import.meta.url) {
-      // ESM environment
-      const __filename = fileURLToPath(import.meta.url);
-      const __dirname = join(__filename, "..");
-      packageJsonPath = join(__dirname, "../../package.json");
-    } else {
-      // CJS environment fallback - use process.cwd() as fallback
-      packageJsonPath = join(process.cwd(), "package.json");
-    }
-
-    const packageJson = await readJsonFile<{ version: string }>(packageJsonPath);
-    return packageJson.version;
-  } catch {
-    // Fallback to a hardcoded version if reading fails
-    return "1.2.0";
-  }
-};
+const getVersion = () => "1.2.1";
 
 const main = async () => {
   const program = new Command();
 
-  const version = await getVersion();
+  const version = getVersion();
 
   program.hook("postAction", () => {
     if (ANNOUNCEMENT.length > 0) {


### PR DESCRIPTION
## Summary
- Update release documentation to clarify versioning process
- Simplify getVersion() function implementation for better maintainability

## Changes Made

### Documentation Updates
- Updated `/workspace/.rulesync/subagents/releaser.md` to specify updating the `getVersion()` function instead of just "version in src/cli/index.ts"
- Improved clarity in release process instructions for version management

### Code Refactoring  
- Simplified `getVersion()` function in `/workspace/src/cli/index.ts` to return hardcoded version string "1.2.1"
- Removed complex file system logic for reading package.json dynamically
- Eliminated dependencies on path utilities and file reading functions
- Made version management more explicit and maintainable

## Test Plan
- [x] Verify CLI still functions correctly with new getVersion implementation
- [x] Ensure version is properly displayed in CLI help and version commands
- [x] Confirm release documentation changes are accurate and clear

🤖 Generated with [Claude Code](https://claude.ai/code)