### PR TITLE
fix: use path.join in modular-mcp tests to prevent double slashes

### DIFF
--- a/src/mcp/modular-mcp.test.ts
+++ b/src/mcp/modular-mcp.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import { type ValidationResult } from "../types/ai-file.js";
@@ -44,7 +45,7 @@ describe("ModularMcp", () => {
         groups: {},
       });
 
-      const customBaseDir = `${testDir}/custom/path`;
+      const customBaseDir = join(testDir, "custom", "path");
       const modularMcp = new ModularMcp({
         baseDir: customBaseDir,
         relativeDirPath: ".",
@@ -52,7 +53,7 @@ describe("ModularMcp", () => {
         fileContent: validJsonContent,
       });
 
-      expect(modularMcp.getFilePath()).toBe(`${customBaseDir}/modular-mcp.json`);
+      expect(modularMcp.getFilePath()).toBe(join(customBaseDir, "modular-mcp.json"));
       expect(modularMcp.getBaseDir()).toBe(customBaseDir);
     });
 
@@ -261,7 +262,7 @@ describe("ModularMcp", () => {
       expect(mcpServers["modular-mcp"]).toEqual({
         type: "stdio",
         command: "npx",
-        args: ["-y", "@kimuson/modular-mcp", `${testDir}/.claude/modular-mcp.json`],
+        args: ["-y", "@kimuson/modular-mcp", join(testDir, ".claude", "modular-mcp.json")],
         env: {},
       });
     });
@@ -277,7 +278,7 @@ describe("ModularMcp", () => {
       expect(mcpServers["modular-mcp"]).toEqual({
         type: "stdio",
         command: "npx",
-        args: ["-y", "@kimuson/modular-mcp", `${testDir}/.codex/modular-mcp.json`],
+        args: ["-y", "@kimuson/modular-mcp", join(testDir, ".codex", "modular-mcp.json")],
         env: {},
       });
     });


### PR DESCRIPTION
## Summary
- Fixed test failures in CI where string template paths could produce double slashes in certain environments
- Replaced template strings with `path.join()` for proper path construction in test expectations
- All 2523 tests now pass

## Test plan
- [x] All tests pass locally
- [x] cicheck passes

Fixes https://github.com/dyoshikawa/rulesync/actions/runs/19191075871

🤖 Generated with [Claude Code](https://claude.com/claude-code)