### PR TITLE
chore: migrate from @anthropic-ai/claude-code to @anthropic-ai/claude-agent-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"zod": "4.1.11"
 	},
 	"devDependencies": {
-		"@anthropic-ai/claude-code": "1.0.128",
+		"@anthropic-ai/claude-agent-sdk": "0.1.1",
 		"@biomejs/biome": "2.2.4",
 		"@eslint/js": "9.36.0",
 		"@secretlint/secretlint-rule-preset-recommend": "11.2.4",

--- a/scripts/run-tasks-md.ts
+++ b/scripts/run-tasks-md.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-console
 
-import { query } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import { readFileContent } from "../src/utils/file.js";
 
 const runClaudeCode = async (task: string) => {

--- a/scripts/run-tasks.ts
+++ b/scripts/run-tasks.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-console
 
-import { query } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { model, tasks } from "../tmp/tasks/tasks.ts";


### PR DESCRIPTION
## Summary

- Updated dev dependency from `@anthropic-ai/claude-code` to `@anthropic-ai/claude-agent-sdk`
- Updated import statements in build scripts to use the new package name

## Changes

### Dependencies
- **package.json**: Changed `@anthropic-ai/claude-code@1.0.128` to `@anthropic-ai/claude-agent-sdk@0.1.1`

### Code Updates
- **scripts/run-tasks-md.ts**: Updated import from `@anthropic-ai/claude-code` to `@anthropic-ai/claude-agent-sdk`
- **scripts/run-tasks.ts**: Updated import from `@anthropic-ai/claude-code` to `@anthropic-ai/claude-agent-sdk`

## Test plan

- [ ] Verify package installs correctly with the new dependency
- [ ] Run build scripts to ensure imports work correctly
- [ ] Confirm all tests pass

## Rationale

This change aligns with the rebranding/restructuring of the Anthropic AI SDK package, ensuring the project uses the latest official package name.