### PR TITLE
docs: add GMO OSS badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dyoshikawa/rulesync)
 [![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code)
 [![Mentioned in Awesome Gemini CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/Piebald-AI/awesome-gemini-cli)
+[![GMO OSS](https://flatt.tech/assets/images/badges/gmo-oss.svg)](https://flatt.tech/oss/gmo/trampoline)
 
 A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files. Features selective generation, comprehensive import/export capabilities, and supports major AI development tools with rules, commands, MCP, ignore files, subagents and skills.
 


### PR DESCRIPTION
## Summary
- Add GMO OSS badge to README badges section

## Test plan
- [ ] Verify badge displays correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)