### PR TITLE
feat: add simulateSkills support for geminicli and agentsmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 
 | Tool                  | rules | ignore | mcp   | commands | subagents | skills |
 |------------------------|:-----:|:------:|:-----:|:--------:|:---------:|:------:|
-| AGENTS.md            |  ✅   |      |       |     🎮     |      🎮     |        |
+| AGENTS.md            |  ✅   |      |       |     🎮     |      🎮     |    🎮   |
 | Claude Code            |  ✅ 🌏   |  ✅   |  ✅ 🌏 📦   |    ✅ 🌏     |    ✅ 🌏     |  ✅ 🌏   |
 | Codex CLI              |  ✅ 🌏   |      |   🌏   |     🌏    |    🎮      |    🎮   |
-| Gemini CLI             |  ✅ 🌏  |   ✅   |  ✅ 🌏  |     ✅ 🌏  |      🎮     |        |
+| Gemini CLI             |  ✅ 🌏  |   ✅   |  ✅ 🌏  |     ✅ 🌏  |      🎮     |    🎮   |
 | GitHub Copilot         |  ✅    |       |  ✅    |     ✅     |    🎮      |    🎮   |
 | Cursor                 |  ✅   |   ✅  |   ✅   |     ✅ 🌏  |     🎮     |    🎮   |
 | OpenCode               |  ✅   |       |       |         |          |        |

