### PR TITLE
fix: improve secretlint performance by adding dedicated ignore file

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -1,0 +1,92 @@
+# Dependencies
+node_modules/
+.pnpm-store/
+
+# Build outputs
+dist/
+coverage/
+
+# Cache directories
+.cache/
+.eslintcache
+.stylelintcache
+.cspellcache
+
+# Lock files
+pnpm-lock.yaml
+package-lock.json
+
+# Temporary files
+tmp/
+ai-tmp/
+.temp/
+
+# Generated files
+**/.github/copilot-instructions.md
+**/.github/instructions/
+**/.cursor/
+**/.cursorignore
+**/.clinerules/
+**/.clineignore
+**/.roo/rules/
+**/.rooignore
+**/.copilotignore
+**/CLAUDE.md
+**/.claude/memories/
+**/.claude/settings.json
+**/GEMINI.md
+**/.gemini/memories/
+**/.aiexclude
+**/.augment/rules/
+**/.augment-guidelines
+**/.codex/
+**/.mcp.json
+**/.cursor/mcp.json
+**/.cline/mcp.json
+**/.vscode/mcp.json
+**/.gemini/settings.json
+**/.roo/mcp.json
+**/.rulesync/copilot__*
+**/.rulesync/cursor__*
+**/.rulesync/cline__*
+**/.rulesync/roo__*
+**/.rulesync/claudecode__*
+**/.rulesync/geminicli__*
+**/.rulesync/augmentcode__*
+**/.aiignore
+**/.kiro/steering/
+**/.augmentignore
+**/.junie/guidelines.md
+**/.noai
+**/.claude/commands/
+**/.claude/agents/
+**/AGENTS.md
+**/.codexignore
+**/.codex/memories/
+**/.gemini/commands/
+**/.codex/mcp-config.json
+.serena/cache/
+.serena/memories/
+**/opencode.json
+**/.opencode/memories/
+**/.opencode/commands/
+**/.amazonq/rules/
+**/.amazonq/mcp.json
+**/.agents/
+**/QWEN.md
+**/.qwen/memories/
+**/.qwen/settings.json
+**/.gemini/subagents/
+**/.github/subagents/
+**/.github/commands/
+**/.github/prompts/
+**/.geminiignore
+**/.warp/
+**/WARP.md
+
+# Data
+data/
+
+# Output files
+repomix-output.xml
+modular-mcp.json

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"oxlint:fix": "oxlint . --fix --max-warnings 0",
 		"prepare": "simple-git-hooks && pnpm generate",
 		"prepublishOnly": "pnpm build",
-		"secretlint": "secretlint --secretlintignore .gitignore \"**/*\"",
+		"secretlint": "secretlint \"**/*\"",
 		"sort": "sort-package-json",
 		"task": "tsx scripts/run-tasks.ts",
 		"test": "vitest run --silent=true",


### PR DESCRIPTION
- Create .secretlintignore with explicit ignore patterns for node_modules and .pnpm-store
- Remove --secretlintignore .gitignore flag from package.json script
- This prevents secretlint from scanning dependency directories, significantly improving scan performance