### PR TITLE
refactor: replace Promise.allSettled with Promise.all

### DIFF
--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -522,7 +522,7 @@ describe("CommandsProcessor", () => {
       expect(result).toEqual(mockRulesyncCommands);
     });
 
-    it("should handle failed file loading gracefully", async () => {
+    it("should throw error when file loading fails", async () => {
       const mockPaths = ["test1.md", "test2.md"];
       const mockRulesyncCommand = new RulesyncCommand({
         baseDir: testDir,
@@ -541,10 +541,7 @@ describe("CommandsProcessor", () => {
         .mockResolvedValueOnce(mockRulesyncCommand)
         .mockRejectedValueOnce(new Error("Failed to load"));
 
-      const result = await processor.loadRulesyncFiles();
-
-      expect(result).toEqual([mockRulesyncCommand]);
-      expect(logger.info).toHaveBeenCalledWith("Successfully loaded 1 rulesync commands");
+      await expect(processor.loadRulesyncFiles()).rejects.toThrow("Failed to load");
     });
 
     it("should return empty array when no files found", async () => {
@@ -787,7 +784,7 @@ describe("CommandsProcessor", () => {
       expect(result).toEqual([mockCommand]);
     });
 
-    it("should handle failed file loading gracefully", async () => {
+    it("should throw error when file loading fails", async () => {
       const mockPaths = ["test1.md", "test2.md"];
       const mockCommand = new ClaudecodeCommand({
         baseDir: testDir,
@@ -804,14 +801,13 @@ describe("CommandsProcessor", () => {
         .mockResolvedValueOnce(mockCommand)
         .mockRejectedValueOnce(new Error("Failed to load"));
 
-      const result = await (processor as any).loadToolCommandDefault({
-        toolTarget: "claudecode",
-        relativeDirPath: join(".claude", "commands"),
-        extension: "md",
-      });
-
-      expect(result).toEqual([mockCommand]);
-      expect(logger.info).toHaveBeenCalledWith("Successfully loaded 1 .claude/commands commands");
+      await expect(
+        (processor as any).loadToolCommandDefault({
+          toolTarget: "claudecode",
+          relativeDirPath: join(".claude", "commands"),
+          extension: "md",
+        }),
+      ).rejects.toThrow("Failed to load");
     });
 
     it("should pass global parameter when loading claudecode commands", async () => {

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -169,15 +169,11 @@ export class CommandsProcessor extends FeatureProcessor {
       join(RulesyncCommand.getSettablePaths().relativeDirPath, "*.md"),
     );
 
-    const rulesyncCommands = (
-      await Promise.allSettled(
-        rulesyncCommandPaths.map((path) =>
-          RulesyncCommand.fromFile({ relativeFilePath: basename(path) }),
-        ),
-      )
-    )
-      .filter((result) => result.status === "fulfilled")
-      .map((result) => result.value);
+    const rulesyncCommands = await Promise.all(
+      rulesyncCommandPaths.map((path) =>
+        RulesyncCommand.fromFile({ relativeFilePath: basename(path) }),
+      ),
+    );
 
     logger.info(`Successfully loaded ${rulesyncCommands.length} rulesync commands`);
     return rulesyncCommands;
@@ -225,58 +221,53 @@ export class CommandsProcessor extends FeatureProcessor {
       join(this.baseDir, relativeDirPath, `*.${extension}`),
     );
 
-    const toolCommands = (
-      await Promise.allSettled(
-        commandFilePaths.map((path) => {
-          switch (toolTarget) {
-            case "agentsmd":
-              return AgentsmdCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-              });
-            case "claudecode":
-              return ClaudecodeCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-                global: this.global,
-              });
-            case "geminicli":
-              return GeminiCliCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-                global: this.global,
-              });
-            case "roo":
-              return RooCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-              });
-            case "copilot":
-              return CopilotCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-              });
-            case "cursor":
-              return CursorCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-                global: this.global,
-              });
-            case "codexcli":
-              return CodexcliCommand.fromFile({
-                baseDir: this.baseDir,
-                relativeFilePath: basename(path),
-                global: this.global,
-              });
-            default:
-              throw new Error(`Unsupported tool target: ${toolTarget}`);
-          }
-        }),
-      )
-    )
-
-      .filter((result) => result.status === "fulfilled")
-      .map((result) => result.value);
+    const toolCommands = await Promise.all(
+      commandFilePaths.map((path) => {
+        switch (toolTarget) {
+          case "agentsmd":
+            return AgentsmdCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+            });
+          case "claudecode":
+            return ClaudecodeCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+              global: this.global,
+            });
+          case "geminicli":
+            return GeminiCliCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+              global: this.global,
+            });
+          case "roo":
+            return RooCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+            });
+          case "copilot":
+            return CopilotCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+            });
+          case "cursor":
+            return CursorCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+              global: this.global,
+            });
+          case "codexcli":
+            return CodexcliCommand.fromFile({
+              baseDir: this.baseDir,
+              relativeFilePath: basename(path),
+              global: this.global,
+            });
+          default:
+            throw new Error(`Unsupported tool target: ${toolTarget}`);
+        }
+      }),
+    );
 
     logger.info(`Successfully loaded ${toolCommands.length} ${relativeDirPath} commands`);
     return toolCommands;

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -159,18 +159,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const dirPaths = await findFilesByGlobs(join(rulesyncSkillsDirPath, "*"), { type: "dir" });
     const dirNames = dirPaths.map((path) => basename(path));
 
