### PR TITLE
feat(codexcli): add project mode support for skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | ------------------ | :---: | :----: | :------: | :------: | :-------: | :----: |
 | AGENTS.md          |  ✅   |        |          |    🎮    |    🎮     |   🎮   |
 | Claude Code        | ✅ 🌏 |   ✅   | ✅ 🌏 📦 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |
-| Codex CLI          | ✅ 🌏 |        |    🌏    |    🌏    |    🎮     |   🌏   |
+| Codex CLI          | ✅ 🌏 |        |    🌏    |    🌏    |    🎮     | ✅ 🌏  |
 | Gemini CLI         | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    🎮     |   🎮   |
 | GitHub Copilot     |  ✅   |        |    ✅    |    ✅    |    ✅     |   ✅   |
 | Cursor             |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    🎮     |   ✅   |
@@ -407,6 +407,8 @@ claudecode: # for claudecode-specific parameters
     - "Read"
     - "Write"
     - "Grep"
+codexcli: # for codexcli-specific parameters
+  short-description: A brief user-facing description
 ---
 
 This is the skill body content.

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -18,6 +18,11 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
     }),
   ),
+  codexcli: z.optional(
+    z.looseObject({
+      "short-description": z.optional(z.string()),
+    }),
+  ),
   opencode: z.optional(
     z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
@@ -41,6 +46,9 @@ export type RulesyncSkillFrontmatterInput = {
   targets?: ("*" | string)[];
   claudecode?: {
     "allowed-tools"?: string[];
+  };
+  codexcli?: {
+    "short-description"?: string;
   };
   opencode?: {
     "allowed-tools"?: string[];

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -631,6 +631,7 @@ Content that would fail parsing`;
         new Set([
           "claudecode",
           "claudecode-legacy",
+          "codexcli",
           "copilot",
           "cursor",
           "kilo",
@@ -647,6 +648,7 @@ Content that would fail parsing`;
           "agentsmd",
           "claudecode",
           "claudecode-legacy",
+          "codexcli",
           "copilot",
           "cursor",
           "geminicli",
@@ -663,6 +665,7 @@ Content that would fail parsing`;
         new Set([
           "claudecode",
           "claudecode-legacy",
+          "codexcli",
           "copilot",
           "cursor",
           "kilo",

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -100,7 +100,7 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
     "codexcli",
     {
       class: CodexCliSkill,
-      meta: { supportsProject: false, supportsSimulated: false, supportsGlobal: true },
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
     },
   ],
   [


### PR DESCRIPTION
## Summary

- Add project mode support for Codex CLI skills (`$CWD/.codex/skills/`)
- Add `metadata.short-description` frontmatter support for user-facing descriptions
- Map Rulesync `codexcli.short-description` to Codex CLI `metadata.short-description`

## Changes

| File | Description |
|------|-------------|
| `src/features/skills/codexcli-skill.ts` | Add metadata.short-description to schema, enable project mode |
| `src/features/skills/codexcli-skill.test.ts` | Add tests for project mode and metadata handling |
| `src/features/skills/rulesync-skill.ts` | Add codexcli section to frontmatter schema |
| `src/features/skills/skills-processor.ts` | Enable supportsProject for codexcli |
| `src/features/skills/skills-processor.test.ts` | Add project target test |
| `README.md` | Update features table (🌏 → ✅ 🌏) |

## Technical Details

- **Project mode path**: `$CWD/.codex/skills/{skill-name}/SKILL.md`
- **Global mode path**: `~/.codex/skills/{skill-name}/SKILL.md`
- **Codex CLI specific**: `metadata.short-description` for user-facing skill descriptions

Closes #804

## Test plan

- [x] All existing tests pass
- [x] New codexcli-skill tests pass (17 tests)
- [x] `pnpm cicheck:code` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)