### PR TITLE
fix: add forDeletion pattern to subagents feature

### DIFF
--- a/src/features/subagents/agentsmd-subagent.ts
+++ b/src/features/subagents/agentsmd-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class AgentsmdSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "agentsmd",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): AgentsmdSubagent {
+    return new AgentsmdSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/claudecode-subagent.ts
+++ b/src/features/subagents/claudecode-subagent.ts
@@ -8,6 +8,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncSubagent, RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -187,6 +188,22 @@ export class ClaudecodeSubagent extends ToolSubagent {
       body: content.trim(),
       fileContent,
       validate,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): ClaudecodeSubagent {
+    return new ClaudecodeSubagent({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      fileContent: "",
+      validate: false,
     });
   }
 }

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CodexCliSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "codexcli",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CodexCliSubagent {
+    return new CodexCliSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CopilotSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "copilot",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CopilotSubagent {
+    return new CopilotSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class CursorSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "cursor",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): CursorSubagent {
+    return new CursorSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/geminicli-subagent.ts
+++ b/src/features/subagents/geminicli-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class GeminiCliSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "geminicli",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): GeminiCliSubagent {
+    return new GeminiCliSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/roo-subagent.ts
+++ b/src/features/subagents/roo-subagent.ts
@@ -3,6 +3,7 @@ import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagent } from "./simulated-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
   ToolSubagentSettablePaths,
@@ -30,5 +31,9 @@ export class RooSubagent extends SimulatedSubagent {
       rulesyncSubagent,
       toolTarget: "roo",
     });
+  }
+
+  static forDeletion(params: ToolSubagentForDeletionParams): RooSubagent {
+    return new RooSubagent(this.forDeletionDefault(params));
   }
 }

--- a/src/features/subagents/simulated-subagent.ts
+++ b/src/features/subagents/simulated-subagent.ts
@@ -7,6 +7,7 @@ import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
+  ToolSubagentForDeletionParams,
   ToolSubagentFromFileParams,
   ToolSubagentFromRulesyncSubagentParams,
 } from "./tool-subagent.js";
@@ -121,6 +122,21 @@ export abstract class SimulatedSubagent extends ToolSubagent {
       frontmatter: result.data,
       body: content.trim(),
       validate,
+    };
+  }
+
+  protected static forDeletionDefault({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
+    return {
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      validate: false,
     };
   }
 }

--- a/src/features/subagents/tool-subagent.ts
+++ b/src/features/subagents/tool-subagent.ts
@@ -18,12 +18,28 @@ export type ToolSubagentSettablePaths = {
 export type ToolSubagentFromFileParams = AiFileFromFileParams & {
   global?: boolean;
 };
+
+export type ToolSubagentForDeletionParams = {
+  baseDir?: string;
+  relativeDirPath: string;
+  relativeFilePath: string;
+  global?: boolean;
+};
 export abstract class ToolSubagent extends ToolFile {
   static getSettablePaths(): ToolSubagentSettablePaths {
     throw new Error("Please implement this method in the subclass.");
   }
 
   static async fromFile(_params: ToolSubagentFromFileParams): Promise<ToolSubagent> {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * Create a minimal instance for deletion purposes.
+   * This method does not read or parse file content, making it safe to use
+   * even when files have old/incompatible formats.
+   */
+  static forDeletion(_params: ToolSubagentForDeletionParams): ToolSubagent {
     throw new Error("Please implement this method in the subclass.");
   }
 


### PR DESCRIPTION
## Summary
- Add `forDeletion` static method to ToolSubagent base class and all concrete subagent subclasses
- Update SubagentsProcessor to use `forDeletion` when loading files for deletion
- Add tests for broken frontmatter scenarios

## Background
When using the `--delete` option with `rulesync generate`, `loadToolFiles` would parse existing files. If files had old/incompatible formats (e.g., broken YAML frontmatter), parsing would fail and deletion would fail.

This is part 6 of splitting #693 into smaller PRs for easier review.

## Test plan
- [x] All 351 subagents tests pass
- [x] Run `pnpm vitest run src/features/subagents/`