### PR TITLE
Revert PR #470: cwd changes

### DIFF
--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -10,53 +10,19 @@ globs: ["**/*.test.ts"]
 - Test code files should be placed next to the implementation. This is called the co-location pattern.
     - For example, if the implementation file is `src/a.ts`, the test code file should be `src/a.test.ts`.
 - For all test code, where directories are specified for actual file generation, use the unified pattern of targeting `./tmp/tests/projects/{RANDOM_STRING}` as the project directory or `./tmp/tests/home/{VITEST_WORKER_ID}` as the pseudo-home directory.
-    - To use the unified test directory, you should use the `setupTestDirectory` function from `src/test-utils/test-directories.ts` and mock `process.cwd()` to return the test directory. If you want to test some behavior in global mode, use the pseudo-home directory by `setupTestDirectory({ home: true })` and mock `getHomeDirectory()` to return the pseudo-home directory.
+    - To use the unified test directory, you should use the `setupTestDirectory` function from `src/test-utils/test-directories.ts`. If you want to test some behavior in global mode, use the pseudo-home directory by `setupTestDirectory({ home: true })`.
     ```typescript
-    // Example with project directory
+    // Example
     describe("Test Name", () => {
       let testDir: string;
       let cleanup: () => Promise<void>;
 
       beforeEach(async () => {
-        ({ testDir, cleanup } = await setupTestDirectory());
-        vi.spyOn(process, "cwd").mockReturnValue(testDir);
+        ({ testDir, cleanup } = await setupTestDirectory()); // or `setupTestDirectory({ home: true })`
       });
 
       afterEach(async () => {
         await cleanup();
-      });
-
-      it("Test Case", async () => {
-        // Run test using testDir
-        const subDir = join(testDir, "subdir");
-        await ensureDir(subDir);
-        // ...
-      });
-    });
-    ```
-    ```typescript
-    // Example with pseudo-home directory
-    const { getHomeDirectoryMock } = vi.hoisted(() => {
-      return {
-        getHomeDirectoryMock: vi.fn(),
-      }
-    })
-    vi.mock("src/utils/file.ts", () => ({
-      getHomeDirectory: getHomeDirectoryMock,
-    }));
-
-    describe("Test Name", () => {
-      let testDir: string;
-      let cleanup: () => Promise<void>;
-
-      beforeEach(async () => {
-        ({ testDir, cleanup } = await setupTestDirectory({ home: true }));
-        getHomeDirectoryMock.mockReturnValue(testDir);
-      });
-
-      afterEach(async () => {
-        await cleanup();
-        getHomeDirectoryMock.mockClear();
       });
 
       it("Test Case", async () => {

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -38,7 +38,7 @@ describe("generateCommand", () => {
     // Setup default mock config
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue([process.cwd()]),
+      getBaseDirs: vi.fn().mockReturnValue(["."]),
       getTargets: vi.fn().mockReturnValue(["claudecode"]),
       getFeatures: vi.fn().mockReturnValue(["rules", "ignore", "mcp", "commands", "subagents"]),
       getDelete: vi.fn().mockReturnValue(false),
@@ -214,7 +214,7 @@ describe("generateCommand", () => {
 
       expect(logger.info).toHaveBeenCalledWith("Generating rule files...");
       expect(RulesProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         global: false,
         toolTarget: "claudecode",
         simulateCommands: false,
@@ -232,7 +232,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(RulesProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         global: false,
         toolTarget: "claudecode",
         simulateCommands: true,
@@ -336,7 +336,7 @@ describe("generateCommand", () => {
 
       expect(logger.info).toHaveBeenCalledWith("Generating MCP files...");
       expect(McpProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
         modularMcp: false,
@@ -406,7 +406,7 @@ describe("generateCommand", () => {
 
       expect(logger.info).toHaveBeenCalledWith("Generating command files...");
       expect(CommandsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -440,7 +440,7 @@ describe("generateCommand", () => {
   describe("ignore feature", () => {
     beforeEach(() => {
       mockConfig.getFeatures.mockReturnValue(["ignore"]);
-      mockConfig.getBaseDirs.mockReturnValue([process.cwd()]);
+      mockConfig.getBaseDirs.mockReturnValue(["."]);
     });
 
     it("should generate ignore files when ignore feature is enabled", async () => {
@@ -479,7 +479,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        `Failed to generate claudecode ignore files for ${process.cwd()}:`,
+        "Failed to generate claudecode ignore files for .:",
         "Test error",
       );
     });
@@ -507,7 +507,7 @@ describe("generateCommand", () => {
 
       expect(logger.info).toHaveBeenCalledWith("Generating subagent files...");
       expect(SubagentsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -548,7 +548,7 @@ describe("generateCommand", () => {
         await generateCommand(options);
 
         expect(SubagentsProcessor).toHaveBeenCalledWith({
-          baseDir: process.cwd(),
+          baseDir: ".",
           toolTarget: "claudecode",
           global: true,
         });
@@ -567,7 +567,7 @@ describe("generateCommand", () => {
           ["claudecode"],
         );
         expect(SubagentsProcessor).toHaveBeenCalledWith({
-          baseDir: process.cwd(),
+          baseDir: ".",
           toolTarget: "claudecode",
           global: true,
         });
@@ -588,7 +588,7 @@ describe("generateCommand", () => {
         expect(SubagentsProcessor.getToolTargets).not.toHaveBeenCalled();
         expect(SubagentsProcessor).toHaveBeenCalledTimes(1);
         expect(SubagentsProcessor).toHaveBeenCalledWith({
-          baseDir: process.cwd(),
+          baseDir: ".",
           toolTarget: "claudecode",
           global: true,
         });
@@ -717,9 +717,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.success).toHaveBeenCalledWith(
-        `Generated 3 claudecode rule(s) in ${process.cwd()}`,
-      );
+      expect(logger.success).toHaveBeenCalledWith("Generated 3 claudecode rule(s) in .");
     });
   });
 
@@ -781,7 +779,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(RulesProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
         simulateCommands: true,
@@ -894,7 +892,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(CommandsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
@@ -922,7 +920,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(SubagentsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
@@ -1056,11 +1054,9 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.success).toHaveBeenCalledWith(
-        `Generated 2 claudecode rule(s) in ${process.cwd()}`,
-      );
+      expect(logger.success).toHaveBeenCalledWith("Generated 2 claudecode rule(s) in .");
       expect(logger.warn).toHaveBeenCalledWith(
-        `Failed to generate claudecode ignore files for ${process.cwd()}:`,
+        "Failed to generate claudecode ignore files for .:",
         "Ignore error",
       );
       expect(logger.success).toHaveBeenCalledWith(

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -34,7 +34,7 @@ describe("importCommand", () => {
       getTargets: vi.fn().mockReturnValue(["claudecode"]),
       getFeatures: vi.fn().mockReturnValue(["rules", "ignore", "mcp", "subagents", "commands"]),
       getGlobal: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue([process.cwd()]),
+      getBaseDirs: vi.fn().mockReturnValue(["."]),
       // Deprecated getter for backward compatibility
       getExperimentalGlobal: vi.fn().mockReturnValue(false),
     };
@@ -134,7 +134,7 @@ describe("importCommand", () => {
       await importCommand(options);
 
       expect(RulesProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -160,7 +160,7 @@ describe("importCommand", () => {
       await importCommand(options);
 
       expect(IgnoreProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
       expect(mockIgnoreProcessor.loadToolFiles).toHaveBeenCalled();
@@ -185,7 +185,7 @@ describe("importCommand", () => {
       await importCommand(options);
 
       expect(McpProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -214,7 +214,7 @@ describe("importCommand", () => {
       // Verify that getToolTargets was called with includeSimulated: false
       expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith({ includeSimulated: false });
       expect(SubagentsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -243,7 +243,7 @@ describe("importCommand", () => {
       // Verify that getToolTargets was called with includeSimulated: false
       expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({ includeSimulated: false });
       expect(CommandsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: false,
       });
@@ -438,7 +438,7 @@ describe("importCommand", () => {
       await importCommand(options);
 
       expect(SubagentsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
@@ -495,22 +495,22 @@ describe("importCommand", () => {
       await importCommand(options);
 
       expect(RulesProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
       expect(McpProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
       expect(CommandsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
       expect(SubagentsProcessor).toHaveBeenCalledWith({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });

--- a/src/commands/agentsmd-command.ts
+++ b/src/commands/agentsmd-command.ts
@@ -18,7 +18,7 @@ export class AgentsmdCommand extends SimulatedCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): AgentsmdCommand {
@@ -28,7 +28,7 @@ export class AgentsmdCommand extends SimulatedCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<AgentsmdCommand> {

--- a/src/commands/claudecode-command.test.ts
+++ b/src/commands/claudecode-command.test.ts
@@ -294,7 +294,7 @@ describe("ClaudecodeCommand", () => {
         rulesyncCommand,
       });
 
-      expect(claudecodeCommand.getBaseDir()).toBe(process.cwd());
+      expect(claudecodeCommand.getBaseDir()).toBe(".");
     });
 
     it("should disable validation when specified", () => {
@@ -363,7 +363,7 @@ Command body`;
         relativeFilePath: "default-test.md",
       });
 
