### PR TITLE
fix: preserve applyTo glob patterns when importing copilot instructions

### DIFF
--- a/src/rules/copilot-rule.test.ts
+++ b/src/rules/copilot-rule.test.ts
@@ -157,7 +157,7 @@ describe("CopilotRule", () => {
         targets: ["*"],
         root: false,
         description: "Test rule",
-        globs: [],
+        globs: ["*.js"],
       });
       expect(rulesyncRule.getBody()).toBe("Test rule content");
       expect(rulesyncRule.getRelativeFilePath()).toBe("test.md");
@@ -779,10 +779,8 @@ description: "Test trimming"
 
       // Verify the round-trip conversion
       expect(convertedCopilot.getFrontmatter().description).toBe("Integration test rule");
-      // Note: CopilotRule.toRulesyncRule() doesn't preserve the original applyTo field
-      // Instead, it creates a RulesyncRule with empty globs for non-root rules,
-      // which becomes undefined when the array is empty
-      expect(convertedCopilot.getFrontmatter().applyTo).toBeUndefined();
+      // applyTo should be preserved through round-trip conversion
+      expect(convertedCopilot.getFrontmatter().applyTo).toBe("*.ts,*.js");
       expect(convertedCopilot.getBody()).toBe("Integration test content");
     });
 

--- a/src/rules/copilot-rule.ts
+++ b/src/rules/copilot-rule.ts
@@ -73,11 +73,20 @@ export class CopilotRule extends ToolRule {
   }
 
   toRulesyncRule(): RulesyncRule {
+    // Convert applyTo field to globs array
+    let globs: string[] | undefined;
+    if (this.isRoot()) {
+      globs = ["**/*"];
+    } else if (this.frontmatter.applyTo) {
+      // Split comma-separated glob patterns
+      globs = this.frontmatter.applyTo.split(",").map((g) => g.trim());
+    }
+
     const rulesyncFrontmatter: RulesyncRuleFrontmatter = {
       targets: ["*"],
       root: this.isRoot(),
       description: this.frontmatter.description,
-      globs: this.isRoot() ? ["**/*"] : [],
+      globs,
     };
 
     // Strip .instructions.md extension and normalize to .md


### PR DESCRIPTION
fixes #462

Copilot instructions with `applyTo` fields were losing their glob patterns during import to rulesync format.

**Root Cause**
`CopilotRule.toRulesyncRule()` hardcoded `globs: []` for non-root rules, discarding the `applyTo` field.

**Changes**
- Parse `applyTo` comma-separated patterns into `globs` array during conversion
- Preserve `undefined` for rules without glob patterns (semantically correct vs empty array)

```typescript
// Before: applyTo lost during conversion
toRulesyncRule(): RulesyncRule {
  const rulesyncFrontmatter = {
    globs: this.isRoot() ? ["**/*"] : [],  // ❌ applyTo ignored
  };
}

// After: applyTo preserved as globs
toRulesyncRule(): RulesyncRule {
  let globs: string[] | undefined;
  if (this.isRoot()) {
    globs = ["**/*"];
  } else if (this.frontmatter.applyTo) {
    globs = this.frontmatter.applyTo.split(",").map((g) => g.trim());
  }
  // ...
}
```

Round-trip conversion now preserves glob patterns:
```yaml
# .github/instructions/typescript.instructions.md
applyTo: "*.ts,*.tsx"

# ↓ import

# .rulesync/rules/typescript.md
globs:
  - '*.ts'
  - '*.tsx'

# ↓ generate

# .github/instructions/typescript.instructions.md
applyTo: '*.ts,*.tsx'  # ✓ preserved
```

</details>

- used coding agent to generate 