### PR TITLE
fix: resolve flaky test failures caused by inconsistent path handling

### DIFF
--- a/src/commands/commands-processor.test.ts
+++ b/src/commands/commands-processor.test.ts
@@ -707,7 +707,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load claudecode commands with correct parameters", async () => {
-      const mockPaths = [`${testDir}/.claude/commands/test.md`];
+      const mockPaths = [join(testDir, ".claude", "commands", "test.md")];
       const mockCommand = new ClaudecodeCommand({
         baseDir: testDir,
         relativeDirPath: join(".claude", "commands"),
@@ -740,7 +740,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load geminicli commands with correct parameters", async () => {
-      const mockPaths = [`${testDir}/.gemini/commands/test.md`];
+      const mockPaths = [join(testDir, ".gemini", "commands", "test.md")];
       const mockCommand = new GeminiCliCommand({
         baseDir: testDir,
         relativeDirPath: join(".gemini", "commands"),
@@ -761,7 +761,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load roo commands with correct parameters", async () => {
-      const mockPaths = [`${testDir}/.roo/commands/test.md`];
+      const mockPaths = [join(testDir, ".roo", "commands", "test.md")];
       const mockCommand = new RooCommand({
         baseDir: testDir,
         relativeDirPath: join(".roo", "commands"),
@@ -819,7 +819,7 @@ describe("CommandsProcessor", () => {
         global: true,
       });
 
-      const mockPaths = [`${testDir}/.claude/commands/test.md`];
+      const mockPaths = [join(testDir, ".claude", "commands", "test.md")];
       const mockCommand = new ClaudecodeCommand({
         baseDir: testDir,
         relativeDirPath: join(".claude", "commands"),
@@ -853,7 +853,7 @@ describe("CommandsProcessor", () => {
         global: true,
       });
 
-      const mockPaths = [`${testDir}/.cursor/commands/test.md`];
+      const mockPaths = [join(testDir, ".cursor", "commands", "test.md")];
       const mockCommand = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: join(".cursor", "commands"),

--- a/src/mcp/modular-mcp.test.ts
+++ b/src/mcp/modular-mcp.test.ts
@@ -344,7 +344,7 @@ describe("ModularMcp", () => {
     });
 
     it("should have correct type definitions for parameters", () => {
-      const customBaseDir = `${testDir}/custom`;
+      const customBaseDir = join(testDir, "custom");
       const constructorParams: ModularMcpParams = {
         baseDir: customBaseDir,
         relativeDirPath: ".",

--- a/src/mcp/tool-mcp.test.ts
+++ b/src/mcp/tool-mcp.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import { type ValidationResult } from "../types/ai-file.js";
@@ -97,7 +98,7 @@ describe("ToolMcp", () => {
         mcpServers: {},
       });
 
-      const customPath = `${testDir}/custom/path`;
+      const customPath = join(testDir, "custom", "path");
       const toolMcp = new TestToolMcp({
         baseDir: customPath,
         relativeDirPath: "test",
@@ -105,7 +106,7 @@ describe("ToolMcp", () => {
         fileContent: validJsonContent,
       });
 
-      expect(toolMcp.getFilePath()).toBe(`${customPath}/test/test.json`);
+      expect(toolMcp.getFilePath()).toBe(join(customPath, "test", "test.json"));
     });
 
     it("should parse JSON content correctly", () => {
@@ -357,7 +358,7 @@ describe("ToolMcp", () => {
       const jsonData = {
         mcpServers: {},
       };
-      const customDir = `${testDir}/custom/base/dir`;
+      const customDir = join(testDir, "custom", "base", "dir");
       const toolMcp = new TestToolMcp({
         baseDir: customDir,
         relativeDirPath: "test",
@@ -368,7 +369,7 @@ describe("ToolMcp", () => {
       const rulesyncMcp = toolMcp.toRulesyncMcp();
 
       expect(rulesyncMcp.getBaseDir()).toBe(customDir);
-      expect(rulesyncMcp.getFilePath()).toBe(`${customDir}/.rulesync/.mcp.json`);
+      expect(rulesyncMcp.getFilePath()).toBe(join(customDir, ".rulesync", ".mcp.json"));
     });
 
     it("should preserve file content exactly", () => {
@@ -461,8 +462,8 @@ describe("ToolMcp", () => {
     });
 
     it("should throw error for fromRulesyncMcp with custom parameters", async () => {
-      const customDir = `${testDir}/custom`;
-      const targetDir = `${testDir}/target`;
+      const customDir = join(testDir, "custom");
+      const targetDir = join(testDir, "target");
       const rulesyncMcp = new RulesyncMcp({
         baseDir: customDir,
         relativeDirPath: ".rulesync",

--- a/src/types/tool-file.test.ts
+++ b/src/types/tool-file.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import { ValidationResult } from "./ai-file.js";
@@ -111,7 +112,7 @@ describe("ToolFile", () => {
         baseDir: testDir,
         relativeDirPath: ".tool",
         relativeFilePath: "config.txt",
-        filePath: `${testDir}/.tool/config.txt`,
+        filePath: join(testDir, ".tool", "config.txt"),
       });
 
       expect(file).toBeInstanceOf(TestToolFile);
@@ -199,7 +200,7 @@ describe("ToolFile", () => {
       });
 
       expect(() => file.getFilePath()).not.toThrow();
-      expect(file.getFilePath()).toBe(`${testDir}/.tool/config/settings.txt`);
+      expect(file.getFilePath()).toBe(join(testDir, ".tool", "config", "settings.txt"));
     });
 
     it("should allow nested directories within baseDir", () => {
@@ -212,12 +213,12 @@ describe("ToolFile", () => {
       });
 
       expect(() => file.getFilePath()).not.toThrow();
-      expect(file.getFilePath()).toBe(`${testDir}/deeply/nested/path/file.txt`);
+      expect(file.getFilePath()).toBe(join(testDir, "deeply", "nested", "path", "file.txt"));
     });
 
     it("should handle baseDir with subdirectory correctly", () => {
       const file = new TestToolFile({
-        baseDir: `${testDir}/project`,
+        baseDir: join(testDir, "project"),
         relativeDirPath: "src",
         relativeFilePath: "index.ts",
         fileContent: "safe content",
@@ -225,12 +226,12 @@ describe("ToolFile", () => {
       });
 
       expect(() => file.getFilePath()).not.toThrow();
-      expect(file.getFilePath()).toBe(`${testDir}/project/src/index.ts`);
+      expect(file.getFilePath()).toBe(join(testDir, "project", "src", "index.ts"));
     });
 
     it("should prevent escaping from nested baseDir", () => {
       const file = new TestToolFile({
-        baseDir: `${testDir}/project/src`,
+        baseDir: join(testDir, "project", "src"),
         relativeDirPath: "../../etc",
         relativeFilePath: "passwd",
         fileContent: "malicious content",


### PR DESCRIPTION
## Summary

Fixed intermittent CI test failures that occurred randomly in test files. The root cause was inconsistent path handling using string template concatenation instead of `path.join()`.

## Problem

CI tests were failing intermittently at `src/mcp/tool-mcp.test.ts:371` and other locations with path assertion mismatches:

```
Expected: "/home/runner/work/rulesync/rulesync/tmp/tests/projects/INZSZSFWaOrIGMK//custom/base/dir/.rulesync/.mcp.json"
Received: "/home/runner/work/rulesync/rulesync/tmp/tests/projects/INZSZSFWaOrIGMK/custom/base/dir/.rulesync/.mcp.json"
```

The issue was caused by:
- Using string template concatenation for paths: `${testDir}/custom/base/dir`
- In some CI environments, `testDir` occasionally had a trailing slash
- This resulted in double slashes in expected values while actual paths were normalized by `path.join()`

## Solution

Changed all test files to use Node's `path.join()` for path construction, ensuring consistent path normalization across all environments.

**Before:**
```typescript
const customDir = `${testDir}/custom/base/dir`;
expect(file.getFilePath()).toBe(`${customDir}/.rulesync/.mcp.json`);
```

**After:**
```typescript
const customDir = join(testDir, "custom", "base", "dir");
expect(file.getFilePath()).toBe(join(customDir, ".rulesync", ".mcp.json"));
```

## Files Changed

- `src/mcp/tool-mcp.test.ts`: Added `path.join` import and updated all path constructions
- `src/types/tool-file.test.ts`: Added `path.join` import and updated all path constructions
- `src/mcp/modular-mcp.test.ts`: Updated path construction
- `src/commands/commands-processor.test.ts`: Updated path construction

## Test Plan

- [x] All 2525 tests pass locally
- [x] No changes to production code, only test files
- [x] Verified path normalization consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)