### PR TITLE
fix: add forDeletion pattern to commands feature

### DIFF
--- a/src/features/commands/agentsmd-command.ts
+++ b/src/features/commands/agentsmd-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 import { SimulatedCommand, SimulatedCommandFrontmatterSchema } from "./simulated-command.js";
 import {
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -60,5 +61,15 @@ export class AgentsmdCommand extends SimulatedCommand {
       rulesyncCommand,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): AgentsmdCommand {
+    return new AgentsmdCommand(
+      this.forDeletionDefault({ baseDir, relativeDirPath, relativeFilePath }),
+    );
   }
 }

--- a/src/features/commands/antigravity-command.ts
+++ b/src/features/commands/antigravity-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -169,6 +170,22 @@ export class AntigravityCommand extends ToolCommand {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): AntigravityCommand {
+    return new AntigravityCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/claudecode-command.ts
+++ b/src/features/commands/claudecode-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -172,6 +173,21 @@ export class ClaudecodeCommand extends ToolCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): ClaudecodeCommand {
+    return new ClaudecodeCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/codexcli-command.ts
+++ b/src/features/commands/codexcli-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -89,6 +90,20 @@ export class CodexcliCommand extends ToolCommand {
       relativeFilePath: basename(relativeFilePath),
       fileContent: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CodexcliCommand {
+    return new CodexcliCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/copilot-command.ts
+++ b/src/features/commands/copilot-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -168,6 +169,21 @@ export class CopilotCommand extends ToolCommand {
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "copilot",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CopilotCommand {
+    return new CopilotCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { mode: "agent", description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/cursor-command.ts
+++ b/src/features/commands/cursor-command.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -86,6 +87,20 @@ export class CursorCommand extends ToolCommand {
       relativeFilePath: basename(relativeFilePath),
       fileContent: content.trim(),
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): CursorCommand {
+    return new CursorCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -8,6 +8,7 @@ import { stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -166,6 +167,20 @@ ${geminiFrontmatter.prompt}
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "geminicli",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): GeminiCliCommand {
+    return new GeminiCliCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/opencode-command.ts
+++ b/src/features/commands/opencode-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
@@ -161,6 +162,21 @@ export class OpenCodeCommand extends ToolCommand {
     return this.isTargetedByRulesyncCommandDefault({
       rulesyncCommand,
       toolTarget: "opencode",
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): OpenCodeCommand {
+    return new OpenCodeCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/roo-command.ts
+++ b/src/features/commands/roo-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -170,6 +171,22 @@ export class RooCommand extends ToolCommand {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): RooCommand {
+    return new RooCommand({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/commands/simulated-command.ts
+++ b/src/features/commands/simulated-command.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncCommand } from "./rulesync-command.js";
 import {
   ToolCommand,
+  ToolCommandForDeletionParams,
   ToolCommandFromFileParams,
   ToolCommandFromRulesyncCommandParams,
 } from "./tool-command.js";
@@ -123,6 +124,21 @@ export abstract class SimulatedCommand extends ToolCommand {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    };
+  }
+
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolCommandForDeletionParams): ConstructorParameters<typeof SimulatedCommand>[0] {
+    return {
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { description: "" },
+      body: "",
+      validate: false,
     };
   }
 }

--- a/src/features/commands/tool-command.ts
+++ b/src/features/commands/tool-command.ts
@@ -15,6 +15,13 @@ export type ToolCommandSettablePaths = {
   relativeDirPath: string;
 };
 
+export type ToolCommandForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 /**
  * Abstract base class for AI development tool-specific command formats.
  *
@@ -49,6 +56,18 @@ export abstract class ToolCommand extends AiFile {
    * @returns Promise resolving to a concrete ToolCommand instance
    */
   static async fromFile(_params: ToolCommandFromFileParams): Promise<ToolCommand> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   *
+   * @param params - Parameters including the file path
+   * @returns A concrete ToolCommand instance with minimal data for deletion
+   */
+  static forDeletion(_params: ToolCommandForDeletionParams): ToolCommand {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolCommand base class and all concrete command subclasses
- Update CommandsProcessor to use `forDeletion` when loading files for deletion
- Update existing tests to use forDeletion mocks

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles` would parse existing files. If files had old/incompatible formats (e.g., broken YAML frontmatter), parsing would fail and deletion would fail.

This is part 2 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 313 commands tests pass
- [x] Run `pnpm vitest run src/features/commands/`