### PR TITLE
fix: add forDeletion pattern to rules feature

### DIFF
--- a/src/features/rules/agentsmd-rule.ts
+++ b/src/features/rules/agentsmd-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -62,6 +63,23 @@ export class AgentsMdRule extends ToolRule {
       relativeFilePath: isRoot ? "AGENTS.md" : relativeFilePath,
       fileContent,
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AgentsMdRule {
+    const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".";
+
+    return new AgentsMdRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/amazonqcli-rule.ts
+++ b/src/features/rules/amazonqcli-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -64,6 +65,21 @@ export class AmazonQCliRule extends ToolRule {
     // The body content can be empty (though not recommended in practice)
     // This follows the same pattern as other rule validation methods
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AmazonQCliRule {
+    return new AmazonQCliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/antigravity-rule.ts
+++ b/src/features/rules/antigravity-rule.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -477,6 +478,22 @@ export class AntigravityRule extends ToolRule {
       return { success: false, error: new Error(formatError(result.error)) };
     }
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AntigravityRule {
+    return new AntigravityRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/augmentcode-legacy-rule.ts
+++ b/src/features/rules/augmentcode-legacy-rule.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -102,6 +103,24 @@ export class AugmentcodeLegacyRule extends ToolRule {
       relativeFilePath: isRoot ? settablePaths.root.relativeFilePath : relativeFilePath,
       fileContent,
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AugmentcodeLegacyRule {
+    const settablePaths = this.getSettablePaths();
+    const isRoot = relativeFilePath === settablePaths.root.relativeFilePath;
+
+    return new AugmentcodeLegacyRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/augmentcode-rule.ts
+++ b/src/features/rules/augmentcode-rule.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -67,6 +68,20 @@ export class AugmentcodeRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AugmentcodeRule {
+    return new AugmentcodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/claudecode-legacy-rule.ts
+++ b/src/features/rules/claudecode-legacy-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -123,6 +124,25 @@ export class ClaudecodeLegacyRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): ClaudecodeLegacyRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new ClaudecodeLegacyRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -160,6 +161,26 @@ export class ClaudecodeRule extends ToolRule {
       body: content.trim(),
       validate,
       root: false,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): ClaudecodeRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new ClaudecodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
+      root: isRoot,
     });
   }
 

--- a/src/features/rules/cline-rule.ts
+++ b/src/features/rules/cline-rule.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -73,6 +74,20 @@ export class ClineRule extends ToolRule {
       relativeFilePath: relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): ClineRule {
+    return new ClineRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/rules/codexcli-rule.ts
+++ b/src/features/rules/codexcli-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -119,6 +120,25 @@ export class CodexcliRule extends ToolRule {
     // The body content can be empty (though not recommended in practice)
     // This follows the same pattern as other rule validation methods
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): CodexcliRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new CodexcliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -201,6 +202,24 @@ export class CopilotRule extends ToolRule {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+      root: isRoot,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): CopilotRule {
+    const isRoot = relativeFilePath === this.getSettablePaths().root.relativeFilePath;
+
+    return new CopilotRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
       root: isRoot,
     });
   }

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -234,6 +235,21 @@ export class CursorRule extends ToolRule {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): CursorRule {
+    return new CursorRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
     });
   }
 

--- a/src/features/rules/geminicli-rule.ts
+++ b/src/features/rules/geminicli-rule.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -117,6 +118,25 @@ export class GeminiCliRule extends ToolRule {
     // Gemini CLI uses plain markdown without frontmatter requirements
     // Validation always succeeds
     return { success: true as const, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): GeminiCliRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new GeminiCliRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/junie-rule.ts
+++ b/src/features/rules/junie-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -84,6 +85,23 @@ export class JunieRule extends ToolRule {
   validate(): ValidationResult {
     // Junie rules are always valid since they don't require frontmatter
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): JunieRule {
+    const isRoot = relativeFilePath === "guidelines.md";
+
+    return new JunieRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -70,6 +71,21 @@ export class KiroRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): KiroRule {
+    return new KiroRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/opencode-rule.ts
+++ b/src/features/rules/opencode-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   type ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
   ToolRuleSettablePaths,
@@ -75,6 +76,23 @@ export class OpenCodeRule extends ToolRule {
     // OpenCode rules are always valid since they use plain markdown format
     // Similar to AgentsMdRule, no complex frontmatter validation needed
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): OpenCodeRule {
+    const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".";
+
+    return new OpenCodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/qwencode-rule.ts
+++ b/src/features/rules/qwencode-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -81,6 +82,23 @@ export class QwencodeRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): QwencodeRule {
+    const isRoot = relativeFilePath === "QWEN.md" && relativeDirPath === ".";
+
+    return new QwencodeRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -97,6 +98,21 @@ export class RooRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): RooRule {
+    return new RooRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -1,6 +1,9 @@
 import { basename, join } from "node:path";
 import { z } from "zod/mini";
-import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import {
+  RULESYNC_RELATIVE_DIR_PATH,
+  RULESYNC_RULES_RELATIVE_DIR_PATH,
+} from "../../constants/rulesync-paths.js";
 import { type ValidationResult } from "../../types/ai-file.js";
 import {
   RulesyncFile,
@@ -11,6 +14,7 @@ import { RulesyncTargetsSchema } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
+import { logger } from "../../utils/logger.js";
 
 export const RulesyncRuleFrontmatterSchema = z.object({
   root: z.optional(z.optional(z.boolean())),
@@ -61,6 +65,9 @@ export type RulesyncRuleSettablePaths = {
   recommended: {
     relativeDirPath: string;
   };
+  legacy: {
+    relativeDirPath: string;
+  };
 };
 
 export class RulesyncRule extends RulesyncFile {
@@ -92,6 +99,9 @@ export class RulesyncRule extends RulesyncFile {
       recommended: {
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
       },
+      legacy: {
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      },
     };
   }
 
@@ -117,6 +127,53 @@ export class RulesyncRule extends RulesyncFile {
         ),
       };
     }
+  }
+
+  static async fromFileLegacy({
+    relativeFilePath,
+    validate = true,
+  }: RulesyncFileFromFileParams): Promise<RulesyncRule> {
+    const legacyPath = join(
+      process.cwd(),
+      this.getSettablePaths().legacy.relativeDirPath,
+      relativeFilePath,
+    );
+    const recommendedPath = join(
+      this.getSettablePaths().recommended.relativeDirPath,
+      relativeFilePath,
+    );
+
+    logger.warn(`⚠️  Using deprecated path "${legacyPath}". Please migrate to "${recommendedPath}"`);
+
+    // Read file content
+    const fileContent = await readFileContent(legacyPath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    // Validate frontmatter using RuleFrontmatterSchema
+    const result = RulesyncRuleFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${legacyPath}: ${formatError(result.error)}`);
+    }
+
+    const validatedFrontmatter: RulesyncRuleFrontmatter = {
+      root: result.data.root ?? false,
+      targets: result.data.targets ?? ["*"],
+      description: result.data.description ?? "",
+      globs: result.data.globs ?? [],
+      agentsmd: result.data.agentsmd,
+      cursor: result.data.cursor,
+    };
+
+    const filename = basename(legacyPath);
+
+    return new RulesyncRule({
+      baseDir: process.cwd(),
+      relativeDirPath: this.getSettablePaths().recommended.relativeDirPath,
+      relativeFilePath: filename,
+      frontmatter: validatedFrontmatter,
+      body: content.trim(),
+      validate,
+    });
   }
 
   static async fromFile({

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -24,6 +24,13 @@ export type ToolRuleFromRulesyncRuleParams = Omit<
 
 export type ToolRuleFromFileParams = AiFileFromFileParams;
 
+export type ToolRuleForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 export type ToolRuleSettablePaths = {
   root?: {
     relativeDirPath: string;
@@ -77,6 +84,15 @@ export abstract class ToolRule extends ToolFile {
   }
 
   static async fromFile(_params: ToolRuleFromFileParams | undefined): Promise<ToolRule> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolRuleForDeletionParams): ToolRule {
     throw new Error("Please implement this method in the subclass.");
   }
 

--- a/src/features/rules/warp-rule.ts
+++ b/src/features/rules/warp-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
@@ -87,6 +88,23 @@ export class WarpRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): WarpRule {
+    const isRoot = relativeFilePath === this.getSettablePaths().root.relativeFilePath;
+
+    return new WarpRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {

--- a/src/features/rules/windsurf-rule.ts
+++ b/src/features/rules/windsurf-rule.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
+  ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
@@ -64,6 +65,20 @@ export class WindsurfRule extends ToolRule {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): WindsurfRule {
+    return new WindsurfRule({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 
   static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolRule base class and all concrete rule subclasses
- Update RulesProcessor to use `forDeletion` when loading files for deletion
- Add tests for broken frontmatter scenarios in rules

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles` would parse existing files. If files had old/incompatible formats (e.g., broken YAML frontmatter), parsing would fail and deletion would fail.

This is part 1 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 802 rules tests pass
- [x] Run `pnpm vitest run src/features/rules/`