### PR TITLE
feat(roo): convert http type to streamable-http for Roo Code MCP

### DIFF
--- a/src/features/mcp/roo-mcp.ts
+++ b/src/features/mcp/roo-mcp.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { ValidationResult } from "../../types/ai-file.js";
+import { McpServers } from "../../types/mcp.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
@@ -9,6 +10,59 @@ import {
   ToolMcpParams,
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
+
+// Roo Code uses "streamable-http" instead of "http" for HTTP-based MCP servers
+// Since "streamable-http" is not part of the standard MCP type schema,
+// we use Record<string, unknown> as the intermediate type for Roo-specific format
+
+type RooMcpServers = Record<string, Record<string, unknown>>;
+
+/**
+ * Type guard to check if a value is a valid RooMcpServers object
+ */
+function isRooMcpServers(value: unknown): value is RooMcpServers {
+  return value !== undefined && value !== null && typeof value === "object";
+}
+
+/**
+ * Convert Rulesync MCP format to Roo MCP format
+ * - type: "http" -> "streamable-http"
+ * - transport: "http" -> "streamable-http"
+ */
+function convertToRooFormat(mcpServers: McpServers): RooMcpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([serverName, serverConfig]) => {
+      const converted: Record<string, unknown> = { ...serverConfig };
+      if (serverConfig.type === "http") {
+        converted.type = "streamable-http";
+      }
+      if (serverConfig.transport === "http") {
+        converted.transport = "streamable-http";
+      }
+      return [serverName, converted];
+    }),
+  );
+}
+
+/**
+ * Convert Roo MCP format to Rulesync MCP format
+ * - type: "streamable-http" -> "http"
+ * - transport: "streamable-http" -> "http"
+ */
+function convertFromRooFormat(mcpServers: RooMcpServers): McpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([serverName, serverConfig]) => {
+      const converted: Record<string, unknown> = { ...serverConfig };
+      if (serverConfig.type === "streamable-http") {
+        converted.type = "http";
+      }
+      if (serverConfig.transport === "streamable-http") {
+        converted.transport = "http";
+      }
+      return [serverName, converted];
+    }),
+  );
+}
 
 export class RooMcp extends ToolMcp {
   private readonly json: Record<string, unknown>;
@@ -54,7 +108,9 @@ export class RooMcp extends ToolMcp {
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): RooMcp {
-    const fileContent = rulesyncMcp.getFileContent();
+    const mcpServers = rulesyncMcp.getMcpServers();
+    const convertedMcpServers = convertToRooFormat(mcpServers);
+    const fileContent = JSON.stringify({ mcpServers: convertedMcpServers }, null, 2);
 
     return new RooMcp({
       baseDir,
@@ -66,7 +122,13 @@ export class RooMcp extends ToolMcp {
   }
 
   toRulesyncMcp(): RulesyncMcp {
-    return this.toRulesyncMcpDefault();
+    const rawMcpServers: RooMcpServers = isRooMcpServers(this.json.mcpServers)
+      ? this.json.mcpServers
+      : {};
+    const convertedMcpServers = convertFromRooFormat(rawMcpServers);
+    return this.toRulesyncMcpDefault({
+      fileContent: JSON.stringify({ mcpServers: convertedMcpServers }, null, 2),
+    });
   }
 
   validate(): ValidationResult {


### PR DESCRIPTION
## Summary

- Roo Code uses `streamable-http` as the type identifier for HTTP-based MCP servers instead of the standard `http`
- Added bidirectional conversion between Rulesync and Roo MCP formats:
  - `fromRulesyncMcp`: `http` → `streamable-http` (when generating for Roo)
  - `toRulesyncMcp`: `streamable-http` → `http` (when importing from Roo)
- Both `type` and `transport` fields are converted
- Other types (`stdio`, `sse`) are passed through unchanged

## Test plan

- [x] Added tests for `fromRulesyncMcp` converting `http` type to `streamable-http`
- [x] Added tests for `fromRulesyncMcp` converting `http` transport to `streamable-http`
- [x] Added tests for `toRulesyncMcp` converting `streamable-http` type to `http`
- [x] Added tests for `toRulesyncMcp` converting `streamable-http` transport to `http`
- [x] Added tests verifying `stdio` and `sse` types are not converted
- [x] Added round-trip test (Rulesync → Roo → Rulesync)
- [x] All 2988 tests pass
- [x] `pnpm cicheck:code` passes

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)