### PR TITLE
chore: migrate from context7 to deepwiki MCP server

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -17,13 +17,9 @@
       ],
       "env": {}
     },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ],
+    "deepwiki": {
+      "type": "sse",
+      "url": "https://mcp.deepwiki.com/sse",
       "env": {}
     },
     "rulesync": {

--- a/.rulesync/mcp.json
+++ b/.rulesync/mcp.json
@@ -1,39 +1,32 @@
 {
-  "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
-      "env": {}
-    },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ],
-      "env": {}
-    },
-    "rulesync": {
-      "type": "stdio",
-      "command": "pnpm",
-      "args": [
-        "dev",
-        "mcp"
-      ],
-      "env": {}
+    "mcpServers": {
+        "serena": {
+            "type": "stdio",
+            "command": "uvx",
+            "args": [
+                "--from",
+                "git+https://github.com/oraios/serena",
+                "serena",
+                "start-mcp-server",
+                "--context",
+                "ide-assistant",
+                "--enable-web-dashboard",
+                "false",
+                "--project",
+                "."
+            ],
+            "env": {}
+        },
+        "deepwiki": {
+            "type": "sse",
+            "url": "https://mcp.deepwiki.com/sse",
+            "env": {}
+        },
+        "rulesync": {
+            "type": "stdio",
+            "command": "pnpm",
+            "args": ["dev", "mcp"],
+            "env": {}
+        }
     }
-  }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -50,15 +50,10 @@
       "enabled": true,
       "environment": {}
     },
-    "context7": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "@upstash/context7-mcp"
-      ],
-      "enabled": true,
-      "environment": {}
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/sse",
+      "enabled": true
     },
     "rulesync": {
       "type": "local",


### PR DESCRIPTION
## Summary

Migrated from context7 to deepwiki MCP server across all AI tool configurations:
- Updated Gemini CLI configuration (`.gemini/settings.json`)
- Updated Rulesync internal configuration (`.rulesync/mcp.json`)
- Updated OpenCode configuration (`opencode.json`)

This change improves documentation search capabilities by leveraging deepwiki's enhanced features.

## Test plan

- [x] All CI checks passed (`pnpm cicheck`)
- [ ] Manual testing with each tool configuration
  - [ ] Test Gemini CLI with deepwiki MCP server
  - [ ] Test Rulesync with deepwiki MCP server
  - [ ] Test OpenCode with deepwiki MCP server
- [ ] Verify deepwiki MCP server connection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)