### PR TITLE
Fix Copilot MCP configuration to use servers key

### DIFF
--- a/src/features/mcp/copilot-mcp.test.ts
+++ b/src/features/mcp/copilot-mcp.test.ts
@@ -23,7 +23,7 @@ describe("CopilotMcp", () => {
   describe("constructor", () => {
     it("should create instance with default parameters", () => {
       const validJsonContent = JSON.stringify({
-        mcpServers: {
+        servers: {
           "@anthropic-ai/mcp-server-filesystem": {
             command: "npx",
             args: ["-y", "@anthropic-ai/mcp-server-filesystem", "/workspace"],
@@ -45,7 +45,7 @@ describe("CopilotMcp", () => {
 
     it("should create instance with custom baseDir", () => {
       const validJsonContent = JSON.stringify({
-        mcpServers: {},
+        servers: {},
       });
 
       const copilotMcp = new CopilotMcp({
@@ -60,7 +60,7 @@ describe("CopilotMcp", () => {
 
     it("should parse JSON content correctly", () => {
       const jsonData = {
-        mcpServers: {
+        servers: {
           "test-server": {
             command: "node",
             args: ["server.js"],
@@ -90,12 +90,12 @@ describe("CopilotMcp", () => {
         fileContent: emptyJsonContent,
       });
 
-      expect(copilotMcp.getJson()).toEqual({});
+      expect(copilotMcp.getJson()).toEqual({ servers: {} });
     });
 
     it("should validate content by default", () => {
       const validJsonContent = JSON.stringify({
-        mcpServers: {},
+        servers: {},
       });
 
       expect(() => {
@@ -109,7 +109,7 @@ describe("CopilotMcp", () => {
 
     it("should skip validation when validate is false", () => {
       const validJsonContent = JSON.stringify({
-        mcpServers: {},
+        servers: {},
       });
 
       expect(() => {
@@ -141,7 +141,7 @@ describe("CopilotMcp", () => {
       await ensureDir(vscodeDir);
 
       const jsonData = {
-        mcpServers: {
+        servers: {
           filesystem: {
             command: "npx",
             args: ["-y", "@modelcontextprotocol/server-filesystem", testDir],
@@ -165,7 +165,7 @@ describe("CopilotMcp", () => {
       await ensureDir(vscodeDir);
 
       const jsonData = {
-        mcpServers: {
+        servers: {
           git: {
             command: "node",
             args: ["git-server.js"],
@@ -187,7 +187,7 @@ describe("CopilotMcp", () => {
       await ensureDir(vscodeDir);
 
       const jsonData = {
-        mcpServers: {
+        servers: {
           "valid-server": {
             command: "node",
             args: ["server.js"],
@@ -209,7 +209,7 @@ describe("CopilotMcp", () => {
       await ensureDir(vscodeDir);
 
       const jsonData = {
-        mcpServers: {},
+        servers: {},
       };
       await writeFileContent(join(vscodeDir, "mcp.json"), JSON.stringify(jsonData));
 
@@ -251,7 +251,7 @@ describe("CopilotMcp", () => {
       });
 
       expect(copilotMcp).toBeInstanceOf(CopilotMcp);
-      expect(copilotMcp.getJson()).toEqual(jsonData);
+      expect(copilotMcp.getJson()).toEqual({ servers: jsonData.mcpServers });
       expect(copilotMcp.getRelativeDirPath()).toBe(".vscode");
       expect(copilotMcp.getRelativeFilePath()).toBe("mcp.json");
     });
@@ -281,7 +281,7 @@ describe("CopilotMcp", () => {
       });
 
       expect(copilotMcp.getFilePath()).toBe("/target/dir/.vscode/mcp.json");
-      expect(copilotMcp.getJson()).toEqual(jsonData);
+      expect(copilotMcp.getJson()).toEqual({ servers: jsonData.mcpServers });
     });
 
     it("should handle validation when validate is true", () => {
@@ -304,7 +304,7 @@ describe("CopilotMcp", () => {
         validate: true,
       });
 
-      expect(copilotMcp.getJson()).toEqual(jsonData);
+      expect(copilotMcp.getJson()).toEqual({ servers: jsonData.mcpServers });
     });
 
     it("should skip validation when validate is false", () => {
@@ -322,7 +322,7 @@ describe("CopilotMcp", () => {
         validate: false,
       });
 
-      expect(copilotMcp.getJson()).toEqual(jsonData);
+      expect(copilotMcp.getJson()).toEqual({ servers: {} });
     });
 
     it("should handle empty mcpServers object", () => {
@@ -339,14 +339,14 @@ describe("CopilotMcp", () => {
         rulesyncMcp,
       });
 
-      expect(copilotMcp.getJson()).toEqual(jsonData);
+      expect(copilotMcp.getJson()).toEqual({ servers: {} });
     });
   });
 
   describe("toRulesyncMcp", () => {
     it("should convert to RulesyncMcp with default configuration", () => {
       const jsonData = {
-        mcpServers: {
+        servers: {
           filesystem: {
             command: "npx",
             args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
@@ -362,14 +362,16 @@ describe("CopilotMcp", () => {
       const rulesyncMcp = copilotMcp.toRulesyncMcp();
 
       expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
-      expect(rulesyncMcp.getFileContent()).toBe(JSON.stringify(jsonData));
+      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
+        mcpServers: jsonData.servers,
+      });
       expect(rulesyncMcp.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
     });
 
     it("should preserve file content when converting to RulesyncMcp", () => {
       const jsonData = {
-        mcpServers: {
+        servers: {
           "complex-server": {
             command: "node",
             args: ["complex-server.js", "--port", "3000"],
@@ -394,12 +396,14 @@ describe("CopilotMcp", () => {
       const rulesyncMcp = copilotMcp.toRulesyncMcp();
 
       expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
-      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual(jsonData);
+      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
+        mcpServers: jsonData.servers,
+      });
     });
 
     it("should handle empty mcpServers object when converting", () => {
       const jsonData = {
-        mcpServers: {},
+        servers: {},
       };
       const copilotMcp = new CopilotMcp({
         relativeDirPath: ".vscode",
@@ -409,14 +413,14 @@ describe("CopilotMcp", () => {
 
       const rulesyncMcp = copilotMcp.toRulesyncMcp();
 
-      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual(jsonData);
+      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({ mcpServers: {} });
     });
   });
 
   describe("validate", () => {
     it("should return successful validation result", () => {
       const jsonData = {
-        mcpServers: {
+        servers: {
           "test-server": {
             command: "node",
             args: ["server.js"],
@@ -438,7 +442,7 @@ describe("CopilotMcp", () => {
 
     it("should always return success (no validation logic implemented)", () => {
       const jsonData = {
-        mcpServers: {},
+        servers: {},
       };
       const copilotMcp = new CopilotMcp({
         relativeDirPath: ".vscode",
@@ -455,7 +459,7 @@ describe("CopilotMcp", () => {
 
     it("should return success for complex MCP configuration", () => {
       const jsonData = {
-        mcpServers: {
+        servers: {
           filesystem: {
             command: "npx",
             args: ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
@@ -501,7 +505,7 @@ describe("CopilotMcp", () => {
       await ensureDir(vscodeDir);
 
       const originalJsonData = {
-        mcpServers: {
+        servers: {
           "workflow-server": {
             command: "node",
             args: ["workflow-server.js", "--config", "config.json"],
@@ -537,7 +541,7 @@ describe("CopilotMcp", () => {
 
     it("should maintain data consistency across transformations", () => {
       const complexJsonData = {
-        mcpServers: {
+        servers: {
           "primary-server": {
             command: "node",
             args: ["primary.js", "--mode", "production"],

--- a/src/features/mcp/copilot-mcp.ts
+++ b/src/features/mcp/copilot-mcp.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { ValidationResult } from "../../types/ai-file.js";
+import { McpServers } from "../../types/mcp.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
@@ -12,12 +13,18 @@ import {
 
 export type CopilotMcpParams = ToolMcpParams;
 
+type CopilotMcpJson = Record<string, unknown> & { servers: McpServers };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 export class CopilotMcp extends ToolMcp {
-  private readonly json: Record<string, unknown>;
+  private readonly json: CopilotMcpJson;
 
   constructor(params: ToolMcpParams) {
     super(params);
-    this.json = this.fileContent !== undefined ? JSON.parse(this.fileContent) : {};
+    const parsedJson = this.fileContent !== undefined ? JSON.parse(this.fileContent) : {};
+    this.json = this.normalizeJson(parsedJson);
   }
 
   getJson(): Record<string, unknown> {
@@ -56,20 +63,67 @@ export class CopilotMcp extends ToolMcp {
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): CopilotMcp {
+    const parsedRulesyncJson = JSON.parse(rulesyncMcp.getFileContent());
+    const rulesyncJson = isRecord(parsedRulesyncJson) ? parsedRulesyncJson : {};
+
+    const servers = rulesyncMcp.getMcpServers();
+    const { mcpServers: _legacyServers, ...rest } = rulesyncJson;
+
     return new CopilotMcp({
       baseDir,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
-      fileContent: rulesyncMcp.getFileContent(),
+      fileContent: JSON.stringify({ ...rest, servers }, null, 2),
       validate,
     });
   }
 
   toRulesyncMcp(): RulesyncMcp {
-    return this.toRulesyncMcpDefault();
+    const { servers, ...rest } = this.json;
+
+    return this.toRulesyncMcpDefault({
+      fileContent: JSON.stringify(
+        {
+          ...rest,
+          mcpServers: servers ?? {},
+        },
+        null,
+        2,
+      ),
+    });
   }
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  private normalizeJson(json: Record<string, unknown>): CopilotMcpJson {
+    const { servers, mcpServers, ...rest } = json;
+    const normalizedServers = this.extractServers({ servers, mcpServers });
+
+    return {
+      ...rest,
+      servers: normalizedServers,
+    };
+  }
+
+  private extractServers({
+    servers,
+    mcpServers,
+  }: {
+    servers?: unknown;
+    mcpServers?: unknown;
+  }): McpServers {
+    if (this.isServerRecord(servers)) {
+      return servers;
+    }
+    if (this.isServerRecord(mcpServers)) {
+      return mcpServers;
+    }
+    return {};
+  }
+
+  private isServerRecord(value: unknown): value is McpServers {
+    return isRecord(value);
   }
 }


### PR DESCRIPTION
## Summary
- normalize Copilot MCP configurations to use the `servers` root key expected by GitHub Copilot
- preserve additional MCP config fields when converting between Copilot and Rulesync files
- update Copilot MCP tests to cover the new structure

## Testing
- pnpm cicheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad5365af48330b263a16a158dd7be)