### PR TITLE
fix: use proper fallback chain for experimentalGlobal in config resolution

### DIFF
--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -43,7 +43,7 @@ export class ConfigResolver {
         delete: isDelete ?? defaults.delete,
         baseDirs: getBaseDirsInLightOfGlobal({
           baseDirs: baseDirs ?? defaults.baseDirs,
-          global: experimentalGlobal ?? false,
+          global: experimentalGlobal ?? defaults.experimentalGlobal,
         }),
         experimentalGlobal: experimentalGlobal ?? defaults.experimentalGlobal,
         experimentalSimulateCommands:
@@ -73,7 +73,8 @@ export class ConfigResolver {
       delete: isDelete ?? configByFile.delete ?? defaults.delete,
       baseDirs: getBaseDirsInLightOfGlobal({
         baseDirs: baseDirs ?? configByFile.baseDirs ?? defaults.baseDirs,
-        global: experimentalGlobal ?? false,
+        global:
+          experimentalGlobal ?? configByFile.experimentalGlobal ?? defaults.experimentalGlobal,
       }),
       experimentalGlobal:
         experimentalGlobal ?? configByFile.experimentalGlobal ?? defaults.experimentalGlobal,


### PR DESCRIPTION
## Summary

Fixed a bug in the config resolution logic where the `global` parameter passed to `getBaseDirsInLightOfGlobal()` was not properly considering the full fallback chain. Previously, it was hardcoded to `false` when `experimentalGlobal` was undefined, which could cause inconsistent behavior when the global setting was defined in the config file.

## Changes

- Line 46: Changed `global: experimentalGlobal ?? false` to `global: experimentalGlobal ?? defaults.experimentalGlobal`
- Lines 76-77: Changed `global: experimentalGlobal ?? false` to properly check CLI arg, then config file, then defaults: `global: experimentalGlobal ?? configByFile.experimentalGlobal ?? defaults.experimentalGlobal`

This ensures the global property follows the same fallback pattern as all other config properties: CLI arguments → config file → defaults.

## Impact

This fix ensures that when `experimentalGlobal` is set in the config file but not passed as a CLI argument, the `baseDirs` calculation correctly respects the config file setting instead of always defaulting to `false`.

## Test Plan

- Existing tests should pass
- The change maintains consistency with the existing config resolution pattern used for all other properties
- Behavior when `experimentalGlobal` is explicitly set via CLI remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)