### PR TITLE
Remove cursor skill additional convention

### DIFF
--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -18,7 +18,6 @@ import { logger } from "../../utils/logger.js";
 import { AgentsmdCommand } from "../commands/agentsmd-command.js";
 import { CommandsProcessor } from "../commands/commands-processor.js";
 import { AgentsmdSkill } from "../skills/agentsmd-skill.js";
-import { CursorSkill } from "../skills/cursor-skill.js";
 import { GeminiCliSkill } from "../skills/geminicli-skill.js";
 import { RulesyncSkill } from "../skills/rulesync-skill.js";
 import { SkillsProcessor } from "../skills/skills-processor.js";
@@ -265,7 +264,6 @@ const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
         ruleDiscoveryMode: "auto",
         additionalConventions: {
           subagents: { subagentClass: CursorSubagent },
-          skills: { skillClass: CursorSkill },
         },
         createsSeparateConventionsRule: true,
       },


### PR DESCRIPTION
## Summary
- remove the cursor skill additional convention entry from the rules processor
- drop the unused CursorSkill import

## Testing
- pnpm cicheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c291bbb4833090cfe12dbae870df)