--- a/src/features/skills/agentsmd-skill.test.ts
+++ b/src/features/skills/agentsmd-skill.test.ts
@@ -1,0 +1,200 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AgentsmdSkill } from "./agentsmd-skill.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+
+describe("AgentsmdSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .agents/skills as relativeDirPath", () => {
+      const paths = AgentsmdSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(join(".agents", "skills"));
+    });
+
+    it("should throw error when global is true", () => {
+      expect(() => AgentsmdSkill.getSettablePaths({ global: true })).toThrow(
+        "AgentsmdSkill does not support global mode.",
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new AgentsmdSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "This is the body of the agentsmd skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(AgentsmdSkill);
+      expect(skill.getBody()).toBe("This is the body of the agentsmd skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from valid skill directory", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: Test Skill
+description: Test skill description
+---
+
+This is the body of the agentsmd skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await AgentsmdSkill.fromDir({
+        baseDir: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill).toBeInstanceOf(AgentsmdSkill);
+      expect(skill.getBody()).toBe("This is the body of the agentsmd skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        AgentsmdSkill.fromDir({
+          baseDir: testDir,
+          dirName: "empty-skill",
+        }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const agentsmdSkill = AgentsmdSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(agentsmdSkill).toBeInstanceOf(AgentsmdSkill);
+      expect(agentsmdSkill.getBody()).toBe("Test body content");
+      expect(agentsmdSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should return true when targets includes '*'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "all-targets-skill",
+        frontmatter: {
+          name: "All Targets Skill",
+          description: "Skill for all targets",
+          targets: ["*"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsmdSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return true when targets includes 'agentsmd'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "agentsmd-skill",
+        frontmatter: {
+          name: "Agentsmd Skill",
+          description: "Skill for agentsmd",
+          targets: ["copilot", "agentsmd"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsmdSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return false when targets does not include 'agentsmd'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "claudecode-only-skill",
+        frontmatter: {
+          name: "ClaudeCode Only Skill",
+          description: "Skill for claudecode only",
+          targets: ["claudecode"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsmdSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should throw error because AgentsmdSkill is simulated", () => {
+      const skill = new AgentsmdSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => skill.toRulesyncSkill()).toThrow(
+        "Not implemented because it is a SIMULATED skill.",
+      );
+    });
+  });
+});

--- a/src/features/skills/agentsmd-skill.ts
+++ b/src/features/skills/agentsmd-skill.ts
@@ -1,0 +1,44 @@
+import { join } from "node:path";
+import { RulesyncSkill } from "./rulesync-skill.js";
+import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
+import {
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+/**
+ * Represents a simulated skill for AGENTS.md.
+ * Since AGENTS.md doesn't have native skill support, this provides
+ * a compatible skill directory format at .agents/skills/.
+ */
+export class AgentsmdSkill extends SimulatedSkill {
+  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
+    if (options?.global) {
+      throw new Error("AgentsmdSkill does not support global mode.");
+    }
+    return {
+      relativeDirPath: join(".agents", "skills"),
+    };
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<AgentsmdSkill> {
+    const baseParams = await this.fromDirDefault(params);
+    return new AgentsmdSkill(baseParams);
+  }
+
+  static fromRulesyncSkill(params: ToolSkillFromRulesyncSkillParams): AgentsmdSkill {
+    const baseParams: SimulatedSkillParams = {
+      ...this.fromRulesyncSkillDefault(params),
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+    };
+    return new AgentsmdSkill(baseParams);
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    return this.isTargetedByRulesyncSkillDefault({
+      rulesyncSkill,
+      toolTarget: "agentsmd",
+    });
+  }
+}

--- a/src/features/skills/geminicli-skill.test.ts
+++ b/src/features/skills/geminicli-skill.test.ts
@@ -1,0 +1,200 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { GeminiCliSkill } from "./geminicli-skill.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+
+describe("GeminiCliSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .gemini/skills as relativeDirPath", () => {
+      const paths = GeminiCliSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(join(".gemini", "skills"));
+    });
+
+    it("should throw error when global is true", () => {
+      expect(() => GeminiCliSkill.getSettablePaths({ global: true })).toThrow(
+        "GeminiCliSkill does not support global mode.",
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new GeminiCliSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".gemini", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "This is the body of the gemini cli skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(GeminiCliSkill);
+      expect(skill.getBody()).toBe("This is the body of the gemini cli skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from valid skill directory", async () => {
+      const skillDir = join(testDir, ".gemini", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: Test Skill
+description: Test skill description
+---
+
+This is the body of the gemini cli skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await GeminiCliSkill.fromDir({
+        baseDir: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill).toBeInstanceOf(GeminiCliSkill);
+      expect(skill.getBody()).toBe("This is the body of the gemini cli skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".gemini", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        GeminiCliSkill.fromDir({
+          baseDir: testDir,
+          dirName: "empty-skill",
+        }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const geminiCliSkill = GeminiCliSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(geminiCliSkill).toBeInstanceOf(GeminiCliSkill);
+      expect(geminiCliSkill.getBody()).toBe("Test body content");
+      expect(geminiCliSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should return true when targets includes '*'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "all-targets-skill",
+        frontmatter: {
+          name: "All Targets Skill",
+          description: "Skill for all targets",
+          targets: ["*"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(GeminiCliSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return true when targets includes 'geminicli'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "geminicli-skill",
+        frontmatter: {
+          name: "GeminiCli Skill",
+          description: "Skill for geminicli",
+          targets: ["copilot", "geminicli"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(GeminiCliSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return false when targets does not include 'geminicli'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "claudecode-only-skill",
+        frontmatter: {
+          name: "ClaudeCode Only Skill",
+          description: "Skill for claudecode only",
+          targets: ["claudecode"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(GeminiCliSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should throw error because GeminiCliSkill is simulated", () => {
+      const skill = new GeminiCliSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".gemini", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(() => skill.toRulesyncSkill()).toThrow(
+        "Not implemented because it is a SIMULATED skill.",
+      );
+    });
+  });
+});

--- a/src/features/skills/geminicli-skill.ts
+++ b/src/features/skills/geminicli-skill.ts
@@ -1,0 +1,44 @@
+import { join } from "node:path";
+import { RulesyncSkill } from "./rulesync-skill.js";
+import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
+import {
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+/**
+ * Represents a simulated skill for Gemini CLI.
+ * Since Gemini CLI doesn't have native skill support, this provides
+ * a compatible skill directory format at .gemini/skills/.
+ */
+export class GeminiCliSkill extends SimulatedSkill {
+  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
+    if (options?.global) {
+      throw new Error("GeminiCliSkill does not support global mode.");
+    }
+    return {
+      relativeDirPath: join(".gemini", "skills"),
+    };
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<GeminiCliSkill> {
+    const baseParams = await this.fromDirDefault(params);
+    return new GeminiCliSkill(baseParams);
+  }
+
+  static fromRulesyncSkill(params: ToolSkillFromRulesyncSkillParams): GeminiCliSkill {
+    const baseParams: SimulatedSkillParams = {
+      ...this.fromRulesyncSkillDefault(params),
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+    };
+    return new GeminiCliSkill(baseParams);
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    return this.isTargetedByRulesyncSkillDefault({
+      rulesyncSkill,
+      toolTarget: "geminicli",
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -637,7 +637,14 @@ Test skill content`;
 
     it("should return all targets including simulated when includeSimulated is true", () => {
       const targets = SkillsProcessor.getToolTargets({ includeSimulated: true });
-      expect(targets).toEqual(["claudecode", "copilot", "cursor", "codexcli"]);
+      expect(targets).toEqual([
+        "claudecode",
+        "copilot",
+        "cursor",
+        "codexcli",
+        "geminicli",
+        "agentsmd",
+      ]);
     });
 
     it("should return only non-simulated targets when includeSimulated is false", () => {
@@ -653,7 +660,7 @@ Test skill content`;
   describe("getToolTargetsSimulated", () => {
     it("should return simulated tool targets", () => {
       const targets = SkillsProcessor.getToolTargetsSimulated();
-      expect(targets).toEqual(["copilot", "cursor", "codexcli"]);
+      expect(targets).toEqual(["copilot", "cursor", "codexcli", "geminicli", "agentsmd"]);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add simulated skills support for Gemini CLI (`.gemini/skills/`)
- Add simulated skills support for AGENTS.md (`.agents/skills/`)
- Follow existing pattern established by copilot, cursor, and codexcli

## Changes

- Create `GeminiCliSkill` class extending `SimulatedSkill`
- Create `AgentsmdSkill` class extending `SimulatedSkill`
- Update `SkillsProcessor` to handle new tool targets
- Add comprehensive tests for new skill classes
- Update README.md feature support table

## Test plan

- [x] All existing tests pass (2803 tests)
- [x] New tests for `GeminiCliSkill` pass
- [x] New tests for `AgentsmdSkill` pass
- [x] Code style checks pass
- [x] Type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)