### PR TITLE
Sync claude settings deny list with rulesync ignore

### DIFF
--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -86,11 +86,21 @@ export class ClaudecodeIgnore extends ToolIgnore {
     const exists = await fileExists(filePath);
     const existingFileContent = exists ? await readFileContent(filePath) : "{}";
     const existingJsonValue: SettingsJsonValue = JSON.parse(existingFileContent);
+    const existingDenies = existingJsonValue.permissions?.deny ?? [];
+    const preservedDenies = existingDenies.filter((deny) => {
+      const isReadPattern = deny.startsWith("Read(") && deny.endsWith(")");
+      if (isReadPattern) {
+        return deniedValues.includes(deny);
+      }
+
+      return true;
+    });
+
     const jsonValue: SettingsJsonValue = {
       ...existingJsonValue,
       permissions: {
         ...existingJsonValue.permissions,
-        deny: uniq([...(existingJsonValue.permissions?.deny ?? []), ...deniedValues].toSorted()),
+        deny: uniq([...preservedDenies, ...deniedValues].toSorted()),
       },
     };
 


### PR DESCRIPTION
## Summary
- rebuild Claudecode permissions deny entries from the current .aiignore so stale Read() entries are removed while preserving other permissions
- add tests covering stale Read() removal and preservation of non-Read permissions

## Testing
- pnpm cicheck

Closes #611

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941207c69cc833082f87bf0d53d3a8a)