### PR TITLE
feat: rename .rulesync/.mcp.json to .rulesync/mcp.json with backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ pnpm-lock.yaml
 **/.codex/
 
 **/.mcp.json
+!.rulesync/mcp.json
 !.rulesync/.mcp.json
 **/.cursor/mcp.json
 **/.cline/mcp.json

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Based on the user's instruction, create a plan while analyzing the related files
 Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
 ```
 
-### `.rulesync/.mcp.json`
+### `.rulesync/mcp.json`
 
 Example:
 

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -62,7 +62,8 @@ describe("gitignoreCommand", () => {
       expect(content).toContain("**/.gemini/memories/");
       expect(content).toContain("**/.roo/rules/");
       expect(content).toContain("**/.aiignore");
-      expect(content).toContain("**/.mcp.json");
+      expect(content).toContain("**/.claude/mcp.json");
+      expect(content).toContain("**/.claude/.mcp.json");
       expect(content).toContain("**/.github/subagents/");
       expect(content).toContain("**/.github/prompts/");
       expect(content).toContain("**/.warp/");
@@ -216,7 +217,8 @@ describe("gitignoreCommand", () => {
 **/.claude/commands/
 **/.claude/agents/
 **/.claude/settings.local.json
-**/.mcp.json
+**/.claude/mcp.json
+**/.claude/.mcp.json
 **/.clinerules/
 **/.clineignore
 **/.cline/mcp.json

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -22,7 +22,8 @@ export const gitignoreCommand = async (): Promise<void> => {
     "**/.claude/commands/",
     "**/.claude/agents/",
     "**/.claude/settings.local.json",
-    "**/.mcp.json",
+    "**/.claude/mcp.json",
+    "**/.claude/.mcp.json",
     // Cline
     "**/.clinerules/",
     "**/.clineignore",

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -61,7 +61,7 @@ describe("initCommand", () => {
       expect(logger.success).toHaveBeenCalledWith("rulesync initialized successfully!");
       expect(logger.info).toHaveBeenCalledWith("Next steps:");
       expect(logger.info).toHaveBeenCalledWith(
-        "1. Edit .rulesync/**/*.md, .rulesync/.mcp.json and .rulesyncignore",
+        "1. Edit .rulesync/**/*.md, .rulesync/mcp.json and .rulesyncignore",
       );
       expect(logger.info).toHaveBeenCalledWith(
         "2. Run 'rulesync generate' to create configuration files",
@@ -273,7 +273,7 @@ describe("initCommand", () => {
 
       expect(logger.info).toHaveBeenCalledWith("Next steps:");
       expect(logger.info).toHaveBeenCalledWith(
-        "1. Edit .rulesync/**/*.md, .rulesync/.mcp.json and .rulesyncignore",
+        "1. Edit .rulesync/**/*.md, .rulesync/mcp.json and .rulesyncignore",
       );
       expect(logger.info).toHaveBeenCalledWith(
         "2. Run 'rulesync generate' to create configuration files",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,7 +17,7 @@ export async function initCommand(): Promise<void> {
 
   logger.success("rulesync initialized successfully!");
   logger.info("Next steps:");
-  logger.info(`1. Edit .rulesync/**/*.md, .rulesync/.mcp.json and .rulesyncignore`);
+  logger.info(`1. Edit .rulesync/**/*.md, .rulesync/mcp.json and .rulesyncignore`);
   logger.info("2. Run 'rulesync generate' to create configuration files");
 }
 

--- a/src/mcp/rulesync-mcp.test.ts
+++ b/src/mcp/rulesync-mcp.test.ts
@@ -34,13 +34,13 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
       });
 
       expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
       expect(rulesyncMcp.getRelativeDirPath()).toBe(".rulesync");
-      expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
+      expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(rulesyncMcp.getFileContent()).toBe(validJsonContent);
     });
 
@@ -52,11 +52,11 @@ describe("RulesyncMcp", () => {
       const rulesyncMcp = new RulesyncMcp({
         baseDir: "/custom/path",
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
       });
 
-      expect(rulesyncMcp.getFilePath()).toBe("/custom/path/.rulesync/.mcp.json");
+      expect(rulesyncMcp.getFilePath()).toBe("/custom/path/.rulesync/mcp.json");
       expect(rulesyncMcp.getBaseDir()).toBe("/custom/path");
     });
 
@@ -80,7 +80,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
       });
 
@@ -92,7 +92,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: emptyJsonContent,
       });
 
@@ -132,7 +132,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: jsonContent,
       });
 
@@ -147,7 +147,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: validJsonContent,
         });
       }).not.toThrow();
@@ -161,7 +161,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: validJsonContent,
           validate: false,
         });
@@ -174,7 +174,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: invalidJsonContent,
         });
       }).toThrow(SyntaxError);
@@ -186,7 +186,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: malformedJsonContent,
         });
       }).toThrow(SyntaxError);
@@ -198,7 +198,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: stringJsonContent,
         });
       }).not.toThrow(); // JSON.parse handles strings just fine
@@ -210,7 +210,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: arrayJsonContent,
         });
       }).not.toThrow(); // JSON.parse handles arrays just fine
@@ -222,7 +222,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: nullJsonContent,
         });
       }).not.toThrow(); // JSON.parse handles null just fine
@@ -234,7 +234,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: numericJsonContent,
         });
       }).not.toThrow(); // JSON.parse handles numbers just fine
@@ -246,7 +246,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new RulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: booleanJsonContent,
         });
       }).not.toThrow(); // JSON.parse handles booleans just fine
@@ -270,7 +270,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new TestRulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: validJsonContent,
           validate: true,
         });
@@ -295,7 +295,7 @@ describe("RulesyncMcp", () => {
       expect(() => {
         const _instance = new TestRulesyncMcp({
           relativeDirPath: ".rulesync",
-          relativeFilePath: ".mcp.json",
+          relativeFilePath: "mcp.json",
           fileContent: validJsonContent,
           validate: false,
         });
@@ -307,7 +307,7 @@ describe("RulesyncMcp", () => {
     it("should return successful validation result", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
         validate: false, // Skip validation in constructor to test method directly
       });
@@ -321,7 +321,7 @@ describe("RulesyncMcp", () => {
     it("should always return success for current implementation", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ invalid: "data" }),
         validate: false,
       });
@@ -345,7 +345,7 @@ describe("RulesyncMcp", () => {
       };
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
@@ -358,7 +358,7 @@ describe("RulesyncMcp", () => {
     it("should return empty object for empty JSON", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({}),
       });
 
@@ -386,7 +386,7 @@ describe("RulesyncMcp", () => {
       };
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(complexData),
       });
 
@@ -399,7 +399,7 @@ describe("RulesyncMcp", () => {
       const primitiveValue = "simple string";
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(primitiveValue),
       });
 
@@ -412,7 +412,7 @@ describe("RulesyncMcp", () => {
       const arrayValue = [1, 2, { key: "value" }, "string"];
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(arrayValue),
       });
 
@@ -424,7 +424,7 @@ describe("RulesyncMcp", () => {
     it("should handle null JSON values", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(null),
       });
 
@@ -436,7 +436,7 @@ describe("RulesyncMcp", () => {
 
   describe("fromFile", () => {
     it("should create RulesyncMcp from existing file", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
       const jsonData = {
         mcpServers: {
           "file-server": {
@@ -464,14 +464,14 @@ describe("RulesyncMcp", () => {
         expect(rulesyncMcp.getJson()).toEqual(jsonData);
         expect(rulesyncMcp.getBaseDir()).toBe(".");
         expect(rulesyncMcp.getRelativeDirPath()).toBe(".rulesync");
-        expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
+        expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       } finally {
         process.chdir(originalCwd);
       }
     });
 
     it("should create RulesyncMcp from file with validation disabled", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
       const jsonData = {
         mcpServers: {
           "no-validation-server": {
@@ -498,7 +498,7 @@ describe("RulesyncMcp", () => {
     });
 
     it("should use validation by default", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
       const jsonData = {
         mcpServers: {},
       };
@@ -520,7 +520,7 @@ describe("RulesyncMcp", () => {
     });
 
     it("should handle complex MCP server configurations", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
       const complexMcpData = {
         mcpServers: {
           "claude-server": {
@@ -579,7 +579,7 @@ describe("RulesyncMcp", () => {
     });
 
     it("should throw error for invalid JSON in file", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
       const invalidJson = "{ invalid json content }";
 
       await ensureDir(join(testDir, ".rulesync"));
@@ -596,7 +596,7 @@ describe("RulesyncMcp", () => {
     });
 
     it("should handle empty file", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
 
       await ensureDir(join(testDir, ".rulesync"));
       await writeFileContent(mcpJsonPath, "");
@@ -612,7 +612,7 @@ describe("RulesyncMcp", () => {
     });
 
     it("should handle file with only whitespace", async () => {
-      const mcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const mcpJsonPath = join(testDir, ".rulesync", "mcp.json");
 
       await ensureDir(join(testDir, ".rulesync"));
       await writeFileContent(mcpJsonPath, "   \n\t  \n  ");
@@ -626,13 +626,81 @@ describe("RulesyncMcp", () => {
         process.chdir(originalCwd);
       }
     });
+
+    it("should support legacy .mcp.json path for backward compatibility", async () => {
+      const legacyMcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+      const jsonData = {
+        mcpServers: {
+          "legacy-server": {
+            command: "node",
+            args: ["legacy-server.js"],
+          },
+        },
+      };
+
+      await ensureDir(join(testDir, ".rulesync"));
+      await writeFileContent(legacyMcpJsonPath, JSON.stringify(jsonData, null, 2));
+
+      const originalCwd = process.cwd();
+      process.chdir(testDir);
+
+      try {
+        const rulesyncMcp = await RulesyncMcp.fromFile({ validate: true });
+
+        expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
+        expect(rulesyncMcp.getJson()).toEqual(jsonData);
+        expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it("should prefer new mcp.json over legacy .mcp.json when both exist", async () => {
+      const newMcpJsonPath = join(testDir, ".rulesync", "mcp.json");
+      const legacyMcpJsonPath = join(testDir, ".rulesync", ".mcp.json");
+
+      const newJsonData = {
+        mcpServers: {
+          "new-server": {
+            command: "node",
+            args: ["new-server.js"],
+          },
+        },
+      };
+
+      const legacyJsonData = {
+        mcpServers: {
+          "legacy-server": {
+            command: "node",
+            args: ["legacy-server.js"],
+          },
+        },
+      };
+
+      await ensureDir(join(testDir, ".rulesync"));
+      await writeFileContent(newMcpJsonPath, JSON.stringify(newJsonData, null, 2));
+      await writeFileContent(legacyMcpJsonPath, JSON.stringify(legacyJsonData, null, 2));
+
+      const originalCwd = process.cwd();
+      process.chdir(testDir);
+
+      try {
+        const rulesyncMcp = await RulesyncMcp.fromFile({ validate: true });
+
+        expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
+        expect(rulesyncMcp.getJson()).toEqual(newJsonData);
+        expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
   });
 
   describe("type exports and schema", () => {
     it("should export RulesyncMcpParams type", () => {
       const params: RulesyncMcpParams = {
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({}),
       };
 
@@ -651,7 +719,7 @@ describe("RulesyncMcp", () => {
       const constructorParams: RulesyncMcpParams = {
         baseDir: "/custom",
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: "{}",
         validate: false,
       };
@@ -669,7 +737,7 @@ describe("RulesyncMcp", () => {
     it("should be instance of RulesyncFile", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({}),
       });
 
@@ -680,7 +748,7 @@ describe("RulesyncMcp", () => {
       const jsonData = { mcpServers: {} };
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
@@ -698,13 +766,13 @@ describe("RulesyncMcp", () => {
       const rulesyncMcp = new RulesyncMcp({
         baseDir: "/test/base",
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
       expect(rulesyncMcp.getBaseDir()).toBe("/test/base");
       expect(rulesyncMcp.getRelativeDirPath()).toBe(".rulesync");
-      expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
+      expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(rulesyncMcp.getFileContent()).toBe(JSON.stringify(jsonData));
     });
   });
@@ -742,7 +810,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(largeJsonData),
       });
 
@@ -768,7 +836,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(unicodeJsonData),
       });
 
@@ -795,14 +863,14 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp1 = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(originalJsonData),
       });
 
       // Create second instance from first instance's content
       const rulesyncMcp2 = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(rulesyncMcp1.getJson()),
       });
 
@@ -824,12 +892,12 @@ describe("RulesyncMcp", () => {
     it("should work correctly with different directory paths", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: "custom-dir",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       expect(rulesyncMcp.getRelativeDirPath()).toBe("custom-dir");
-      expect(rulesyncMcp.getFilePath()).toBe("custom-dir/.mcp.json");
+      expect(rulesyncMcp.getFilePath()).toBe("custom-dir/mcp.json");
     });
 
     it("should handle deeply nested JSON structures", () => {
@@ -858,7 +926,7 @@ describe("RulesyncMcp", () => {
 
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
-        relativeFilePath: ".mcp.json",
+        relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(deeplyNestedData),
       });
 


### PR DESCRIPTION
## Summary

- Renamed `.rulesync/.mcp.json` to `.rulesync/mcp.json` (removing the dot prefix)
- Added backward compatibility support for legacy `.mcp.json` path with deprecation warning
- Updated all documentation and code references to use the new path
- Modified `.gitignore` patterns to properly exclude MCP configurations while allowing the rulesync source file

## Changes

### Core Functionality
- **src/mcp/rulesync-mcp.ts**: 
  - Added `getLegacySettablePaths()` method for backward compatibility
  - Enhanced `fromFile()` to check both new and legacy paths, preferring the new path
  - Added deprecation warning when legacy path is used
  - Updated `getSettablePaths()` to return new path without dot prefix

### Tests
- **src/mcp/rulesync-mcp.test.ts**: 
  - Updated all test cases to use new `mcp.json` path
  - Added tests for legacy path support
  - Added test to verify new path is preferred when both exist

### CLI Commands
- **src/cli/commands/init.ts**: Updated user-facing messages to reference new path
- **src/cli/commands/gitignore.ts**: Updated gitignore patterns to use `.claude/mcp.json` and `.claude/.mcp.json`

### Documentation
- **README.md**: Updated all references from `.rulesync/.mcp.json` to `.rulesync/mcp.json`
- **.gitignore**: Added `!.rulesync/mcp.json` to ensure the source MCP config is tracked

## Migration Path

Users with existing `.rulesync/.mcp.json` files will:
1. Continue to work without any changes required (backward compatibility)
2. See a deprecation warning suggesting they rename to the new path
3. Can rename at their convenience - both paths are supported

## Test plan

- [x] All existing tests pass with new path
- [x] Legacy path support tested with dedicated test cases
- [x] Path preference tested (new path preferred when both exist)
- [x] Documentation updated
- [x] Gitignore patterns updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)