### PR TITLE
feat: add OpenCode Skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Gemini CLI             |  ✅ 🌏  |   ✅   |  ✅ 🌏  |     ✅ 🌏  |      🎮     |    🎮   |
 | GitHub Copilot         |  ✅    |       |  ✅    |     ✅     |    🎮      |    🎮   |
 | Cursor                 |  ✅   |   ✅  |   ✅   |     ✅ 🌏  |     🎮     |    🎮   |
-| OpenCode               |  ✅   |       |   ✅   |    ✅ 🌏    |          |        |
+| OpenCode               |  ✅   |       |   ✅   |    ✅ 🌏    |          | ✅ 🌏  |
 | Cline                  |  ✅    |   ✅    |  ✅    |          |          |        |
 | Roo Code               |  ✅   |   ✅   |  ✅    |   ✅     |     🎮     |        |
 | Qwen Code              |  ✅   |   ✅   |       |         |          |        |

--- a/src/features/skills/opencode-skill.test.ts
+++ b/src/features/skills/opencode-skill.test.ts
@@ -1,0 +1,582 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileBuffer, writeFileContent } from "../../utils/file.js";
+import {
+  OpencodeSkill,
+  type OpencodeSkillFrontmatter,
+  OpencodeSkillFrontmatterSchema,
+} from "./opencode-skill.js";
+import { RulesyncSkill, type RulesyncSkillFrontmatterInput } from "./rulesync-skill.js";
+
+describe("OpencodeSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create an OpencodeSkill with valid frontmatter and body", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill description",
+      };
+
+      const skill = new OpencodeSkill({
+        dirName: "test-skill",
+        frontmatter,
+        body: "This is a test skill body",
+        otherFiles: [],
+      });
+
+      expect(skill.getFrontmatter()).toEqual(frontmatter);
+      expect(skill.getBody()).toBe("This is a test skill body");
+      expect(skill.getOtherFiles()).toEqual([]);
+    });
+
+    it("should validate frontmatter by default", () => {
+      const invalidFrontmatter = {
+        name: 123, // Should be string
+        description: true, // Should be string
+      } as any;
+
+      expect(() => {
+        const skill = new OpencodeSkill({
+          dirName: "invalid-skill",
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          otherFiles: [],
+        });
+        return skill;
+      }).toThrow();
+    });
+
+    it("should skip validation when validate is false", () => {
+      const invalidFrontmatter = {
+        name: 123,
+        description: true,
+      } as any;
+
+      expect(() => {
+        const skill = new OpencodeSkill({
+          dirName: "invalid-skill",
+          frontmatter: invalidFrontmatter,
+          body: "Test body",
+          otherFiles: [],
+          validate: false,
+        });
+        return skill;
+      }).not.toThrow();
+    });
+
+    it("should use default relativeDirPath", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const skill = new OpencodeSkill({
+        baseDir: testDir,
+        dirName: "test-skill",
+        frontmatter,
+        body: "Test body",
+      });
+
+      expect(skill.getRelativeDirPath()).toBe(join(".opencode", "skill"));
+    });
+
+    it("should accept custom relativeDirPath", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const skill = new OpencodeSkill({
+        baseDir: testDir,
+        relativeDirPath: join("custom", "skills"),
+        dirName: "test-skill",
+        frontmatter,
+        body: "Test body",
+      });
+
+      expect(skill.getRelativeDirPath()).toBe(join("custom", "skills"));
+    });
+
+    it("should support global mode", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "global-skill",
+        description: "Global skill",
+      };
+
+      const skill = new OpencodeSkill({
+        dirName: "global-skill",
+        frontmatter,
+        body: "Global skill body",
+        global: true,
+      });
+
+      expect(skill.getGlobal()).toBe(true);
+    });
+  });
+
+  describe("validate", () => {
+    it("should validate successfully with valid frontmatter", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "valid-skill",
+        description: "Valid skill description",
+      };
+
+      const skill = new OpencodeSkill({
+        dirName: "valid-skill",
+        frontmatter,
+        body: "Valid body",
+        validate: false,
+      });
+
+      const result = skill.validate();
+      expect(result.success).toBe(true);
+    });
+
+    it("should fail validation with invalid frontmatter", () => {
+      const invalidFrontmatter = {
+        name: 123,
+        description: true,
+      } as any;
+
+      const skill = new OpencodeSkill({
+        dirName: "invalid-skill",
+        frontmatter: invalidFrontmatter,
+        body: "Test body",
+        validate: false,
+      });
+
+      const result = skill.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+    });
+
+    it("should fail validation when mainFile is undefined", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const skill = new OpencodeSkill({
+        dirName: "test-skill",
+        frontmatter,
+        body: "Test body",
+        validate: false,
+      });
+
+      // Manually set mainFile to undefined to test this edge case
+      (skill as any).mainFile = undefined;
+
+      const result = skill.validate();
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toContain("SKILL.md file does not exist");
+    });
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return default paths", () => {
+      const paths = OpencodeSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(join(".opencode", "skill"));
+    });
+
+    it("should return same paths for global mode", () => {
+      const paths = OpencodeSkill.getSettablePaths({ global: true });
+      expect(paths.relativeDirPath).toBe(join(".opencode", "skill"));
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should convert to RulesyncSkill", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test description",
+      };
+
+      const skill = new OpencodeSkill({
+        dirName: "test-skill",
+        frontmatter,
+        body: "Test body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+      expect(rulesyncFrontmatter.name).toBe("test-skill");
+      expect(rulesyncFrontmatter.description).toBe("Test description");
+      expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+
+    it("should preserve other files during conversion", () => {
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const otherFiles = [
+        {
+          relativeFilePathToDirPath: "helper.ts",
+          fileBuffer: Buffer.from("helper code"),
+        },
+      ];
+
+      const skill = new OpencodeSkill({
+        dirName: "test-skill",
+        frontmatter,
+        body: "Test body",
+        otherFiles,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getOtherFiles()).toEqual(otherFiles);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should convert from RulesyncSkill", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "test-skill",
+        description: "Test description",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "test-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Test body",
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({ rulesyncSkill });
+      const frontmatter = opencodeSkill.getFrontmatter();
+
+      expect(frontmatter.name).toBe("test-skill");
+      expect(frontmatter.description).toBe("Test description");
+    });
+
+    it("should ignore claudecode-specific options from RulesyncSkill", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "restricted-skill",
+        description: "Restricted skill",
+        claudecode: {
+          "allowed-tools": ["Bash", "Read"],
+        },
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "restricted-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Restricted body",
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({ rulesyncSkill });
+      const frontmatter = opencodeSkill.getFrontmatter();
+
+      // OpenCode skills don't support allowed-tools
+      expect(frontmatter.name).toBe("restricted-skill");
+      expect(frontmatter.description).toBe("Restricted skill");
+      expect((frontmatter as any)["allowed-tools"]).toBeUndefined();
+    });
+
+    it("should set correct relativeDirPath", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        dirName: "test-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Test body",
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({ rulesyncSkill });
+
+      expect(opencodeSkill.getRelativeDirPath()).toBe(join(".opencode", "skill"));
+    });
+
+    it("should preserve other files during conversion", () => {
+      const otherFiles = [
+        {
+          relativeFilePathToDirPath: "helper.ts",
+          fileBuffer: Buffer.from("helper code"),
+        },
+      ];
+
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "test-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Test body",
+        otherFiles,
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({ rulesyncSkill });
+      expect(opencodeSkill.getOtherFiles()).toEqual(otherFiles);
+    });
+
+    it("should skip validation when validate is false", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "valid-skill",
+        description: "Valid skill",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "valid-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Test body",
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: false,
+      });
+
+      // Even with validate=false, the skill should be created
+      expect(opencodeSkill).toBeInstanceOf(OpencodeSkill);
+    });
+
+    it("should support global mode", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "global-skill",
+        description: "Global skill",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "global-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Global body",
+        global: true,
+      });
+
+      const opencodeSkill = OpencodeSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        global: true,
+      });
+
+      expect(opencodeSkill.getGlobal()).toBe(true);
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should always return true for any RulesyncSkill", () => {
+      const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+        name: "test-skill",
+        description: "Test skill",
+      };
+
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "test-skill",
+        frontmatter: rulesyncFrontmatter,
+        body: "Test body",
+      });
+
+      expect(OpencodeSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should load skill from directory", async () => {
+      const skillDir = join(testDir, ".opencode", "skill", "test-skill");
+      await ensureDir(skillDir);
+
+      const frontmatter: OpencodeSkillFrontmatter = {
+        name: "test-skill",
+        description: "Test skill description",
+      };
+
+      const content = `---
+name: test-skill
+description: Test skill description
+---
+
+This is the skill body.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await OpencodeSkill.fromDir({
+        baseDir: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill.getFrontmatter()).toEqual(frontmatter);
+      expect(skill.getBody()).toBe("This is the skill body.");
+    });
+
+    it("should load skill with other files", async () => {
+      const skillDir = join(testDir, ".opencode", "skill", "multi-file-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: multi-file-skill
+description: Skill with multiple files
+---
+
+Main skill content.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      await writeFileBuffer(
+        join(skillDir, "helper.ts"),
+        Buffer.from("export function helper() {}"),
+      );
+
+      const skill = await OpencodeSkill.fromDir({
+        baseDir: testDir,
+        dirName: "multi-file-skill",
+      });
+
+      const otherFiles = skill.getOtherFiles();
+      expect(otherFiles).toHaveLength(1);
+      expect(otherFiles[0]?.relativeFilePathToDirPath).toBe("helper.ts");
+      expect(otherFiles[0]?.fileBuffer.toString()).toBe("export function helper() {}");
+    });
+
+    it("should throw error when SKILL.md does not exist", async () => {
+      const skillDir = join(testDir, ".opencode", "skill", "missing-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        OpencodeSkill.fromDir({
+          baseDir: testDir,
+          dirName: "missing-skill",
+        }),
+      ).rejects.toThrow("SKILL.md not found");
+    });
+
+    it("should throw error with invalid frontmatter", async () => {
+      const skillDir = join(testDir, ".opencode", "skill", "invalid-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: 123
+description: true
+---
+
+Invalid frontmatter.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      await expect(
+        OpencodeSkill.fromDir({
+          baseDir: testDir,
+          dirName: "invalid-skill",
+        }),
+      ).rejects.toThrow("Invalid frontmatter");
+    });
+
+    it("should use custom relativeDirPath when provided", async () => {
+      const customPath = join("custom", "skills");
+      const skillDir = join(testDir, customPath, "custom-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: custom-skill
+description: Custom path skill
+---
+
+Custom path content.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await OpencodeSkill.fromDir({
+        baseDir: testDir,
+        relativeDirPath: customPath,
+        dirName: "custom-skill",
+      });
+
+      expect(skill.getRelativeDirPath()).toBe(customPath);
+    });
+
+    it("should support global mode", async () => {
+      const skillDir = join(testDir, ".opencode", "skill", "global-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: global-skill
+description: Global mode skill
+---
+
+Global skill content.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await OpencodeSkill.fromDir({
+        baseDir: testDir,
+        dirName: "global-skill",
+        global: true,
+      });
+
+      expect(skill.getGlobal()).toBe(true);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a minimal skill instance for deletion", () => {
+      const skill = OpencodeSkill.forDeletion({
+        baseDir: testDir,
+        relativeDirPath: join(".opencode", "skill"),
+        dirName: "skill-to-delete",
+      });
+
+      expect(skill).toBeInstanceOf(OpencodeSkill);
+      expect(skill.getDirName()).toBe("skill-to-delete");
+    });
+
+    it("should support global mode", () => {
+      const skill = OpencodeSkill.forDeletion({
+        baseDir: testDir,
+        relativeDirPath: join(".opencode", "skill"),
+        dirName: "global-skill-to-delete",
+        global: true,
+      });
+
+      expect(skill.getGlobal()).toBe(true);
+    });
+  });
+
+  describe("OpencodeSkillFrontmatterSchema", () => {
+    it("should validate valid frontmatter", () => {
+      const validFrontmatter = {
+        name: "test-skill",
+        description: "Test description",
+      };
+
+      const result = OpencodeSkillFrontmatterSchema.safeParse(validFrontmatter);
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject frontmatter without name", () => {
+      const invalidFrontmatter = {
+        description: "Test description",
+      };
+
+      const result = OpencodeSkillFrontmatterSchema.safeParse(invalidFrontmatter);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject frontmatter without description", () => {
+      const invalidFrontmatter = {
+        name: "test-skill",
+      };
+
+      const result = OpencodeSkillFrontmatterSchema.safeParse(invalidFrontmatter);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/features/skills/opencode-skill.ts
+++ b/src/features/skills/opencode-skill.ts
@@ -1,0 +1,215 @@
+import { join } from "node:path";
+import { z } from "zod/mini";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { ValidationResult } from "../../types/ai-dir.js";
+import { formatError } from "../../utils/error.js";
+import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  ToolSkill,
+  ToolSkillForDeletionParams,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+export const OpencodeSkillFrontmatterSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+});
+
+export type OpencodeSkillFrontmatter = z.infer<typeof OpencodeSkillFrontmatterSchema>;
+
+export type OpencodeSkillParams = {
+  baseDir?: string;
+  relativeDirPath?: string;
+  dirName: string;
+  frontmatter: OpencodeSkillFrontmatter;
+  body: string;
+  otherFiles?: SkillFile[];
+  validate?: boolean;
+  global?: boolean;
+};
+
+/**
+ * Represents an OpenCode skill directory.
+ * Unlike subagents and commands, skills are directories containing SKILL.md and other files.
+ * Extends ToolSkill to inherit directory management and security features from AiDir.
+ *
+ * OpenCode skills are stored in:
+ * - Project mode: .opencode/skill/{skill-name}/SKILL.md
+ * - Global mode: ~/.opencode/skill/{skill-name}/SKILL.md
+ */
+export class OpencodeSkill extends ToolSkill {
+  constructor({
+    baseDir = process.cwd(),
+    relativeDirPath = join(".opencode", "skill"),
+    dirName,
+    frontmatter,
+    body,
+    otherFiles = [],
+    validate = true,
+    global = false,
+  }: OpencodeSkillParams) {
+    super({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      mainFile: {
+        name: SKILL_FILE_NAME,
+        body,
+        frontmatter: { ...frontmatter },
+      },
+      otherFiles,
+      global,
+    });
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static getSettablePaths({
+    global: _global = false,
+  }: {
+    global?: boolean;
+  } = {}): ToolSkillSettablePaths {
+    // OpenCode skills use the same relative path for both project and global modes
+    // The actual location differs based on baseDir:
+    // - Project mode: {process.cwd()}/.opencode/skill/
+    // - Global mode: {getHomeDirectory()}/.opencode/skill/
+    return {
+      relativeDirPath: join(".opencode", "skill"),
+    };
+  }
+
+  getFrontmatter(): OpencodeSkillFrontmatter {
+    if (!this.mainFile?.frontmatter) {
+      throw new Error("Frontmatter is not defined");
+    }
+    const result = OpencodeSkillFrontmatterSchema.parse(this.mainFile.frontmatter);
+    return result;
+  }
+
+  getBody(): string {
+    return this.mainFile?.body ?? "";
+  }
+
+  validate(): ValidationResult {
+    if (this.mainFile === undefined) {
+      return {
+        success: false,
+        error: new Error(`${this.getDirPath()}: ${SKILL_FILE_NAME} file does not exist`),
+      };
+    }
+    const result = OpencodeSkillFrontmatterSchema.safeParse(this.mainFile.frontmatter);
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${this.getDirPath()}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+
+    return { success: true, error: null };
+  }
+
+  toRulesyncSkill(): RulesyncSkill {
+    const frontmatter = this.getFrontmatter();
+    const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      targets: ["*"],
+    };
+
+    return new RulesyncSkill({
+      baseDir: this.baseDir,
+      relativeDirPath: this.relativeDirPath,
+      dirName: this.getDirName(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.getBody(),
+      otherFiles: this.getOtherFiles(),
+      validate: true,
+      global: this.global,
+    });
+  }
+
+  static fromRulesyncSkill({
+    rulesyncSkill,
+    validate = true,
+    global = false,
+  }: ToolSkillFromRulesyncSkillParams): OpencodeSkill {
+    const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+    const opencodeFrontmatter: OpencodeSkillFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    const settablePaths = OpencodeSkill.getSettablePaths({ global });
+
+    return new OpencodeSkill({
+      baseDir: rulesyncSkill.getBaseDir(),
+      relativeDirPath: settablePaths.relativeDirPath,
+      dirName: rulesyncSkill.getDirName(),
+      frontmatter: opencodeFrontmatter,
+      body: rulesyncSkill.getBody(),
+      otherFiles: rulesyncSkill.getOtherFiles(),
+      validate,
+      global,
+    });
+  }
+
+  static isTargetedByRulesyncSkill(_rulesyncSkill: RulesyncSkill): boolean {
+    // Skills don't have targets field like commands/subagents do
+    // All skills are available to OpenCode
+    return true;
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<OpencodeSkill> {
+    const loaded = await this.loadSkillDirContent({
+      ...params,
+      getSettablePaths: OpencodeSkill.getSettablePaths,
+    });
+
+    const result = OpencodeSkillFrontmatterSchema.safeParse(loaded.frontmatter);
+    if (!result.success) {
+      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      throw new Error(
+        `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
+      );
+    }
+
+    return new OpencodeSkill({
+      baseDir: loaded.baseDir,
+      relativeDirPath: loaded.relativeDirPath,
+      dirName: loaded.dirName,
+      frontmatter: result.data,
+      body: loaded.body,
+      otherFiles: loaded.otherFiles,
+      validate: true,
+      global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): OpencodeSkill {
+    return new OpencodeSkill({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -624,21 +624,21 @@ Content that would fail parsing`;
   });
 
   describe("getToolTargets", () => {
-    it("should return claudecode as the only supported target by default", () => {
+    it("should return non-simulated project targets by default", () => {
       const targets = SkillsProcessor.getToolTargets();
-      expect(targets).toEqual(["claudecode"]);
+      expect(new Set(targets)).toEqual(new Set(["claudecode", "opencode"]));
     });
 
     it("should return all targets including simulated when includeSimulated is true", () => {
       const targets = SkillsProcessor.getToolTargets({ includeSimulated: true });
       expect(new Set(targets)).toEqual(
-        new Set(["agentsmd", "claudecode", "copilot", "cursor", "geminicli"]),
+        new Set(["agentsmd", "claudecode", "copilot", "cursor", "geminicli", "opencode"]),
       );
     });
 
     it("should return only non-simulated targets when includeSimulated is false", () => {
       const targets = SkillsProcessor.getToolTargets({ includeSimulated: false });
-      expect(targets).toEqual(["claudecode"]);
+      expect(new Set(targets)).toEqual(new Set(["claudecode", "opencode"]));
     });
 
     it("should be callable without instance", () => {
@@ -656,16 +656,16 @@ Content that would fail parsing`;
   describe("getToolTargetsGlobal", () => {
     it("should return global targets in global mode", () => {
       const targets = SkillsProcessor.getToolTargetsGlobal();
-      expect(targets).toEqual(["claudecode", "codexcli"]);
-      expect(targets).toEqual(skillsProcessorToolTargetsGlobal);
+      expect(new Set(targets)).toEqual(new Set(["claudecode", "codexcli", "opencode"]));
+      expect(new Set(targets)).toEqual(new Set(skillsProcessorToolTargetsGlobal));
     });
   });
 
   describe("getToolTargets with global: true", () => {
     it("should return global targets when global option is true", () => {
       const targets = SkillsProcessor.getToolTargets({ global: true });
-      expect(targets).toEqual(["claudecode", "codexcli"]);
-      expect(targets).toEqual(skillsProcessorToolTargetsGlobal);
+      expect(new Set(targets)).toEqual(new Set(["claudecode", "codexcli", "opencode"]));
+      expect(new Set(targets)).toEqual(new Set(skillsProcessorToolTargetsGlobal));
     });
 
     it("should be callable without instance", () => {
@@ -677,6 +677,7 @@ Content that would fail parsing`;
     it("should export SkillsProcessorToolTargetSchema", () => {
       expect(SkillsProcessorToolTargetSchema).toBeDefined();
       expect(() => SkillsProcessorToolTargetSchema.parse("claudecode")).not.toThrow();
+      expect(() => SkillsProcessorToolTargetSchema.parse("opencode")).not.toThrow();
       expect(() => SkillsProcessorToolTargetSchema.parse("invalid")).toThrow();
     });
   });

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -12,6 +12,7 @@ import { CodexCliSkill } from "./codexcli-skill.js";
 import { CopilotSkill } from "./copilot-skill.js";
 import { CursorSkill } from "./cursor-skill.js";
 import { GeminiCliSkill } from "./geminicli-skill.js";
+import { OpencodeSkill } from "./opencode-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill } from "./simulated-skill.js";
 import {
@@ -55,6 +56,7 @@ const skillsProcessorToolTargetTuple = [
   "copilot",
   "cursor",
   "geminicli",
+  "opencode",
 ] as const;
 
 export type SkillsProcessorToolTarget = (typeof skillsProcessorToolTargetTuple)[number];
@@ -107,6 +109,13 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
     {
       class: GeminiCliSkill,
       meta: { supportsProject: true, supportsSimulated: true, supportsGlobal: false },
+    },
+  ],
+  [
+    "opencode",
+    {
+      class: OpencodeSkill,
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
     },
   ],
 ]);


### PR DESCRIPTION
- Add OpencodeSkill class for generating OpenCode skill files
- Support both project (.opencode/skill/) and global (~/.opencode/skill/) modes
- Register opencode skill in SkillsProcessor
- Update README feature table to reflect new skill support
- Add comprehensive test coverage for OpencodeSkill

Closes #715