### PR TITLE
refactor: apply factory resolver pattern to all feature processors

### DIFF
--- a/src/features/mcp/mcp-processor.test.ts
+++ b/src/features/mcp/mcp-processor.test.ts
@@ -15,7 +15,6 @@ import {
   McpProcessor,
   type McpProcessorToolTarget,
   McpProcessorToolTargetSchema,
-  mcpProcessorToolTargets,
 } from "./mcp-processor.js";
 import { RooMcp } from "./roo-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
@@ -165,6 +164,7 @@ describe("McpProcessor", () => {
         expect(AmazonqcliMcp.fromFile).toHaveBeenCalledWith({
           baseDir: testDir,
           validate: true,
+          global: false,
         });
       });
     });
@@ -247,6 +247,7 @@ describe("McpProcessor", () => {
         expect(ClineMcp.fromFile).toHaveBeenCalledWith({
           baseDir: testDir,
           validate: true,
+          global: false,
         });
       });
     });
@@ -274,6 +275,7 @@ describe("McpProcessor", () => {
         expect(CopilotMcp.fromFile).toHaveBeenCalledWith({
           baseDir: testDir,
           validate: true,
+          global: false,
         });
       });
     });
@@ -301,6 +303,7 @@ describe("McpProcessor", () => {
         expect(CursorMcp.fromFile).toHaveBeenCalledWith({
           baseDir: testDir,
           validate: true,
+          global: false,
         });
       });
     });
@@ -426,6 +429,7 @@ describe("McpProcessor", () => {
         expect(RooMcp.fromFile).toHaveBeenCalledWith({
           baseDir: testDir,
           validate: true,
+          global: false,
         });
       });
     });
@@ -490,6 +494,8 @@ describe("McpProcessor", () => {
       expect(AmazonqcliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
         baseDir: testDir,
         rulesyncMcp,
+        global: false,
+        modularMcp: false,
       });
     });
 
@@ -591,6 +597,8 @@ describe("McpProcessor", () => {
       expect(ClineMcp.fromRulesyncMcp).toHaveBeenCalledWith({
         baseDir: testDir,
         rulesyncMcp,
+        global: false,
+        modularMcp: false,
       });
     });
 
@@ -623,6 +631,8 @@ describe("McpProcessor", () => {
       expect(CopilotMcp.fromRulesyncMcp).toHaveBeenCalledWith({
         baseDir: testDir,
         rulesyncMcp,
+        global: false,
+        modularMcp: false,
       });
     });
 
@@ -655,6 +665,8 @@ describe("McpProcessor", () => {
       expect(CursorMcp.fromRulesyncMcp).toHaveBeenCalledWith({
         baseDir: testDir,
         rulesyncMcp,
+        global: false,
+        modularMcp: false,
       });
     });
 
@@ -688,6 +700,7 @@ describe("McpProcessor", () => {
         baseDir: testDir,
         rulesyncMcp,
         global: false,
+        modularMcp: false,
       });
     });
 
@@ -722,6 +735,7 @@ describe("McpProcessor", () => {
         baseDir: testDir,
         rulesyncMcp,
         global: true,
+        modularMcp: false,
       });
     });
 
@@ -754,6 +768,7 @@ describe("McpProcessor", () => {
         baseDir: testDir,
         rulesyncMcp,
         global: true,
+        modularMcp: false,
       });
     });
 
@@ -786,6 +801,8 @@ describe("McpProcessor", () => {
       expect(RooMcp.fromRulesyncMcp).toHaveBeenCalledWith({
         baseDir: testDir,
         rulesyncMcp,
+        global: false,
+        modularMcp: false,
       });
     });
 
@@ -842,13 +859,13 @@ describe("McpProcessor", () => {
     it("should return supported tool targets", () => {
       const targets = McpProcessor.getToolTargets();
 
-      expect(targets).toEqual(mcpProcessorToolTargets);
       expect(targets).toContain("amazonqcli");
       expect(targets).toContain("claudecode");
       expect(targets).toContain("cline");
       expect(targets).toContain("copilot");
       expect(targets).toContain("cursor");
       expect(targets).toContain("roo");
+      expect(targets).not.toContain("codexcli"); // codexcli is global-only
     });
   });
 
