### PR TITLE
chore: add Bun installation to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -91,8 +91,9 @@ RUN /home/node/.local/bin/mise trust /workspace && /home/node/.local/bin/mise in
 # Install global npm packages
 RUN npm i -g opencode-ai @openai/codex opencommit @google/gemini-cli
 
-# Configure Bun with smol mode to reduce memory usage
+# Install Bun with smol mode to reduce memory usage
 RUN echo 'smol = true' > /home/node/bunfig.toml
+RUN curl -fsSL https://bun.sh/install | bash
 
 # Aliases
 RUN echo "alias claude=\"claude --dangerously-skip-permissions\"" >> "/home/node/.zshrc"


### PR DESCRIPTION
## Summary

- Install Bun using the official installation script in the devcontainer
- Configure smol mode to reduce memory usage for Bun
- Fix comment to clarify that this step installs Bun

## Test plan

- [ ] Build the devcontainer and verify Bun is installed correctly
- [ ] Verify `bunfig.toml` is created with `smol = true` configuration
- [ ] Test Bun commands work as expected in the devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)