### PR TITLE
refactor: consolidate getMcpServers methods into single unified API

### DIFF
--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -86,10 +86,10 @@ export class ClaudecodeMcp extends ToolMcp {
                 })
               : ModularMcp.getMcpServers({ baseDir, global: false })),
             // Merge exposed servers
-            ...rulesyncMcp.getExposedMcpServers(),
+            ...rulesyncMcp.getMcpServers({ type: "exposed" }),
           },
         }
-      : { ...json, mcpServers: rulesyncMcp.getExposedMcpServers() };
+      : { ...json, mcpServers: rulesyncMcp.getMcpServers({ type: "exposed" }) };
 
     return new ClaudecodeMcp({
       baseDir,

--- a/src/features/mcp/modular-mcp.ts
+++ b/src/features/mcp/modular-mcp.ts
@@ -119,7 +119,7 @@ export class ModularMcp extends AiFile {
     );
 
     const modularMcpJson = {
-      mcpServers: rulesyncMcp.getModularizedMcpServers(),
+      mcpServers: rulesyncMcp.getMcpServers({ type: "modularized" }),
     };
 
     return new ModularMcp({

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -606,7 +606,7 @@ describe("RulesyncMcp", () => {
     });
   });
 
-  describe("getExposedMcpServers", () => {
+  describe("getMcpServers with type: exposed", () => {
     it("should return only servers with exposed: true", () => {
       const jsonData = {
         mcpServers: {
@@ -643,7 +643,7 @@ describe("RulesyncMcp", () => {
         modularMcp: true,
       });
 
-      const result = rulesyncMcp.getExposedMcpServers();
+      const result = rulesyncMcp.getMcpServers({ type: "exposed" });
 
       // Only exposed servers should be returned
       expect(Object.keys(result)).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Merge `getExposedMcpServers` and `getModularizedMcpServers` into `getMcpServers` with a `type` parameter
- New API: `getMcpServers({ type?: "all" | "exposed" | "modularized" } = {})`
- Cleaner API with single method handling all filtering modes

## Test plan
- [x] All existing tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)