### PR TITLE
Adjust PR line-change guideline to 400-500 range

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Issues and Pull Requests are welcome!
 
+## Pull Request Guidelines
+
+- For external contributors, keep the number of changed lines in a PR under 400-500 whenever possible.
+
 ## Development Setup
 
 ```bash


### PR DESCRIPTION
### Motivation

- Relax the existing PR size guidance to allow a 400–500 line range for external contributors.
- Make contribution expectations clearer and less strict while still encouraging smaller, reviewable PRs.
- Keep documentation aligned with contributor expectations to reduce friction when submitting PRs.

### Description

- Update `CONTRIBUTING.md` to add a `## Pull Request Guidelines` section with the line: "For external contributors, keep the number of changed lines in a PR under 400-500 whenever possible.".
- This change is documentation-only and does not modify application code or behavior.

### Testing

- Ran `pnpm cicheck` to validate formatting, linting, type checking, and tests.
- Formatting (`oxfmt`) and linting (`oxlint`/`eslint`) checks completed successfully under `pnpm cicheck`.
- Type checking (`tsgo`/`typecheck`) completed successfully under `pnpm cicheck`.
- The `vitest` test suite completed successfully with all test files passing (107 test files, 3098 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e222833a48330888c9e99f9ef4225)