-      expect(command.getBaseDir()).toBe(process.cwd());
+      expect(command.getBaseDir()).toBe(".");
     });
 
     it("should throw error for invalid frontmatter", async () => {

--- a/src/commands/claudecode-command.ts
+++ b/src/commands/claudecode-command.ts
@@ -71,7 +71,7 @@ export class ClaudecodeCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -82,7 +82,7 @@ export class ClaudecodeCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
     global = false,
@@ -135,7 +135,7 @@ export class ClaudecodeCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,

--- a/src/commands/codexcli-command.ts
+++ b/src/commands/codexcli-command.ts
@@ -29,7 +29,7 @@ export class CodexcliCommand extends ToolCommand {
     };
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -40,7 +40,7 @@ export class CodexcliCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
     global = false,
@@ -72,7 +72,7 @@ export class CodexcliCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,

--- a/src/commands/copilot-command.ts
+++ b/src/commands/copilot-command.ts
@@ -72,7 +72,7 @@ export class CopilotCommand extends ToolCommand {
     const relativeFilePath = originalFilePath.replace(/\.prompt\.md$/, ".md");
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      baseDir: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -101,7 +101,7 @@ export class CopilotCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): CopilotCommand {
@@ -130,7 +130,7 @@ export class CopilotCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<CopilotCommand> {

--- a/src/commands/cursor-command.ts
+++ b/src/commands/cursor-command.ts
@@ -26,7 +26,7 @@ export class CursorCommand extends ToolCommand {
     };
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -37,7 +37,7 @@ export class CursorCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
     global = false,
@@ -69,7 +69,7 @@ export class CursorCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,

--- a/src/commands/geminicli-command.ts
+++ b/src/commands/geminicli-command.ts
@@ -84,7 +84,7 @@ export class GeminiCliCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -95,7 +95,7 @@ export class GeminiCliCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
     global = false,
@@ -125,7 +125,7 @@ ${geminiFrontmatter.prompt}
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,

--- a/src/commands/roo-command.test.ts
+++ b/src/commands/roo-command.test.ts
@@ -15,7 +15,7 @@ describe("RooCommand", () => {
       const body = "This is a test command body";
 
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -37,7 +37,7 @@ describe("RooCommand", () => {
       const body = "Command with argument hint";
 
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test-with-hint.md",
         frontmatter,
@@ -55,7 +55,7 @@ describe("RooCommand", () => {
 
       expect(() => {
         new RooCommand({
-          baseDir: process.cwd(),
+          baseDir: ".",
           relativeDirPath: ".roo/commands",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -73,7 +73,7 @@ describe("RooCommand", () => {
 
       expect(() => {
         new RooCommand({
-          baseDir: process.cwd(),
+          baseDir: ".",
           relativeDirPath: ".roo/commands",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -92,7 +92,7 @@ describe("RooCommand", () => {
       };
 
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -107,7 +107,7 @@ describe("RooCommand", () => {
 
     it("should return error for invalid frontmatter", () => {
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 } as any,
@@ -124,7 +124,7 @@ describe("RooCommand", () => {
     it("should return success when frontmatter is undefined", () => {
       // Create a command with undefined frontmatter by manipulating the private field
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "test" },
@@ -168,7 +168,7 @@ describe("RooCommand", () => {
       });
       expect(rulesyncCommand.getRelativeDirPath()).toBe(".rulesync/commands");
       expect(rulesyncCommand.getRelativeFilePath()).toBe("convert-test.md");
-      expect(rulesyncCommand.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncCommand.getBaseDir()).toBe(".");
     });
   });
 
@@ -219,7 +219,7 @@ describe("RooCommand", () => {
         rulesyncCommand,
       });
 
-      expect(rooCommand.getBaseDir()).toBe(process.cwd());
+      expect(rooCommand.getBaseDir()).toBe(".");
     });
 
     it("should handle validation parameter", () => {
@@ -298,7 +298,7 @@ describe("RooCommand", () => {
           relativeFilePath: "default-base.md",
         });
 
-        expect(command.getBaseDir()).toBe(process.cwd());
+        expect(command.getBaseDir()).toBe(".");
       } finally {
         await cleanup();
         // Clean up the file created in current working directory
@@ -465,7 +465,7 @@ This file has invalid frontmatter`;
     it("should return correct body", () => {
       const body = "Test command body content";
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "test" },
@@ -482,7 +482,7 @@ This file has invalid frontmatter`;
         "argument-hint": "Test hint",
       };
       const command = new RooCommand({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,

--- a/src/commands/roo-command.ts
+++ b/src/commands/roo-command.ts
@@ -75,7 +75,7 @@ export class RooCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -86,7 +86,7 @@ export class RooCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): RooCommand {
@@ -138,7 +138,7 @@ export class RooCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<RooCommand> {

--- a/src/commands/rulesync-command.ts
+++ b/src/commands/rulesync-command.ts
@@ -36,7 +36,7 @@ export class RulesyncCommand extends RulesyncFile {
       const result = RulesyncCommandFrontmatterSchema.safeParse(frontmatter);
       if (!result.success) {
         throw new Error(
-          `Invalid frontmatter in ${join(rest.baseDir ?? process.cwd(), rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+          `Invalid frontmatter in ${join(rest.baseDir ?? ".", rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
         );
       }
     }
@@ -102,7 +102,7 @@ export class RulesyncCommand extends RulesyncFile {
     const filename = basename(relativeFilePath);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
       relativeFilePath: filename,
       frontmatter: result.data,

--- a/src/commands/simulated-command.ts
+++ b/src/commands/simulated-command.ts
@@ -58,7 +58,7 @@ export abstract class SimulatedCommand extends ToolCommand {
   }
 
   protected static fromRulesyncCommandDefault({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): ConstructorParameters<typeof SimulatedCommand>[0] {
@@ -99,7 +99,7 @@ export abstract class SimulatedCommand extends ToolCommand {
   }
 
   protected static async fromFileDefault({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<ConstructorParameters<typeof SimulatedCommand>[0]> {

--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import { writeFileContent } from "../utils/file.js";
 import { ConfigResolver } from "./config-resolver.js";
@@ -10,12 +10,10 @@ describe("config-resolver", () => {
 
   beforeEach(async () => {
     ({ testDir, cleanup } = await setupTestDirectory());
-    vi.spyOn(process, "cwd").mockReturnValue(testDir);
   });
 
   afterEach(async () => {
     await cleanup();
-    vi.restoreAllMocks();
   });
 
   describe("global configuration", () => {
@@ -205,9 +203,9 @@ describe("config-resolver", () => {
         configPath: join(testDir, "rulesync.jsonc"),
       });
 
-      // baseDirs are now absolute paths
-      expect(config.getBaseDirs()).toContain(join(testDir, "src"));
-      expect(config.getBaseDirs()).toContain(join(testDir, "packages"));
+      // baseDirs might be normalized (`./ ` prefix removed)
+      expect(config.getBaseDirs()).toContain("src");
+      expect(config.getBaseDirs()).toContain("packages");
     });
 
     it("should handle multiple baseDirs", async () => {
@@ -220,11 +218,11 @@ describe("config-resolver", () => {
         configPath: join(testDir, "rulesync.jsonc"),
       });
 
-      // baseDirs are now absolute paths
+      // baseDirs might be normalized (`./ ` prefix removed)
       expect(config.getBaseDirs()).toHaveLength(3);
-      expect(config.getBaseDirs()).toContain(join(testDir, "app1"));
-      expect(config.getBaseDirs()).toContain(join(testDir, "app2"));
-      expect(config.getBaseDirs()).toContain(join(testDir, "app3"));
+      expect(config.getBaseDirs()).toContain("app1");
+      expect(config.getBaseDirs()).toContain("app2");
+      expect(config.getBaseDirs()).toContain("app3");
     });
   });
 });

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -180,7 +180,7 @@ function getBaseDirsInLightOfGlobal({
 }): string[] {
   if (isEnvTest) {
     // When in test environment, the base directory is always the relative directory from the project root
-    return baseDirs.map((baseDir) => join(process.cwd(), baseDir));
+    return baseDirs.map((baseDir) => join(".", baseDir));
   }
 
   if (global) {

--- a/src/ignore/amazonqcli-ignore.test.ts
+++ b/src/ignore/amazonqcli-ignore.test.ts
@@ -152,7 +152,7 @@ describe("AmazonqcliIgnore", () => {
       });
 
       expect(amazonqcliIgnore).toBeInstanceOf(AmazonqcliIgnore);
-      expect(amazonqcliIgnore.getBaseDir()).toBe(process.cwd());
+      expect(amazonqcliIgnore.getBaseDir()).toBe(".");
       expect(amazonqcliIgnore.getRelativeDirPath()).toBe(".");
       expect(amazonqcliIgnore.getRelativeFilePath()).toBe(".amazonqignore");
       expect(amazonqcliIgnore.getFileContent()).toBe(fileContent);
@@ -336,7 +336,7 @@ q-temp/`;
 
         const amazonqcliIgnore = await AmazonqcliIgnore.fromFile({});
 
-        expect(amazonqcliIgnore.getBaseDir()).toBe(process.cwd());
+        expect(amazonqcliIgnore.getBaseDir()).toBe(".");
         expect(amazonqcliIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/amazonqcli-ignore.ts
+++ b/src/ignore/amazonqcli-ignore.ts
@@ -44,7 +44,7 @@ export class AmazonqcliIgnore extends ToolIgnore {
    * Supports conversion from unified rulesync format to Amazon Q CLI specific format
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): AmazonqcliIgnore {
     const body = rulesyncIgnore.getFileContent();
@@ -62,7 +62,7 @@ export class AmazonqcliIgnore extends ToolIgnore {
    * Supports both proposed .q-ignore and .amazonqignore formats
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<AmazonqcliIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/augmentcode-ignore.test.ts
+++ b/src/ignore/augmentcode-ignore.test.ts
@@ -138,7 +138,7 @@ describe("AugmentcodeIgnore", () => {
       });
 
       expect(augmentcodeIgnore).toBeInstanceOf(AugmentcodeIgnore);
-      expect(augmentcodeIgnore.getBaseDir()).toBe(process.cwd());
+      expect(augmentcodeIgnore.getBaseDir()).toBe(".");
       expect(augmentcodeIgnore.getRelativeDirPath()).toBe(".");
       expect(augmentcodeIgnore.getRelativeFilePath()).toBe(".augmentignore");
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -329,7 +329,7 @@ desktop.ini
 
         const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({});
 
-        expect(augmentcodeIgnore.getBaseDir()).toBe(process.cwd());
+        expect(augmentcodeIgnore.getBaseDir()).toBe(".");
         expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/augmentcode-ignore.ts
+++ b/src/ignore/augmentcode-ignore.ts
@@ -50,7 +50,7 @@ export class AugmentcodeIgnore extends ToolIgnore {
    * Supports conversion from unified rulesync format to AugmentCode specific format
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): AugmentcodeIgnore {
     return new AugmentcodeIgnore({
@@ -66,7 +66,7 @@ export class AugmentcodeIgnore extends ToolIgnore {
    * Reads and parses .augmentignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<AugmentcodeIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/claudecode-ignore.test.ts
+++ b/src/ignore/claudecode-ignore.test.ts
@@ -558,7 +558,7 @@ describe("ClaudecodeIgnore", () => {
 
         const claudecodeIgnore = await ClaudecodeIgnore.fromFile({});
 
-        expect(claudecodeIgnore.getBaseDir()).toBe(process.cwd());
+        expect(claudecodeIgnore.getBaseDir()).toBe(".");
         expect(claudecodeIgnore.getPatterns()).toEqual(["Read(*.log)"]);
       } finally {
         process.chdir(originalCwd);

--- a/src/ignore/claudecode-ignore.ts
+++ b/src/ignore/claudecode-ignore.ts
@@ -59,7 +59,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
   }
 
   static async fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): Promise<ClaudecodeIgnore> {
     const fileContent = rulesyncIgnore.getFileContent();
@@ -96,7 +96,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<ClaudecodeIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/cline-ignore.test.ts
+++ b/src/ignore/cline-ignore.test.ts
@@ -124,7 +124,7 @@ describe("ClineIgnore", () => {
       });
 
       expect(clineIgnore).toBeInstanceOf(ClineIgnore);
-      expect(clineIgnore.getBaseDir()).toBe(process.cwd());
+      expect(clineIgnore.getBaseDir()).toBe(".");
       expect(clineIgnore.getRelativeDirPath()).toBe(".");
       expect(clineIgnore.getRelativeFilePath()).toBe(".clineignore");
       expect(clineIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const clineIgnore = await ClineIgnore.fromFile({});
 
-        expect(clineIgnore.getBaseDir()).toBe(process.cwd());
+        expect(clineIgnore.getBaseDir()).toBe(".");
         expect(clineIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/cline-ignore.ts
+++ b/src/ignore/cline-ignore.ts
@@ -37,7 +37,7 @@ export class ClineIgnore extends ToolIgnore {
    * Create ClineIgnore from RulesyncIgnore
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): ClineIgnore {
     const body = rulesyncIgnore.getFileContent();
@@ -54,7 +54,7 @@ export class ClineIgnore extends ToolIgnore {
    * Load ClineIgnore from .clineignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<ClineIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/cursor-ignore.test.ts
+++ b/src/ignore/cursor-ignore.test.ts
@@ -124,7 +124,7 @@ describe("CursorIgnore", () => {
       });
 
       expect(cursorIgnore).toBeInstanceOf(CursorIgnore);
-      expect(cursorIgnore.getBaseDir()).toBe(process.cwd());
+      expect(cursorIgnore.getBaseDir()).toBe(".");
       expect(cursorIgnore.getRelativeDirPath()).toBe(".");
       expect(cursorIgnore.getRelativeFilePath()).toBe(".cursorignore");
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const cursorIgnore = await CursorIgnore.fromFile({});
 
-        expect(cursorIgnore.getBaseDir()).toBe(process.cwd());
+        expect(cursorIgnore.getBaseDir()).toBe(".");
         expect(cursorIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/cursor-ignore.ts
+++ b/src/ignore/cursor-ignore.ts
@@ -18,7 +18,7 @@ export class CursorIgnore extends ToolIgnore {
 
   toRulesyncIgnore(): RulesyncIgnore {
     return new RulesyncIgnore({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: ".",
       relativeFilePath: ".rulesyncignore",
       fileContent: this.fileContent,
@@ -26,7 +26,7 @@ export class CursorIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): CursorIgnore {
     const body = rulesyncIgnore.getFileContent();
@@ -40,7 +40,7 @@ export class CursorIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<CursorIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/geminicli-ignore.test.ts
+++ b/src/ignore/geminicli-ignore.test.ts
@@ -124,7 +124,7 @@ describe("GeminiCliIgnore", () => {
       });
 
       expect(geminiCliIgnore).toBeInstanceOf(GeminiCliIgnore);
-      expect(geminiCliIgnore.getBaseDir()).toBe(process.cwd());
+      expect(geminiCliIgnore.getBaseDir()).toBe(".");
       expect(geminiCliIgnore.getRelativeDirPath()).toBe(".");
       expect(geminiCliIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const geminiCliIgnore = await GeminiCliIgnore.fromFile({});
 
-        expect(geminiCliIgnore.getBaseDir()).toBe(process.cwd());
+        expect(geminiCliIgnore.getBaseDir()).toBe(".");
         expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/geminicli-ignore.ts
+++ b/src/ignore/geminicli-ignore.ts
@@ -21,7 +21,7 @@ export class GeminiCliIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): GeminiCliIgnore {
     return new GeminiCliIgnore({
@@ -33,7 +33,7 @@ export class GeminiCliIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<GeminiCliIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/junie-ignore.test.ts
+++ b/src/ignore/junie-ignore.test.ts
@@ -124,7 +124,7 @@ describe("JunieIgnore", () => {
       });
 
       expect(junieIgnore).toBeInstanceOf(JunieIgnore);
-      expect(junieIgnore.getBaseDir()).toBe(process.cwd());
+      expect(junieIgnore.getBaseDir()).toBe(".");
       expect(junieIgnore.getRelativeDirPath()).toBe(".");
       expect(junieIgnore.getRelativeFilePath()).toBe(".junieignore");
       expect(junieIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const junieIgnore = await JunieIgnore.fromFile({});
 
-        expect(junieIgnore.getBaseDir()).toBe(process.cwd());
+        expect(junieIgnore.getBaseDir()).toBe(".");
         expect(junieIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/junie-ignore.ts
+++ b/src/ignore/junie-ignore.ts
@@ -21,7 +21,7 @@ export class JunieIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): JunieIgnore {
     return new JunieIgnore({
@@ -33,7 +33,7 @@ export class JunieIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<JunieIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/kiro-ignore.test.ts
+++ b/src/ignore/kiro-ignore.test.ts
@@ -124,7 +124,7 @@ describe("KiroIgnore", () => {
       });
 
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
-      expect(kiroIgnore.getBaseDir()).toBe(process.cwd());
+      expect(kiroIgnore.getBaseDir()).toBe(".");
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
       expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const kiroIgnore = await KiroIgnore.fromFile({});
 
-        expect(kiroIgnore.getBaseDir()).toBe(process.cwd());
+        expect(kiroIgnore.getBaseDir()).toBe(".");
         expect(kiroIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/kiro-ignore.ts
+++ b/src/ignore/kiro-ignore.ts
@@ -21,7 +21,7 @@ export class KiroIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): KiroIgnore {
     return new KiroIgnore({
@@ -33,7 +33,7 @@ export class KiroIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<KiroIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/qwencode-ignore.test.ts
+++ b/src/ignore/qwencode-ignore.test.ts
@@ -124,7 +124,7 @@ describe("QwencodeIgnore", () => {
       });
 
       expect(qwencodeIgnore).toBeInstanceOf(QwencodeIgnore);
-      expect(qwencodeIgnore.getBaseDir()).toBe(process.cwd());
+      expect(qwencodeIgnore.getBaseDir()).toBe(".");
       expect(qwencodeIgnore.getRelativeDirPath()).toBe(".");
       expect(qwencodeIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const qwencodeIgnore = await QwencodeIgnore.fromFile({});
 
-        expect(qwencodeIgnore.getBaseDir()).toBe(process.cwd());
+        expect(qwencodeIgnore.getBaseDir()).toBe(".");
         expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/qwencode-ignore.ts
+++ b/src/ignore/qwencode-ignore.ts
@@ -21,7 +21,7 @@ export class QwencodeIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): QwencodeIgnore {
     return new QwencodeIgnore({
@@ -33,7 +33,7 @@ export class QwencodeIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<QwencodeIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/roo-ignore.test.ts
+++ b/src/ignore/roo-ignore.test.ts
@@ -124,7 +124,7 @@ describe("RooIgnore", () => {
       });
 
       expect(rooIgnore).toBeInstanceOf(RooIgnore);
-      expect(rooIgnore.getBaseDir()).toBe(process.cwd());
+      expect(rooIgnore.getBaseDir()).toBe(".");
       expect(rooIgnore.getRelativeDirPath()).toBe(".");
       expect(rooIgnore.getRelativeFilePath()).toBe(".rooignore");
       expect(rooIgnore.getFileContent()).toBe(fileContent);
@@ -287,7 +287,7 @@ Thumbs.db`;
 
         const rooIgnore = await RooIgnore.fromFile({});
 
-        expect(rooIgnore.getBaseDir()).toBe(process.cwd());
+        expect(rooIgnore.getBaseDir()).toBe(".");
         expect(rooIgnore.getFileContent()).toBe(fileContent);
       } finally {
         // Restore original cwd

--- a/src/ignore/roo-ignore.ts
+++ b/src/ignore/roo-ignore.ts
@@ -33,7 +33,7 @@ export class RooIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): RooIgnore {
     return new RooIgnore({
@@ -45,7 +45,7 @@ export class RooIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<RooIgnore> {
     const fileContent = await readFileContent(

--- a/src/ignore/rulesync-ignore.test.ts
+++ b/src/ignore/rulesync-ignore.test.ts
@@ -162,7 +162,7 @@ Thumbs.db`;
         const rulesyncIgnore = await RulesyncIgnore.fromFile();
 
         expect(rulesyncIgnore).toBeInstanceOf(RulesyncIgnore);
-        expect(rulesyncIgnore.getBaseDir()).toBe(process.cwd());
+        expect(rulesyncIgnore.getBaseDir()).toBe(".");
         expect(rulesyncIgnore.getRelativeDirPath()).toBe(".");
         expect(rulesyncIgnore.getRelativeFilePath()).toBe(".rulesyncignore");
         expect(rulesyncIgnore.getFileContent()).toBe(fileContent);
@@ -524,7 +524,7 @@ build/`;
         const rulesyncIgnore = await RulesyncIgnore.fromFile();
 
         // fromFile always uses these fixed parameters
-        expect(rulesyncIgnore.getBaseDir()).toBe(process.cwd());
+        expect(rulesyncIgnore.getBaseDir()).toBe(".");
         expect(rulesyncIgnore.getRelativeDirPath()).toBe(".");
         expect(rulesyncIgnore.getRelativeFilePath()).toBe(".rulesyncignore");
       } finally {

--- a/src/ignore/rulesync-ignore.ts
+++ b/src/ignore/rulesync-ignore.ts
@@ -23,7 +23,7 @@ export class RulesyncIgnore extends RulesyncFile {
     const fileContent = await readFileContent(this.getSettablePaths().relativeFilePath);
 
     return new RulesyncIgnore({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,

--- a/src/ignore/tool-ignore.test.ts
+++ b/src/ignore/tool-ignore.test.ts
@@ -319,7 +319,7 @@ describe("ToolIgnore", () => {
       });
 
       const rulesyncIgnore = toolIgnore.toRulesyncIgnore();
-      expect(rulesyncIgnore.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncIgnore.getBaseDir()).toBe(".");
       expect(rulesyncIgnore.getRelativeDirPath()).toBe(".");
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(".rulesyncignore");
       expect(rulesyncIgnore.getFileContent()).toBe(fileContent);

--- a/src/ignore/tool-ignore.ts
+++ b/src/ignore/tool-ignore.ts
@@ -61,7 +61,7 @@ export abstract class ToolIgnore extends ToolFile {
 
   protected toRulesyncIgnoreDefault(): RulesyncIgnore {
     return new RulesyncIgnore({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: ".",
       relativeFilePath: ".rulesyncignore",
       fileContent: this.fileContent,

--- a/src/ignore/windsurf-ignore.test.ts
+++ b/src/ignore/windsurf-ignore.test.ts
@@ -189,7 +189,7 @@ desktop.ini`;
         rulesyncIgnore,
       });
 
-      expect(windsurfIgnore.getBaseDir()).toBe(process.cwd());
+      expect(windsurfIgnore.getBaseDir()).toBe(".");
     });
 
     it("should preserve complex content from RulesyncIgnore", () => {
@@ -285,7 +285,7 @@ Thumbs.db`;
 
         const windsurfIgnore = await WindsurfIgnore.fromFile({});
 
-        expect(windsurfIgnore.getBaseDir()).toBe(process.cwd());
+        expect(windsurfIgnore.getBaseDir()).toBe(".");
         expect(windsurfIgnore.getFileContent()).toBe(fileContent);
       } finally {
         process.chdir(originalCwd);

--- a/src/ignore/windsurf-ignore.ts
+++ b/src/ignore/windsurf-ignore.ts
@@ -26,7 +26,7 @@ export class WindsurfIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): WindsurfIgnore {
     return new WindsurfIgnore({
@@ -38,7 +38,7 @@ export class WindsurfIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<WindsurfIgnore> {
     const fileContent = await readFileContent(

--- a/src/mcp/amazonqcli-mcp.ts
+++ b/src/mcp/amazonqcli-mcp.ts
@@ -30,7 +30,7 @@ export class AmazonqcliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolMcpFromFileParams): Promise<AmazonqcliMcp> {
     const fileContent = await readFileContent(
@@ -51,7 +51,7 @@ export class AmazonqcliMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): AmazonqcliMcp {

--- a/src/mcp/claudecode-mcp.ts
+++ b/src/mcp/claudecode-mcp.ts
@@ -37,7 +37,7 @@ export class ClaudecodeMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<ClaudecodeMcp> {
@@ -59,7 +59,7 @@ export class ClaudecodeMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
     global = false,

--- a/src/mcp/cline-mcp.ts
+++ b/src/mcp/cline-mcp.ts
@@ -32,7 +32,7 @@ export class ClineMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolMcpFromFileParams): Promise<ClineMcp> {
     const fileContent = await readFileContent(
@@ -53,7 +53,7 @@ export class ClineMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): ClineMcp {

--- a/src/mcp/codexcli-mcp.ts
+++ b/src/mcp/codexcli-mcp.ts
@@ -45,7 +45,7 @@ export class CodexcliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<CodexcliMcp> {
@@ -64,7 +64,7 @@ export class CodexcliMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
     global = false,

--- a/src/mcp/copilot-mcp.ts
+++ b/src/mcp/copilot-mcp.ts
@@ -31,7 +31,7 @@ export class CopilotMcp extends ToolMcp {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolMcpFromFileParams): Promise<CopilotMcp> {
     const fileContent = await readFileContent(
@@ -52,7 +52,7 @@ export class CopilotMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): CopilotMcp {

--- a/src/mcp/cursor-mcp.test.ts
+++ b/src/mcp/cursor-mcp.test.ts
@@ -453,7 +453,7 @@ describe("CursorMcp", () => {
 
         expect(cursorMcp).toBeInstanceOf(CursorMcp);
         expect(cursorMcp.getJson()).toEqual(jsonData);
-        expect(cursorMcp.getBaseDir()).toBe(process.cwd());
+        expect(cursorMcp.getBaseDir()).toBe(".");
         expect(cursorMcp.getRelativeDirPath()).toBe(".cursor");
         expect(cursorMcp.getRelativeFilePath()).toBe("mcp.json");
       } finally {
@@ -664,7 +664,7 @@ describe("CursorMcp", () => {
       expect(cursorMcp.getJson()).toEqual({
         mcpServers: rulesyncMcpData.mcpServers,
       });
-      expect(cursorMcp.getBaseDir()).toBe(process.cwd());
+      expect(cursorMcp.getBaseDir()).toBe(".");
       expect(cursorMcp.getRelativeDirPath()).toBe(".cursor");
       expect(cursorMcp.getRelativeFilePath()).toBe("mcp.json");
     });
@@ -1049,7 +1049,6 @@ describe("CursorMcp", () => {
 
     it("should work correctly with different file extensions", () => {
       const cursorMcp = new CursorMcp({
-        baseDir: ".",
         relativeDirPath: ".cursor",
         relativeFilePath: "custom-config.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -1061,7 +1060,6 @@ describe("CursorMcp", () => {
 
     it("should work correctly with different directory paths", () => {
       const cursorMcp = new CursorMcp({
-        baseDir: ".",
         relativeDirPath: "custom-dir",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),

--- a/src/mcp/cursor-mcp.ts
+++ b/src/mcp/cursor-mcp.ts
@@ -32,7 +32,7 @@ export class CursorMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolMcpFromFileParams): Promise<CursorMcp> {
     const fileContent = await readFileContent(
@@ -53,7 +53,7 @@ export class CursorMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): CursorMcp {

--- a/src/mcp/geminicli-mcp.ts
+++ b/src/mcp/geminicli-mcp.ts
@@ -36,7 +36,7 @@ export class GeminiCliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<GeminiCliMcp> {
@@ -58,7 +58,7 @@ export class GeminiCliMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
     global = false,

--- a/src/mcp/mcp-processor.ts
+++ b/src/mcp/mcp-processor.ts
@@ -43,7 +43,7 @@ export class McpProcessor extends FeatureProcessor {
   private readonly modularMcp: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    baseDir = ".",
     toolTarget,
     global = false,
     modularMcp = false,

--- a/src/mcp/modular-mcp.ts
+++ b/src/mcp/modular-mcp.ts
@@ -60,7 +60,7 @@ export class ModularMcp extends AiFile {
     }:
       | { baseDir: string; global: false; relativeDirPath?: undefined }
       | { baseDir: string; global: true; relativeDirPath: string } = {
-      baseDir: process.cwd(),
+      baseDir: ".",
       global: false,
       relativeDirPath: undefined,
     },
@@ -95,7 +95,7 @@ export class ModularMcp extends AiFile {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
     global = false,

--- a/src/mcp/roo-mcp.test.ts
+++ b/src/mcp/roo-mcp.test.ts
@@ -209,7 +209,7 @@ describe("RooMcp", () => {
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe(process.cwd());
+      expect(rooMcp.getBaseDir()).toBe(".");
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rooMcp.getFileContent())).toEqual(mcpContent);

--- a/src/mcp/roo-mcp.ts
+++ b/src/mcp/roo-mcp.ts
@@ -30,7 +30,7 @@ export class RooMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     validate = true,
   }: ToolMcpFromFileParams): Promise<RooMcp> {
     const fileContent = await readFileContent(
@@ -50,7 +50,7 @@ export class RooMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): RooMcp {

--- a/src/mcp/rulesync-mcp.test.ts
+++ b/src/mcp/rulesync-mcp.test.ts
@@ -729,7 +729,7 @@ describe("RulesyncMcp", () => {
 
         expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
         expect(rulesyncMcp.getJson()).toEqual(jsonData);
-        expect(rulesyncMcp.getBaseDir()).toBe(process.cwd());
+        expect(rulesyncMcp.getBaseDir()).toBe(".");
         expect(rulesyncMcp.getRelativeDirPath()).toBe(".rulesync");
         expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       } finally {
@@ -1164,7 +1164,7 @@ describe("RulesyncMcp", () => {
       });
 
       expect(rulesyncMcp.getRelativeFilePath()).toBe("custom-config.json");
-      expect(rulesyncMcp.getRelativePathFromCwd()).toBe(".rulesync/custom-config.json");
+      expect(rulesyncMcp.getFilePath()).toBe(".rulesync/custom-config.json");
     });
 
     it("should work correctly with different directory paths", () => {
@@ -1175,7 +1175,7 @@ describe("RulesyncMcp", () => {
       });
 
       expect(rulesyncMcp.getRelativeDirPath()).toBe("custom-dir");
-      expect(rulesyncMcp.getRelativePathFromCwd()).toBe("custom-dir/.mcp.json");
+      expect(rulesyncMcp.getFilePath()).toBe("custom-dir/.mcp.json");
     });
 
     it("should handle deeply nested JSON structures", () => {

--- a/src/mcp/rulesync-mcp.ts
+++ b/src/mcp/rulesync-mcp.ts
@@ -134,7 +134,7 @@ export class RulesyncMcp extends RulesyncFile {
     if (await fileExists(recommendedPath)) {
       const fileContent = await readFileContent(recommendedPath);
       return new RulesyncMcp({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: paths.recommended.relativeDirPath,
         relativeFilePath: paths.recommended.relativeFilePath,
         fileContent,
@@ -150,7 +150,7 @@ export class RulesyncMcp extends RulesyncFile {
       );
       const fileContent = await readFileContent(legacyPath);
       return new RulesyncMcp({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: paths.legacy.relativeDirPath,
         relativeFilePath: paths.legacy.relativeFilePath,
         fileContent,
@@ -162,7 +162,7 @@ export class RulesyncMcp extends RulesyncFile {
     // If neither exists, try to read recommended path (will throw appropriate error)
     const fileContent = await readFileContent(recommendedPath);
     return new RulesyncMcp({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: paths.recommended.relativeDirPath,
       relativeFilePath: paths.recommended.relativeFilePath,
       fileContent,

--- a/src/rules/agentsmd-rule.ts
+++ b/src/rules/agentsmd-rule.ts
@@ -45,7 +45,7 @@ export class AgentsMdRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AgentsMdRule> {
@@ -67,7 +67,7 @@ export class AgentsMdRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AgentsMdRule {

--- a/src/rules/amazonqcli-rule.test.ts
+++ b/src/rules/amazonqcli-rule.test.ts
@@ -253,7 +253,7 @@ describe("AmazonQCliRule", () => {
 
       const rulesyncRule = amazonQCliRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/metadata-test.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/metadata-test.md");
       expect(rulesyncRule.getFileContent()).toContain("# Metadata Test");
     });
   });

--- a/src/rules/amazonqcli-rule.ts
+++ b/src/rules/amazonqcli-rule.ts
@@ -23,7 +23,7 @@ export class AmazonQCliRule extends ToolRule {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AmazonQCliRule> {
@@ -42,7 +42,7 @@ export class AmazonQCliRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AmazonQCliRule {

--- a/src/rules/augmentcode-legacy-rule.test.ts
+++ b/src/rules/augmentcode-legacy-rule.test.ts
@@ -109,7 +109,7 @@ describe("AugmentcodeLegacyRule", () => {
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(rulesyncRule.getBody()).toBe("# Test Legacy Rule\n\nThis is a test legacy rule.");
@@ -133,7 +133,7 @@ describe("AugmentcodeLegacyRule", () => {
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe(".augment-guidelines");
       expect(rulesyncRule.getBody()).toBe("# Root Guidelines\n\nThese are root guidelines.");
@@ -156,7 +156,7 @@ describe("AugmentcodeLegacyRule", () => {
 
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("complex-rule.md");
       expect(rulesyncRule.getBody()).toBe(

--- a/src/rules/augmentcode-legacy-rule.ts
+++ b/src/rules/augmentcode-legacy-rule.ts
@@ -32,7 +32,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
     };
 
     return new RulesyncRule({
-      baseDir: process.cwd(), // RulesyncRule baseDir is always the project root directory
+      baseDir: ".", // RulesyncRule baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: join(".rulesync", "rules"),
@@ -54,7 +54,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
@@ -81,7 +81,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AugmentcodeLegacyRule> {

--- a/src/rules/augmentcode-rule.test.ts
+++ b/src/rules/augmentcode-rule.test.ts
@@ -286,7 +286,7 @@ describe("AugmentcodeRule", () => {
       const rulesyncRule = augmentcodeRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(rulesyncRule.getBody()).toBe("# Test Rule\n\nThis is a test rule.");
@@ -303,7 +303,7 @@ describe("AugmentcodeRule", () => {
 
       const rulesyncRule = augmentcodeRule.toRulesyncRule();
 
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("complex-rule.md");
       expect(rulesyncRule.getBody()).toBe(

--- a/src/rules/augmentcode-rule.ts
+++ b/src/rules/augmentcode-rule.ts
@@ -32,7 +32,7 @@ export class AugmentcodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AugmentcodeRule {
@@ -47,7 +47,7 @@ export class AugmentcodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AugmentcodeRule> {

--- a/src/rules/claudecode-rule.test.ts
+++ b/src/rules/claudecode-rule.test.ts
@@ -357,7 +357,7 @@ describe("ClaudecodeRule", () => {
 
       const rulesyncRule = claudecodeRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/CLAUDE.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/CLAUDE.md");
       expect(rulesyncRule.getFileContent()).toContain(
         "# Metadata Test\n\nWith metadata preserved.",
       );

--- a/src/rules/claudecode-rule.ts
+++ b/src/rules/claudecode-rule.ts
@@ -54,7 +54,7 @@ export class ClaudecodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,
@@ -95,7 +95,7 @@ export class ClaudecodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
     global = false,

--- a/src/rules/cline-rule.ts
+++ b/src/rules/cline-rule.ts
@@ -32,7 +32,7 @@ export class ClineRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
@@ -58,7 +58,7 @@ export class ClineRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<ClineRule> {

--- a/src/rules/codexcli-rule.ts
+++ b/src/rules/codexcli-rule.ts
@@ -52,7 +52,7 @@ export class CodexcliRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,
@@ -93,7 +93,7 @@ export class CodexcliRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
     global = false,

--- a/src/rules/copilot-rule.test.ts
+++ b/src/rules/copilot-rule.test.ts
@@ -302,7 +302,7 @@ describe("CopilotRule", () => {
         rulesyncRule,
       });
 
-      expect(copilotRule.getBaseDir()).toBe(process.cwd());
+      expect(copilotRule.getBaseDir()).toBe(".");
     });
 
     it("should handle RulesyncRule without globs", () => {
@@ -401,7 +401,7 @@ Content with default baseDir.`;
         relativeFilePath: "default.instructions.md",
       });
 
-      expect(copilotRule.getBaseDir()).toBe(process.cwd());
+      expect(copilotRule.getBaseDir()).toBe(".");
     });
 
     it("should throw error for invalid frontmatter with validation", async () => {

--- a/src/rules/copilot-rule.ts
+++ b/src/rules/copilot-rule.ts
@@ -95,7 +95,7 @@ export class CopilotRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): CopilotRule {
@@ -140,7 +140,7 @@ export class CopilotRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<CopilotRule> {

--- a/src/rules/cursor-rule.ts
+++ b/src/rules/cursor-rule.ts
@@ -175,7 +175,7 @@ export class CursorRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): CursorRule {
@@ -206,7 +206,7 @@ export class CursorRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<CursorRule> {

--- a/src/rules/geminicli-rule.test.ts
+++ b/src/rules/geminicli-rule.test.ts
@@ -72,7 +72,7 @@ describe("GeminiCliRule", () => {
       });
 
       expect(geminiCliRule.getFileContent()).toBe("# Root Rule");
-      expect(geminiCliRule.getRelativePathFromCwd()).toBe("GEMINI.md");
+      expect(geminiCliRule.getFilePath()).toBe("GEMINI.md");
     });
   });
 
@@ -295,7 +295,7 @@ describe("GeminiCliRule", () => {
 
       const rulesyncRule = geminiCliRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/GEMINI.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/GEMINI.md");
       expect(rulesyncRule.getFileContent()).toContain("# Root Gemini Rule\n\nRoot content.");
     });
   });

--- a/src/rules/geminicli-rule.ts
+++ b/src/rules/geminicli-rule.ts
@@ -51,7 +51,7 @@ export class GeminiCliRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,
@@ -92,7 +92,7 @@ export class GeminiCliRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
     global = false,

--- a/src/rules/junie-rule.test.ts
+++ b/src/rules/junie-rule.test.ts
@@ -351,7 +351,7 @@ describe("JunieRule", () => {
 
       const rulesyncRule = junieRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/metadata-test.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/metadata-test.md");
       expect(rulesyncRule.getFileContent()).toContain(
         "# Metadata Test\n\nWith metadata preserved.",
       );

--- a/src/rules/junie-rule.ts
+++ b/src/rules/junie-rule.ts
@@ -41,7 +41,7 @@ export class JunieRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<JunieRule> {
@@ -62,7 +62,7 @@ export class JunieRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): JunieRule {

--- a/src/rules/kiro-rule.test.ts
+++ b/src/rules/kiro-rule.test.ts
@@ -418,7 +418,7 @@ describe("KiroRule", () => {
 
       const rulesyncRule = kiroRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/metadata-test.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/metadata-test.md");
       expect(rulesyncRule.getFileContent()).toContain(
         "# Metadata Test\n\nWith metadata preserved.",
       );

--- a/src/rules/kiro-rule.ts
+++ b/src/rules/kiro-rule.ts
@@ -31,7 +31,7 @@ export class KiroRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<KiroRule> {
@@ -50,7 +50,7 @@ export class KiroRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): KiroRule {

--- a/src/rules/opencode-rule.test.ts
+++ b/src/rules/opencode-rule.test.ts
@@ -357,7 +357,7 @@ describe("OpenCodeRule", () => {
 
       const rulesyncRule = opencodeRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/AGENTS.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/AGENTS.md");
       expect(rulesyncRule.getFileContent()).toContain(
         "# Metadata Test\n\nWith metadata preserved.",
       );

--- a/src/rules/opencode-rule.ts
+++ b/src/rules/opencode-rule.ts
@@ -31,7 +31,7 @@ export class OpenCodeRule extends ToolRule {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: AiFileFromFileParams): Promise<OpenCodeRule> {
@@ -52,7 +52,7 @@ export class OpenCodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): OpenCodeRule {

--- a/src/rules/qwencode-rule.test.ts
+++ b/src/rules/qwencode-rule.test.ts
@@ -391,7 +391,7 @@ describe("QwencodeRule", () => {
 
       const rulesyncRule = qwencodeRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/metadata-test.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/metadata-test.md");
       expect(rulesyncRule.getBody()).toBe("# Metadata Test\n\nContent with metadata.");
     });
   });

--- a/src/rules/qwencode-rule.ts
+++ b/src/rules/qwencode-rule.ts
@@ -42,7 +42,7 @@ export class QwencodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<QwencodeRule> {
@@ -63,7 +63,7 @@ export class QwencodeRule extends ToolRule {
   }
 
   static fromRulesyncRule(params: ToolRuleFromRulesyncRuleParams): QwencodeRule {
-    const { baseDir = process.cwd(), rulesyncRule, validate = true } = params;
+    const { baseDir = ".", rulesyncRule, validate = true } = params;
     return new QwencodeRule(
       this.buildToolRuleParamsDefault({
         baseDir,

--- a/src/rules/roo-rule.test.ts
+++ b/src/rules/roo-rule.test.ts
@@ -299,7 +299,7 @@ describe("RooRule", () => {
 
       const rulesyncRule = rooRule.toRulesyncRule();
 
-      expect(rulesyncRule.getRelativePathFromCwd()).toBe(".rulesync/rules/metadata-test.md");
+      expect(rulesyncRule.getFilePath()).toBe(".rulesync/rules/metadata-test.md");
       expect(rulesyncRule.getFileContent()).toContain("# Metadata Test");
     });
   });

--- a/src/rules/roo-rule.ts
+++ b/src/rules/roo-rule.ts
@@ -35,7 +35,7 @@ export class RooRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<RooRule> {
@@ -54,7 +54,7 @@ export class RooRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): RooRule {

--- a/src/rules/rules-processor.ts
+++ b/src/rules/rules-processor.ts
@@ -76,7 +76,7 @@ export class RulesProcessor extends FeatureProcessor {
   private readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    baseDir = ".",
     toolTarget,
     simulateCommands = false,
     simulateSubagents = false,

--- a/src/rules/rulesync-rule.ts
+++ b/src/rules/rulesync-rule.ts
@@ -141,7 +141,7 @@ export class RulesyncRule extends RulesyncFile {
     const filename = basename(legacyPath);
 
     return new RulesyncRule({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: this.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath: filename,
       frontmatter: validatedFrontmatter,
@@ -178,7 +178,7 @@ export class RulesyncRule extends RulesyncFile {
     const filename = basename(filePath);
 
     return new RulesyncRule({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: this.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath: filename,
       frontmatter: validatedFrontmatter,

--- a/src/rules/tool-rule.test.ts
+++ b/src/rules/tool-rule.test.ts
@@ -463,7 +463,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: "packages/my-app",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Test Rule",
@@ -492,7 +492,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule",
@@ -524,7 +524,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root Rule",
@@ -556,7 +556,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule",
@@ -585,7 +585,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule",
@@ -690,7 +690,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule",
@@ -719,7 +719,7 @@ describe("ToolRule", () => {
       });
 
       expect(params).toEqual({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root Rule",
@@ -904,7 +904,7 @@ describe("ToolRule", () => {
       const rulesyncRule = (toolRule as any).toRulesyncRuleDefault();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("non-root.md");
       expect(rulesyncRule.getBody()).toBe("# Non-Root Rule");
@@ -946,7 +946,7 @@ describe("ToolRule", () => {
       const rulesyncRule = (toolRule as any).toRulesyncRuleDefault();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncRule.getBaseDir()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(".rulesync/rules");
       expect(rulesyncRule.getRelativeFilePath()).toBe("root.md");
       expect(rulesyncRule.getBody()).toBe("# Root Rule");

--- a/src/rules/tool-rule.ts
+++ b/src/rules/tool-rule.ts
@@ -81,7 +81,7 @@ export abstract class ToolRule extends ToolFile {
   }
 
   protected static buildToolRuleParamsDefault({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
     rootPath = { relativeDirPath: ".", relativeFilePath: "AGENTS.md" },
@@ -120,7 +120,7 @@ export abstract class ToolRule extends ToolFile {
   }
 
   protected static buildToolRuleParamsAgentsmd({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
     rootPath = { relativeDirPath: ".", relativeFilePath: "AGENTS.md" },
@@ -147,7 +147,7 @@ export abstract class ToolRule extends ToolFile {
 
   protected toRulesyncRuleDefault(): RulesyncRule {
     return new RulesyncRule({
-      baseDir: process.cwd(), // RulesyncRule baseDir is always the project root directory
+      baseDir: ".", // RulesyncRule baseDir is always the project root directory
       relativeDirPath: join(".rulesync", "rules"),
       relativeFilePath: this.getRelativeFilePath(),
       frontmatter: {

--- a/src/rules/warp-rule.test.ts
+++ b/src/rules/warp-rule.test.ts
@@ -244,7 +244,7 @@ describe("WarpRule", () => {
         rulesyncRule,
       });
 
-      expect(warpRule.getBaseDir()).toBe(process.cwd());
+      expect(warpRule.getBaseDir()).toBe(".");
     });
 
     it("should handle validation parameter", () => {

--- a/src/rules/warp-rule.ts
+++ b/src/rules/warp-rule.ts
@@ -45,7 +45,7 @@ export class WarpRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<WarpRule> {
@@ -66,7 +66,7 @@ export class WarpRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): WarpRule {

--- a/src/rules/windsurf-rule.ts
+++ b/src/rules/windsurf-rule.ts
@@ -26,7 +26,7 @@ export class WindsurfRule extends ToolRule {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<WindsurfRule> {
@@ -44,7 +44,7 @@ export class WindsurfRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {

--- a/src/subagents/claudecode-subagent.test.ts
+++ b/src/subagents/claudecode-subagent.test.ts
@@ -360,7 +360,7 @@ describe("ClaudecodeSubagent", () => {
       const rulesyncSubagent = subagent.toRulesyncSubagent();
 
       // RulesyncSubagent baseDir is always the project root directory
-      expect(rulesyncSubagent.getBaseDir()).toBe(process.cwd());
+      expect(rulesyncSubagent.getBaseDir()).toBe(".");
       expect(rulesyncSubagent.getRelativeFilePath()).toBe("custom/test-agent.md");
     });
   });
@@ -462,7 +462,7 @@ describe("ClaudecodeSubagent", () => {
         validate: true,
       });
 
-      expect(claudecodeSubagent.getBaseDir()).toBe(process.cwd());
+      expect(claudecodeSubagent.getBaseDir()).toBe(".");
     });
 
     it("should use global paths when global is true", () => {
@@ -650,7 +650,7 @@ describe("ClaudecodeSubagent", () => {
           validate: true,
         });
 
-        expect(subagent.getBaseDir()).toBe(process.cwd());
+        expect(subagent.getBaseDir()).toBe(".");
       } finally {
         // Clean up the file in current directory
         const fs = await import("node:fs/promises");

--- a/src/subagents/claudecode-subagent.ts
+++ b/src/subagents/claudecode-subagent.ts
@@ -78,7 +78,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncSubagent({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: join(".rulesync", "subagents"),
@@ -89,7 +89,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -145,7 +145,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
     global = false,

--- a/src/subagents/rulesync-subagent.test.ts
+++ b/src/subagents/rulesync-subagent.test.ts
@@ -117,7 +117,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -141,7 +141,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "claude.md",
         fileContent: "claude content",
@@ -161,7 +161,7 @@ describe("RulesyncSubagent", () => {
 
       expect(() => {
         const _instance = new RulesyncSubagent({
-          baseDir: process.cwd(),
+          baseDir: ".",
           relativeDirPath: ".rulesync/subagents",
           relativeFilePath: "invalid.md",
           fileContent: "invalid content",
@@ -180,7 +180,7 @@ describe("RulesyncSubagent", () => {
 
       expect(() => {
         const _instance = new RulesyncSubagent({
-          baseDir: process.cwd(),
+          baseDir: ".",
           relativeDirPath: ".rulesync/subagents",
           relativeFilePath: "skip-validation.md",
           fileContent: "content",
@@ -226,7 +226,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "multi.md",
         fileContent: "multi content",
@@ -246,7 +246,7 @@ describe("RulesyncSubagent", () => {
       const body = "This is the subagent body content with instructions.";
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "body-test.md",
         fileContent: "full content",
@@ -263,7 +263,7 @@ describe("RulesyncSubagent", () => {
 
     it("should handle empty body", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "empty-body.md",
         fileContent: "only frontmatter",
@@ -282,7 +282,7 @@ describe("RulesyncSubagent", () => {
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "valid.md",
         fileContent: "valid content",
@@ -303,7 +303,7 @@ describe("RulesyncSubagent", () => {
     it("should return success when frontmatter is undefined", () => {
       // Create a subagent with invalid frontmatter but skip validation
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "undefined.md",
         fileContent: "content",
@@ -319,7 +319,7 @@ describe("RulesyncSubagent", () => {
 
     it("should return error for invalid frontmatter", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "invalid-validate.md",
         fileContent: "invalid content",
@@ -513,7 +513,7 @@ description: Testing whitespace handling
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "poly.md",
         fileContent: "poly content",
@@ -537,7 +537,7 @@ description: Testing whitespace handling
 
     it("should maintain type safety", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "typed.md",
         fileContent: "typed content",
@@ -607,7 +607,7 @@ description: File with empty body
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "complex.md",
         fileContent: "complex content",

--- a/src/subagents/rulesync-subagent.ts
+++ b/src/subagents/rulesync-subagent.ts
@@ -110,7 +110,7 @@ export class RulesyncSubagent extends RulesyncFile {
     const filename = basename(relativeFilePath);
 
     return new RulesyncSubagent({
-      baseDir: process.cwd(),
+      baseDir: ".",
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: filename,
       frontmatter: result.data,

--- a/src/subagents/simulated-subagent.ts
+++ b/src/subagents/simulated-subagent.ts
@@ -59,7 +59,7 @@ export abstract class SimulatedSubagent extends ToolSubagent {
   }
 
   protected static fromRulesyncSubagentDefault({
-    baseDir = process.cwd(),
+    baseDir = ".",
     rulesyncSubagent,
     validate = true,
   }: ToolSubagentFromRulesyncSubagentParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
@@ -101,7 +101,7 @@ export abstract class SimulatedSubagent extends ToolSubagent {
   }
 
   protected static async fromFileDefault({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeFilePath,
     validate = true,
   }: ToolSubagentFromFileParams): Promise<ConstructorParameters<typeof SimulatedSubagent>[0]> {

--- a/src/subagents/subagents-processor.test.ts
+++ b/src/subagents/subagents-processor.test.ts
@@ -36,7 +36,7 @@ describe("SubagentsProcessor", () => {
   describe("constructor", () => {
     it("should create instance with valid tool target", () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
 
@@ -54,7 +54,7 @@ describe("SubagentsProcessor", () => {
     it("should validate tool target with schema", () => {
       expect(() => {
         const _processor = new SubagentsProcessor({
-          baseDir: process.cwd(),
+          baseDir: ".",
           toolTarget: "invalid" as SubagentsProcessorToolTarget,
         });
       }).toThrow();
@@ -64,7 +64,7 @@ describe("SubagentsProcessor", () => {
       for (const toolTarget of subagentsProcessorToolTargets) {
         expect(() => {
           const _processor = new SubagentsProcessor({
-            baseDir: process.cwd(),
+            baseDir: ".",
             toolTarget,
           });
         }).not.toThrow();
@@ -77,14 +77,14 @@ describe("SubagentsProcessor", () => {
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
     });
 
     it("should filter and convert RulesyncSubagent instances for claudecode", async () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -120,13 +120,13 @@ Test agent content`,
 
     it("should convert with global flag when processor is in global mode", async () => {
       const globalProcessor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
         global: true,
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "global-test-agent.md",
         fileContent: `---
@@ -175,7 +175,7 @@ Global test agent content`,
       processorWithMockTarget.toolTarget = "unsupported";
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test.md",
         fileContent: '---\nname: test\ndescription: test\ntargets: ["*"]\n---\ntest',
@@ -191,12 +191,12 @@ Global test agent content`,
 
     it("should convert RulesyncSubagent to CopilotSubagent for copilot target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "copilot",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -222,12 +222,12 @@ Test agent content`,
 
     it("should convert RulesyncSubagent to CursorSubagent for cursor target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "cursor",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -253,12 +253,12 @@ Test agent content`,
 
     it("should convert RulesyncSubagent to CodexCliSubagent for codexcli target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "codexcli",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -288,14 +288,14 @@ Test agent content`,
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
     });
 
     it("should filter and convert ToolSubagent instances", async () => {
       const claudecodeSubagent = new ClaudecodeSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -343,7 +343,7 @@ Test agent content`,
 
     it("should skip simulated subagents when converting to rulesync", async () => {
       const claudecodeSubagent = new ClaudecodeSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".claude/agents",
         relativeFilePath: "claude-agent.md",
         fileContent: `---
@@ -360,7 +360,7 @@ Claude content`,
       });
 
       const copilotSubagent = new CopilotSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".github/subagents",
         relativeFilePath: "copilot-agent.md",
         frontmatter: {
@@ -372,7 +372,7 @@ Claude content`,
       });
 
       const cursorSubagent = new CursorSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".cursor/subagents",
         relativeFilePath: "cursor-agent.md",
         frontmatter: {
@@ -384,7 +384,7 @@ Claude content`,
       });
 
       const codexCliSubagent = new CodexCliSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".codex/subagents",
         relativeFilePath: "codex-agent.md",
         frontmatter: {
@@ -412,7 +412,7 @@ Claude content`,
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
     });
@@ -519,7 +519,7 @@ Invalid content`;
   describe("loadToolFiles", () => {
     it("should delegate to loadClaudecodeSubagents for claudecode target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -528,7 +528,7 @@ Invalid content`;
 
     it("should delegate to loadCopilotSubagents for copilot target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "copilot",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -537,7 +537,7 @@ Invalid content`;
 
     it("should delegate to loadCursorSubagents for cursor target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "cursor",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -546,7 +546,7 @@ Invalid content`;
 
     it("should delegate to loadCodexCliSubagents for codexcli target", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "codexcli",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -570,7 +570,7 @@ Invalid content`;
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "copilot",
       });
     });
@@ -604,7 +604,7 @@ Copilot agent content`;
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "cursor",
       });
     });
@@ -638,7 +638,7 @@ Cursor agent content`;
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "codexcli",
       });
     });
@@ -672,7 +672,7 @@ CodexCli agent content`;
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
     });
@@ -940,7 +940,7 @@ Second global content`;
   describe("inheritance from FeatureProcessor", () => {
     it("should extend FeatureProcessor", () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
 
@@ -958,7 +958,7 @@ Second global content`;
 
     beforeEach(() => {
       processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
     });
@@ -1012,7 +1012,7 @@ Valid content`,
   describe("loadToolFilesToDelete", () => {
     it("should return the same files as loadToolFiles", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
 
@@ -1048,7 +1048,7 @@ Test agent content`;
 
       for (const target of targets) {
         const processor = new SubagentsProcessor({
-          baseDir: process.cwd(),
+          baseDir: ".",
           toolTarget: target,
         });
 
@@ -1061,7 +1061,7 @@ Test agent content`;
 
     it("should return empty array when no files exist", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
 
@@ -1071,7 +1071,7 @@ Test agent content`;
 
     it("should handle multiple files correctly", async () => {
       const processor = new SubagentsProcessor({
-        baseDir: process.cwd(),
+        baseDir: ".",
         toolTarget: "claudecode",
       });
 

--- a/src/subagents/subagents-processor.ts
+++ b/src/subagents/subagents-processor.ts
@@ -46,7 +46,7 @@ export class SubagentsProcessor extends FeatureProcessor {
   private readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    baseDir = ".",
     toolTarget,
     global = false,
   }: { baseDir?: string; toolTarget: SubagentsProcessorToolTarget; global?: boolean }) {

--- a/src/subagents/tool-subagent.test.ts
+++ b/src/subagents/tool-subagent.test.ts
@@ -85,7 +85,7 @@ describe("ToolSubagent", () => {
 
     it("should throw error when calling fromRulesyncSubagent on base class", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test.md",
         fileContent: "---\nname: test\ndescription: test desc\ntargets: [all]\n---\ntest body",
@@ -101,7 +101,7 @@ describe("ToolSubagent", () => {
       expect(() => {
         ToolSubagent.fromRulesyncSubagent({
           rulesyncSubagent,
-          baseDir: process.cwd(),
+          baseDir: ".",
           relativeDirPath: ".test",
         });
       }).toThrow("Please implement this method in the subclass.");
@@ -175,7 +175,7 @@ describe("ToolSubagent", () => {
 
     it("should work with fromRulesyncSubagent static method", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "source.md",
         fileContent:
@@ -262,18 +262,18 @@ describe("ToolSubagent", () => {
     it("should have correct ToolSubagentFromFileParams type", () => {
       const params: ToolSubagentFromFileParams = {
         relativeFilePath: "test.md",
-        baseDir: process.cwd(),
+        baseDir: ".",
         validate: true,
       };
 
       expect(params.relativeFilePath).toBe("test.md");
-      expect(params.baseDir).toBe(process.cwd());
+      expect(params.baseDir).toBe(".");
       expect(params.validate).toBe(true);
     });
 
     it("should have correct ToolSubagentFromRulesyncSubagentParams type", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "test.md",
         fileContent: "---\nname: test\ndescription: test desc\ntargets: [all]\n---\ntest body",
@@ -288,13 +288,13 @@ describe("ToolSubagent", () => {
 
       const params: ToolSubagentFromRulesyncSubagentParams = {
         rulesyncSubagent,
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".test",
         validate: true,
       };
 
       expect(params.rulesyncSubagent).toBe(rulesyncSubagent);
-      expect(params.baseDir).toBe(process.cwd());
+      expect(params.baseDir).toBe(".");
       expect(params.validate).toBe(true);
     });
   });

--- a/src/test-utils/test-directories.ts
+++ b/src/test-utils/test-directories.ts
@@ -11,7 +11,7 @@ export async function setupTestDirectory({ home }: { home: boolean } = { home: f
   testDir: string;
   cleanup: () => Promise<void>;
 }> {
-  const testsDir = join(process.cwd(), "tmp", "tests");
+  const testsDir = join("./tmp", "tests");
   const testDir = home
     ? join(testsDir, "home", getVitestWorkerId())
     : join(testsDir, "projects", randomString(16));

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -49,7 +49,7 @@ export abstract class AiFile {
   protected readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    baseDir = ".",
     relativeDirPath,
     relativeFilePath,
     fileContent,

--- a/src/types/tool-file.test.ts
+++ b/src/types/tool-file.test.ts
@@ -142,7 +142,7 @@ describe("ToolFile", () => {
   describe("path traversal security", () => {
     it("should prevent path traversal via relativeDirPath", () => {
       const file = new TestToolFile({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: "../../etc",
         relativeFilePath: "passwd",
         fileContent: "malicious content",
@@ -154,7 +154,7 @@ describe("ToolFile", () => {
 
     it("should prevent path traversal via relativeFilePath", () => {
       const file = new TestToolFile({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".tool",
         relativeFilePath: "../../etc/passwd",
         fileContent: "malicious content",
@@ -166,7 +166,7 @@ describe("ToolFile", () => {
 
     it("should prevent complex path traversal attacks", () => {
       const file = new TestToolFile({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: "foo/../../..",
         relativeFilePath: "etc/passwd",
         fileContent: "malicious content",
@@ -178,7 +178,7 @@ describe("ToolFile", () => {
 
     it("should allow safe relative paths within baseDir", () => {
       const file = new TestToolFile({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: ".tool/config",
         relativeFilePath: "settings.txt",
         fileContent: "safe content",
@@ -186,12 +186,12 @@ describe("ToolFile", () => {
       });
 
       expect(() => file.getFilePath()).not.toThrow();
-      expect(file.getRelativePathFromCwd()).toBe(".tool/config/settings.txt");
+      expect(file.getFilePath()).toBe(".tool/config/settings.txt");
     });
 
     it("should allow nested directories within baseDir", () => {
       const file = new TestToolFile({
-        baseDir: process.cwd(),
+        baseDir: ".",
         relativeDirPath: "deeply/nested/path",
         relativeFilePath: "file.txt",
         fileContent: "safe content",
@@ -199,7 +199,7 @@ describe("ToolFile", () => {
       });
 
       expect(() => file.getFilePath()).not.toThrow();
-      expect(file.getRelativePathFromCwd()).toBe("deeply/nested/path/file.txt");
+      expect(file.getFilePath()).toBe("deeply/nested/path/file.txt");
     });
 
     it("should handle baseDir with subdirectory correctly", () => {

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -512,8 +512,7 @@ describe("file utilities", () => {
       const homeDir = getHomeDirectory();
 
       // Should match the format from setupTestDirectory in test-directories.ts
-      // Now returns absolute path: /workspace/tmp/tests/home/{WORKER_ID}
-      expect(homeDir).toMatch(/^.*tmp\/tests\/home\/\d+$/);
+      expect(homeDir).toMatch(/^(\.\/)?tmp\/tests\/home\/\d+$/);
     });
   });
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -199,7 +199,7 @@ export async function removeFile(filepath: string): Promise<void> {
 export function getHomeDirectory(): string {
   if (isEnvTest) {
     // Have to match the value in setupTestDirectory() in src/test-utils/test-directories.ts
-    return join(process.cwd(), "tmp", "tests", "home", getVitestWorkerId());
+    return join("./tmp", "tests", "home", getVitestWorkerId());
   }
 
   return os.homedir();
@@ -231,8 +231,8 @@ export function validateBaseDir(baseDir: string): void {
   }
 
   // Additional check: ensure normalized path doesn't escape current directory
-  const normalized = resolve(baseDir);
-  const rel = relative(process.cwd(), normalized);
+  const normalized = resolve(".", baseDir);
+  const rel = relative(".", normalized);
   if (rel.startsWith("..")) {
     throw new Error(`baseDir cannot contain directory traversal (..): ${baseDir}`);
   }


### PR DESCRIPTION
## Summary

This PR reverts the merge commit fdbb4c050d3d581476622c4539192421966e0791 (PR #470) which introduced `process.cwd()` changes throughout the codebase.

## Changes

- Reverts all changes from PR #470 related to process.cwd() usage
- Restores the previous behavior where base directories use relative paths (`.`) instead of absolute paths

## Test Plan

- Run existing test suite to ensure all tests pass
- Verify that the codebase behavior is restored to the state before PR #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)