### PR TITLE
fix: restrict AI code review workflow to maintainers and collaborators

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   code-review:
+    if: >-
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
- Add `author_association` check to AI code review workflow
- Only runs for PRs from `OWNER`, `MEMBER`, or `COLLABORATOR`
- Prevents external contributors from potentially abusing CI resources and API keys

## Test plan
- [ ] Verify workflow is skipped for PRs from external contributors
- [ ] Verify workflow runs for PRs from maintainers/collaborators

🤖 Generated with [Claude Code](https://claude.com/claude-code)