### PR TITLE
chore: remove excessive pnpm cicheck from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run cicheck
-        run: |
-          pnpm cicheck
-
       - name: Publish to npm
         run: pnpm publish


### PR DESCRIPTION
Remove the pnpm cicheck step from the release workflow as it's an excessive check.