### PR TITLE
Add Trivy GitHub Actions workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,29 @@
+name: Trivy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Trivy Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"


### PR DESCRIPTION
### Motivation
- Add an automated vulnerability scan to CI using the Trivy GitHub Action to detect OS and library vulnerabilities in the repository filesystem.
- Pin the action to a specific release SHA to ensure reproducible behavior of the workflow.

### Description
- Add `.github/workflows/trivy.yml` which runs on `push` and `pull_request` against the `main` branch and grants `contents: read` permission.
- The workflow checks out the repository with `actions/checkout` and runs `aquasecurity/trivy-action` pinned to the release SHA `b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` (v0.33.1) in `fs` scan mode with severity filters and an exit code on findings.

### Testing
- Ran `pnpm cicheck` (which executes `pnpm cicheck:code` and `pnpm cicheck:content`) and the checks completed successfully after formatting was applied.
- The code-style and static checks invoked by `pnpm cicheck:code` (including `oxfmt`, `oxlint`, `eslint`, `tsgo`) completed successfully.
- Unit tests executed via `vitest` as part of `pnpm cicheck:code` completed with all tests passing.
- Content checks (`cspell` and `secretlint`) executed via `pnpm cicheck:content` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625b34fcdc83308cc0affc879b12dd)