### PR TITLE
chore: migrate macOS Intel runner to macos-15-intel

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -49,7 +49,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
 
     steps:
       - name: Checkout code
@@ -70,8 +70,8 @@ jobs:
           if [ "$MATRIX_OS" = "ubuntu-latest" ]; then
             chmod +x dist-bun/rulesync-linux-x64
             BINARY_PATH=dist-bun/rulesync-linux-x64
-          elif [ "$MATRIX_OS" = "macos-13" ]; then
-            # macos-13 is Intel (x64)
+          elif [ "$MATRIX_OS" = "macos-15-intel" ]; then
+            # macos-15-intel is Intel (x64)
             chmod +x dist-bun/rulesync-darwin-x64
             BINARY_PATH=dist-bun/rulesync-darwin-x64
           else


### PR DESCRIPTION
Update e2e-binaries.yml to use macos-15-intel instead of macos-13.
This is necessary as macos-13 is being deprecated (retirement on Dec 4, 2025).
macos-15-intel is the new Intel-based runner label available until Aug 2027.