### PR TITLE
fix: add forDeletion pattern to skills feature

### DIFF
--- a/src/features/skills/agentsmd-skill.ts
+++ b/src/features/skills/agentsmd-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class AgentsmdSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): AgentsmdSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new AgentsmdSkill(baseParams);
   }
 }

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -6,6 +6,7 @@ import { formatError } from "../../utils/error.js";
 import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -194,6 +195,24 @@ export class ClaudecodeSkill extends ToolSkill {
       otherFiles: loaded.otherFiles,
       validate: true,
       global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): ClaudecodeSkill {
+    return new ClaudecodeSkill({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
     });
   }
 }

--- a/src/features/skills/codexcli-skill.ts
+++ b/src/features/skills/codexcli-skill.ts
@@ -6,6 +6,7 @@ import { formatError } from "../../utils/error.js";
 import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -180,6 +181,24 @@ export class CodexCliSkill extends ToolSkill {
       otherFiles: loaded.otherFiles,
       validate: true,
       global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): CodexCliSkill {
+    return new CodexCliSkill({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
     });
   }
 }

--- a/src/features/skills/copilot-skill.ts
+++ b/src/features/skills/copilot-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class CopilotSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "copilot",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): CopilotSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new CopilotSkill(baseParams);
   }
 }

--- a/src/features/skills/cursor-skill.ts
+++ b/src/features/skills/cursor-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class CursorSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "cursor",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): CursorSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new CursorSkill(baseParams);
   }
 }

--- a/src/features/skills/geminicli-skill.ts
+++ b/src/features/skills/geminicli-skill.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill, SimulatedSkillParams } from "./simulated-skill.js";
 import {
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -40,5 +41,10 @@ export class GeminiCliSkill extends SimulatedSkill {
       rulesyncSkill,
       toolTarget: "geminicli",
     });
+  }
+
+  static forDeletion(params: ToolSkillForDeletionParams): GeminiCliSkill {
+    const baseParams = this.forDeletionDefault(params);
+    return new GeminiCliSkill(baseParams);
   }
 }

--- a/src/features/skills/simulated-skill.ts
+++ b/src/features/skills/simulated-skill.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncSkill, SkillFile } from "./rulesync-skill.js";
 import {
   ToolSkill,
+  ToolSkillForDeletionParams,
   ToolSkillFromDirParams,
   ToolSkillFromRulesyncSkillParams,
   ToolSkillSettablePaths,
@@ -171,6 +172,27 @@ export abstract class SimulatedSkill extends ToolSkill {
       body: content.trim(),
       otherFiles,
       validate: true,
+    };
+  }
+
+  /**
+   * Create minimal params for deletion purposes.
+   * This method does not read or parse directory content, making it safe to use
+   * even when skill files have old/incompatible formats.
+   */
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+  }: ToolSkillForDeletionParams): SimulatedSkillParams {
+    return {
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
     };
   }
 

--- a/src/features/skills/tool-skill.ts
+++ b/src/features/skills/tool-skill.ts
@@ -22,6 +22,13 @@ export type ToolSkillFromDirParams = {
   global?: boolean;
 };
 
+export type ToolSkillForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  dirName: string;
+  global?: boolean;
+};
+
 /**
  * Common data loaded from a skill directory.
  * Used by loadSkillDirContent to return parsed file data.
@@ -81,6 +88,15 @@ export abstract class ToolSkill extends AiDir {
    * @returns Promise resolving to a concrete ToolSkill instance
    */
   static async fromDir(_params: ToolSkillFromDirParams): Promise<ToolSkill> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse directory content, making it safe to use
+   * even when skill files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolSkillForDeletionParams): ToolSkill {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolSkill base class and all concrete skill subclasses
- Update SkillsProcessor to use `forDeletion` when loading dirs for deletion
- Add tests for broken frontmatter scenarios

## Background
When using the `--delete` option with `rulesync generate`, `loadToolDirs` would parse existing files. If files had old/incompatible formats (e.g., broken YAML frontmatter), parsing would fail and deletion would fail.

This is part 5 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 174 skills tests pass
- [x] Run `pnpm vitest run src/features/skills/`