### PR TITLE
feat: add --check flag to rulesync generate for CI/CD integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ npx rulesync generate --targets "*" --features rules
 # Generate simulated commands and subagents
 npx rulesync generate --targets copilot,cursor,codexcli --features commands,subagents --simulate-commands --simulate-subagents
 
+# Check if generated files are synchronized (for CI/CD)
+npx rulesync generate --targets "*" --features "*" --check
+
 # Add generated files to .gitignore
 npx rulesync gitignore
 ```
@@ -265,7 +268,8 @@ Example:
   "simulateCommands": false,  // Generate simulated commands
   "simulateSubagents": false,  // Generate simulated subagents
   "simulateSkills": false,  // Generate simulated skills
-  "modularMcp": false  // Enable modular-mcp for context compression (experimental, Claude Code only)
+  "modularMcp": false,  // Enable modular-mcp for context compression (experimental, Claude Code only)
+  "check": false  // Check if generated files are synchronized without writing (for CI/CD)
 
   // Deprecated experimental options (for backward compatibility)
   // "experimentalGlobal": false,
@@ -688,6 +692,29 @@ Focus on the difference of MCP tools usage.
 
 So, in this case, approximately 92% reduction in MCP tools consumption!
 </details>
+
+## CI/CD Integration
+
+Use the `--check` flag to validate that generated files are synchronized with source rules without modifying any files:
+
+```bash
+npx rulesync generate --targets "*" --features "*" --check
+```
+
+- Exit code 0: All files are up to date
+- Exit code 1: Files are out of sync
+
+### Use Cases
+
+- **Pre-commit validation**: Prevent commits when developers forget to run `rulesync generate`
+- **CI/CD pipeline checks**: Fail builds if configuration files don't match source rules
+
+### Example GitHub Actions Workflow
+
+```yaml
+- name: Check rulesync files are up to date
+  run: npx rulesync generate --targets "*" --features "*" --check
+```
 
 ## Rulesync MCP Server (Experimental)
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -75,6 +75,9 @@
     "modularMcp": {
       "type": "boolean"
     },
+    "check": {
+      "type": "boolean"
+    },
     "experimentalGlobal": {
       "type": "boolean"
     },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -143,6 +143,10 @@ const main = async () => {
       "--modular-mcp",
       "Generate modular-mcp configuration for context compression (experimental)",
     )
+    .option(
+      "--check",
+      "Check if generated files are synchronized without writing (exit 1 if out of sync)",
+    )
     .action(async (options) => {
       try {
         await generateCommand({
@@ -157,6 +161,7 @@ const main = async () => {
           simulateSubagents: options.simulateSubagents,
           simulateSkills: options.simulateSkills,
           modularMcp: options.modularMcp,
+          check: options.check,
           experimentalGlobal: options.experimentalGlobal,
           experimentalSimulateCommands: options.experimentalSimulateCommands,
           experimentalSimulateSubagents: options.experimentalSimulateSubagents,

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -36,6 +36,7 @@ const getDefaults = (): RequiredConfigParams & { configPath: string } => ({
   simulateSubagents: false,
   simulateSkills: false,
   modularMcp: false,
+  check: false,
   experimentalGlobal: false,
   experimentalSimulateCommands: false,
   experimentalSimulateSubagents: false,
@@ -55,6 +56,7 @@ export class ConfigResolver {
     simulateSubagents,
     simulateSkills,
     modularMcp,
+    check,
     experimentalGlobal,
     experimentalSimulateCommands,
     experimentalSimulateSubagents,
@@ -132,6 +134,7 @@ export class ConfigResolver {
       simulateSubagents: resolvedSimulateSubagents,
       simulateSkills: resolvedSimulateSkills,
       modularMcp: modularMcp ?? configByFile.modularMcp ?? getDefaults().modularMcp,
+      check: check ?? configByFile.check ?? getDefaults().check,
     };
     return new Config(configParams);
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,6 +24,7 @@ export const ConfigParamsSchema = z.object({
   simulateSubagents: optional(z.boolean()),
   simulateSkills: optional(z.boolean()),
   modularMcp: optional(z.boolean()),
+  check: optional(z.boolean()),
   // Deprecated experimental options (for backward compatibility)
   experimentalGlobal: optional(z.boolean()),
   experimentalSimulateCommands: optional(z.boolean()),
@@ -69,6 +70,7 @@ export class Config {
   private readonly simulateSubagents: boolean;
   private readonly simulateSkills: boolean;
   private readonly modularMcp: boolean;
+  private readonly check: boolean;
 
   constructor({
     baseDirs,
@@ -81,6 +83,7 @@ export class Config {
     simulateSubagents,
     simulateSkills,
     modularMcp,
+    check,
     experimentalGlobal,
     experimentalSimulateCommands,
     experimentalSimulateSubagents,
@@ -100,6 +103,7 @@ export class Config {
     this.simulateSubagents = simulateSubagents ?? experimentalSimulateSubagents ?? false;
     this.simulateSkills = simulateSkills ?? false;
     this.modularMcp = modularMcp ?? false;
+    this.check = check ?? false;
   }
 
   private validateConflictingTargets(targets: RulesyncTargets): void {
@@ -170,6 +174,10 @@ export class Config {
 
   public getModularMcp(): boolean {
     return this.modularMcp;
+  }
+
+  public getCheck(): boolean {
+    return this.check;
   }
 
   // Deprecated getters for backward compatibility

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -1,7 +1,16 @@
 import { join } from "node:path";
-import { addTrailingNewline, ensureDir, removeDirectory, writeFileContent } from "../utils/file.js";
+import {
+  addTrailingNewline,
+  directoryExists,
+  ensureDir,
+  fileExists,
+  readFileContent,
+  removeDirectory,
+  writeFileContent,
+} from "../utils/file.js";
 import { stringifyFrontmatter } from "../utils/frontmatter.js";
 import { AiDir, AiDirFile } from "./ai-dir.js";
+import type { CompareAiFilesResult, FileComparisonResult } from "./file-comparison.js";
 import { ToolTarget } from "./tool-targets.js";
 
 export abstract class DirFeatureProcessor {
@@ -66,5 +75,71 @@ export abstract class DirFeatureProcessor {
     for (const aiDir of aiDirs) {
       await removeDirectory(aiDir.getDirPath());
     }
+  }
+
+  /**
+   * Compare generated directories with existing directories on disk.
+   * Returns comparison results without modifying any files.
+   */
+  async compareAiDirs(aiDirs: AiDir[]): Promise<CompareAiFilesResult> {
+    const results: FileComparisonResult[] = [];
+
+    for (const aiDir of aiDirs) {
+      const dirPath = aiDir.getDirPath();
+
+      // Check if directory exists
+      if (!(await directoryExists(dirPath))) {
+        results.push({ filePath: dirPath, status: "create" });
+        continue;
+      }
+
+      // Compare main file if exists
+      const mainFile = aiDir.getMainFile();
+      if (mainFile) {
+        const mainFilePath = join(dirPath, mainFile.name);
+        const newContent = addTrailingNewline(
+          stringifyFrontmatter(mainFile.body, mainFile.frontmatter),
+        );
+
+        if (await fileExists(mainFilePath)) {
+          const existingContent = await readFileContent(mainFilePath);
+          if (existingContent !== newContent) {
+            results.push({ filePath: dirPath, status: "update" });
+            continue;
+          }
+        } else {
+          results.push({ filePath: dirPath, status: "update" });
+          continue;
+        }
+      }
+
+      // Compare other files
+      const otherFiles: AiDirFile[] = aiDir.getOtherFiles();
+      let hasChanges = false;
+      for (const file of otherFiles) {
+        const filePath = join(dirPath, file.relativeFilePathToDirPath);
+        const newContent = addTrailingNewline(file.fileBuffer.toString("utf-8"));
+
+        if (await fileExists(filePath)) {
+          const existingContent = await readFileContent(filePath);
+          if (existingContent !== newContent) {
+            hasChanges = true;
+            break;
+          }
+        } else {
+          hasChanges = true;
+          break;
+        }
+      }
+
+      if (hasChanges) {
+        results.push({ filePath: dirPath, status: "update" });
+      } else {
+        results.push({ filePath: dirPath, status: "unchanged" });
+      }
+    }
+
+    const outOfSyncCount = results.filter((r) => r.status !== "unchanged").length;
+    return { results, outOfSyncCount };
   }
 }

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -1,5 +1,12 @@
-import { addTrailingNewline, removeFile, writeFileContent } from "../utils/file.js";
+import {
+  addTrailingNewline,
+  fileExists,
+  readFileContent,
+  removeFile,
+  writeFileContent,
+} from "../utils/file.js";
 import { AiFile } from "./ai-file.js";
+import type { CompareAiFilesResult, FileComparisonResult } from "./file-comparison.js";
 import { RulesyncFile } from "./rulesync-file.js";
 import { ToolFile } from "./tool-file.js";
 import { ToolTarget } from "./tool-targets.js";
@@ -45,5 +52,32 @@ export abstract class FeatureProcessor {
     for (const aiFile of aiFiles) {
       await removeFile(aiFile.getFilePath());
     }
+  }
+
+  /**
+   * Compare generated files with existing files on disk.
+   * Returns comparison results without modifying any files.
+   */
+  async compareAiFiles(aiFiles: AiFile[]): Promise<CompareAiFilesResult> {
+    const results: FileComparisonResult[] = [];
+
+    for (const aiFile of aiFiles) {
+      const filePath = aiFile.getFilePath();
+      const newContent = addTrailingNewline(aiFile.getFileContent());
+
+      if (await fileExists(filePath)) {
+        const existingContent = await readFileContent(filePath);
+        if (existingContent === newContent) {
+          results.push({ filePath, status: "unchanged" });
+        } else {
+          results.push({ filePath, status: "update" });
+        }
+      } else {
+        results.push({ filePath, status: "create" });
+      }
+    }
+
+    const outOfSyncCount = results.filter((r) => r.status !== "unchanged").length;
+    return { results, outOfSyncCount };
   }
 }

--- a/src/types/file-comparison.ts
+++ b/src/types/file-comparison.ts
@@ -1,0 +1,11 @@
+export type FileComparisonStatus = "create" | "update" | "delete" | "unchanged";
+
+export type FileComparisonResult = {
+  filePath: string;
+  status: FileComparisonStatus;
+};
+
+export type CompareAiFilesResult = {
+  results: FileComparisonResult[];
+  outOfSyncCount: number;
+};


### PR DESCRIPTION
## Summary

- Add `--check` flag to `rulesync generate` command for CI/CD integration
- Validates whether generated files are synchronized with source rules without modifying any files
- Returns exit code 0 when synchronized, exit code 1 when out of sync

## Features

- Reports what would be created, updated, or deleted
- Works with all features (rules, ignore, mcp, commands, subagents, skills)
- Supports `--delete` flag to check deletions
- Can be configured via `rulesync.jsonc` with `"check": true`

## Use Cases

- **Pre-commit validation**: Prevent commits when developers forget to run `rulesync generate`
- **CI/CD pipeline checks**: Fail builds if configuration files don't match source rules

## Example Usage

```bash
npx rulesync generate --targets "*" --features "*" --check
```

## Example GitHub Actions Workflow

```yaml
- name: Check rulesync files are up to date
  run: npx rulesync generate --targets "*" --features "*" --check
```

## Test plan

- [x] Add tests for check mode in generate.test.ts
- [x] Verify exit code 0 when files are synchronized
- [x] Verify exit code 1 when files are out of sync
- [x] Verify files are not written when `--check` is enabled
- [x] Verify "Would create/update/delete" messages are logged
- [x] Run `pnpm cicheck:code` - all 3037 tests pass

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)