### PR TITLE
docs: remove Kilo Code specific sections from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,14 +323,6 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 ...
 ```
 
-### `.kilocode/rules/*.md` (Kilo Code)
-
-Kilo Code loads project rules from `.kilocode/rules/` and global rules from `~/.kilocode/rules/`. The tool also supports mode-specific directories like `.kilocode/rules-{mode}` and legacy single-file fallbacks such as `.kilocoderules-{mode}` (or `.kilocoderules`, `.clinerules`, and `.roorules`), but Rulesync generates the directory-based layout by default.
-
-### `.kilocode/skills/*/SKILL.md` (Kilo Code Skills)
-
-Kilo Code discovers Agent Skills from `.kilocode/skills/` in the project and `~/.kilocode/skills/` globally. You can also add mode-scoped skills using directories like `.kilocode/skills-code/`. Each skill folder must include a `SKILL.md` file whose `name` frontmatter matches the directory name and describes the skill.
-
 ### `rulesync/commands/*.md`
 
 Example:


### PR DESCRIPTION
## Summary
- Remove `.kilocode/rules/*.md` (Kilo Code) section from Each File Format documentation
- Remove `.kilocode/skills/*/SKILL.md` (Kilo Code Skills) section from Each File Format documentation
- These tool-specific details are already covered in the Supported Tools and Features table

## Test plan
- [ ] Verify README.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)