### PR TITLE
feat(file): add trailing newline to all generated files

### DIFF
--- a/src/ignore/ignore-processor.test.ts
+++ b/src/ignore/ignore-processor.test.ts
@@ -540,4 +540,88 @@ describe("IgnoreProcessor", () => {
       expect(hasClaudecodeIgnore).toBe(false);
     });
   });
+
+  describe("writeAiFiles with trailing newlines", () => {
+    it("should write ignore files with exactly one trailing newline", async () => {
+      const processor = new IgnoreProcessor({
+        baseDir: testDir,
+        toolTarget: "cursor",
+      });
+
+      // Create a mock CursorIgnore file
+      const mockCursorIgnore = new CursorIgnore({
+        baseDir: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".cursorignore",
+        fileContent: "*.log\nnode_modules/\n*.tmp",
+      });
+
+      // Write the file using writeAiFiles
+      await processor.writeAiFiles([mockCursorIgnore]);
+
+      // Read the generated file directly to check for trailing newline
+      const { readFile } = await import("node:fs/promises");
+      const cursorIgnorePath = join(testDir, ".cursorignore");
+      const content = await readFile(cursorIgnorePath, "utf-8");
+
+      // Check that file ends with exactly one newline
+      expect(content).toMatch(/[^\n]\n$/);
+      expect(content).not.toMatch(/\n\n$/);
+
+      // Check content is preserved correctly
+      expect(content).toBe("*.log\nnode_modules/\n*.tmp\n");
+    });
+
+    it("should handle files already ending with newline", async () => {
+      const processor = new IgnoreProcessor({
+        baseDir: testDir,
+        toolTarget: "cline",
+      });
+
+      // Create a mock ClineIgnore file with trailing newline
+      const mockClineIgnore = new ClineIgnore({
+        baseDir: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".clineignore",
+        fileContent: "*.log\nnode_modules/\n",
+      });
+
+      // Write the file using writeAiFiles
+      await processor.writeAiFiles([mockClineIgnore]);
+
+      const { readFile } = await import("node:fs/promises");
+      const clineIgnorePath = join(testDir, ".clineignore");
+      const content = await readFile(clineIgnorePath, "utf-8");
+
+      // Should still have exactly one trailing newline
+      expect(content).toBe("*.log\nnode_modules/\n");
+      expect(content).not.toMatch(/\n\n$/);
+    });
+
+    it("should handle files with multiple trailing newlines", async () => {
+      const processor = new IgnoreProcessor({
+        baseDir: testDir,
+        toolTarget: "windsurf",
+      });
+
+      // Create a mock WindsurfIgnore file with multiple trailing newlines
+      const mockWindsurfIgnore = new WindsurfIgnore({
+        baseDir: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".windsurfignore",
+        fileContent: "*.log\n\n\n",
+      });
+
+      // Write the file using writeAiFiles
+      await processor.writeAiFiles([mockWindsurfIgnore]);
+
+      const { readFile } = await import("node:fs/promises");
+      const windsurfIgnorePath = join(testDir, ".windsurfignore");
+      const content = await readFile(windsurfIgnorePath, "utf-8");
+
+      // Should have exactly one trailing newline
+      expect(content).toBe("*.log\n");
+      expect(content).not.toMatch(/\n\n$/);
+    });
+  });
 });

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -1,4 +1,4 @@
-import { removeFile, writeFileContent } from "../utils/file.js";
+import { addTrailingNewline, removeFile, writeFileContent } from "../utils/file.js";
 import { AiFile } from "./ai-file.js";
 import { RulesyncFile } from "./rulesync-file.js";
 import { ToolFile } from "./tool-file.js";
