### PR TITLE
chore(dependabot): update schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 1
     open-pull-requests-limit: 2
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 1
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary
• Changes Dependabot update schedule from weekly to daily for npm dependencies
• Changes Dependabot update schedule from weekly to daily for GitHub Actions dependencies

## Rationale
This change will ensure more frequent dependency updates, helping to:
- Keep dependencies more current with the latest security patches
- Reduce the accumulation of outdated dependencies
- Maintain better project security posture through timely updates

## Changes Made
- Modified `.github/dependabot.yml` to set `interval: "daily"` for both npm and github-actions package ecosystems
- Maintained existing cooldown and pull request limits to avoid overwhelming the repository

🤖 Generated with [Claude Code](https://claude.ai/code)