### PR TITLE
fix: use containerWorkspaceFolder variable for pnpm store path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
-    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/workspace/.pnpm-store,type=volume"
+    "source=${localWorkspaceFolderBasename}-pnpm-store,target=${containerWorkspaceFolder}/.pnpm-store,type=volume"
   ],
   "remoteEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
## Summary
- Replace hardcoded `/workspace` path with `${containerWorkspaceFolder}` variable for pnpm store volume mount
- Ensures consistency with other volume configurations in devcontainer.json

## Test plan
- [ ] Rebuild devcontainer and verify pnpm store is correctly mounted
- [ ] Verify pnpm commands work as expected in the devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)