### PR TITLE
Fix trailing newline in rules output format

### DIFF
--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -994,7 +994,7 @@ export class RulesProcessor extends FeatureProcessor {
       );
     }
 
-    return lines.join("\n") + "\n";
+    return lines.join("\n") + "\n\n";
   }
 
   private generateAdditionalConventionsSection({


### PR DESCRIPTION
## Summary
- Add an extra newline at the end of generated rules content to ensure proper file formatting

## Test plan
- [ ] Verify generated rules files have proper trailing newlines
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)