@@ -34,7 +34,8 @@ export abstract class FeatureProcessor {
    */
   async writeAiFiles(aiFiles: AiFile[]): Promise<number> {
     for (const aiFile of aiFiles) {
-      await writeFileContent(aiFile.getFilePath(), aiFile.getFileContent());
+      const contentWithNewline = addTrailingNewline(aiFile.getFileContent());
+      await writeFileContent(aiFile.getFilePath(), contentWithNewline);
     }
 
     return aiFiles.length;

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import {
+  addTrailingNewline,
   createPathResolver,
   directoryExists,
   ensureDir,
@@ -47,6 +48,48 @@ describe("file utilities", () => {
 
       await expect(ensureDir(dirPath)).resolves.toBeUndefined();
       expect(await directoryExists(dirPath)).toBe(true);
+    });
+  });
+
+  describe("addTrailingNewline", () => {
+    it("should add newline to content without trailing newline", () => {
+      const result = addTrailingNewline("content");
+      expect(result).toBe("content\n");
+    });
+
+    it("should keep single newline if already present", () => {
+      const result = addTrailingNewline("content\n");
+      expect(result).toBe("content\n");
+    });
+
+    it("should reduce multiple trailing newlines to one", () => {
+      const result = addTrailingNewline("content\n\n\n");
+      expect(result).toBe("content\n");
+    });
+
+    it("should handle empty string", () => {
+      const result = addTrailingNewline("");
+      expect(result).toBe("\n");
+    });
+
+    it("should remove trailing spaces and tabs before newline", () => {
+      const result = addTrailingNewline("content  \t  ");
+      expect(result).toBe("content\n");
+    });
+
+    it("should handle content with mixed trailing whitespace", () => {
+      const result = addTrailingNewline("content \n \t\n");
+      expect(result).toBe("content\n");
+    });
+
+    it("should handle Windows line endings", () => {
+      const result = addTrailingNewline("content\r\n");
+      expect(result).toBe("content\n");
+    });
+
+    it("should handle multiple lines with trailing whitespace", () => {
+      const result = addTrailingNewline("line1\nline2  \t");
+      expect(result).toBe("line1\nline2\n");
     });
   });
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -83,6 +83,18 @@ export async function readFileContent(filepath: string): Promise<string> {
   return readFile(filepath, "utf-8");
 }
 
+/**
+ * Adds exactly one trailing newline to content.
+ * Removes any existing trailing whitespace and appends a single newline.
+ */
+export function addTrailingNewline(content: string): string {
+  if (!content) {
+    return "\n";
+  }
+
+  return content.trimEnd() + "\n";
+}
+
 export async function writeFileContent(filepath: string, content: string): Promise<void> {
   logger.debug(`Writing file: ${filepath}`);
 


### PR DESCRIPTION
## Summary

This PR implements automatic trailing newline addition to all generated files, resolving issue #61 where users had to manually add newlines to generated files.

- Automatic trailing newline: All generated files now automatically have exactly one trailing newline
- Unified implementation: Applied at the core `writeAiFiles` method level for consistent behavior across all file types
- Comprehensive coverage: Works for all output types (ignore files, rules, MCP configs, commands, subagents)
- Smart handling: Properly handles edge cases (empty files, existing newlines, multiple trailing newlines)

## Changes

### New Functionality
- `src/utils/file.ts`: Added `addTrailingNewline` utility function that ensures exactly one trailing newline
- `src/types/feature-processor.ts`: Modified `writeAiFiles` method to apply trailing newline to all output files

### Tests
- `src/utils/file.test.ts`: Added 8 unit tests for `addTrailingNewline` function covering various edge cases
- `src/ignore/ignore-processor.test.ts`: Added 3 integration tests for `writeAiFiles` with trailing newlines

## Implementation Details

The implementation uses a centralized approach:
- addTrailingNewline function: Trims any trailing whitespace and adds exactly one newline
- writeAiFiles integration: Applied before writing any file through the standard utility
- Handles edge cases: Empty content, existing newlines, multiple newlines, Windows line endings

## Benefits

1. User experience: No more manual editing of generated files to add trailing newlines
2. Consistency: All generated files have consistent formatting
3. Editor compatibility: Eliminates warnings in editors that expect trailing newlines
4. Git-friendly: Improves diff display and prevents "No newline at end of file" messages

## Test Plan

- [x] Verify `addTrailingNewline` correctly handles content without trailing newline
- [x] Verify function preserves single trailing newline if already present
- [x] Verify multiple trailing newlines are reduced to one
- [x] Verify empty string handling
- [x] Verify trailing whitespace is properly removed
- [x] Verify Windows line endings are handled correctly
- [x] Run full test suite: `pnpm test` (2266 tests passing)
- [x] Run code quality checks: `pnpm check` (all passing)
- [x] Test actual file generation: `pnpm dev generate`
- [x] Verify generated files have trailing newlines

## Breaking Changes

⚠️ **Output format change (minor):**

- All generated files will now have a trailing newline automatically added
- This affects: ignore files, rule files, MCP configurations, commands, and subagents
- Existing generated files without trailing newlines will have them added on regeneration
- This is generally a positive change that improves compatibility with editors and version control systems

**Note**: While technically a change in output format, this is an improvement that aligns with common file formatting standards and should not cause any functional issues.

## Related Issue

Fixes #61