### PR TITLE
chore: pin Node.js version to 24.11.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 bun = "1.3.2"
 deno = "2.5.6"
 go = "1.25.4"
-node = "24"
+node = "24.11.1"
 pnpm = "10.23.0"
 python = "3"
 uv = "latest"


### PR DESCRIPTION
## Summary
- Pin Node.js version from "24" to "24.11.1" in mise.toml for more reproducible builds

## Test plan
- [ ] Verify mise installs the correct Node.js version (24.11.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)