### PR TITLE
refactor: unify getToolTargets and getToolTargetsGlobal methods

### DIFF
--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -78,14 +78,10 @@ describe("generateCommand", () => {
 
     // Setup processor static method mocks
     vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-    vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
     vi.mocked(IgnoreProcessor.getToolTargets).mockReturnValue(["claudecode"]);
     vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-    vi.mocked(McpProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
     vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-    vi.mocked(SubagentsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
     vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-    vi.mocked(CommandsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
 
     // Setup processor constructor mocks - create new instance each time to ensure isolation
     vi.mocked(RulesProcessor).mockImplementation(function () {
@@ -420,6 +416,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({
+        global: false,
         includeSimulated: true,
       });
     });
@@ -521,6 +518,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith({
+        global: false,
         includeSimulated: true,
       });
     });
@@ -531,18 +529,19 @@ describe("generateCommand", () => {
         mockConfig.getExperimentalGlobal.mockReturnValue(true);
       });
 
-      it("should use getToolTargetsGlobal in global mode", async () => {
-        vi.mocked(SubagentsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+      it("should use getToolTargets with global: true in global mode", async () => {
+        vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
         const options: GenerateOptions = {};
 
         await generateCommand(options);
 
-        expect(SubagentsProcessor.getToolTargetsGlobal).toHaveBeenCalled();
-        expect(SubagentsProcessor.getToolTargets).not.toHaveBeenCalled();
+        expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith(
+          expect.objectContaining({ global: true }),
+        );
       });
 
       it("should pass global flag to SubagentsProcessor constructor", async () => {
-        vi.mocked(SubagentsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+        vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
         const options: GenerateOptions = {};
 
         await generateCommand(options);
@@ -556,7 +555,7 @@ describe("generateCommand", () => {
 
       it("should only process claudecode target in global mode", async () => {
         mockConfig.getTargets.mockReturnValue(["claudecode", "copilot", "cursor"]);
-        vi.mocked(SubagentsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+        vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
         vi.mocked(intersection).mockReturnValue(["claudecode"]);
         const options: GenerateOptions = {};
 
@@ -577,15 +576,16 @@ describe("generateCommand", () => {
         mockConfig.getSimulatedSubagents.mockReturnValue(true);
         mockConfig.getExperimentalSimulateSubagents.mockReturnValue(true);
         mockConfig.getTargets.mockReturnValue(["claudecode", "copilot"]);
-        vi.mocked(SubagentsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+        vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
         vi.mocked(intersection).mockReturnValue(["claudecode"]);
         const options: GenerateOptions = {};
 
         await generateCommand(options);
 
-        // Should use getToolTargetsGlobal instead of getToolTargets with includeSimulated
-        expect(SubagentsProcessor.getToolTargetsGlobal).toHaveBeenCalled();
-        expect(SubagentsProcessor.getToolTargets).not.toHaveBeenCalled();
+        // Should use getToolTargets with global: true instead of includeSimulated
+        expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith(
+          expect.objectContaining({ global: true }),
+        );
         expect(SubagentsProcessor).toHaveBeenCalledTimes(1);
         expect(SubagentsProcessor).toHaveBeenCalledWith({
           baseDir: ".",
@@ -754,16 +754,15 @@ describe("generateCommand", () => {
       mockConfig.getFeatures.mockReturnValue(["rules", "mcp", "commands", "ignore", "subagents"]);
     });
 
-    it("should use getToolTargetsGlobal when experimentalGlobal is enabled", async () => {
+    it("should use getToolTargets with global: true when experimentalGlobal is enabled", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
       const options: GenerateOptions = {};
 
       await generateCommand(options);
 
-      expect(RulesProcessor.getToolTargetsGlobal).toHaveBeenCalled();
-      expect(RulesProcessor.getToolTargets).not.toHaveBeenCalled();
+      expect(RulesProcessor.getToolTargets).toHaveBeenCalledWith({ global: true });
     });
 
     it("should pass simulation options to RulesProcessor in global mode", async () => {
@@ -772,7 +771,7 @@ describe("generateCommand", () => {
       mockConfig.getSimulatedSubagents.mockReturnValue(true);
       mockConfig.getExperimentalSimulateCommands.mockReturnValue(true);
       mockConfig.getExperimentalSimulateSubagents.mockReturnValue(true);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
       const options: GenerateOptions = {};
 
@@ -790,7 +789,7 @@ describe("generateCommand", () => {
     it("should process delete option in global mode", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
       mockConfig.getDelete.mockReturnValue(true);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
 
       // Create a custom mock instance to track calls
@@ -817,7 +816,7 @@ describe("generateCommand", () => {
 
     it("should call loadRulesyncFilesLegacy in global mode when loadRulesyncFiles returns empty", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
 
       // Create a custom mock instance that returns empty rulesync files
@@ -844,7 +843,7 @@ describe("generateCommand", () => {
     it("should use each baseDir in global mode", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
       mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2", "dir3"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
       const options: GenerateOptions = {};
 
@@ -876,7 +875,7 @@ describe("generateCommand", () => {
 
     it("should skip MCP generation in global mode when no targets match", async () => {
       // When targets is ["claudecode"] and global targets is ["codexcli"], intersection is empty
-      vi.mocked(McpProcessor.getToolTargetsGlobal).mockReturnValue(["codexcli"]);
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["codexcli"]);
       const options: GenerateOptions = {};
 
       await generateCommand(options);
@@ -896,7 +895,9 @@ describe("generateCommand", () => {
         toolTarget: "claudecode",
         global: true,
       });
-      expect(CommandsProcessor.getToolTargetsGlobal).toHaveBeenCalled();
+      expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith(
+        expect.objectContaining({ global: true }),
+      );
     });
 
     it("should skip ignore generation in global mode with log message", async () => {
@@ -928,7 +929,7 @@ describe("generateCommand", () => {
 
     it("should show success message with only rules count in global mode", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
 
       // Create a custom mock instance that returns 5
@@ -956,9 +957,9 @@ describe("generateCommand", () => {
 
     it("should only process rules, commands, mcp, and subagents when global mode is enabled with multiple features", async () => {
       mockConfig.getTargets.mockReturnValue(["claudecode", "codexcli"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
-      vi.mocked(CommandsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
-      vi.mocked(McpProcessor.getToolTargetsGlobal).mockReturnValue(["codexcli"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["codexcli"]);
       vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
 
       // Set up intersection to return correct values

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -83,9 +83,10 @@ async function generateRules(config: Config): Promise<number> {
   let totalRulesOutputs = 0;
   logger.info("Generating rule files...");
 
-  const toolTargets = config.getGlobal()
-    ? intersection(config.getTargets(), RulesProcessor.getToolTargetsGlobal())
-    : intersection(config.getTargets(), RulesProcessor.getToolTargets());
+  const toolTargets = intersection(
+    config.getTargets(),
+    RulesProcessor.getToolTargets({ global: config.getGlobal() }),
+  );
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
       const processor = new RulesProcessor({
@@ -175,9 +176,10 @@ async function generateMcp(config: Config): Promise<number> {
     logger.info("ℹ️  Modular MCP support is experimental.");
   }
 
-  const toolTargets = config.getGlobal()
-    ? intersection(config.getTargets(), McpProcessor.getToolTargetsGlobal())
-    : intersection(config.getTargets(), McpProcessor.getToolTargets());
+  const toolTargets = intersection(
+    config.getTargets(),
+    McpProcessor.getToolTargets({ global: config.getGlobal() }),
+  );
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
       const processor = new McpProcessor({
@@ -212,14 +214,13 @@ async function generateCommands(config: Config): Promise<number> {
   let totalCommandOutputs = 0;
   logger.info("Generating command files...");
 
-  const toolTargets = config.getGlobal()
-    ? intersection(config.getTargets(), CommandsProcessor.getToolTargetsGlobal())
-    : intersection(
-        config.getTargets(),
-        CommandsProcessor.getToolTargets({
-          includeSimulated: config.getSimulatedCommands(),
-        }),
-      );
+  const toolTargets = intersection(
+    config.getTargets(),
+    CommandsProcessor.getToolTargets({
+      global: config.getGlobal(),
+      includeSimulated: config.getSimulatedCommands(),
+    }),
+  );
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -254,14 +255,13 @@ async function generateSubagents(config: Config): Promise<number> {
   let totalSubagentOutputs = 0;
   logger.info("Generating subagent files...");
 
-  const toolTargets = config.getGlobal()
-    ? intersection(config.getTargets(), SubagentsProcessor.getToolTargetsGlobal())
-    : intersection(
-        config.getTargets(),
-        SubagentsProcessor.getToolTargets({
-          includeSimulated: config.getSimulatedSubagents(),
-        }),
-      );
+  const toolTargets = intersection(
+    config.getTargets(),
+    SubagentsProcessor.getToolTargets({
+      global: config.getGlobal(),
+      includeSimulated: config.getSimulatedSubagents(),
+    }),
+  );
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -296,9 +296,10 @@ async function generateSkills(config: Config): Promise<number> {
   let totalSkillOutputs = 0;
   logger.info("Generating skill files...");
 
-  const toolTargets = config.getGlobal()
-    ? intersection(config.getTargets(), SkillsProcessor.getToolTargetsGlobal())
-    : intersection(config.getTargets(), SkillsProcessor.getToolTargets());
+  const toolTargets = intersection(
+    config.getTargets(),
+    SkillsProcessor.getToolTargets({ global: config.getGlobal() }),
+  );
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -46,13 +46,10 @@ describe("importCommand", () => {
 
     // Setup processor mocks with default return values
     vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "roo", "geminicli"]);
-    vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode", "codexcli"]);
     vi.mocked(IgnoreProcessor.getToolTargets).mockReturnValue(["claudecode", "roo", "geminicli"]);
     vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-    vi.mocked(McpProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
     vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
     vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode", "roo"]);
-    vi.mocked(CommandsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
 
     // Mock processor instances - create separate objects for each processor
     vi.mocked(RulesProcessor).mockImplementation(function () {
@@ -212,7 +209,10 @@ describe("importCommand", () => {
       await importCommand(options);
 
       // Verify that getToolTargets was called with includeSimulated: false
-      expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith({ includeSimulated: false });
+      expect(SubagentsProcessor.getToolTargets).toHaveBeenCalledWith({
+        global: false,
+        includeSimulated: false,
+      });
       expect(SubagentsProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -241,7 +241,10 @@ describe("importCommand", () => {
       await importCommand(options);
 
       // Verify that getToolTargets was called with includeSimulated: false
-      expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({ includeSimulated: false });
+      expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({
+        global: false,
+        includeSimulated: false,
+      });
       expect(CommandsProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -482,11 +485,9 @@ describe("importCommand", () => {
       });
 
       vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
       vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
       vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
       vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-      vi.mocked(CommandsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
 
       const options: ImportOptions = {
         targets: ["claudecode"],
@@ -516,7 +517,7 @@ describe("importCommand", () => {
       });
     });
 
-    it("should use getToolTargetsGlobal for supported processors in global mode", async () => {
+    it("should use getToolTargets with global: true for supported processors in global mode", async () => {
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
@@ -553,12 +554,10 @@ describe("importCommand", () => {
         } as any;
       });
 
-      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "roo"]);
-      vi.mocked(RulesProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode"]);
       vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
       vi.mocked(SubagentsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
-      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode", "roo"]);
-      vi.mocked(CommandsProcessor.getToolTargetsGlobal).mockReturnValue(["claudecode"]);
+      vi.mocked(CommandsProcessor.getToolTargets).mockReturnValue(["claudecode"]);
 
       const options: ImportOptions = {
         targets: ["claudecode"],
@@ -566,9 +565,12 @@ describe("importCommand", () => {
 
       await importCommand(options);
 
-      // Verify getToolTargetsGlobal is called for processors that support it
-      expect(RulesProcessor.getToolTargetsGlobal).toHaveBeenCalled();
-      expect(CommandsProcessor.getToolTargetsGlobal).toHaveBeenCalled();
+      // Verify getToolTargets is called with global: true for processors that support it
+      expect(RulesProcessor.getToolTargets).toHaveBeenCalledWith({ global: true });
+      expect(CommandsProcessor.getToolTargets).toHaveBeenCalledWith({
+        global: true,
+        includeSimulated: false,
+      });
     });
   });
 });

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -56,9 +56,7 @@ async function importRules(config: Config, tool: ToolTarget): Promise<number> {
 
   const global = config.getGlobal();
 
-  const supportedTargets = global
-    ? RulesProcessor.getToolTargetsGlobal()
-    : RulesProcessor.getToolTargets();
+  const supportedTargets = RulesProcessor.getToolTargets({ global });
 
   if (!supportedTargets.includes(tool)) {
     return 0;
@@ -130,9 +128,7 @@ async function importMcp(config: Config, tool: ToolTarget): Promise<number> {
 
   const global = config.getGlobal();
 
-  const supportedTargets = global
-    ? McpProcessor.getToolTargetsGlobal()
-    : McpProcessor.getToolTargets();
+  const supportedTargets = McpProcessor.getToolTargets({ global });
 
   if (!supportedTargets.includes(tool)) {
     return 0;
@@ -166,9 +162,7 @@ async function importCommands(config: Config, tool: ToolTarget): Promise<number>
 
   const global = config.getGlobal();
 
-  const supportedTargets = global
-    ? CommandsProcessor.getToolTargetsGlobal()
-    : CommandsProcessor.getToolTargets({ includeSimulated: false });
+  const supportedTargets = CommandsProcessor.getToolTargets({ global, includeSimulated: false });
 
   if (!supportedTargets.includes(tool)) {
     return 0;
@@ -201,7 +195,8 @@ async function importSubagents(config: Config, tool: ToolTarget): Promise<number
   }
 
   // Use SubagentsProcessor for supported tools, excluding simulated ones
-  const supportedTargets = SubagentsProcessor.getToolTargets({ includeSimulated: false });
+  const global = config.getGlobal();
+  const supportedTargets = SubagentsProcessor.getToolTargets({ global, includeSimulated: false });
   if (!supportedTargets.includes(tool)) {
     return 0;
   }
@@ -234,7 +229,7 @@ async function importSkills(config: Config, tool: ToolTarget): Promise<number> {
 
   const global = config.getGlobal();
 
-  const supportedTargets = SkillsProcessor.getToolTargets();
+  const supportedTargets = SkillsProcessor.getToolTargets({ global });
 
   if (!supportedTargets.includes(tool)) {
     return 0;

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -904,9 +904,9 @@ describe("CommandsProcessor", () => {
     });
   });
 
-  describe("getToolTargetsGlobal", () => {
+  describe("getToolTargets with global: true", () => {
     it("should return claudecode and cursor for global mode", () => {
-      const targets = CommandsProcessor.getToolTargetsGlobal();
+      const targets = CommandsProcessor.getToolTargets({ global: true });
       expect(targets).toEqual(["claudecode", "cursor", "geminicli", "codexcli"]);
     });
   });

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -368,24 +368,24 @@ export class CommandsProcessor extends FeatureProcessor {
    * Return the tool targets that this processor supports
    */
   static getToolTargets({
+    global = false,
     includeSimulated = false,
   }: {
+    global?: boolean;
     includeSimulated?: boolean;
   } = {}): ToolTarget[] {
+    if (global) {
+      return commandsProcessorToolTargetsGlobal;
+    }
     if (!includeSimulated) {
       return commandsProcessorToolTargets.filter(
         (target) => !commandsProcessorToolTargetsSimulated.includes(target),
       );
     }
-
     return commandsProcessorToolTargets;
   }
 
   static getToolTargetsSimulated(): ToolTarget[] {
     return commandsProcessorToolTargetsSimulated;
-  }
-
-  static getToolTargetsGlobal(): ToolTarget[] {
-    return commandsProcessorToolTargetsGlobal;
   }
 }

--- a/src/features/ignore/ignore-processor.ts
+++ b/src/features/ignore/ignore-processor.ts
@@ -226,7 +226,10 @@ export class IgnoreProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(): ToolTarget[] {
+  static getToolTargets({ global = false }: { global?: boolean } = {}): ToolTarget[] {
+    if (global) {
+      throw new Error("IgnoreProcessor does not support global mode");
+    }
     return ignoreProcessorToolTargets;
   }
 }

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -290,11 +290,10 @@ export class McpProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(): ToolTarget[] {
+  static getToolTargets({ global = false }: { global?: boolean } = {}): ToolTarget[] {
+    if (global) {
+      return mcpProcessorToolTargetsGlobal;
+    }
     return mcpProcessorToolTargets;
-  }
-
-  static getToolTargetsGlobal(): ToolTarget[] {
-    return mcpProcessorToolTargetsGlobal;
   }
 }

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -502,15 +502,15 @@ describe("RulesProcessor", () => {
     });
   });
 
-  describe("getToolTargetsGlobal", () => {
+  describe("getToolTargets with global: true", () => {
     it("should return claudecode and codexcli as global targets", () => {
-      const globalTargets = RulesProcessor.getToolTargetsGlobal();
+      const globalTargets = RulesProcessor.getToolTargets({ global: true });
 
       expect(globalTargets).toEqual(["claudecode", "codexcli", "geminicli"]);
     });
 
     it("should return a subset of regular tool targets", () => {
-      const globalTargets = RulesProcessor.getToolTargetsGlobal();
+      const globalTargets = RulesProcessor.getToolTargets({ global: true });
       const regularTargets = RulesProcessor.getToolTargets();
 
       // All global targets should be in regular targets
@@ -523,7 +523,7 @@ describe("RulesProcessor", () => {
     });
 
     it("should only include targets that support global mode", () => {
-      const globalTargets = RulesProcessor.getToolTargetsGlobal();
+      const globalTargets = RulesProcessor.getToolTargets({ global: true });
 
       // These are the targets that support global mode
       expect(globalTargets).toContain("claudecode");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -887,12 +887,11 @@ export class RulesProcessor extends FeatureProcessor {
    * Implementation of abstract method from FeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(): ToolTarget[] {
+  static getToolTargets({ global = false }: { global?: boolean } = {}): ToolTarget[] {
+    if (global) {
+      return rulesProcessorToolTargetsGlobal;
+    }
     return rulesProcessorToolTargets;
-  }
-
-  static getToolTargetsGlobal(): ToolTarget[] {
-    return rulesProcessorToolTargetsGlobal;
   }
 
   private generateXmlReferencesSection(toolRules: ToolRule[]): string {

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -635,25 +635,20 @@ Test skill content`;
       expect(targets).toEqual(["claudecode"]);
     });
 
-    it("should ignore includeSimulated parameter", () => {
-      const targets = SkillsProcessor.getToolTargets({ includeSimulated: true });
-      expect(targets).toEqual(["claudecode"]);
-    });
-
     it("should be callable without instance", () => {
       expect(() => SkillsProcessor.getToolTargets()).not.toThrow();
     });
   });
 
-  describe("getToolTargetsGlobal", () => {
+  describe("getToolTargets with global: true", () => {
     it("should return claudecode for global mode", () => {
-      const targets = SkillsProcessor.getToolTargetsGlobal();
+      const targets = SkillsProcessor.getToolTargets({ global: true });
       expect(targets).toEqual(["claudecode"]);
       expect(targets).toEqual(skillsProcessorToolTargetsGlobal);
     });
 
     it("should be callable without instance", () => {
-      expect(() => SkillsProcessor.getToolTargetsGlobal()).not.toThrow();
+      expect(() => SkillsProcessor.getToolTargets({ global: true })).not.toThrow();
     });
   });
 

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -146,14 +146,10 @@ export class SkillsProcessor extends DirFeatureProcessor {
    * Implementation of abstract method from DirFeatureProcessor
    * Return the tool targets that this processor supports
    */
-  static getToolTargets(_params: { includeSimulated?: boolean } = {}): ToolTarget[] {
+  static getToolTargets({ global = false }: { global?: boolean } = {}): ToolTarget[] {
+    if (global) {
+      return skillsProcessorToolTargetsGlobal;
+    }
     return skillsProcessorToolTargets;
-  }
-
-  /**
-   * Return the tool targets that this processor supports in global mode
-   */
-  static getToolTargetsGlobal(): ToolTarget[] {
-    return skillsProcessorToolTargetsGlobal;
   }
 }

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -835,16 +835,16 @@ Second global content`;
     });
   });
 
-  describe("getToolTargetsGlobal", () => {
+  describe("getToolTargets with global: true", () => {
     it("should return only claudecode as global-supported target", () => {
-      const toolTargets = SubagentsProcessor.getToolTargetsGlobal();
+      const toolTargets = SubagentsProcessor.getToolTargets({ global: true });
 
       expect(Array.isArray(toolTargets)).toBe(true);
       expect(toolTargets).toEqual(["claudecode"]);
     });
 
     it("should not include simulated targets", () => {
-      const toolTargets = SubagentsProcessor.getToolTargetsGlobal();
+      const toolTargets = SubagentsProcessor.getToolTargets({ global: true });
 
       expect(toolTargets).not.toContain("copilot");
       expect(toolTargets).not.toContain("cursor");
@@ -855,7 +855,7 @@ Second global content`;
     });
 
     it("should be callable without instance", () => {
-      expect(() => SubagentsProcessor.getToolTargetsGlobal()).not.toThrow();
+      expect(() => SubagentsProcessor.getToolTargets({ global: true })).not.toThrow();
     });
   });
 

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -346,24 +346,24 @@ export class SubagentsProcessor extends FeatureProcessor {
    * Return the tool targets that this processor supports
    */
   static getToolTargets({
+    global = false,
     includeSimulated = false,
   }: {
+    global?: boolean;
     includeSimulated?: boolean;
   } = {}): ToolTarget[] {
+    if (global) {
+      return subagentsProcessorToolTargetsGlobal;
+    }
     if (!includeSimulated) {
       return subagentsProcessorToolTargets.filter(
         (target) => !subagentsProcessorToolTargetsSimulated.includes(target),
       );
     }
-
     return subagentsProcessorToolTargets;
   }
 
   static getToolTargetsSimulated(): ToolTarget[] {
     return subagentsProcessorToolTargetsSimulated;
-  }
-
-  static getToolTargetsGlobal(): ToolTarget[] {
-    return subagentsProcessorToolTargetsGlobal;
   }
 }

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -23,7 +23,9 @@ export abstract class DirFeatureProcessor {
   /**
    * Return tool targets that this feature supports.
    */
-  static getToolTargets(_params: { includeSimulated?: boolean } = {}): ToolTarget[] {
+  static getToolTargets(
+    _params: { global?: boolean; includeSimulated?: boolean } = {},
+  ): ToolTarget[] {
     throw new Error("Not implemented");
   }
 

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -24,7 +24,9 @@ export abstract class FeatureProcessor {
   /**
    * Return tool targets that this feature supports.
    */
-  static getToolTargets(_params: { includeSimulated?: boolean } = {}): ToolTarget[] {
+  static getToolTargets(
+    _params: { global?: boolean; includeSimulated?: boolean } = {},
+  ): ToolTarget[] {
     throw new Error("Not implemented");
   }
 


### PR DESCRIPTION
## Summary

- `getToolTargets()` と `getToolTargetsGlobal()` を `getToolTargets({ global?: boolean } = {})` に統合
- 全6つのプロセッサファイルで統一されたAPIを提供
- IgnoreProcessor は `global: true` でエラーをthrow（グローバルモード非サポート）

## Changes

### Processor files (6 files)
- `RulesProcessor` - 統合
- `McpProcessor` - 統合
- `CommandsProcessor` - 統合 (`includeSimulated` 維持)
- `SubagentsProcessor` - 統合 (`includeSimulated` 維持)
- `SkillsProcessor` - 統合
- `IgnoreProcessor` - 統合 (`global: true` でエラー)

### Base classes (2 files)
- `FeatureProcessor` - シグネチャ更新
- `DirFeatureProcessor` - シグネチャ更新

### CLI commands (2 files)
- `generate.ts` - コールサイト更新
- `import.ts` - コールサイト更新

## Test plan
- [x] `pnpm cicheck:code` パス (2730 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)