### PR TITLE
docs: update mocking example in testing guidelines

### DIFF
--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -43,9 +43,13 @@ globs: ["**/*.test.ts"]
         getHomeDirectoryMock: vi.fn(),
       }
     })
-    vi.mock("src/utils/file.ts", () => ({
-      getHomeDirectory: getHomeDirectoryMock,
-    }));
+    vi.mock("../utils/file.js", async () => {
+      const actual = await vi.importActual<typeof import("../utils/file.js")>("../utils/file.js");
+      return {
+        ...actual,
+        getHomeDirectory: getHomeDirectoryMock,
+      };
+    });
 
     describe("Test Name", () => {
       let testDir: string;


### PR DESCRIPTION
## Summary
- Updates vi.mock example to use relative paths instead of absolute paths
- Demonstrates proper use of vi.importActual for partial mocking
- Uses spread operator to preserve non-mocked exports

This aligns the documentation with modern Vitest best practices and matches the actual implementation patterns used in the codebase.

## Test plan
- [x] Verify documentation is clear and accurate
- [ ] Review that the example follows current project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)