### PR TITLE
fix: remove conditional trigger from openrouter code review workflow

### DIFF
--- a/.github/workflows/openrouter-code-review.yml
+++ b/.github/workflows/openrouter-code-review.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
     code-review:
-        if: ${{ contains(github.event.pull_request.title, ":review") }}
         runs-on: ubuntu-latest
         steps:
             - name: Display PR title


### PR DESCRIPTION
## Summary
- Remove the `if` condition from `openrouter-code-review.yml` that required `:review` in PR title
- The workflow now runs on all pull requests automatically

## Test plan
- [ ] Verify workflow triggers on any PR (not just those with `:review` in title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)