### PR TITLE
chore: enable tool search in devcontainer claude alias

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -116,7 +116,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN curl -fsSL https://opencode.ai/install | bash
 
 # Aliases
-ENV CLAUDE_COMMAND="alias claude=\"claude --dangerously-skip-permissions\""
+ENV CLAUDE_COMMAND="alias claude=\"ENABLE_TOOL_SEARCH=1 claude --dangerously-skip-permissions\""
 RUN echo ${CLAUDE_COMMAND} >> "/home/node/.zshrc"
 RUN echo ${CLAUDE_COMMAND} >> "/home/node/.bashrc"
 


### PR DESCRIPTION
## Summary
- Add `ENABLE_TOOL_SEARCH=1` environment variable to the claude command alias in devcontainer
- This enables tool search functionality when using claude command in the development container

## Test plan
- [ ] Build the devcontainer and verify the claude alias includes `ENABLE_TOOL_SEARCH=1`
- [ ] Confirm claude command works correctly with the new environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)