### PR TITLE
docs: change admonition type from WARNING to NOTE for global mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Currently, supports rules and commands generation for Claude Code. Import for gl
     npx rulesync generate
     ```
 
-> [!WARNING]
+> [!NOTE]
 > Currently, when in the directory enabled global mode:
 > * `rulesync.jsonc` only supports `global`, `features`, `delete` and `verbose`. `Features` can be set `"rules"` and `"commands"`. Other parameters are ignored.
 > * `rules/*.md` only supports single file has `root: true`, and frontmatter parameters without `root` are ignored.


### PR DESCRIPTION
## Summary
- Changed the admonition type from WARNING to NOTE for the global mode limitations section in README.md
- This makes the tone more informative rather than cautionary, as these are current limitations rather than warnings about potential issues

## Changes
- Updated the admonition marker from `> [!WARNING]` to `> [!NOTE]` in the global mode section
- The content remains the same, only the presentation type has changed

## Context
The global mode limitations are informational constraints about what is currently supported, not warnings about dangerous operations or potential problems. Using NOTE is more appropriate for documenting current feature limitations.

Generated with [Claude Code](https://claude.com/claude-code)