### PR TITLE
docs: document last-wins behavior for overlapping targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,34 @@ Example:
 }
 ```
 
+### Target Order and File Conflicts
+
+When multiple targets write to the same output file, **the last target in the array wins**. This is the "last-wins" behavior.
+
+For example, both `agentsmd` and `opencode` generate `AGENTS.md`:
+
+```jsonc
+{
+  // opencode wins because it comes last
+  "targets": ["agentsmd", "opencode"],
+  "features": ["rules"]
+}
+```
+
+In this case:
+1. `agentsmd` generates `AGENTS.md` first
+2. `opencode` generates `AGENTS.md` second, overwriting the previous file
+
+If you want `agentsmd`'s output instead, reverse the order:
+
+```jsonc
+{
+  // agentsmd wins because it comes last
+  "targets": ["opencode", "agentsmd"],
+  "features": ["rules"]
+}
+```
+
 ## Each File Format
 
 ### `rulesync/rules/*.md`


### PR DESCRIPTION
## Summary

- Add "Target Order and File Conflicts" section to README documenting that when multiple targets write to the same output file, the last target in the array wins
- Add tests to verify last-wins behavior for agentsmd and opencode both writing to AGENTS.md

## Test plan

- [x] `pnpm cicheck:code` passes
- [x] New tests verify last-wins behavior in both target orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)