### PR TITLE
fix: add forDeletion pattern to mcp feature

### DIFF
--- a/src/features/mcp/amazonqcli-mcp.ts
+++ b/src/features/mcp/amazonqcli-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -70,5 +71,19 @@ export class AmazonqcliMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): AmazonqcliMcp {
+    return new AmazonqcliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -5,6 +5,7 @@ import { ModularMcp } from "./modular-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -117,5 +118,19 @@ export class ClaudecodeMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): ClaudecodeMcp {
+    return new ClaudecodeMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/cline-mcp.ts
+++ b/src/features/mcp/cline-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -72,5 +73,19 @@ export class ClineMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): ClineMcp {
+    return new ClineMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -6,6 +6,7 @@ import { readFileContent, readOrInitializeFileContent } from "../../utils/file.j
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   type ToolMcpParams,
@@ -124,5 +125,19 @@ export class CodexcliMcp extends ToolMcp {
     }
 
     return filtered;
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CodexcliMcp {
+    return new CodexcliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/copilot-mcp.ts
+++ b/src/features/mcp/copilot-mcp.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -88,5 +89,19 @@ export class CopilotMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CopilotMcp {
+    return new CopilotMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -87,5 +88,19 @@ export class CursorMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): CursorMcp {
+    return new CursorMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/geminicli-mcp.ts
+++ b/src/features/mcp/geminicli-mcp.ts
@@ -4,6 +4,7 @@ import { readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -89,5 +90,19 @@ export class GeminiCliMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): GeminiCliMcp {
+    return new GeminiCliMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/junie-mcp.ts
+++ b/src/features/mcp/junie-mcp.ts
@@ -4,6 +4,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -70,5 +71,19 @@ export class JunieMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): JunieMcp {
+    return new JunieMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -6,6 +6,7 @@ import { readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -233,5 +234,19 @@ export class OpencodeMcp extends ToolMcp {
       return { success: false, error: result.error };
     }
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): OpencodeMcp {
+    return new OpencodeMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/roo-mcp.ts
+++ b/src/features/mcp/roo-mcp.ts
@@ -5,6 +5,7 @@ import { readFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
+  ToolMcpForDeletionParams,
   ToolMcpFromFileParams,
   ToolMcpFromRulesyncMcpParams,
   ToolMcpParams,
@@ -133,5 +134,19 @@ export class RooMcp extends ToolMcp {
 
   validate(): ValidationResult {
     return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): RooMcp {
+    return new RooMcp({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+    });
   }
 }

--- a/src/features/mcp/tool-mcp.ts
+++ b/src/features/mcp/tool-mcp.ts
@@ -14,6 +14,13 @@ export type ToolMcpFromRulesyncMcpParams = Omit<
 
 export type ToolMcpFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate" | "global">;
 
+export type ToolMcpForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
+
 export type ToolMcpSettablePaths = {
   relativeDirPath: string;
   relativeFilePath: string;
@@ -59,6 +66,15 @@ export abstract class ToolMcp extends ToolFile {
   }
 
   static async fromFile(_params: ToolMcpFromFileParams): Promise<ToolMcp> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolMcpForDeletionParams): ToolMcp {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolMcp base class and all concrete mcp subclasses
- Update McpProcessor to use `forDeletion` when loading files for deletion
- Update existing tests to use forDeletion mocks

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles` would parse existing files. If files had old/incompatible formats, parsing would fail and deletion would fail.

This is part 4 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 489 mcp tests pass
- [x] Run `pnpm vitest run src/features/mcp/`