### PR TITLE
feat: add Mac Intel environment check to e2e-binaries workflow

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -49,7 +49,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13]
 
     steps:
       - name: Checkout code
@@ -70,7 +70,12 @@ jobs:
           if [ "$MATRIX_OS" = "ubuntu-latest" ]; then
             chmod +x dist-bun/rulesync-linux-x64
             BINARY_PATH=dist-bun/rulesync-linux-x64
+          elif [ "$MATRIX_OS" = "macos-13" ]; then
+            # macos-13 is Intel (x64)
+            chmod +x dist-bun/rulesync-darwin-x64
+            BINARY_PATH=dist-bun/rulesync-darwin-x64
           else
+            # macos-latest is Apple Silicon (arm64)
             chmod +x dist-bun/rulesync-darwin-arm64
             BINARY_PATH=dist-bun/rulesync-darwin-arm64
           fi


### PR DESCRIPTION
- Added macos-13 runner to test darwin-x64 binary on Intel Mac
- Updated binary selection logic to distinguish between Mac Intel (x64) and Mac ARM (arm64)
- Ensures comprehensive testing across all supported platforms