### PR TITLE
docs: add missing skills support indicator for Kilo Code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Cursor             |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    🎮     |   ✅   |
 | OpenCode           |  ✅   |        |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |
 | Cline              |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           |        |
-| Kilo Code          | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           |        |
+| Kilo Code          | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |
 | Roo Code           |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |
 | Qwen Code          |  ✅   |   ✅   |          |          |           |        |
 | Kiro IDE           |  ✅   |   ✅   |          |          |           |        |


### PR DESCRIPTION
## Summary
- Fix missing skills support indicator for Kilo Code in the feature table

## Details
The README feature matrix showed empty skills column for Kilo Code,
but `KiloSkill` is fully implemented in `skills-processor.ts` with
both project and global mode support.

## Changes
- README.md: Add ✅ 🌏 to Kilo Code skills column