### PR TITLE
Release v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import { gitignoreCommand } from "./commands/gitignore.js";
 import { importCommand } from "./commands/import.js";
 import { initCommand } from "./commands/init.js";
 
-const getVersion = () => "1.2.1";
+const getVersion = () => "1.2.2";
 
 const main = async () => {
   const program = new Command();


### PR DESCRIPTION
## Summary
- Update fallback version to 1.2.2
- Bump package.json version to 1.2.2

## Release Notes

### What's Changed
* fix: update fallback version to 1.2.1 by @chenrui333 in #306
* chore(releaser.md): update instructions to specify updating getVersion() function for versioning by @dyoshikawa in #307

### Contributors
* @chenrui333
* @dyoshikawa

### Full Changelog
https://github.com/dyoshikawa/rulesync/compare/v1.2.1...v1.2.2