### PR TITLE
fix: strip .instructions.md and .prompt.md extensions when importing from Copilot

### DIFF
--- a/src/commands/copilot-command.test.ts
+++ b/src/commands/copilot-command.test.ts
@@ -189,7 +189,25 @@ Body content`;
         targets: ["*"],
         description: "Test description",
       });
-      expect(rulesyncCommand.getRelativeFilePath()).toBe("test-command.prompt.md");
+      expect(rulesyncCommand.getRelativeFilePath()).toBe("test-command.md");
+    });
+
+    it("should strip .prompt.md extension when converting to RulesyncCommand", () => {
+      const command = new CopilotCommand({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "prompts"),
+        relativeFilePath: "example.prompt.md",
+        frontmatter: {
+          mode: "agent",
+          description: "Example description",
+        },
+        body: "Example body",
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getRelativeFilePath()).toBe("example.md");
     });
   });
 

--- a/src/commands/copilot-command.ts
+++ b/src/commands/copilot-command.ts
@@ -66,12 +66,16 @@ export class CopilotCommand extends ToolCommand {
       description: this.frontmatter.description,
     };
 
+    // Strip .prompt.md extension and normalize to .md
+    const originalFilePath = this.relativeFilePath;
+    const relativeFilePath = originalFilePath.replace(/\.prompt\.md$/, ".md");
+
     return new RulesyncCommand({
       baseDir: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
-      relativeFilePath: this.relativeFilePath,
+      relativeFilePath,
       fileContent: this.getFileContent(),
       validate: true,
     });

--- a/src/rules/copilot-rule.test.ts
+++ b/src/rules/copilot-rule.test.ts
@@ -160,6 +160,24 @@ describe("CopilotRule", () => {
         globs: [],
       });
       expect(rulesyncRule.getBody()).toBe("Test rule content");
+      expect(rulesyncRule.getRelativeFilePath()).toBe("test.md");
+    });
+
+    it("should strip .instructions.md extension when converting to RulesyncRule", () => {
+      const copilotRule = new CopilotRule({
+        baseDir: testDir,
+        relativeDirPath: ".github/instructions",
+        relativeFilePath: "example.instructions.md",
+        frontmatter: {
+          description: "Example rule",
+          applyTo: "*.ts",
+        },
+        body: "Example rule content",
+      });
+
+      const rulesyncRule = copilotRule.toRulesyncRule();
+
+      expect(rulesyncRule.getRelativeFilePath()).toBe("example.md");
     });
 
     it("should convert root CopilotRule to RulesyncRule", () => {

--- a/src/rules/copilot-rule.ts
+++ b/src/rules/copilot-rule.ts
@@ -79,12 +79,16 @@ export class CopilotRule extends ToolRule {
       globs: this.isRoot() ? ["**/*"] : [],
     };
 
+    // Strip .instructions.md extension and normalize to .md
+    const originalFilePath = this.getRelativeFilePath();
+    const relativeFilePath = originalFilePath.replace(/\.instructions\.md$/, ".md");
+
     return new RulesyncRule({
       baseDir: this.getBaseDir(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: ".rulesync/rules",
-      relativeFilePath: this.getRelativeFilePath(),
+      relativeFilePath,
       validate: true,
     });
   }


### PR DESCRIPTION
## Summary
- Fixed extension handling when importing rules and commands from GitHub Copilot
- Prevents double extensions like `.instructions.instructions.md` or `.instructions.prompt.md` when regenerating files

## Changes
- Modified `CopilotRule.toRulesyncRule()` to strip `.instructions.md` extension and normalize to `.md`
- Modified `CopilotCommand.toRulesyncCommand()` to strip `.prompt.md` extension and normalize to `.md`
- Added comprehensive tests to verify extension stripping behavior for both rules and commands

## Test Results
- All 2,412 tests pass
- CI checks pass

Fixes #381