@@ -869,23 +886,6 @@ describe("McpProcessor", () => {
       expect(() => McpProcessorToolTargetSchema.parse(123)).toThrow();
       expect(() => McpProcessorToolTargetSchema.parse(null)).toThrow();
       expect(() => McpProcessorToolTargetSchema.parse(undefined)).toThrow();
-    });
-  });
-
-  describe("mcpProcessorToolTargets constant", () => {
-    it("should contain all expected tool targets", () => {
-      expect(mcpProcessorToolTargets).toHaveLength(9);
-      expect(mcpProcessorToolTargets).toEqual([
-        "amazonqcli",
-        "claudecode",
-        "cline",
-        "junie",
-        "copilot",
-        "cursor",
-        "geminicli",
-        "opencode",
-        "roo",
-      ]);
     });
   });
 

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -204,6 +204,9 @@ describe("SkillsProcessor", () => {
       processorWithMockTarget.baseDir = testDir;
       processorWithMockTarget.toolTarget = "unsupported";
       processorWithMockTarget.global = false;
+      processorWithMockTarget.getFactory = (target: any) => {
+        throw new Error(`Unsupported tool target: ${target}`);
+      };
 
       const rulesyncSkill = new RulesyncSkill({
         baseDir: testDir,
@@ -408,6 +411,9 @@ Invalid content`;
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);
       processorWithMockTarget.baseDir = testDir;
       processorWithMockTarget.toolTarget = "unsupported";
+      processorWithMockTarget.getFactory = (target: any) => {
+        throw new Error(`Unsupported tool target: ${target}`);
+      };
 
       await expect(processorWithMockTarget.loadToolDirs()).rejects.toThrow(
         "Unsupported tool target: unsupported",
@@ -595,14 +601,9 @@ Test skill content`;
 
     it("should return all targets including simulated when includeSimulated is true", () => {
       const targets = SkillsProcessor.getToolTargets({ includeSimulated: true });
-      expect(targets).toEqual([
-        "claudecode",
-        "copilot",
-        "cursor",
-        "codexcli",
-        "geminicli",
-        "agentsmd",
-      ]);
+      expect(new Set(targets)).toEqual(
+        new Set(["agentsmd", "claudecode", "codexcli", "copilot", "cursor", "geminicli"]),
+      );
     });
 
     it("should return only non-simulated targets when includeSimulated is false", () => {
@@ -618,7 +619,9 @@ Test skill content`;
   describe("getToolTargetsSimulated", () => {
     it("should return simulated tool targets", () => {
       const targets = SkillsProcessor.getToolTargetsSimulated();
-      expect(targets).toEqual(["copilot", "cursor", "codexcli", "geminicli", "agentsmd"]);
+      expect(new Set(targets)).toEqual(
+        new Set(["agentsmd", "codexcli", "copilot", "cursor", "geminicli"]),
+      );
     });
   });
 

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -14,37 +14,112 @@ import { CursorSkill } from "./cursor-skill.js";
 import { GeminiCliSkill } from "./geminicli-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill } from "./simulated-skill.js";
-import { ToolSkill } from "./tool-skill.js";
+import {
+  ToolSkill,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
 
-const skillsProcessorToolTargets: ToolTarget[] = [
+/**
+ * Factory entry for each tool skill class.
+ * Stores the class reference and metadata for a tool.
+ */
+type ToolSkillFactory = {
+  class: {
+    isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean;
+    fromRulesyncSkill(params: ToolSkillFromRulesyncSkillParams): ToolSkill;
+    fromDir(params: ToolSkillFromDirParams): Promise<ToolSkill>;
+    getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths;
+  };
+  meta: {
+    /** Whether the tool supports simulated skills (embedded in rules) */
+    supportsSimulated: boolean;
+    /** Whether the tool supports global (user-level) skills */
+    supportsGlobal: boolean;
+  };
+};
+
+/**
+ * Supported tool targets for SkillsProcessor.
+ * Using a tuple to preserve order for consistent iteration.
+ */
+const skillsProcessorToolTargetTuple = [
+  "agentsmd",
   "claudecode",
+  "codexcli",
   "copilot",
   "cursor",
-  "codexcli",
   "geminicli",
-  "agentsmd",
-];
-export const skillsProcessorToolTargetsSimulated: ToolTarget[] = [
-  "copilot",
-  "cursor",
-  "codexcli",
-  "geminicli",
-  "agentsmd",
-];
-export const skillsProcessorToolTargetsGlobal: ToolTarget[] = ["claudecode"];
-export const SkillsProcessorToolTargetSchema = z.enum(skillsProcessorToolTargets);
+] as const;
 
-export type SkillsProcessorToolTarget = z.infer<typeof SkillsProcessorToolTargetSchema>;
+export type SkillsProcessorToolTarget = (typeof skillsProcessorToolTargetTuple)[number];
+
+// Schema for runtime validation
+export const SkillsProcessorToolTargetSchema = z.enum(skillsProcessorToolTargetTuple);
+
+/**
+ * Factory Map mapping tool targets to their skill factories.
+ * Using Map to preserve insertion order for consistent iteration.
+ */
+const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>([
+  ["agentsmd", { class: AgentsmdSkill, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["claudecode", { class: ClaudecodeSkill, meta: { supportsSimulated: false, supportsGlobal: true } }],
+  ["codexcli", { class: CodexCliSkill, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["copilot", { class: CopilotSkill, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["cursor", { class: CursorSkill, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["geminicli", { class: GeminiCliSkill, meta: { supportsSimulated: true, supportsGlobal: false } }],
+]);
+
+/**
+ * Factory retrieval function type for dependency injection.
+ * Allows injecting custom factory implementations for testing purposes.
+ */
+type GetFactory = (target: SkillsProcessorToolTarget) => ToolSkillFactory;
+
+const defaultGetFactory: GetFactory = (target) => {
+  const factory = toolSkillFactories.get(target);
+  if (!factory) {
+    throw new Error(`Unsupported tool target: ${target}`);
+  }
+  return factory;
+};
+
+// Derive tool target arrays from factory metadata
+const allToolTargetKeys = [...toolSkillFactories.keys()];
+
+const skillsProcessorToolTargets: ToolTarget[] = allToolTargetKeys;
+
+export const skillsProcessorToolTargetsSimulated: ToolTarget[] = allToolTargetKeys.filter(
+  (target) => {
+    const factory = toolSkillFactories.get(target);
+    return factory?.meta.supportsSimulated ?? false;
+  },
+);
+
+export const skillsProcessorToolTargetsGlobal: ToolTarget[] = allToolTargetKeys.filter(
+  (target) => {
+    const factory = toolSkillFactories.get(target);
+    return factory?.meta.supportsGlobal ?? false;
+  },
+);
 
 export class SkillsProcessor extends DirFeatureProcessor {
   private readonly toolTarget: SkillsProcessorToolTarget;
   private readonly global: boolean;
+  private readonly getFactory: GetFactory;
 
   constructor({
     baseDir = process.cwd(),
     toolTarget,
     global = false,
-  }: { baseDir?: string; toolTarget: SkillsProcessorToolTarget; global?: boolean }) {
+    getFactory = defaultGetFactory,
+  }: {
+    baseDir?: string;
+    toolTarget: ToolTarget;
+    global?: boolean;
+    getFactory?: GetFactory;
+  }) {
     super({ baseDir });
     const result = SkillsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
@@ -54,6 +129,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     }
     this.toolTarget = result.data;
     this.global = global;
+    this.getFactory = getFactory;
   }
 
   async convertRulesyncDirsToToolDirs(rulesyncDirs: AiDir[]): Promise<AiDir[]> {
@@ -61,74 +137,19 @@ export class SkillsProcessor extends DirFeatureProcessor {
       (dir): dir is RulesyncSkill => dir instanceof RulesyncSkill,
     );
 
-    const toolSkills: ToolSkill[] = [];
-    for (const rulesyncSkill of rulesyncSkills) {
-      switch (this.toolTarget) {
-        case "claudecode":
-          if (!ClaudecodeSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            ClaudecodeSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-              global: this.global,
-            }),
-          );
-          break;
-        case "copilot":
-          if (!CopilotSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            CopilotSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-            }),
-          );
-          break;
-        case "cursor":
-          if (!CursorSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            CursorSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-            }),
-          );
-          break;
-        case "codexcli":
-          if (!CodexCliSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            CodexCliSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-            }),
-          );
-          break;
-        case "geminicli":
-          if (!GeminiCliSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            GeminiCliSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-            }),
-          );
-          break;
-        case "agentsmd":
-          if (!AgentsmdSkill.isTargetedByRulesyncSkill(rulesyncSkill)) {
-            continue;
-          }
-          toolSkills.push(
-            AgentsmdSkill.fromRulesyncSkill({
-              rulesyncSkill: rulesyncSkill,
-            }),
-          );
-          break;
-        default:
-          throw new Error(`Unsupported tool target: ${this.toolTarget}`);
-      }
-    }
+    const factory = this.getFactory(this.toolTarget);
+
+    const toolSkills = rulesyncSkills
+      .map((rulesyncSkill) => {
+        if (!factory.class.isTargetedByRulesyncSkill(rulesyncSkill)) {
+          return null;
+        }
+        return factory.class.fromRulesyncSkill({
+          rulesyncSkill: rulesyncSkill,
+          global: this.global,
+        });
+      })
+      .filter((skill): skill is ToolSkill => skill !== null);
 
     return toolSkills;
   }
@@ -174,40 +195,16 @@ export class SkillsProcessor extends DirFeatureProcessor {
    * Load tool-specific skill configurations and parse them into ToolSkill instances
    */
   async loadToolDirs(): Promise<AiDir[]> {
-    switch (this.toolTarget) {
-      case "claudecode":
-        return await this.loadClaudecodeSkills();
-      case "copilot":
-        return await this.loadSimulatedSkills(CopilotSkill);
-      case "cursor":
-        return await this.loadSimulatedSkills(CursorSkill);
-      case "codexcli":
-        return await this.loadSimulatedSkills(CodexCliSkill);
-      case "geminicli":
-        return await this.loadSimulatedSkills(GeminiCliSkill);
-      case "agentsmd":
-        return await this.loadSimulatedSkills(AgentsmdSkill);
-      default:
-        throw new Error(`Unsupported tool target: ${this.toolTarget}`);
-    }
-  }
+    const factory = this.getFactory(this.toolTarget);
+    const paths = factory.class.getSettablePaths({ global: this.global });
 
-  async loadToolDirsToDelete(): Promise<AiDir[]> {
-    return this.loadToolDirs();
-  }
-
-  /**
-   * Load Claude Code skill configurations from .claude/skills/ directory
-   */
-  private async loadClaudecodeSkills(): Promise<ToolSkill[]> {
-    const paths = ClaudecodeSkill.getSettablePaths({ global: this.global });
     const skillsDirPath = join(this.baseDir, paths.relativeDirPath);
     const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), { type: "dir" });
     const dirNames = dirPaths.map((path) => basename(path));
 
     const toolSkills = await Promise.all(
       dirNames.map((dirName) =>
-        ClaudecodeSkill.fromDir({
+        factory.class.fromDir({
           baseDir: this.baseDir,
           dirName,
           global: this.global,
@@ -219,33 +216,8 @@ export class SkillsProcessor extends DirFeatureProcessor {
     return toolSkills;
   }
 
-  /**
-   * Load simulated skill configurations from tool-specific directories
-   */
-  private async loadSimulatedSkills(
-    SkillClass:
-      | typeof CopilotSkill
-      | typeof CursorSkill
-      | typeof CodexCliSkill
-      | typeof GeminiCliSkill
-      | typeof AgentsmdSkill,
-  ): Promise<ToolSkill[]> {
-    const paths = SkillClass.getSettablePaths();
-    const skillsDirPath = join(this.baseDir, paths.relativeDirPath);
-    const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), { type: "dir" });
-    const dirNames = dirPaths.map((path) => basename(path));
-
-    const toolSkills = await Promise.all(
-      dirNames.map((dirName) =>
-        SkillClass.fromDir({
-          baseDir: this.baseDir,
-          dirName,
-        }),
-      ),
-    );
-
-    logger.info(`Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills`);
-    return toolSkills;
+  async loadToolDirsToDelete(): Promise<AiDir[]> {
+    return this.loadToolDirs();
   }
 
   /**

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -3,7 +3,7 @@ import { z } from "zod/mini";
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
-import { ToolTarget } from "../../types/tool-targets.js";
+import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { directoryExists, findFilesByGlobs, listDirectoryFiles } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
@@ -16,40 +16,114 @@ import { GeminiCliSubagent } from "./geminicli-subagent.js";
 import { RooSubagent } from "./roo-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
-import { ToolSubagent } from "./tool-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+  ToolSubagentSettablePaths,
+} from "./tool-subagent.js";
 
-export const subagentsProcessorToolTargets: ToolTarget[] = [
+/**
+ * Factory entry for each tool subagent class.
+ * Stores the class reference and metadata for a tool.
+ */
+type ToolSubagentFactory = {
+  class: {
+    isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean;
+    fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent;
+    fromFile(params: ToolSubagentFromFileParams): Promise<ToolSubagent>;
+    getSettablePaths(options?: { global?: boolean }): ToolSubagentSettablePaths;
+  };
+  meta: {
+    /** Whether the tool supports simulated subagents (embedded in rules) */
+    supportsSimulated: boolean;
+    /** Whether the tool supports global (user-level) subagents */
+    supportsGlobal: boolean;
+  };
+};
+
+/**
+ * Supported tool targets for SubagentsProcessor.
+ * Using a tuple to preserve order for consistent iteration.
+ */
+const subagentsProcessorToolTargetTuple = [
   "agentsmd",
   "claudecode",
+  "codexcli",
   "copilot",
   "cursor",
-  "codexcli",
   "geminicli",
   "roo",
-];
+] as const;
 
-export const subagentsProcessorToolTargetsSimulated: ToolTarget[] = [
-  "agentsmd",
-  "copilot",
-  "cursor",
-  "codexcli",
-  "geminicli",
-  "roo",
-];
-export const subagentsProcessorToolTargetsGlobal: ToolTarget[] = ["claudecode"];
-export const SubagentsProcessorToolTargetSchema = z.enum(subagentsProcessorToolTargets);
+export type SubagentsProcessorToolTarget = (typeof subagentsProcessorToolTargetTuple)[number];
 
-export type SubagentsProcessorToolTarget = z.infer<typeof SubagentsProcessorToolTargetSchema>;
+// Schema for runtime validation
+export const SubagentsProcessorToolTargetSchema = z.enum(subagentsProcessorToolTargetTuple);
+
+/**
+ * Factory Map mapping tool targets to their subagent factories.
+ * Using Map to preserve insertion order for consistent iteration.
+ */
+const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolSubagentFactory>([
+  ["agentsmd", { class: AgentsmdSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["claudecode", { class: ClaudecodeSubagent, meta: { supportsSimulated: false, supportsGlobal: true } }],
+  ["codexcli", { class: CodexCliSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["copilot", { class: CopilotSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["cursor", { class: CursorSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["geminicli", { class: GeminiCliSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  ["roo", { class: RooSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+]);
+
+/**
+ * Factory retrieval function type for dependency injection.
+ * Allows injecting custom factory implementations for testing purposes.
+ */
+type GetFactory = (target: SubagentsProcessorToolTarget) => ToolSubagentFactory;
+
+const defaultGetFactory: GetFactory = (target) => {
+  const factory = toolSubagentFactories.get(target);
+  if (!factory) {
+    throw new Error(`Unsupported tool target: ${target}`);
+  }
+  return factory;
+};
+
+// Derive tool target arrays from factory metadata
+const allToolTargetKeys = [...toolSubagentFactories.keys()];
+
+export const subagentsProcessorToolTargets: ToolTarget[] = allToolTargetKeys;
+
+export const subagentsProcessorToolTargetsSimulated: ToolTarget[] = allToolTargetKeys.filter(
+  (target) => {
+    const factory = toolSubagentFactories.get(target);
+    return factory?.meta.supportsSimulated ?? false;
+  },
+);
+
+export const subagentsProcessorToolTargetsGlobal: ToolTarget[] = allToolTargetKeys.filter(
+  (target) => {
+    const factory = toolSubagentFactories.get(target);
+    return factory?.meta.supportsGlobal ?? false;
+  },
+);
 
 export class SubagentsProcessor extends FeatureProcessor {
   private readonly toolTarget: SubagentsProcessorToolTarget;
   private readonly global: boolean;
+  private readonly getFactory: GetFactory;
 
   constructor({
     baseDir = process.cwd(),
     toolTarget,
     global = false,
-  }: { baseDir?: string; toolTarget: SubagentsProcessorToolTarget; global?: boolean }) {
+    getFactory = defaultGetFactory,
+  }: {
+    baseDir?: string;
+    toolTarget: ToolTarget;
+    global?: boolean;
+    getFactory?: GetFactory;
+  }) {
     super({ baseDir });
     const result = SubagentsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
@@ -59,6 +133,7 @@ export class SubagentsProcessor extends FeatureProcessor {
     }
     this.toolTarget = result.data;
     this.global = global;
+    this.getFactory = getFactory;
   }
 
   async convertRulesyncFilesToToolFiles(rulesyncFiles: RulesyncFile[]): Promise<ToolFile[]> {
@@ -66,76 +141,19 @@ export class SubagentsProcessor extends FeatureProcessor {
       (file): file is RulesyncSubagent => file instanceof RulesyncSubagent,
     );
 
+    const factory = this.getFactory(this.toolTarget);
+
     const toolSubagents = rulesyncSubagents
       .map((rulesyncSubagent) => {
-        switch (this.toolTarget) {
-          case "agentsmd":
-            if (!AgentsmdSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return AgentsmdSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          case "claudecode":
-            if (!ClaudecodeSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return ClaudecodeSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-              global: this.global,
-            });
-          case "copilot":
-            if (!CopilotSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return CopilotSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          case "cursor":
-            if (!CursorSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return CursorSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          case "codexcli":
-            if (!CodexCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return CodexCliSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          case "geminicli":
-            if (!GeminiCliSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return GeminiCliSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          case "roo":
-            if (!RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-              return null;
-            }
-            return RooSubagent.fromRulesyncSubagent({
-              baseDir: this.baseDir,
-              relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-              rulesyncSubagent: rulesyncSubagent,
-            });
-          default:
-            throw new Error(`Unsupported tool target: ${this.toolTarget}`);
+        if (!factory.class.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
+          return null;
         }
+        return factory.class.fromRulesyncSubagent({
+          baseDir: this.baseDir,
+          relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+          rulesyncSubagent: rulesyncSubagent,
+          global: this.global,
+        });
       })
       .filter((subagent): subagent is ToolSubagent => subagent !== null);
 
@@ -223,120 +241,33 @@ export class SubagentsProcessor extends FeatureProcessor {
    * Load tool-specific subagent configurations and parse them into ToolSubagent instances
    */
   async loadToolFiles({
-    forDeletion: _forDeletion = false,
+    forDeletion = false,
   }: {
     forDeletion?: boolean;
   } = {}): Promise<ToolFile[]> {
-    switch (this.toolTarget) {
-      case "agentsmd":
-        return await this.loadAgentsmdSubagents();
-      case "claudecode":
-        return await this.loadClaudecodeSubagents();
-      case "copilot":
-        return await this.loadCopilotSubagents();
-      case "cursor":
-        return await this.loadCursorSubagents();
-      case "codexcli":
-        return await this.loadCodexCliSubagents();
-      case "geminicli":
-        return await this.loadGeminiCliSubagents();
-      case "roo":
-        return await this.loadRooSubagents();
-      default:
-        throw new Error(`Unsupported tool target: ${this.toolTarget}`);
-    }
-  }
+    const factory = this.getFactory(this.toolTarget);
+    const paths = factory.class.getSettablePaths({ global: this.global });
 
-  /**
-   * Load Agents.md subagent configurations from .agents/subagents/ directory
-   */
-  private async loadAgentsmdSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: AgentsmdSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => AgentsmdSubagent.fromFile({ relativeFilePath }),
-    });
-  }
+    const subagentFilePaths = await findFilesByGlobs(
+      join(this.baseDir, paths.relativeDirPath, "*.md"),
+    );
 
-  /**
-   * Load Claude Code subagent configurations from .claude/agents/ directory
-   */
-  private async loadClaudecodeSubagents(): Promise<ToolSubagent[]> {
-    const paths = ClaudecodeSubagent.getSettablePaths({ global: this.global });
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: paths.relativeDirPath,
-      fromFile: (relativeFilePath) =>
-        ClaudecodeSubagent.fromFile({
+    const toolSubagents = await Promise.all(
+      subagentFilePaths.map((path) =>
+        factory.class.fromFile({
           baseDir: this.baseDir,
-          relativeFilePath,
+          relativeFilePath: basename(path),
           global: this.global,
         }),
-    });
-  }
+      ),
+    );
 
-  /**
-   * Load Copilot subagent configurations from .github/subagents/ directory
-   */
-  private async loadCopilotSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: CopilotSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => CopilotSubagent.fromFile({ relativeFilePath }),
-    });
-  }
+    const result = forDeletion
+      ? toolSubagents.filter((subagent) => subagent.isDeletable())
+      : toolSubagents;
 
-  /**
-   * Load Cursor subagent configurations from .cursor/subagents/ directory
-   */
-  private async loadCursorSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: CursorSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => CursorSubagent.fromFile({ relativeFilePath }),
-    });
-  }
-
-  /**
-   * Load CodexCli subagent configurations from .codex/subagents/ directory
-   */
-  private async loadCodexCliSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: CodexCliSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => CodexCliSubagent.fromFile({ relativeFilePath }),
-    });
-  }
-
-  /**
-   * Load GeminiCli subagent configurations from .gemini/subagents/ directory
-   */
-  private async loadGeminiCliSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: GeminiCliSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => GeminiCliSubagent.fromFile({ relativeFilePath }),
-    });
-  }
-
-  /**
-   * Load Roo subagent configurations from .roo/subagents/ directory
-   */
-  private async loadRooSubagents(): Promise<ToolSubagent[]> {
-    return await this.loadToolSubagentsDefault({
-      relativeDirPath: RooSubagent.getSettablePaths().relativeDirPath,
-      fromFile: (relativeFilePath) => RooSubagent.fromFile({ relativeFilePath }),
-    });
-  }
-
-  private async loadToolSubagentsDefault({
-    relativeDirPath,
-    fromFile,
-  }: {
-    relativeDirPath: string;
-    fromFile: (relativeFilePath: string) => Promise<ToolSubagent>;
-  }): Promise<ToolSubagent[]> {
-    const paths = await findFilesByGlobs(join(this.baseDir, relativeDirPath, "*.md"));
-
-    const subagents = await Promise.all(paths.map((path) => fromFile(basename(path))));
-
-    logger.info(`Successfully loaded ${subagents.length} ${relativeDirPath} subagents`);
-
-    return subagents;
+    logger.info(`Successfully loaded ${result.length} ${paths.relativeDirPath} subagents`);
+    return result;
   }
 
   /**
@@ -351,17 +282,17 @@ export class SubagentsProcessor extends FeatureProcessor {
     includeSimulated?: boolean;
   } = {}): ToolTarget[] {
     if (global) {
-      return subagentsProcessorToolTargetsGlobal;
+      return [...subagentsProcessorToolTargetsGlobal];
     }
     if (!includeSimulated) {
       return subagentsProcessorToolTargets.filter(
         (target) => !subagentsProcessorToolTargetsSimulated.includes(target),
       );
     }
-    return subagentsProcessorToolTargets;
+    return [...subagentsProcessorToolTargets];
   }
 
   static getToolTargetsSimulated(): ToolTarget[] {
-    return subagentsProcessorToolTargetsSimulated;
+    return [...subagentsProcessorToolTargetsSimulated];
   }
 }


### PR DESCRIPTION
## Summary
- Apply factory resolver pattern to all feature processors (rules, mcp, ignore, commands, skills, subagents)
- Replace large switch statements with factory object lookup pattern
- Add `*-factories.ts` files for unified factory interfaces
- Support dependency injection via optional factory constructor parameters for better testability
- Add utility functions in `src/utils/object.ts` and `src/utils/targeting.ts`

## Changes by feature
1. **utils**: Add object and targeting utilities
2. **ignore**: Apply factory resolver pattern to ignore processor
3. **rules**: Apply factory resolver pattern to rules processor
4. **mcp**: Apply factory resolver pattern to mcp processor
5. **commands**: Apply factory resolver pattern to commands processor
6. **skills**: Apply factory resolver pattern to skills processor
7. **subagents**: Apply factory resolver pattern to subagents processor

## Test plan
- [x] All existing tests pass
- [x] Added new tests for factory method invocation with mock injection
- [x] `pnpm cicheck:code` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)