### PR TITLE
chore: add gitignore rules for user-specific language settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,7 @@ rulesync-deno
 # MCP configuration files
 .mcp.json
 modular-mcp.json
+
+# User-specific rule files
+.rulesync/rules/my-language.md
+.claude/memories/my-language.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 Please also reference the following documents as needed:
 
 @.claude/memories/coding-guidelines.md description: "When you write any code, must follow these guidelines." globs: "**/*.ts"
+@.claude/memories/my-language.md description: "You must always answer in Japanese. On the other hand, reasoning(thinking) should be in English to improve token efficiency." globs: "**/*"
 @.claude/memories/testing-guidelines.md description: "When you write tests, must follow these guidelines." globs: "**/*.test.ts"
 # Rulesync Project Overview
 


### PR DESCRIPTION
## Summary
- Add gitignore entries for user-specific my-language.md files in .rulesync/rules/ and .claude/memories/
- Update CLAUDE.md to reference my-language.md memory file for language preference handling

## Test plan
- [x] Verify .gitignore excludes my-language.md files from version control
- [x] Confirm CLAUDE.md correctly references the my-language memory file
- [x] Pre-commit hooks pass successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)