### PR TITLE
fix: add forDeletion pattern to ignore feature

### DIFF
--- a/src/features/ignore/amazonqcli-ignore.ts
+++ b/src/features/ignore/amazonqcli-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -79,6 +80,20 @@ export class AmazonqcliIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): AmazonqcliIgnore {
+    return new AmazonqcliIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/augmentcode-ignore.ts
+++ b/src/features/ignore/augmentcode-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -83,6 +84,20 @@ export class AugmentcodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): AugmentcodeIgnore {
+    return new AugmentcodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -4,6 +4,7 @@ import { fileExists, readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreParams,
@@ -131,6 +132,20 @@ export class ClaudecodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): ClaudecodeIgnore {
+    return new ClaudecodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/cline-ignore.ts
+++ b/src/features/ignore/cline-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -71,6 +72,20 @@ export class ClineIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): ClineIgnore {
+    return new ClineIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/cursor-ignore.ts
+++ b/src/features/ignore/cursor-ignore.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -58,6 +59,20 @@ export class CursorIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): CursorIgnore {
+    return new CursorIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/geminicli-ignore.ts
+++ b/src/features/ignore/geminicli-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class GeminiCliIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): GeminiCliIgnore {
+    return new GeminiCliIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -493,7 +493,7 @@ describe("IgnoreProcessor", () => {
       expect(filesToDelete).toHaveLength(0);
     });
 
-    it("should return all deletable files for targets with deletable files", async () => {
+    it("should return deletable files with correct paths", async () => {
       await writeFileContent(join(testDir, ".cursorignore"), "*.log\nnode_modules/");
 
       const processor = new IgnoreProcessor({
@@ -501,23 +501,27 @@ describe("IgnoreProcessor", () => {
         toolTarget: "cursor",
       });
 
-      const allFiles = await processor.loadToolFiles();
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
 
-      // CursorIgnore is deletable, so should return the same files
-      expect(filesToDelete).toEqual(allFiles);
+      // CursorIgnore is deletable, so should return the file
       expect(filesToDelete).toHaveLength(1);
       expect(filesToDelete[0]?.isDeletable()).toBe(true);
+      expect(filesToDelete[0]?.getRelativeFilePath()).toBe(".cursorignore");
     });
 
-    it("should return empty array when no tool files exist", async () => {
+    it("should return instance for standard path even when file does not exist on disk", async () => {
+      // No file created on disk
       const processor = new IgnoreProcessor({
         baseDir: testDir,
         toolTarget: "cursor",
       });
 
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
-      expect(filesToDelete).toHaveLength(0);
+
+      // forDeletion creates an instance for the standard path regardless of file existence
+      // The actual deletion logic handles checking if the file exists
+      expect(filesToDelete).toHaveLength(1);
+      expect(filesToDelete[0]?.getRelativeFilePath()).toBe(".cursorignore");
     });
   });
 

--- a/src/features/ignore/junie-ignore.ts
+++ b/src/features/ignore/junie-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class JunieIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): JunieIgnore {
+    return new JunieIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/kiro-ignore.ts
+++ b/src/features/ignore/kiro-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class KiroIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): KiroIgnore {
+    return new KiroIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/qwencode-ignore.ts
+++ b/src/features/ignore/qwencode-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -50,6 +51,20 @@ export class QwencodeIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): QwencodeIgnore {
+    return new QwencodeIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/roo-ignore.ts
+++ b/src/features/ignore/roo-ignore.ts
@@ -3,6 +3,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import {
   ToolIgnore,
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -62,6 +63,20 @@ export class RooIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): RooIgnore {
+    return new RooIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/ignore/tool-ignore.ts
+++ b/src/features/ignore/tool-ignore.ts
@@ -21,6 +21,12 @@ export type ToolIgnoreSettablePaths = {
 };
 
 export type ToolIgnoreFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate">;
+
+export type ToolIgnoreForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+};
 export abstract class ToolIgnore extends ToolFile {
   protected patterns: string[];
 
@@ -73,6 +79,15 @@ export abstract class ToolIgnore extends ToolFile {
   }
 
   static async fromFile(_params: ToolIgnoreFromFileParams): Promise<ToolIgnore> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolIgnoreForDeletionParams): ToolIgnore {
     throw new Error("Please implement this method in the subclass.");
   }
 }

--- a/src/features/ignore/windsurf-ignore.ts
+++ b/src/features/ignore/windsurf-ignore.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
+  ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
@@ -55,6 +56,20 @@ export class WindsurfIgnore extends ToolIgnore {
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): WindsurfIgnore {
+    return new WindsurfIgnore({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolIgnore base class and all concrete ignore subclasses
- Update IgnoreProcessor to use `forDeletion` when loading files for deletion
- Update existing tests to use forDeletion mocks

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles` would parse existing files. If files had old/incompatible formats, parsing would fail and deletion would fail.

This is part 3 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 488 ignore tests pass
- [x] Run `pnpm vitest run src/features/ignore/`