### PR TITLE
chore: remove opencode.json and rulesync.jsonc from biome file includes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["src/**/*.ts", "scripts/**/*.ts", "opencode.json", "rulesync.jsonc"]
+    "includes": ["src/**/*.ts", "scripts/**/*.ts"]
   },
   "vcs": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Remove `opencode.json` and `rulesync.jsonc` from biome file includes as these files are now in `.gitignore` and should not be checked by biome

## Test plan
- [x] Verify `pnpm cicheck:code` passes
- [x] Confirm the removed files are in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)