-    const results = await Promise.allSettled(
+    const rulesyncSkills = await Promise.all(
       dirNames.map((dirName) =>
         RulesyncSkill.fromDir({ baseDir: this.baseDir, dirName, global: this.global }),
       ),
     );
-
-    const rulesyncSkills: RulesyncSkill[] = [];
-    for (const result of results) {
-      if (result.status === "fulfilled") {
-        rulesyncSkills.push(result.value);
-      }
-    }
 
     logger.info(`Successfully loaded ${rulesyncSkills.length} rulesync skills`);
     return rulesyncSkills;
@@ -212,19 +205,15 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), { type: "dir" });
     const dirNames = dirPaths.map((path) => basename(path));
 
-    const toolSkills = (
-      await Promise.allSettled(
-        dirNames.map((dirName) =>
-          ClaudecodeSkill.fromDir({
-            baseDir: this.baseDir,
-            dirName,
-            global: this.global,
-          }),
-        ),
-      )
-    )
-      .filter((result) => result.status === "fulfilled")
-      .map((result) => result.value);
+    const toolSkills = await Promise.all(
+      dirNames.map((dirName) =>
+        ClaudecodeSkill.fromDir({
+          baseDir: this.baseDir,
+          dirName,
+          global: this.global,
+        }),
+      ),
+    );
 
     logger.info(`Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills`);
     return toolSkills;
@@ -246,18 +235,14 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), { type: "dir" });
     const dirNames = dirPaths.map((path) => basename(path));
 
-    const toolSkills = (
-      await Promise.allSettled(
-        dirNames.map((dirName) =>
-          SkillClass.fromDir({
-            baseDir: this.baseDir,
-            dirName,
-          }),
-        ),
-      )
-    )
-      .filter((result) => result.status === "fulfilled")
-      .map((result) => result.value);
+    const toolSkills = await Promise.all(
+      dirNames.map((dirName) =>
+        SkillClass.fromDir({
+          baseDir: this.baseDir,
+          dirName,
+        }),
+      ),
+    );
 
     logger.info(`Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills`);
     return toolSkills;

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -693,31 +693,17 @@ Second content`;
       expect(toolFiles.every((file) => file instanceof ClaudecodeSubagent)).toBe(true);
     });
 
-    it("should handle files that fail to load gracefully", async () => {
+    it("should throw error when file fails to load", async () => {
       const agentsDir = join(testDir, ".claude", "agents");
       await ensureDir(agentsDir);
 
-      // Create a file that will cause loading to fail
-      await writeFileContent(
-        join(agentsDir, "valid.md"),
-        `---
-name: valid
-description: Valid agent
----
-Valid content`,
-      );
-
-      // Create another file (this one might fail due to invalid format, depending on ClaudecodeSubagent implementation)
+      // Create a file that will cause loading to fail (invalid format without frontmatter)
       await writeFileContent(
         join(agentsDir, "might-fail.md"),
         "Invalid format without frontmatter",
       );
 
-      const toolFiles = await processor.loadToolFiles();
-
-      // Should at least load the valid file, may or may not load the invalid one depending on ClaudecodeSubagent's error handling
-      expect(toolFiles.length).toBeGreaterThanOrEqual(1);
-      expect(toolFiles.some((file) => file instanceof ClaudecodeSubagent)).toBe(true);
+      await expect(processor.loadToolFiles()).rejects.toThrow();
     });
 
     describe("global mode", () => {

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -332,9 +332,7 @@ export class SubagentsProcessor extends FeatureProcessor {
   }): Promise<ToolSubagent[]> {
     const paths = await findFilesByGlobs(join(this.baseDir, relativeDirPath, "*.md"));
 
-    const subagents = (await Promise.allSettled(paths.map((path) => fromFile(basename(path)))))
-      .filter((r): r is PromiseFulfilledResult<ToolSubagent> => r.status === "fulfilled")
-      .map((r) => r.value);
+    const subagents = await Promise.all(paths.map((path) => fromFile(basename(path))));
 
     logger.info(`Successfully loaded ${subagents.length} ${relativeDirPath} subagents`);
 


### PR DESCRIPTION
## Summary
- Replace `Promise.allSettled` with `Promise.all` in skills-processor.ts, subagents-processor.ts, and commands-processor.ts
- Update corresponding tests to expect errors to be thrown when file loading fails instead of gracefully continuing

## Test plan
- [x] All existing tests pass
- [x] `pnpm cicheck:code` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)