### PR TITLE
fix(ci): use correct actions/checkout@v5.0.1 hash for OpenCode compatibility

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout repository
         # actions/checkout@v6 is not compatible with anomalyco/opencode@v1.1.2
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

- Fix the `actions/checkout` hash in `ai-code-review.yml` to use the correct v5.0.1 hash
- The previous hash (`8e8c483db84b4bee98b60c0593521ed34d9990e8`) was v6.0.1 despite the comment saying v5
- This caused "Duplicate header: Authorization" errors when running the OpenCode GitHub action

## Root Cause

`actions/checkout@v6` changed how Git credentials are persisted, which conflicts with `anomalyco/opencode` action's internal Git operations.

Related issues:
- https://github.com/anomalyco/opencode/issues/5827
- https://github.com/actions/checkout/issues/2299

## Test plan

- [ ] Verify the AI Code Review workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)