### PR TITLE
ci: change dependabot schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 1
     open-pull-requests-limit: 2
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 1
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary
- Change dependabot schedule interval from daily to weekly for npm ecosystem
- Change dependabot schedule interval from daily to weekly for github-actions ecosystem

This reduces the frequency of dependency update PRs, making it easier to manage.

## Test plan
- [ ] Verify dependabot configuration is valid YAML
- [ ] Confirm no CI failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)