### PR TITLE
fix: add forDeletion pattern to handle files with incompatible formats

### DIFF
--- a/src/features/commands/agentsmd-command.ts
+++ b/src/features/commands/agentsmd-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
 import {
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -60,5 +61,15 @@ export class AgentsmdCommand extends SimulatedCommand {
       rulesyncCommand,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): AgentsmdCommand {
+    return new AgentsmdCommand(
+      this.forDeletionDefault({ baseDir, relativeDirPath, relativeFilePath }),
+    );
   }
 }

--- a/src/features/commands/antigravity-command.ts
+++ b/src/features/commands/antigravity-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -169,6 +170,22 @@ export class AntigravityCommand extends ToolCommand {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): AntigravityCommand {
+    return new AntigravityCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/claudecode-command.ts
+++ b/src/features/commands/claudecode-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -172,6 +173,21 @@ export class ClaudecodeCommand extends ToolCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): ClaudecodeCommand {
+    return new ClaudecodeCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/codexcli-command.ts
+++ b/src/features/commands/codexcli-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -89,6 +90,20 @@ export class CodexcliCommand extends ToolCommand {
       relativeFilePath: basename(relativeFilePath),
       fileContent: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CodexcliCommand {
+    return new CodexcliCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/copilot-command.ts
+++ b/src/features/commands/copilot-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -168,6 +169,21 @@ export class CopilotCommand extends ToolCommand {
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "copilot",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CopilotCommand {
+    return new CopilotCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { mode: "agent", description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/cursor-command.ts
+++ b/src/features/commands/cursor-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -86,6 +87,20 @@ export class CursorCommand extends ToolCommand {
       relativeFilePath: basename(relativeFilePath),
       fileContent: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CursorCommand {
+    return new CursorCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -8,6 +8,7 @@ import { stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -166,6 +167,20 @@ ${geminiFrontmatter.prompt}
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "geminicli",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): GeminiCliCommand {
+    return new GeminiCliCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/opencode-command.ts
+++ b/src/features/commands/opencode-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -161,6 +162,21 @@ export class OpenCodeCommand extends ToolCommand {
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "opencode",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): OpenCodeCommand {
+    return new OpenCodeCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/roo-command.ts
+++ b/src/features/commands/roo-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -170,6 +171,22 @@ export class RooCommand extends ToolCommand {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): RooCommand {
+    return new RooCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/simulated-command.ts
+++ b/src/features/commands/simulated-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -123,6 +124,21 @@ export abstract class SimulatedCommand extends ToolCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    };
+  }
+
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): ConstructorParameters<typeof SimulatedCommand>[0] {
+    return {
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     };
   }
 }

--- a/src/features/commands/tool-command.ts
+++ b/src/features/commands/tool-command.ts
@@ -15,6 +15,13 @@ export type ToolCommandSettablePaths = {
   relativeDirPath: string;
 };
 
+export type ToolCommandForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 /**
  * Abstract base class for AI development tool-specific command formats.
  *
@@ -49,6 +56,18 @@ export abstract class ToolCommand extends AiFile {
    * @returns Promise resolving to a concrete ToolCommand instance
    */
   static async fromFile(_params: ToolCommandFromFileParams): Promise<ToolCommand> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   *
+   * @param params - Parameters including the file path
+   * @returns A concrete ToolCommand instance with minimal data for deletion
+   */
+  static forDeletion(_params: ToolCommandForDeletionParams): ToolCommand {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/features/ignore/amazonqcli-ignore.ts
+++ b/src/features/ignore/amazonqcli-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -79,6 +80,20 @@ export class AmazonqcliIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): AmazonqcliIgnore {
+    return new AmazonqcliIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/augmentcode-ignore.ts
+++ b/src/features/ignore/augmentcode-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -83,6 +84,20 @@ export class AugmentcodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): AugmentcodeIgnore {
+    return new AugmentcodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -4,6 +4,7 @@ import { fileExists, readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -131,6 +132,20 @@ export class ClaudecodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): ClaudecodeIgnore {
+    return new ClaudecodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/cline-ignore.ts
+++ b/src/features/ignore/cline-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -71,6 +72,20 @@ export class ClineIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): ClineIgnore {
+    return new ClineIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/cursor-ignore.ts
+++ b/src/features/ignore/cursor-ignore.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -58,6 +59,20 @@ export class CursorIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): CursorIgnore {
+    return new CursorIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/geminicli-ignore.ts
+++ b/src/features/ignore/geminicli-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class GeminiCliIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): GeminiCliIgnore {
+    return new GeminiCliIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -493,7 +493,7 @@ describe("IgnoreProcessor", () => {
       expect(filesToDelete).toHaveLength(0);
     });
 
-    it("should return all deletable files for targets with deletable files", async () => {
+    it("should return deletable files with correct paths", async () => {
       await writeFileContent(join(testDir, ".cursorignore"), "*.log\nnode_modules/");
 
       const processor = new IgnoreProcessor({
@@ -501,23 +501,27 @@ describe("IgnoreProcessor", () => {
         toolTarget: "cursor",
       });
 
-      const allFiles = await processor.loadToolFiles();
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
 
-      // CursorIgnore is deletable, so should return the same files
-      expect(filesToDelete).toEqual(allFiles);
+      // CursorIgnore is deletable, so should return the file
       expect(filesToDelete).toHaveLength(1);
       expect(filesToDelete[0]?.isDeletable()).toBe(true);
+      expect(filesToDelete[0]?.getRelativeFilePath()).toBe(".cursorignore");
     });
 
-    it("should return empty array when no tool files exist", async () => {
+    it("should return instance for standard path even when file does not exist on disk", async () => {
+      // No file created on disk
       const processor = new IgnoreProcessor({
         baseDir: testDir,
         toolTarget: "cursor",
       });
 
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
-      expect(filesToDelete).toHaveLength(0);
+
+      // forDeletion creates an instance for the standard path regardless of file existence
+      // The actual deletion logic handles checking if the file exists
+      expect(filesToDelete).toHaveLength(1);
+      expect(filesToDelete[0]?.getRelativeFilePath()).toBe(".cursorignore");
     });
   });
 

--- a/src/features/ignore/junie-ignore.ts
+++ b/src/features/ignore/junie-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class JunieIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): JunieIgnore {
+    return new JunieIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/kiro-ignore.ts
+++ b/src/features/ignore/kiro-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class KiroIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): KiroIgnore {
+    return new KiroIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/qwencode-ignore.ts
+++ b/src/features/ignore/qwencode-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class QwencodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): QwencodeIgnore {
+    return new QwencodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/roo-ignore.ts
+++ b/src/features/ignore/roo-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -62,6 +63,20 @@ export class RooIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): RooIgnore {
+    return new RooIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/tool-ignore.ts
+++ b/src/features/ignore/tool-ignore.ts
@@ -21,6 +21,12 @@ export type ToolIgnoreSettablePaths = {
 };
 
 export type ToolIgnoreFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate">;
+
+export type ToolIgnoreForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+};
 export abstract class ToolIgnore extends ToolFile {
   protected patterns: string[];
 
@@ -73,6 +79,15 @@ export abstract class ToolIgnore extends ToolFile {
   }
 
   static async fromFile(_params: ToolIgnoreFromFileParams): Promise<ToolIgnore> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolIgnoreForDeletionParams): ToolIgnore {
     throw new Error("Please implement this method in the subclass.");
   }
 }

--- a/src/features/ignore/windsurf-ignore.ts
+++ b/src/features/ignore/windsurf-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -55,6 +56,20 @@ export class WindsurfIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): WindsurfIgnore {
+    return new WindsurfIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/mcp/amazonqcli-mcp.ts
+++ b/src/features/mcp/amazonqcli-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -70,5 +71,19 @@ export class AmazonqcliMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): AmazonqcliMcp {
+    return new AmazonqcliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -5,6 +5,7 @@ import { ModularMcp } from "./modular-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -117,5 +118,19 @@ export class ClaudecodeMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): ClaudecodeMcp {
+    return new ClaudecodeMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/cline-mcp.ts
+++ b/src/features/mcp/cline-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -72,5 +73,19 @@ export class ClineMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): ClineMcp {
+    return new ClineMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -6,6 +6,7 @@ import { readFileContent, readOrInitializeFileContent } from "../../utils/file.j
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   type ToolMcpParams,
@@ -124,5 +125,19 @@ export class CodexcliMcp extends ToolMcp {
     }
 
     return filtered;
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CodexcliMcp {
+    return new CodexcliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/copilot-mcp.ts
+++ b/src/features/mcp/copilot-mcp.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -88,5 +89,19 @@ export class CopilotMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CopilotMcp {
+    return new CopilotMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -87,5 +88,19 @@ export class CursorMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CursorMcp {
+    return new CursorMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/geminicli-mcp.ts
+++ b/src/features/mcp/geminicli-mcp.ts
@@ -4,6 +4,7 @@ import { readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -89,5 +90,19 @@ export class GeminiCliMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): GeminiCliMcp {
+    return new GeminiCliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/junie-mcp.ts
+++ b/src/features/mcp/junie-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -70,5 +71,19 @@ export class JunieMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): JunieMcp {
+    return new JunieMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -6,6 +6,7 @@ import { readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -233,5 +234,19 @@ export class OpencodeMcp extends ToolMcp {
       return { success: false, error: result.error };
     }
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): OpencodeMcp {
+    return new OpencodeMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/roo-mcp.ts
+++ b/src/features/mcp/roo-mcp.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -133,5 +134,19 @@ export class RooMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): RooMcp {
+    return new RooMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/tool-mcp.ts
+++ b/src/features/mcp/tool-mcp.ts
@@ -14,6 +14,13 @@ export type ToolMcpFromRulesyncMcpParams = Omit<
 
 export type ToolMcpFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate" | "global">;
 
+export type ToolMcpForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 export type ToolMcpSettablePaths = {
   relativeDirPath: string;
   relativeFilePath: string;
@@ -59,6 +66,15 @@ export abstract class ToolMcp extends ToolFile {
   }
 
   static async fromFile(_params: ToolMcpFromFileParams): Promise<ToolMcp> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolMcpForDeletionParams): ToolMcp {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/features/rules/agentsmd-rule.ts
+++ b/src/features/rules/agentsmd-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -62,6 +63,23 @@ export class AgentsMdRule extends ToolRule {
       relativeFilePath: isRoot ? "AGENTS.md" : relativeFilePath,
       fileContent,
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AgentsMdRule {
+    const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".";
+
+    return new AgentsMdRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/amazonqcli-rule.ts
+++ b/src/features/rules/amazonqcli-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -64,6 +65,21 @@ export class AmazonQCliRule extends ToolRule {
     // The body content can be empty (though not recommended in practice)
     // This follows the same pattern as other rule validation methods
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AmazonQCliRule {
+    return new AmazonQCliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/antigravity-rule.ts
+++ b/src/features/rules/antigravity-rule.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -477,6 +478,22 @@ export class AntigravityRule extends ToolRule {
       return { success: false, error: new Error(formatError(result.error)) };
     }
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AntigravityRule {
+    return new AntigravityRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/augmentcode-legacy-rule.ts
+++ b/src/features/rules/augmentcode-legacy-rule.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -102,6 +103,24 @@ export class AugmentcodeLegacyRule extends ToolRule {
       relativeFilePath: isRoot ? settablePaths.root.relativeFilePath : relativeFilePath,
       fileContent,
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AugmentcodeLegacyRule {
+    const settablePaths = this.getSettablePaths();
+    const isRoot = relativeFilePath === settablePaths.root.relativeFilePath;
+
+    return new AugmentcodeLegacyRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/augmentcode-rule.ts
+++ b/src/features/rules/augmentcode-rule.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -67,6 +68,20 @@ export class AugmentcodeRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AugmentcodeRule {
+    return new AugmentcodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/claudecode-legacy-rule.ts
+++ b/src/features/rules/claudecode-legacy-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -123,6 +124,25 @@ export class ClaudecodeLegacyRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): ClaudecodeLegacyRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new ClaudecodeLegacyRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -160,6 +161,26 @@ export class ClaudecodeRule extends ToolRule {
       body: content.trim(),
       validate,
       root: false,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): ClaudecodeRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new ClaudecodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
+      root: isRoot,
     });
   }
 

--- a/src/features/rules/cline-rule.ts
+++ b/src/features/rules/cline-rule.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -73,6 +74,20 @@ export class ClineRule extends ToolRule {
       relativeFilePath: relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): ClineRule {
+    return new ClineRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/rules/codexcli-rule.ts
+++ b/src/features/rules/codexcli-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -119,6 +120,25 @@ export class CodexcliRule extends ToolRule {
     // The body content can be empty (though not recommended in practice)
     // This follows the same pattern as other rule validation methods
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): CodexcliRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new CodexcliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -201,6 +202,24 @@ export class CopilotRule extends ToolRule {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): CopilotRule {
+    const isRoot = relativeFilePath === this.getSettablePaths().root.relativeFilePath;
+
+    return new CopilotRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -234,6 +235,21 @@ export class CursorRule extends ToolRule {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): CursorRule {
+    return new CursorRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
     });
   }
 

--- a/src/features/rules/geminicli-rule.ts
+++ b/src/features/rules/geminicli-rule.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -117,6 +118,25 @@ export class GeminiCliRule extends ToolRule {
     // Gemini CLI uses plain markdown without frontmatter requirements
     // Validation always succeeds
     return { success: true as const, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): GeminiCliRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new GeminiCliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/junie-rule.ts
+++ b/src/features/rules/junie-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -84,6 +85,23 @@ export class JunieRule extends ToolRule {
   validate(): ValidationResult {
     // Junie rules are always valid since they don't require frontmatter
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): JunieRule {
+    const isRoot = relativeFilePath === "guidelines.md";
+
+    return new JunieRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -70,6 +71,21 @@ export class KiroRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): KiroRule {
+    return new KiroRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/opencode-rule.ts
+++ b/src/features/rules/opencode-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   type ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
   ToolRuleSettablePaths,
@@ -75,6 +76,23 @@ export class OpenCodeRule extends ToolRule {
     // OpenCode rules are always valid since they use plain markdown format
     // Similar to AgentsMdRule, no complex frontmatter validation needed
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): OpenCodeRule {
+    const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".";
+
+    return new OpenCodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/qwencode-rule.ts
+++ b/src/features/rules/qwencode-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -81,6 +82,23 @@ export class QwencodeRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): QwencodeRule {
+    const isRoot = relativeFilePath === "QWEN.md" && relativeDirPath === ".";
+
+    return new QwencodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -97,6 +98,21 @@ export class RooRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): RooRule {
+    return new RooRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -24,6 +24,13 @@ export type ToolRuleFromRulesyncRuleParams = Omit<
 
 export type ToolRuleFromFileParams = AiFileFromFileParams;
 
+export type ToolRuleForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 export type ToolRuleSettablePaths = {
   root?: {
     relativeDirPath: string;
@@ -77,6 +84,15 @@ export abstract class ToolRule extends ToolFile {
   }
 
   static async fromFile(_params: ToolRuleFromFileParams | undefined): Promise<ToolRule> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolRuleForDeletionParams): ToolRule {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/features/rules/warp-rule.ts
+++ b/src/features/rules/warp-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -87,6 +88,23 @@ export class WarpRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): WarpRule {
+    const isRoot = relativeFilePath === this.getSettablePaths().root.relativeFilePath;
+
+    return new WarpRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/windsurf-rule.ts
+++ b/src/features/rules/windsurf-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -64,6 +65,20 @@ export class WindsurfRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): WindsurfRule {
+    return new WindsurfRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/skills/agentsmd-skill.ts
+++ b/src/features/skills/agentsmd-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class AgentsmdSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): AgentsmdSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new AgentsmdSkill(baseParams);
   }
 }

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -6,6 +6,7 @@ import { formatError } from "../../utils/error.js";
 import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -194,6 +195,24 @@ export class ClaudecodeSkill extends ToolSkill {
       otherFiles: loaded.otherFiles,
       validate: true,
       global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): ClaudecodeSkill {
+    return new ClaudecodeSkill({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
     });
   }
 }

--- a/src/features/skills/codexcli-skill.ts
+++ b/src/features/skills/codexcli-skill.ts
@@ -6,6 +6,7 @@ import { formatError } from "../../utils/error.js";
 import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -180,6 +181,24 @@ export class CodexCliSkill extends ToolSkill {
       otherFiles: loaded.otherFiles,
       validate: true,
       global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): CodexCliSkill {
+    return new CodexCliSkill({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
     });
   }
 }

--- a/src/features/skills/copilot-skill.ts
+++ b/src/features/skills/copilot-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class CopilotSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "copilot",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): CopilotSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new CopilotSkill(baseParams);
   }
 }

--- a/src/features/skills/cursor-skill.ts
+++ b/src/features/skills/cursor-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class CursorSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "cursor",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): CursorSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new CursorSkill(baseParams);
   }
 }

--- a/src/features/skills/geminicli-skill.ts
+++ b/src/features/skills/geminicli-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class GeminiCliSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "geminicli",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): GeminiCliSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new GeminiCliSkill(baseParams);
   }
 }

--- a/src/features/skills/simulated-skill.ts
+++ b/src/features/skills/simulated-skill.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncSkill, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -171,6 +172,27 @@ export abstract class SimulatedSkill extends ToolSkill {
       body: content.trim(),
       otherFiles,
       validate: true,
+    };
+  }
+
+  /**
+   * Create minimal params for deletion purposes.
+   * This method does not read or parse directory content, making it safe to use
+   * even when skill files have old/incompatible formats.
+   */
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+  }: ToolSkillForDeletionParams): SimulatedSkillParams {
+    return {
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
     };
   }
 

--- a/src/features/skills/tool-skill.ts
+++ b/src/features/skills/tool-skill.ts
@@ -22,6 +22,13 @@ export type ToolSkillFromDirParams = {
   global?: boolean;
 };
 
+export type ToolSkillForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  dirName: string;
+  global?: boolean;
+};
+
 /**
  * Common data loaded from a skill directory.
  * Used by loadSkillDirContent to return parsed file data.
@@ -81,6 +88,15 @@ export abstract class ToolSkill extends AiDir {
    * @returns Promise resolving to a concrete ToolSkill instance
    */
   static async fromDir(_params: ToolSkillFromDirParams): Promise<ToolSkill> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse directory content, making it safe to use
+   * even when skill files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolSkillForDeletionParams): ToolSkill {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/features/subagents/agentsmd-subagent.ts
+++ b/src/features/subagents/agentsmd-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class AgentsmdSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): AgentsmdSubagent {
+    return new AgentsmdSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/claudecode-subagent.ts
+++ b/src/features/subagents/claudecode-subagent.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncSubagent, RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -187,6 +188,22 @@ export class ClaudecodeSubagent extends ToolSubagent {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): ClaudecodeSubagent {
+    return new ClaudecodeSubagent({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CodexCliSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "codexcli",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CodexCliSubagent {
+    return new CodexCliSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CopilotSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "copilot",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CopilotSubagent {
+    return new CopilotSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CursorSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "cursor",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CursorSubagent {
+    return new CursorSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/geminicli-subagent.ts
+++ b/src/features/subagents/geminicli-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class GeminiCliSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "geminicli",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): GeminiCliSubagent {
+    return new GeminiCliSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/roo-subagent.ts
+++ b/src/features/subagents/roo-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class RooSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "roo",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): RooSubagent {
+    return new RooSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/simulated-subagent.ts
+++ b/src/features/subagents/simulated-subagent.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
 } from "./tool-subagent.js";
@@ -121,6 +122,21 @@ export abstract class SimulatedSubagent extends ToolSubagent {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    };
+  }
+
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
+    return {
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      validate: false,
     };
   }
 }

--- a/src/features/subagents/tool-subagent.ts
+++ b/src/features/subagents/tool-subagent.ts
@@ -18,12 +18,28 @@ export type ToolSubagentSettablePaths = {
 export type ToolSubagentFromFileParams = AiFileFromFileParams & {
   global?: boolean;
 };
+
+export type ToolSubagentForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
 export abstract class ToolSubagent extends ToolFile {
   static getSettablePaths(): ToolSubagentSettablePaths {
     throw new Error("Please implement this method in the subclass.");
   }
 
   static async fromFile(_params: ToolSubagentFromFileParams): Promise<ToolSubagent> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolSubagentForDeletionParams): ToolSubagent {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to all tool base classes (ToolRule, ToolCommand, ToolSubagent, ToolMcp, ToolIgnore, ToolSkill)
- Implement `forDeletion` in all concrete subclasses to create minimal instances without parsing file content
- Modify all processors to use `forDeletion` when loading files/dirs for deletion
- Add tests for broken frontmatter scenarios

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles`/`loadToolDirs` would parse existing files. If files had old/incompatible formats (e.g., broken YAML frontmatter), parsing would fail and deletion would fail.

## Test plan
- [x] Add tests for broken frontmatter in rules-processor.test.ts
- [x] Add tests for broken frontmatter in subagents-processor.test.ts
- [x] Add tests for broken frontmatter in skills-processor.test.ts
- [x] Run `pnpm cicheck:code` - all 3034 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)