### PR TITLE
chore: remove duplicate entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,10 +122,8 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
-dist-bun
 
 # Gatsby files
-.cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
@@ -135,7 +133,6 @@ dist-bun
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus


### PR DESCRIPTION
- Remove duplicate `.cache` entries (kept in parcel-bundler section)
- Remove duplicate `dist-bun` entry (kept in Bun compiled binaries section)