### PR TITLE
chore: add Safe Chain installation and update claudecode target

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -95,6 +95,9 @@ RUN mise trust /workspace && mise install
 RUN mise exec -- go install github.com/suzuki-shunsuke/pinact/cmd/pinact@latest
 ENV PATH=$PATH:/home/node/go/bin
 
+# Install Safe Chain
+RUN curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh
+
 # Install global packages
 ENV PNPM_HOME=/home/node/.pnpm
 ENV PATH=$PATH:$PNPM_HOME

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
 
   // List of tools to generate configurations for
-  "targets": ["cursor", "claudecode", "geminicli", "codexcli", "copilot", "opencode"],
+  "targets": ["cursor", "claudecode-legacy", "geminicli", "codexcli", "copilot", "opencode"],
 
   "features": ["rules", "ignore", "mcp", "commands", "subagents", "skills"],
 


### PR DESCRIPTION
## Summary
- Add Safe Chain installation to devcontainer Dockerfile for enhanced security
- Change claudecode to claudecode-legacy in rulesync.jsonc

## Test plan
- [ ] Verify devcontainer builds successfully with Safe Chain
- [ ] Verify rulesync generate works with claudecode-legacy target

🤖 Generated with [Claude Code](https://claude.com/claude-code)