### PR TITLE
chore: relocate pnpm store to workspace directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
-    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/home/node/.local/share/pnpm/store,type=volume"
+    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/workspace/.pnpm-store,type=volume"
   ],
   "remoteEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -2,7 +2,7 @@
 
 # Ensure node_modules and pnpm-store volumes have correct ownership for non-root user
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
-sudo chown -R node:node /home/node/.local/share/pnpm/store 2>/dev/null || true
+sudo chown -R node:node /workspace/.pnpm-store 2>/dev/null || true
 
 mise trust
 mise install


### PR DESCRIPTION
## Summary
- Moved pnpm store from `/home/node/.local/share/pnpm/store` to `/workspace/.pnpm-store`
- Updated devcontainer volume mount configuration
- Updated init.sh to ensure correct ownership for the new location

## Rationale
This change improves isolation and volume management in the devcontainer by placing the pnpm store within the workspace directory instead of the user's home directory.

## Test plan
- [ ] Rebuild devcontainer and verify pnpm operations work correctly
- [ ] Verify volume mounting works as expected
- [ ] Verify ownership permissions are correct after container initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)