### PR TITLE
Trigger AI code review on PR comments with `[review]` from maintainers

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,18 +1,19 @@
 name: AI Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - "images/**"
-      - "LICENSE"
+  issue_comment:
+    types: [created]
 
 jobs:
   code-review:
     if: >-
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '[review]') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Motivation
- Replace the workflow trigger so AI code review runs when a privileged user explicitly requests it via a PR comment containing `[review]` rather than on every pull-request lifecycle event.

### Description
- Update `.github/workflows/ai-code-review.yml` to use `on: issue_comment` with `types: [created]` instead of `on: pull_request` and removed the previous `paths-ignore` block.
- Add an `if` condition that ensures the comment is on a pull request, that the comment body contains `[review]`, and that the commenter’s `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`.
- Preserve the existing job steps (checkout, setup, install, generate, run OpenCode Review) and permissions.

### Testing
- Ran `pnpm cicheck` which runs formatting, linting, type checks and `vitest` tests, and the command completed successfully with all automated checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aee2bc9a8833080e0d98403f4b640)