### PR TITLE
docs: add Awesome Claude Code badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/rulesync)](https://www.npmjs.com/package/rulesync)
 [![npm downloads](https://img.shields.io/npm/dt/rulesync)](https://www.npmjs.com/package/rulesync)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dyoshikawa/rulesync)
+[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code)
 [![Mentioned in Awesome Gemini CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/Piebald-AI/awesome-gemini-cli)
 
 A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files. Features selective generation, comprehensive import/export capabilities, and supports major AI development tools with rules, commands, MCP, ignore files, and subagents. Uses the recommended `.rulesync/rules/*.md` structure, with full backward compatibility for legacy `.rulesync/*.md` layouts.


### PR DESCRIPTION
## Summary

- Added Awesome Claude Code badge to the README badges section
- Badge links to the [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) repository

## Details

This PR adds recognition that rulesync has been mentioned in the Awesome Claude Code list, following the same pattern as the existing Awesome Gemini CLI badge.

## Test plan

- [ ] Verify the badge renders correctly in the README
- [ ] Confirm the badge link navigates to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)