### PR TITLE
docs: add cicheck requirement before git commit

### DIFF
--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -22,5 +22,6 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
     - `pnpm cicheck` to check both code and content.
   - Basically, I recommend you to run `pnpm cicheck:code` only to daily checks. Because it is fast, `pnpm cicheck:content` and `pnpm cicheck` are slower.
 - When doing `git commit`:
+  - You must run `pnpm cicheck` before committing to verify quality.
   - You must not use here documents because it causes a sandbox error.
   - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.


### PR DESCRIPTION
## Summary
- Add instruction to run `pnpm cicheck` before committing to ensure code quality verification
- This ensures developers verify quality before each commit

## Test plan
- [x] Verify the documentation change is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)