### PR TITLE
feat: add global mode support to Cursor commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Codex CLI              |  ✅ 🌏   |   ✅   |      |    🎮     |    🎮      |
 | Gemini CLI             |  ✅   |   ✅   |      |     ✅   |      🎮     |
 | GitHub Copilot         |  ✅    |       |  ✅    |    🎮      |    🎮      |
-| Cursor                 |  ✅   |   ✅  |   ✅   |     ✅    |     🎮     |
+| Cursor                 |  ✅   |   ✅  |   ✅   |     ✅ 🌏  |     🎮     |
 | OpenCode               |  ✅   |       |       |         |          |
 | Cline                  |  ✅    |   ✅    |  ✅    |          |          |
 | Roo Code               |  ✅   |   ✅   |  ✅    |   ✅     |     🎮     |

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -271,7 +271,7 @@ export class CommandsProcessor extends FeatureProcessor {
   }
 
   /**
-   * Load Gemini CLI command configurations from .gemini/commands/ directory
+   * Load Cursor command configurations from .cursor/commands/ directory
    */
   private async loadCursorCommands(): Promise<ToolCommand[]> {
     const paths = this.global

--- a/src/commands/commands-processor.ts
+++ b/src/commands/commands-processor.ts
@@ -91,6 +91,7 @@ export class CommandsProcessor extends FeatureProcessor {
             return CursorCommand.fromRulesyncCommand({
               baseDir: this.baseDir,
               rulesyncCommand: rulesyncCommand,
+              global: this.global,
             });
           case "codexcli":
             if (!CodexCliCommand.isTargetedByRulesyncCommand(rulesyncCommand)) {
@@ -223,6 +224,7 @@ export class CommandsProcessor extends FeatureProcessor {
               return CursorCommand.fromFile({
                 baseDir: this.baseDir,
                 relativeFilePath: basename(path),
+                global: this.global,
               });
             case "codexcli":
               return CodexCliCommand.fromFile({
@@ -272,9 +274,12 @@ export class CommandsProcessor extends FeatureProcessor {
    * Load Gemini CLI command configurations from .gemini/commands/ directory
    */
   private async loadCursorCommands(): Promise<ToolCommand[]> {
+    const paths = this.global
+      ? CursorCommand.getSettablePathsGlobal()
+      : CursorCommand.getSettablePaths();
     return await this.loadToolCommandDefault({
       toolTarget: "cursor",
-      relativeDirPath: CursorCommand.getSettablePaths().relativeDirPath,
+      relativeDirPath: paths.relativeDirPath,
       extension: "md",
     });
   }
@@ -335,6 +340,6 @@ export class CommandsProcessor extends FeatureProcessor {
   }
 
   static getToolTargetsGlobal(): ToolTarget[] {
-    return ["claudecode"];
+    return ["claudecode", "cursor"];
   }
 }

--- a/src/commands/cursor-command.ts
+++ b/src/commands/cursor-command.ts
@@ -15,7 +15,13 @@ export type CursorCommandParams = AiFileParams;
 export class CursorCommand extends ToolCommand {
   static getSettablePaths(): ToolCommandSettablePaths {
     return {
-      relativeDirPath: ".cursor/commands",
+      relativeDirPath: join(".cursor", "commands"),
+    };
+  }
+
+  static getSettablePathsGlobal(): ToolCommandSettablePaths {
+    return {
+      relativeDirPath: join(".cursor", "commands"),
     };
   }
 
@@ -40,11 +46,14 @@ export class CursorCommand extends ToolCommand {
     baseDir = ".",
     rulesyncCommand,
     validate = true,
+    global = false,
   }: ToolCommandFromRulesyncCommandParams): CursorCommand {
+    const paths = global ? this.getSettablePathsGlobal() : this.getSettablePaths();
+
     return new CursorCommand({
       baseDir: baseDir,
       fileContent: rulesyncCommand.getBody(),
-      relativeDirPath: CursorCommand.getSettablePaths().relativeDirPath,
+      relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath(),
       validate,
     });
@@ -69,19 +78,17 @@ export class CursorCommand extends ToolCommand {
     baseDir = ".",
     relativeFilePath,
     validate = true,
+    global = false,
   }: ToolCommandFromFileParams): Promise<CursorCommand> {
-    const filePath = join(
-      baseDir,
-      CursorCommand.getSettablePaths().relativeDirPath,
-      relativeFilePath,
-    );
+    const paths = global ? this.getSettablePathsGlobal() : this.getSettablePaths();
+    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { body: content } = parseFrontmatter(fileContent);
 
     return new CursorCommand({
       baseDir: baseDir,
-      relativeDirPath: CursorCommand.getSettablePaths().relativeDirPath,
+      relativeDirPath: paths.relativeDirPath,
       relativeFilePath: basename(relativeFilePath),
       fileContent: content.trim(),
       validate,


### PR DESCRIPTION
## Summary
- Added global mode support to Cursor commands, enabling global command generation similar to Claude Code commands
- Updated `CursorCommand` class to support both local and global paths
- Modified `CommandsProcessor` to handle global mode for Cursor commands
- Added Cursor to the list of supported tools for global mode

## Changes
- Added `getSettablePathsGlobal()` method to `CursorCommand` class
- Updated `fromRulesyncCommand()` and `fromFile()` methods to accept `global` parameter
- Modified `loadCursorCommands()` to use appropriate paths based on global mode
- Added "cursor" to `getToolTargetsGlobal()` in `CommandsProcessor`

## Test plan
- [ ] Verify global Cursor commands are generated in correct directory
- [ ] Verify local Cursor commands continue to work as expected
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)