### PR TITLE
feat: add JSON Schema for rulesync.jsonc editor validation

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,8 @@
 export default {
   "*": ["npx secretlint"],
   "package.json": ["npx sort-package-json"],
+  // Regenerate JSON Schema when config schema or related types change
+  "src/config/config.ts": ["pnpm generate:schema", "git add config-schema.json"],
+  "src/types/features.ts": ["pnpm generate:schema", "git add config-schema.json"],
+  "src/types/tool-targets.ts": ["pnpm generate:schema", "git add config-schema.json"],
 };

--- a/README.md
+++ b/README.md
@@ -213,11 +213,28 @@ npx rulesync gitignore
 
 You can configure Rulesync by creating a `rulesync.jsonc` file in the root of your project.
 
+### JSON Schema Support
+
+Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `rulesync.jsonc`:
+
+```jsonc
+// rulesync.jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
+  "targets": ["claudecode"],
+  "features": ["rules"]
+}
+```
+
+### Configuration Options
+
 Example:
 
 ```jsonc
 // rulesync.jsonc
 {
+  "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
+
   // List of tools to generate configurations for. You can specify "*" to generate all tools.
   "targets": ["cursor", "claudecode", "geminicli", "opencode", "codexcli"],
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "baseDirs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "agentsmd",
+          "amazonqcli",
+          "antigravity",
+          "augmentcode",
+          "augmentcode-legacy",
+          "copilot",
+          "cursor",
+          "cline",
+          "claudecode",
+          "codexcli",
+          "opencode",
+          "qwencode",
+          "roo",
+          "geminicli",
+          "kiro",
+          "junie",
+          "warp",
+          "windsurf",
+          "*"
+        ]
+      }
+    },
+    "features": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "rules",
+          "ignore",
+          "mcp",
+          "subagents",
+          "commands",
+          "skills",
+          "*"
+        ]
+      }
+    },
+    "verbose": {
+      "type": "boolean"
+    },
+    "delete": {
+      "type": "boolean"
+    },
+    "global": {
+      "type": "boolean"
+    },
+    "simulateCommands": {
+      "type": "boolean"
+    },
+    "simulateSubagents": {
+      "type": "boolean"
+    },
+    "simulateSkills": {
+      "type": "boolean"
+    },
+    "modularMcp": {
+      "type": "boolean"
+    },
+    "experimentalGlobal": {
+      "type": "boolean"
+    },
+    "experimentalSimulateCommands": {
+      "type": "boolean"
+    },
+    "experimentalSimulateSubagents": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "$id": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
+  "title": "Rulesync Configuration",
+  "description": "Configuration file for Rulesync CLI tool"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,7 +58,11 @@ export default defineConfig([
         [
           {
             module: "node:fs",
-            allowReferenceFrom: ["src/utils/file.ts", "src/utils/file.test.ts"],
+            allowReferenceFrom: [
+              "src/utils/file.ts",
+              "src/utils/file.test.ts",
+              "scripts/**/*.ts",
+            ],
             allowSameModule: false,
           },
           {
@@ -91,6 +95,15 @@ export default defineConfig([
       "@typescript-eslint/no-explicit-any": "off", // Allow any in tests
       "no-new": "off", // Allow new in tests
       "no-type-assertion/no-type-assertion": "off", // Allow type assertions in tests
+    },
+  },
+
+  {
+    // Scripts are run locally by developers, not bundled for distribution
+    // Allow full zod (not zod/mini) for JSON Schema generation
+    files: ["scripts/**/*.ts"],
+    rules: {
+      "zod-import/zod-import": "off",
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"eslint:fix": "eslint . --fix --max-warnings 0 --cache",
 		"fix": "pnpm run bcheck:fix && pnpm run oxlint:fix && pnpm run eslint:fix",
 		"generate": "pnpm run dev generate",
+		"generate:schema": "tsx scripts/generate-json-schema.ts",
 		"knip": "knip",
 		"oxlint": "oxlint . --max-warnings 0",
 		"oxlint:fix": "oxlint . --fix --max-warnings 0",

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
+
   // List of tools to generate configurations for
   "targets": ["cursor", "claudecode", "geminicli", "codexcli", "copilot", "opencode"],
 

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -1,0 +1,29 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as z from "zod";
+// Import schema directly from source - zod and zod/mini schemas are compatible in Zod v4
+import { ConfigFileSchema } from "../src/config/config.js";
+
+// Generate JSON Schema from the source schema
+// Note: zod/mini schemas work with zod's toJSONSchema in Zod v4
+const generatedSchema = z.toJSONSchema(ConfigFileSchema, {
+  reused: "ref",
+});
+
+// Add JSON Schema meta properties (override Zod's default $schema with draft-07 for broader compatibility)
+const jsonSchema = {
+  ...generatedSchema,
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
+  title: "Rulesync Configuration",
+  description: "Configuration file for Rulesync CLI tool",
+};
+
+// Output to project root
+const outputPath = join(process.cwd(), "config-schema.json");
+
+// Write schema file
+writeFileSync(outputPath, JSON.stringify(jsonSchema, null, 2) + "\n");
+
+// oxlint-disable-next-line no-console
+console.log(`JSON Schema generated: ${outputPath}`);

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -11,9 +11,10 @@ import {
 import { logger } from "../utils/logger.js";
 import {
   Config,
+  ConfigFile,
+  ConfigFileSchema,
   ConfigParams,
   PartialConfigParams,
-  PartialConfigParamsSchema,
   RequiredConfigParams,
 } from "./config.js";
 
@@ -66,7 +67,11 @@ export class ConfigResolver {
       try {
         const fileContent = await readFileContent(validatedConfigPath);
         const jsonData = parseJsonc(fileContent);
-        configByFile = PartialConfigParamsSchema.parse(jsonData);
+        // Parse with ConfigFileSchema to allow $schema property, then extract config params
+        const parsed: ConfigFile = ConfigFileSchema.parse(jsonData);
+        // Exclude $schema from config params
+        const { $schema: _schema, ...configParams } = parsed;
+        configByFile = configParams;
       } catch (error) {
         logger.error(`Failed to load config file: ${formatError(error)}`);
         throw error;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -34,6 +34,13 @@ export type ConfigParams = z.infer<typeof ConfigParamsSchema>;
 export const PartialConfigParamsSchema = z.partial(ConfigParamsSchema);
 export type PartialConfigParams = z.infer<typeof PartialConfigParamsSchema>;
 
+// Schema for config file that includes $schema property for editor support
+export const ConfigFileSchema = z.object({
+  $schema: optional(z.string()),
+  ...z.partial(ConfigParamsSchema).shape,
+});
+export type ConfigFile = z.infer<typeof ConfigFileSchema>;
+
 export const RequiredConfigParamsSchema = z.required(ConfigParamsSchema);
 export type RequiredConfigParams = z.infer<typeof RequiredConfigParamsSchema>;
 


### PR DESCRIPTION
## Summary

Adds JSON Schema support for `rulesync.jsonc` configuration file to enable editor validation and autocompletion.

Closes #618

## Changes

- Add `scripts/generate-json-schema.ts` - Generation script using Zod v4's `z.toJSONSchema()`
- Add `ConfigFileSchema` to `src/config/config.ts` with `$schema` property support
- Generate `config-schema.json` at project root, referenced via GitHub raw URL
- Auto-regenerate schema on pre-commit via lint-staged when source files change
- Update README.md with JSON Schema documentation

## Test plan

- [x] `pnpm generate:schema` generates valid JSON Schema
- [x] `pnpm cicheck:code` passes
- [ ] Editor validates `rulesync.jsonc` with `$schema` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)