### PR TITLE
fix: respect cursor.globs when explicitly set to empty array

### DIFF
--- a/src/rules/cursor-rule.test.ts
+++ b/src/rules/cursor-rule.test.ts
@@ -247,6 +247,75 @@ Test content`;
       // is handled differently (cursor.description is for output, not input)
       expect(cursorRule.getFrontmatter().description).toBe("General description");
     });
+
+    it("should respect cursor.globs when explicitly set to empty array", () => {
+      const rulesyncRule = new RulesyncRule({
+        frontmatter: {
+          targets: ["*"],
+          root: false,
+          description: "Test",
+          globs: ["**/*"],
+          cursor: {
+            globs: [],
+          },
+        },
+        body: "Content",
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+      });
+
+      const cursorRule = CursorRule.fromRulesyncRule({
+        rulesyncRule,
+      });
+
+      // cursor.globs: [] should override parent globs
+      expect(cursorRule.getFrontmatter().globs).toBeUndefined();
+    });
+
+    it("should use parent globs when cursor.globs is not set", () => {
+      const rulesyncRule = new RulesyncRule({
+        frontmatter: {
+          targets: ["*"],
+          root: false,
+          description: "Test",
+          globs: ["*.ts", "*.js"],
+        },
+        body: "Content",
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+      });
+
+      const cursorRule = CursorRule.fromRulesyncRule({
+        rulesyncRule,
+      });
+
+      // Should use parent globs when cursor.globs is not explicitly set
+      expect(cursorRule.getFrontmatter().globs).toBe("*.ts,*.js");
+    });
+
+    it("should use cursor.globs when explicitly set with values", () => {
+      const rulesyncRule = new RulesyncRule({
+        frontmatter: {
+          targets: ["*"],
+          root: false,
+          description: "Test",
+          globs: ["**/*"],
+          cursor: {
+            globs: ["*.ts", "*.tsx"],
+          },
+        },
+        body: "Content",
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+      });
+
+      const cursorRule = CursorRule.fromRulesyncRule({
+        rulesyncRule,
+      });
+
+      // cursor.globs should override parent globs
+      expect(cursorRule.getFrontmatter().globs).toBe("*.ts,*.tsx");
+    });
   });
 
   describe("fromFile", () => {

--- a/src/rules/cursor-rule.ts
+++ b/src/rules/cursor-rule.ts
@@ -159,6 +159,20 @@ export class CursorRule extends ToolRule {
     });
   }
 
+  /**
+   * Resolve cursor globs with priority: cursor-specific > parent
+   * Returns comma-separated string for Cursor format, or undefined if no globs
+   * @param cursorSpecificGlobs - Cursor-specific globs (takes priority if defined)
+   * @param parentGlobs - Parent globs (used if cursorSpecificGlobs is undefined)
+   */
+  private static resolveCursorGlobs(
+    cursorSpecificGlobs: string[] | undefined,
+    parentGlobs: string[] | undefined,
+  ): string | undefined {
+    const targetGlobs = cursorSpecificGlobs !== undefined ? cursorSpecificGlobs : parentGlobs;
+    return targetGlobs && targetGlobs.length > 0 ? targetGlobs.join(",") : undefined;
+  }
+
   static fromRulesyncRule({
     baseDir = ".",
     rulesyncRule,
@@ -168,10 +182,7 @@ export class CursorRule extends ToolRule {
 
     const cursorFrontmatter: CursorRuleFrontmatter = {
       description: rulesyncFrontmatter.description,
-      globs:
-        (rulesyncFrontmatter.globs?.length ?? 0 > 0)
-          ? rulesyncFrontmatter.globs?.join(",")
-          : undefined,
+      globs: this.resolveCursorGlobs(rulesyncFrontmatter.cursor?.globs, rulesyncFrontmatter.globs),
       alwaysApply: rulesyncFrontmatter.cursor?.alwaysApply ?? undefined,
     };
 


### PR DESCRIPTION
## Summary

When `cursor.globs: []` is explicitly set in the source rule file, it should override the parent `globs` value instead of inheriting it. This fix enables Cursor's "Apply Intelligently" feature to work correctly.

Fixes #344

## Changes

### Code
- Add `resolveCursorGlobs` helper function to handle priority resolution
- Update `fromRulesyncRule` to use cursor-specific globs when explicitly defined

### Tests
- Add test case: `cursor.globs: []` overrides parent globs
- Add test case: parent globs used when `cursor.globs` is undefined
- Add test case: `cursor.globs` with values overrides parent globs

## Behavior

**Before:**
```yaml
globs: ["**/*"]
cursor:
  globs: []
```
Generated file has `globs: **/*` (inherited from parent)

**After:**
```yaml
globs: ["**/*"]
cursor:
  globs: []
```
Generated file has no `globs` field (respects empty array)

## Testing

- All tests pass (2463 tests)
- No linter errors

