### PR TITLE
Add support for streamable-http MCP transport

### DIFF
--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -523,6 +523,39 @@ describe("OpencodeMcp", () => {
       expect(opencodeMcp.getJson()).toEqual({ mcp: {} });
     });
 
+    it("should convert streamable-http servers to remote entries", async () => {
+      const jsonData = {
+        mcpServers: {
+          "streaming-server": {
+            type: "streamable-http" as const,
+            url: "https://example.com/mcp",
+            headers: { Authorization: "Bearer token" },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        baseDir: testDir,
+        rulesyncMcp,
+      });
+
+      expect(opencodeMcp.getJson()).toEqual({
+        mcp: {
+          "streaming-server": {
+            type: "remote",
+            url: "https://example.com/mcp",
+            enabled: true,
+            headers: { Authorization: "Bearer token" },
+          },
+        },
+      });
+    });
+
     it("should create instance from RulesyncMcp in global mode", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -13,7 +13,7 @@ import {
 } from "./tool-mcp.js";
 
 // OpenCode MCP server schemas
-// OpenCode uses "local"/"remote" instead of "stdio"/"sse"/"http",
+// OpenCode uses "local"/"remote" instead of "stdio"/"sse"/"http"/"streamable-http",
 // "environment" instead of "env", and "enabled" instead of "disabled"
 
 // OpenCode native format for local servers
@@ -92,7 +92,7 @@ function convertFromOpencodeFormat(opencodeMcp: Record<string, OpencodeMcpServer
 
 /**
  * Convert standard MCP format to OpenCode native format
- * - type: "stdio" -> "local", "sse"/"http" -> "remote"
+ * - type: "stdio" -> "local", "sse"/"http"/"streamable-http" -> "remote"
  * - command + args -> command (merged array)
  * - env -> environment
  * - disabled -> enabled (inverted)
@@ -101,7 +101,10 @@ function convertToOpencodeFormat(mcpServers: McpServers): Record<string, Opencod
   return Object.fromEntries(
     Object.entries(mcpServers).map(([serverName, serverConfig]) => {
       const isRemote =
-        serverConfig.type === "sse" || serverConfig.type === "http" || serverConfig.url;
+        serverConfig.type === "sse" ||
+        serverConfig.type === "http" ||
+        serverConfig.type === "streamable-http" ||
+        serverConfig.url;
 
       if (isRemote) {
         const remoteServer: OpencodeMcpServer = {

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/mini";
 
 export const McpServerSchema = z.object({
-  type: z.optional(z.enum(["stdio", "sse", "http"])),
+  type: z.optional(z.enum(["stdio", "sse", "http", "streamable-http"])),
   command: z.optional(z.union([z.string(), z.array(z.string())])),
   args: z.optional(z.array(z.string())),
   url: z.optional(z.string()),
@@ -12,7 +12,7 @@ export const McpServerSchema = z.object({
   timeout: z.optional(z.number()),
   trust: z.optional(z.boolean()),
   cwd: z.optional(z.string()),
-  transport: z.optional(z.enum(["stdio", "sse", "http"])),
+  transport: z.optional(z.enum(["stdio", "sse", "http", "streamable-http"])),
   alwaysAllow: z.optional(z.array(z.string())),
   tools: z.optional(z.array(z.string())),
   kiroAutoApprove: z.optional(z.array(z.string())),


### PR DESCRIPTION
## Summary
- allow the streamable-http transport in MCP server schema definitions
- treat streamable-http servers as remote entries when converting to the OpenCode format
- cover the new transport with an OpencodeMcp conversion test

## Testing
- pnpm cicheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad54b13e48330a46e5e95f71a65ea)