### PR TITLE
feat(claudecode): migrate to modular rules system

### DIFF
--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -1,14 +1,37 @@
 import { join } from "node:path";
+import { z } from "zod/mini";
+import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-file.js";
+import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
-import { RulesyncRule } from "./rulesync-rule.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
+import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
+  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
 } from "./tool-rule.js";
+
+/**
+ * Claude Code rule frontmatter schema
+ * Supports the `paths` field for conditional rule application based on file patterns
+ * @see https://code.claude.com/docs/en/memory#modular-rules-with-claude/rules/
+ */
+export const ClaudecodeRuleFrontmatterSchema = z.object({
+  // Glob pattern for conditional rule application
+  // @example "src/api/**/*.ts"
+  paths: z.optional(z.string()),
+});
+
+export type ClaudecodeRuleFrontmatter = z.infer<typeof ClaudecodeRuleFrontmatterSchema>;
+
+export type ClaudecodeRuleParams = Omit<ToolRuleParams, "fileContent"> & {
+  frontmatter: ClaudecodeRuleFrontmatter;
+  body: string;
+};
 
 export type ClaudecodeRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   root: {
@@ -25,10 +48,15 @@ export type ClaudecodeRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
 /**
  * Rule generator for Claude Code AI assistant
  *
- * Generates CLAUDE.md memory files based on rulesync rule content.
- * Supports the Claude Code memory system with import references.
+ * Generates .claude/CLAUDE.md and .claude/rules/*.md files based on rulesync rule content.
+ * Supports the Claude Code modular rules system with frontmatter for path-specific rules.
+ *
+ * @see https://code.claude.com/docs/en/memory#modular-rules-with-claude/rules/
  */
 export class ClaudecodeRule extends ToolRule {
+  private readonly frontmatter: ClaudecodeRuleFrontmatter;
+  private readonly body: string;
+
   static getSettablePaths({
     global,
   }: {
@@ -44,13 +72,35 @@ export class ClaudecodeRule extends ToolRule {
     }
     return {
       root: {
-        relativeDirPath: ".",
+        relativeDirPath: ".claude",
         relativeFilePath: "CLAUDE.md",
       },
       nonRoot: {
-        relativeDirPath: join(".claude", "memories"),
+        relativeDirPath: join(".claude", "rules"),
       },
     };
+  }
+
+  constructor({ frontmatter, body, ...rest }: ClaudecodeRuleParams) {
+    // Validate frontmatter before calling super
+    if (rest.validate !== false) {
+      const result = ClaudecodeRuleFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw new Error(
+          `Invalid frontmatter in ${join(rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+    }
+
+    super({
+      ...rest,
+      // Root file: no frontmatter, just body
+      // Non-root file: frontmatter with paths field + body
+      fileContent: rest.root ? body : stringifyFrontmatter(body, frontmatter),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
   }
 
   static async fromFile({
@@ -63,16 +113,16 @@ export class ClaudecodeRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     if (isRoot) {
-      const relativePath = paths.root.relativeFilePath;
-      const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
-      );
+      const relativePath = join(paths.root.relativeDirPath, paths.root.relativeFilePath);
+      const fileContent = await readFileContent(join(baseDir, relativePath));
 
+      // Root file: no frontmatter expected
       return new ClaudecodeRule({
         baseDir,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
-        fileContent,
+        frontmatter: {},
+        body: fileContent.trim(),
         validate,
         root: true,
       });
@@ -84,11 +134,24 @@ export class ClaudecodeRule extends ToolRule {
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(join(baseDir, relativePath));
+
+    // Non-root file: parse frontmatter
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    // Validate frontmatter using ClaudecodeRuleFrontmatterSchema
+    const result = ClaudecodeRuleFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(
+        `Invalid frontmatter in ${join(baseDir, relativePath)}: ${formatError(result.error)}`,
+      );
+    }
+
     return new ClaudecodeRule({
       baseDir,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
-      fileContent,
+      frontmatter: result.data,
+      body: content.trim(),
       validate,
       root: false,
     });
@@ -101,23 +164,104 @@ export class ClaudecodeRule extends ToolRule {
     global = false,
   }: ToolRuleFromRulesyncRuleParams): ClaudecodeRule {
     const paths = this.getSettablePaths({ global });
-    return new ClaudecodeRule(
-      this.buildToolRuleParamsDefault({
-        baseDir,
-        rulesyncRule,
+    const rulesyncFrontmatter = rulesyncRule.getFrontmatter();
+    const root = rulesyncFrontmatter.root ?? false;
+
+    // Convert globs to paths field for Claude Code
+    // Priority: claudecode.paths > globs (joined with comma)
+    const pathsField =
+      rulesyncFrontmatter.claudecode?.paths ?? rulesyncFrontmatter.globs?.join(", ");
+
+    const claudecodeFrontmatter: ClaudecodeRuleFrontmatter = {
+      paths: pathsField,
+    };
+
+    const body = rulesyncRule.getBody();
+
+    if (root) {
+      // Root file: .claude/CLAUDE.md (no frontmatter for root file)
+      return new ClaudecodeRule({
+        baseDir: baseDir,
+        frontmatter: claudecodeFrontmatter,
+        body,
+        relativeDirPath: paths.root.relativeDirPath,
+        relativeFilePath: paths.root.relativeFilePath,
         validate,
-        rootPath: paths.root,
-        nonRootPath: paths.nonRoot,
-      }),
-    );
+        root,
+      });
+    }
+
+    if (!paths.nonRoot) {
+      throw new Error("nonRoot path is not set in non-global mode");
+    }
+
+    // Non-root file: .claude/rules/*.md
+    return new ClaudecodeRule({
+      baseDir: baseDir,
+      frontmatter: claudecodeFrontmatter,
+      body,
+      relativeDirPath: paths.nonRoot.relativeDirPath,
+      relativeFilePath: rulesyncRule.getRelativeFilePath(),
+      validate,
+      root,
+    });
   }
 
   toRulesyncRule(): RulesyncRule {
-    return this.toRulesyncRuleDefault();
+    // Convert paths field back to globs array
+    let globs: string[] | undefined;
+    if (this.isRoot()) {
+      globs = ["**/*"];
+    } else if (this.frontmatter.paths) {
+      // Split comma-separated glob patterns
+      globs = this.frontmatter.paths.split(",").map((g) => g.trim());
+    }
+
+    const rulesyncFrontmatter: RulesyncRuleFrontmatter = {
+      targets: ["*"],
+      root: this.isRoot(),
+      description: this.description,
+      globs,
+      ...(this.frontmatter.paths && {
+        claudecode: { paths: this.frontmatter.paths },
+      }),
+    };
+
+    return new RulesyncRule({
+      baseDir: this.getBaseDir(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.body,
+      relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+      relativeFilePath: this.isRoot() ? "overview.md" : this.getRelativeFilePath(),
+      validate: true,
+    });
   }
 
   validate(): ValidationResult {
-    return { success: true, error: null };
+    // Check if frontmatter is set (may be undefined during construction)
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
+    const result = ClaudecodeRuleFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+  }
+
+  getFrontmatter(): ClaudecodeRuleFrontmatter {
+    return this.frontmatter;
+  }
+
+  getBody(): string {
+    return this.body;
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -278,10 +278,8 @@ export class RulesProcessor extends FeatureProcessor {
         return toolRules;
       }
       case "claudecode": {
-        const rootRule = toolRules[rootRuleIndex];
-        rootRule?.setFileContent(
-          this.generateReferencesSection(toolRules) + rootRule.getFileContent(),
-        );
+        // Claude Code's modular rules system (.claude/rules/*.md with frontmatter)
+        // no longer requires @ references in the root file
         return toolRules;
       }
       case "codexcli": {
@@ -531,30 +529,6 @@ export class RulesProcessor extends FeatureProcessor {
       rules,
     });
     lines.push(toonContent);
-
-    return lines.join("\n") + "\n\n";
-  }
-
-  private generateReferencesSection(toolRules: ToolRule[]): string {
-    const toolRulesWithoutRoot = toolRules.filter((rule) => !rule.isRoot());
-
-    if (toolRulesWithoutRoot.length === 0) {
-      return "";
-    }
-
-    const lines: string[] = [];
-    lines.push("Please also reference the following rules as needed:");
-    lines.push("");
-
-    for (const toolRule of toolRulesWithoutRoot) {
-      // Escape double quotes in description
-      const escapedDescription = toolRule.getDescription()?.replace(/"/g, '\\"');
-      const globsText = toolRule.getGlobs()?.join(",");
-
-      lines.push(
-        `@${toolRule.getRelativePathFromCwd()} description: "${escapedDescription}" applyTo: "${globsText}"`,
-      );
-    }
 
     return lines.join("\n") + "\n\n";
   }

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -39,6 +39,13 @@ export const RulesyncRuleFrontmatterSchema = z.object({
       excludeAgent: z.optional(z.union([z.literal("code-review"), z.literal("coding-agent")])),
     }),
   ),
+  claudecode: z.optional(
+    z.object({
+      // Override globs with Claude Code specific paths field
+      // @example "src/**/*.ts"
+      paths: z.optional(z.string()),
+    }),
+  ),
 });
 
 export type RulesyncRuleFrontmatter = z.infer<typeof RulesyncRuleFrontmatterSchema>;
@@ -149,6 +156,7 @@ export class RulesyncRule extends RulesyncFile {
       globs: result.data.globs ?? [],
       agentsmd: result.data.agentsmd,
       cursor: result.data.cursor,
+      claudecode: result.data.claudecode,
     };
 
     const filename = basename(legacyPath);
@@ -190,6 +198,7 @@ export class RulesyncRule extends RulesyncFile {
       globs: result.data.globs ?? [],
       agentsmd: result.data.agentsmd,
       cursor: result.data.cursor,
+      claudecode: result.data.claudecode,
     };
 
     const filename = basename(filePath);


### PR DESCRIPTION
## Summary
- Migrate Claude Code rule generation to the new modular rules specification
- Update output file paths from legacy to modular system
- Add YAML frontmatter support with `paths` field for non-root files
- Remove legacy `@` reference generation from root files

## Details

### Breaking Changes
Claude Code rule generation now uses the new modular rules system as specified in the [official documentation](https://code.claude.com/docs/en/memory#modular-rules-with-claude/rules/).

**Old structure (deprecated):**
- Root file: `PJROOT/CLAUDE.md`
- Non-root files: `PJROOT/.claude/memories/*.md`
- Root file contained `@.claude/memories/xxx.md` references

**New structure:**
- Root file: `PJROOT/.claude/CLAUDE.md`
- Non-root files: `PJROOT/.claude/rules/*.md` with YAML frontmatter
- No `@` references needed (files are automatically loaded)

### Non-root file frontmatter format
```yaml
---
paths: src/**/*.ts
---

# Rule content here
```

### Rulesync rule configuration
Added `claudecode.paths` field to RulesyncRuleFrontmatter:
```yaml
---
root: false
targets: ["claudecode"]
globs: ["src/**/*.ts"]
claudecode:
  paths: "src/**/*.ts"  # Overrides globs for Claude Code
---
```

## Test plan
- [x] Run `pnpm cicheck:code` to verify all tests pass
- [ ] Manual test: Generate claude code rules and verify output structure
- [ ] Verify root file at `.claude/CLAUDE.md`
- [ ] Verify non-root files at `.claude/rules/*.md` with proper frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)