### PR TITLE
chore(gitignore): clean up duplicate Claude Code patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,7 +214,9 @@ CLAUDE.md
 **/.augment/rules/
 **/.augment-guidelines
 **/CLAUDE.md
+**/.claude/CLAUDE.md
 **/.claude/memories/
+**/.claude/rules/
 **/.claude/commands/
 **/.claude/agents/
 **/.claude/skills/
@@ -257,6 +259,3 @@ CLAUDE.md
 **/WARP.md
 **/modular-mcp.json
 !.rulesync/.aiignore
-
-**/.claude/CLAUDE.md
-**/.claude/rules/


### PR DESCRIPTION
## Summary
- Move `**/.claude/CLAUDE.md` and `**/.claude/rules/` patterns to proper location within the Claude Code section
- Remove duplicate entries from the end of `.gitignore` file
- Consolidate related patterns together for better maintainability

## Test plan
- [x] Verify the patterns still match the intended files
- [x] Check no functionality is affected by pattern reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)