### PR TITLE
fix: standardize volume naming in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,8 +37,8 @@
   },
   "remoteUser": "node",
   "mounts": [
-    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=${localWorkspaceFolderBasename}-claude-code-bashhistory,target=/commandhistory,type=volume",
+    "source=${localWorkspaceFolderBasename}-claude-code-config,target=/home/node/.claude,type=volume",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
     "source=${localWorkspaceFolderBasename}-pnpm-store,target=${containerWorkspaceFolder}/.pnpm-store,type=volume"
   ],


### PR DESCRIPTION
## Summary

- Standardized devcontainer volume naming to use `${localWorkspaceFolderBasename}` prefix instead of `${devcontainerId}`
- This change affects the bash history and Claude Code config volume mounts
- Makes volume names consistent with the existing node_modules and pnpm-store volumes

## Changes

Changed the following volume mount sources in `.devcontainer/devcontainer.json`:
- `claude-code-bashhistory-${devcontainerId}` → `${localWorkspaceFolderBasename}-claude-code-bashhistory`
- `claude-code-config-${devcontainerId}` → `${localWorkspaceFolderBasename}-claude-code-config`

## Test plan

- [ ] Rebuild the devcontainer and verify it starts successfully
- [ ] Verify that bash history is preserved across container rebuilds
- [ ] Verify that Claude Code config is preserved across container rebuilds
- [ ] Verify that the volume names follow the expected pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)