### PR TITLE
chore: migrate PR review from ChatGPT-CodeReview to OpenCode

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -15,6 +15,7 @@ jobs:
             issues: read
         steps:
             - name: Checkout repository
+              # actions/checkout@v6 is not compatible with anomalyco/opencode@v1.1.2
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
               with:
                   fetch-depth: 1
@@ -25,7 +26,10 @@ jobs:
                   experimental: true
 
             - name: Install dependencies
-              run: pnpm install
+              run: pnpm install --ignore-scripts
+
+            - name: Generate AI files
+              run: pnpm run dev generate
 
             - name: Run OpenCode Review
               uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2


### PR DESCRIPTION
## Summary

- Replace `anc95/ChatGPT-CodeReview` with `anomalyco/opencode/github@v1.1.2` for automated PR code review
- Add checkout, mise setup, and pnpm install steps for OpenCode to access project commands
- Use `/review-pr` command which invokes code-reviewer and security-reviewer subagents

## Test plan

- [ ] Create a test PR to verify the workflow triggers
- [ ] Confirm OpenCode posts review comments on the PR
- [ ] Verify code-reviewer and security-reviewer subagents are invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)