### PR TITLE
chore: remove deprecated pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-# https://pnpm.io/settings#minimumreleaseage
-# minimumReleaseAge: 1440


### PR DESCRIPTION
## Summary
- Remove `pnpm-workspace.yaml` as it is no longer needed for this single-package project
- This file was causing Dependabot issues and is unnecessary since there are no workspace packages

## Test plan
- [x] Verify `pnpm install` works correctly without the workspace file
- [x] Verify build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)