### PR TITLE
fix: remove XML references from copilot-instructions.md

### DIFF
--- a/src/rules/rules-processor.ts
+++ b/src/rules/rules-processor.ts
@@ -360,14 +360,12 @@ export class RulesProcessor extends FeatureProcessor {
       case "copilot": {
         const rootRule = toolRules[rootRuleIndex];
         rootRule?.setFileContent(
-          this.generateXmlReferencesSection(toolRules) +
-            this.generateAdditionalConventionsSection({
-              commands: { relativeDirPath: CopilotCommand.getSettablePaths().relativeDirPath },
-              subagents: {
-                relativeDirPath: CopilotSubagent.getSettablePaths().relativeDirPath,
-              },
-            }) +
-            rootRule.getFileContent(),
+          this.generateAdditionalConventionsSection({
+            commands: { relativeDirPath: CopilotCommand.getSettablePaths().relativeDirPath },
+            subagents: {
+              relativeDirPath: CopilotSubagent.getSettablePaths().relativeDirPath,
+            },
+          }) + rootRule.getFileContent(),
         );
         return toolRules;
       }


### PR DESCRIPTION
## Summary
Removes XML document references from the generated `copilot-instructions.md` file to optimize context window usage.

## Related Issue
Closes #423

## Problem
GitHub Copilot's `copilot-instructions.md` file was being generated with an XML `<Documents>` section that listed all non-root instruction files with their paths, descriptions, and file patterns. This XML formatting unnecessarily consumed valuable context window space without providing clear benefits for Copilot.

## Solution
Modified the `RulesProcessor` to skip the `generateXmlReferencesSection()` call for the `copilot` target. The generated root file now only includes:
1. Additional conventions section (for commands/subagents, if configured)
2. The root rule content

## Changes
- **Modified:** `src/rules/rules-processor.ts:360-371`
  - Removed `generateXmlReferencesSection(toolRules)` call from the copilot case
  - Kept `generateAdditionalConventionsSection()` for commands/subagents support

## Testing
- ✅ All copilot-related tests pass (140 tests)
- ✅ Full test suite passes (2,470 tests)
- ✅ Manual verification confirms XML references removed from generated files
- ✅ Pre-commit hooks passed

## Example Output
**Before:**
```markdown
Please also reference the following documents as needed. In this case, `@` stands for the project root directory.

<Documents>
  <Document>
    <Path>@/.github/instructions/coding-standards.instructions.md</Path>
    <Description>Coding standards for the project</Description>
    <FilePatterns>**/*.ts</FilePatterns>
  </Document>
</Documents>

# Additional Conventions Beyond the Built-in Functions
...
```

**After:**
```markdown
# Additional Conventions Beyond the Built-in Functions
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)