### PR TITLE
Add OpenCode custom command support

### DIFF
--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -241,7 +241,7 @@ describe("gitignoreCommand", () => {
 **/.kiro/steering/
 **/.aiignore
 **/.opencode/memories/
-**/.opencode/commands/
+**/.opencode/command/
 **/opencode.json
 **/QWEN.md
 **/.qwen/memories/

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -56,7 +56,7 @@ export const gitignoreCommand = async (): Promise<void> => {
     "**/.aiignore",
     // OpenCode
     "**/.opencode/memories/",
-    "**/.opencode/commands/",
+    "**/.opencode/command/",
     "**/opencode.json",
     // Qwen
     "**/QWEN.md",

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -14,6 +14,7 @@ import { CodexcliCommand } from "./codexcli-command.js";
 import { CopilotCommand } from "./copilot-command.js";
 import { CursorCommand } from "./cursor-command.js";
 import { GeminiCliCommand } from "./geminicli-command.js";
+import { OpencodeCommand } from "./opencode-command.js";
 import { RooCommand } from "./roo-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 import {
@@ -58,6 +59,7 @@ const commandsProcessorToolTargetTuple = [
   "copilot",
   "cursor",
   "geminicli",
+  "opencode",
   "roo",
 ] as const;
 
@@ -123,6 +125,13 @@ const toolCommandFactories = new Map<CommandsProcessorToolTarget, ToolCommandFac
     {
       class: GeminiCliCommand,
       meta: { extension: "toml", supportsProject: true, supportsGlobal: true, isSimulated: false },
+    },
+  ],
+  [
+    "opencode",
+    {
+      class: OpencodeCommand,
+      meta: { extension: "md", supportsProject: true, supportsGlobal: true, isSimulated: false },
     },
   ],
   [

--- a/src/features/commands/opencode-command.test.ts
+++ b/src/features/commands/opencode-command.test.ts
@@ -1,0 +1,164 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { OpencodeCommand, OpencodeCommandFrontmatterSchema } from "./opencode-command.js";
+import { RulesyncCommand } from "./rulesync-command.js";
+
+describe("OpencodeCommand", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("creates a valid instance with frontmatter and body", () => {
+      const command = new OpencodeCommand({
+        baseDir: testDir,
+        relativeDirPath: ".opencode/command",
+        relativeFilePath: "deploy.md",
+        frontmatter: { description: "Deploy app", agent: "build" },
+        body: "Run deployment",
+      });
+
+      expect(command).toBeInstanceOf(OpencodeCommand);
+      expect(command.getBody()).toBe("Run deployment");
+      expect(command.getFrontmatter()).toEqual({ description: "Deploy app", agent: "build" });
+    });
+
+    it("validates frontmatter when validate is true", () => {
+      expect(() => {
+        new OpencodeCommand({
+          baseDir: testDir,
+          relativeDirPath: ".opencode/command",
+          relativeFilePath: "deploy.md",
+          frontmatter: { description: 123 as any },
+          body: "Run deployment",
+          validate: true,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe("toRulesyncCommand", () => {
+    it("converts to a RulesyncCommand with opencode frontmatter", () => {
+      const opencodeCommand = new OpencodeCommand({
+        baseDir: testDir,
+        relativeDirPath: ".opencode/command",
+        relativeFilePath: "deploy.md",
+        frontmatter: { description: "Deploy app", agent: "build" },
+        body: "Run deployment",
+      });
+
+      const rulesyncCommand = opencodeCommand.toRulesyncCommand();
+
+      expect(rulesyncCommand).toBeInstanceOf(RulesyncCommand);
+      expect(rulesyncCommand.getFrontmatter()).toEqual({
+        targets: ["opencode"],
+        description: "Deploy app",
+        opencode: { agent: "build" },
+      });
+      expect(rulesyncCommand.getBody()).toBe("Run deployment");
+    });
+  });
+
+  describe("fromRulesyncCommand", () => {
+    it("builds an OpencodeCommand using opencode-specific fields", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "deploy.md",
+        frontmatter: {
+          targets: ["opencode"],
+          description: "Deploy app",
+          opencode: { agent: "build", model: "openaipreview" },
+        },
+        body: "Run deployment",
+      });
+
+      const opencodeCommand = OpencodeCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+      });
+
+      expect(opencodeCommand.getFrontmatter()).toEqual({
+        description: "Deploy app",
+        agent: "build",
+        model: "openaipreview",
+      });
+      expect(opencodeCommand.getBody()).toBe("Run deployment");
+      expect(opencodeCommand.getRelativeDirPath()).toBe(".opencode/command");
+    });
+
+    it("uses global command path when requested", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "deploy.md",
+        frontmatter: { targets: ["opencode"], description: "Deploy" },
+        body: "Run deployment",
+      });
+
+      const opencodeCommand = OpencodeCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+        global: true,
+      });
+
+      expect(opencodeCommand.getRelativeDirPath()).toBe(".config/opencode/command");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("reads a command file and parses frontmatter", async () => {
+      const commandDir = join(testDir, ".opencode", "command");
+      await ensureDir(commandDir);
+      await writeFileContent(
+        join(commandDir, "deploy.md"),
+        `---\ndescription: Deploy app\nagent: build\n---\nRun deployment`,
+      );
+
+      const command = await OpencodeCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "deploy.md",
+      });
+
+      expect(command.getFrontmatter()).toEqual({ description: "Deploy app", agent: "build" });
+      expect(command.getBody()).toBe("Run deployment");
+    });
+  });
+
+  describe("validate", () => {
+    it("returns failure result when frontmatter invalid", () => {
+      const command = new OpencodeCommand({
+        baseDir: testDir,
+        relativeDirPath: ".opencode/command",
+        relativeFilePath: "deploy.md",
+        frontmatter: { description: 123 as any },
+        body: "Run deployment",
+        validate: false,
+      });
+
+      const result = command.validate();
+
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain("Invalid frontmatter");
+    });
+  });
+});
+
+describe("OpencodeCommandFrontmatterSchema", () => {
+  it("accepts description and extra fields", () => {
+    const result = OpencodeCommandFrontmatterSchema.safeParse({ description: "Test", agent: "build" });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/features/commands/opencode-command.ts
+++ b/src/features/commands/opencode-command.ts
@@ -1,0 +1,169 @@
+import { basename, join } from "node:path";
+import { z } from "zod/mini";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContent } from "../../utils/file.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
+import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
+import {
+  ToolCommand,
+  type ToolCommandFromFileParams,
+  type ToolCommandFromRulesyncCommandParams,
+  type ToolCommandSettablePaths,
+} from "./tool-command.js";
+
+export const OpencodeCommandFrontmatterSchema = z.looseObject({
+  description: z.string(),
+});
+
+export type OpencodeCommandFrontmatter = z.infer<typeof OpencodeCommandFrontmatterSchema>;
+
+export type OpencodeCommandParams = {
+  frontmatter: OpencodeCommandFrontmatter;
+  body: string;
+} & Omit<AiFileParams, "fileContent">;
+
+export class OpencodeCommand extends ToolCommand {
+  private readonly frontmatter: OpencodeCommandFrontmatter;
+  private readonly body: string;
+
+  constructor({ frontmatter, body, ...rest }: OpencodeCommandParams) {
+    if (rest.validate) {
+      const result = OpencodeCommandFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw new Error(
+          `Invalid frontmatter in ${join(rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyFrontmatter(body, frontmatter),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
+  static getSettablePaths({ global }: { global?: boolean } = {}): ToolCommandSettablePaths {
+    if (global) {
+      return {
+        relativeDirPath: join(".config", "opencode", "command"),
+      };
+    }
+
+    return {
+      relativeDirPath: join(".opencode", "command"),
+    };
+  }
+
+  getBody(): string {
+    return this.body;
+  }
+
+  getFrontmatter(): Record<string, unknown> {
+    return this.frontmatter;
+  }
+
+  toRulesyncCommand(): RulesyncCommand {
+    const { description, ...restFields } = this.frontmatter;
+
+    const rulesyncFrontmatter: RulesyncCommandFrontmatter = {
+      targets: ["opencode"],
+      description,
+      ...(Object.keys(restFields).length > 0 && { opencode: restFields }),
+    };
+
+    const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
+
+    return new RulesyncCommand({
+      baseDir: ".",
+      frontmatter: rulesyncFrontmatter,
+      body: this.body,
+      relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath: this.relativeFilePath,
+      fileContent,
+      validate: true,
+    });
+  }
+
+  static fromRulesyncCommand({
+    baseDir = process.cwd(),
+    rulesyncCommand,
+    validate = true,
+    global = false,
+  }: ToolCommandFromRulesyncCommandParams): OpencodeCommand {
+    const rulesyncFrontmatter = rulesyncCommand.getFrontmatter();
+    const opencodeFields = rulesyncFrontmatter.opencode ?? {};
+
+    const opencodeFrontmatter: OpencodeCommandFrontmatter = {
+      description: rulesyncFrontmatter.description,
+      ...opencodeFields,
+    };
+
+    const body = rulesyncCommand.getBody();
+    const paths = this.getSettablePaths({ global });
+
+    return new OpencodeCommand({
+      baseDir,
+      frontmatter: opencodeFrontmatter,
+      body,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: rulesyncCommand.getRelativeFilePath(),
+      validate,
+    });
+  }
+
+  validate(): ValidationResult {
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
+    const result = OpencodeCommandFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    }
+
+    return {
+      success: false,
+      error: new Error(
+        `Invalid frontmatter in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+      ),
+    };
+  }
+
+  static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
+    return this.isTargetedByRulesyncCommandDefault({
+      rulesyncCommand,
+      toolTarget: "opencode",
+    });
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    relativeFilePath,
+    validate = true,
+    global = false,
+  }: ToolCommandFromFileParams): Promise<OpencodeCommand> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    const result = OpencodeCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${formatError(result.error)}`);
+    }
+
+    return new OpencodeCommand({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an OpenCode command implementation that converts to and from rulesync commands
- include OpenCode commands in command processing and update gitignore entries
- cover the new command paths and conversions with tests

## Testing
- Not run (pnpm/npm unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69341e15d1fc83308eed0d37722db0c3)