### PR TITLE
fix: remove allow option from npm dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,6 @@ updates:
     reviewers:
       - "dyoshikawa"
       - "cm-dyoshikawa"
-    allow:
-      # Allow all security updates
-      - dependency-type: "all"
 
   # Automatic updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Remove `allow` option from npm package ecosystem in dependabot.yml
- The `allow` option was incorrectly restricting npm dependency updates (it acts as a filter, not an enabler)
- Without this option, all dependencies are updated by default

## Test plan
- [ ] Verify dependabot runs successfully on next daily schedule
- [ ] Confirm npm dependency update PRs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)