### PR TITLE
chore: bump version to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rulesync",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",


### PR DESCRIPTION
## Summary
- Bump version from 1.2.5 to 1.2.6 in package.json for new release

## Changes
- Updated version field in package.json to 1.2.6

This is part of the release process for version 1.2.6.