### PR TITLE
feat: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install dependencies using pnpm
+pnpm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,5 +60,17 @@
       ],
       "allowLocalBinding": true
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Set up SessionStart hook to automatically install pnpm dependencies
when starting Claude Code web sessions, ensuring linters and tests
work correctly.