### PR TITLE
Remove Copilot simulated subagent conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Claude Code            |  ✅ 🌏   |  ✅   |  ✅ 🌏 📦   |    ✅ 🌏     |    ✅ 🌏     |  ✅ 🌏   |
 | Codex CLI              |  ✅ 🌏   |      |   🌏   |     🌏    |    🎮      |    🌏   |
 | Gemini CLI             |  ✅ 🌏  |   ✅   |  ✅ 🌏  |     ✅ 🌏  |      🎮     |    🎮   |
-| GitHub Copilot         |  ✅    |       |  ✅    |     ✅     |    🎮      |    ✅   |
+| GitHub Copilot         |  ✅    |       |  ✅    |     ✅     |    ✅      |    ✅   |
 | Cursor                 |  ✅   |   ✅  |   ✅   |     ✅ 🌏  |     🎮     |    🎮   |
 | OpenCode               |  ✅   |       |   ✅   |    ✅ 🌏    |          |   ✅ 🌏  |
 | Cline                  |  ✅    |   ✅    |  ✅    |          |          |        |
@@ -358,6 +358,9 @@ description: >- # subagent description
   fix a bug. This agent can be called by the user explicitly only.
 claudecode: # for claudecode-specific parameters
   model: inherit # opus, sonnet, haiku or inherit
+copilot: # copilot-specific parameters
+  tools:
+    - web/fetch # agent/runSubagent is always included automatically
 ---
 
 You are the planner for any tasks.
@@ -365,7 +368,10 @@ You are the planner for any tasks.
 Based on the user's instruction, create a plan while analyzing the related files. Then, report the plan in detail. You can output files to @tmp/ if needed.
 
 Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
+
 ```
+
+Rulesync always adds `agent/runSubagent` to Copilot custom agents' `tools` list and merges any additional tools you specify without creating duplicates.
 
 ### `.rulesync/skills/*/SKILL.md`
 

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -56,6 +56,7 @@ describe("gitignoreCommand", () => {
       expect(content).toContain("**/.roo/rules/");
       expect(content).toContain("**/.aiignore");
       expect(content).toContain("**/.mcp.json");
+      expect(content).toContain("**/.github/agents/");
       expect(content).toContain("**/.github/subagents/");
       expect(content).toContain("**/.github/prompts/");
       expect(content).toContain("**/.warp/");
@@ -216,6 +217,7 @@ dist/`;
 **/.github/copilot-instructions.md
 **/.github/instructions/
 **/.github/prompts/
+**/.github/agents/
 **/.github/subagents/
 **/.github/skills/
 **/.vscode/mcp.json

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -47,6 +47,7 @@ const RULESYNC_IGNORE_ENTRIES = [
   "**/.github/copilot-instructions.md",
   "**/.github/instructions/",
   "**/.github/prompts/",
+  "**/.github/agents/",
   "**/.github/subagents/",
   "**/.github/skills/",
   "**/.vscode/mcp.json",

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -180,6 +180,35 @@ describe("RulesProcessor", () => {
       expect(result).toHaveLength(0);
     });
 
+    it("should not generate simulated subagent conventions for copilot", async () => {
+      const processor = new RulesProcessor({
+        toolTarget: "copilot",
+        simulateSubagents: true,
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "copilot-rule.md",
+          frontmatter: {
+            targets: ["copilot"],
+            root: true,
+          },
+          body: "Root body",
+        }),
+      ];
+
+      const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+      expect(result).toHaveLength(1);
+      const rule = result[0];
+      expect(rule).toBeDefined();
+      if (!rule) return;
+      expect(rule).toBeInstanceOf(CopilotRule);
+      expect(rule.getFileContent()).toBe("Root body");
+    });
+
     it("should throw error for unsupported tool target", () => {
       expect(() => {
         new RulesProcessor({

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -24,7 +24,6 @@ import { RulesyncSkill } from "../skills/rulesync-skill.js";
 import { SkillsProcessor } from "../skills/skills-processor.js";
 import { AgentsmdSubagent } from "../subagents/agentsmd-subagent.js";
 import { CodexCliSubagent } from "../subagents/codexcli-subagent.js";
-import { CopilotSubagent } from "../subagents/copilot-subagent.js";
 import { CursorSubagent } from "../subagents/cursor-subagent.js";
 import { GeminiCliSubagent } from "../subagents/geminicli-subagent.js";
 import { RooSubagent } from "../subagents/roo-subagent.js";
@@ -253,9 +252,6 @@ const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
         extension: "md",
         supportsGlobal: false,
         ruleDiscoveryMode: "auto",
-        additionalConventions: {
-          subagents: { subagentClass: CopilotSubagent },
-        },
       },
     },
   ],

--- a/src/features/subagents/simulated-subagent.ts
+++ b/src/features/subagents/simulated-subagent.ts
@@ -12,9 +12,10 @@ import {
   ToolSubagentFromRulesyncSubagentParams,
 } from "./tool-subagent.js";
 
-export const SimulatedSubagentFrontmatterSchema = z.object({
+export const SimulatedSubagentFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  tools: z.optional(z.array(z.string())),
 });
 
 export type SimulatedSubagentFrontmatter = z.infer<typeof SimulatedSubagentFrontmatterSchema>;

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -338,7 +338,7 @@ Claude content`,
 
       const copilotSubagent = new CopilotSubagent({
         baseDir: testDir,
-        relativeDirPath: ".github/subagents",
+        relativeDirPath: ".github/agents",
         relativeFilePath: "copilot-agent.md",
         frontmatter: {
           name: "copilot-agent",
@@ -558,8 +558,8 @@ Invalid content`;
       expect(toolFiles).toEqual([]);
     });
 
-    it("should load copilot subagent files from .github/subagents", async () => {
-      const subagentsDir = join(testDir, ".github", "subagents");
+    it("should load copilot subagent files from .github/agents", async () => {
+      const subagentsDir = join(testDir, ".github", "agents");
       await ensureDir(subagentsDir);
 
       const subagentContent = `---


### PR DESCRIPTION
## Summary
- stop treating Copilot subagents as simulated additional conventions in the rules processor
- add coverage to ensure simulated subagent instructions are not injected for Copilot rules

## Testing
- pnpm cicheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d3a0ecf1c8330a4664bd3507fdc09)