### PR TITLE
chore: allow all dependency types in dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
     reviewers:
       - "dyoshikawa"
       - "cm-dyoshikawa"
+    allow:
+      - dependency-type: "all"
 
   # Automatic updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Add `allow` configuration to explicitly include all dependency types for npm package updates
- Ensures indirect dependencies are also updated by dependabot

## Test plan
- [ ] Verify dependabot picks up the configuration change
- [ ] Confirm npm dependency updates include indirect dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)