### PR TITLE
Set allowUnsandboxedCommands to false explicitly in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,8 @@
         "/var/run/docker.sock"
       ],
       "allowLocalBinding": true
-    }
+    },
+    "allowUnsandboxedCommands": false
   },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Changes

### Specification Changes
- Explicitly set `allowUnsandboxedCommands` to `false` in `.claude/settings.json`

### Code Changes
- Added `"allowUnsandboxedCommands": false` to `.claude/settings.json`

### Notes
- This change makes the security setting explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)