### PR TITLE
fix(gitignore): add Antigravity skills directory to gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ modular-mcp.json
 **/AGENTS.md
 **/.agents/
 **/.agent/rules/
+**/.agent/skills/
 **/.agent/workflows/
 **/.augmentignore
 **/.augment/rules/

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -191,6 +191,7 @@ dist/`;
 **/AGENTS.md
 **/.agents/
 **/.agent/rules/
+**/.agent/skills/
 **/.agent/workflows/
 **/.augmentignore
 **/.augment/rules/

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -12,6 +12,7 @@ const RULESYNC_IGNORE_ENTRIES = [
   "**/.agents/",
   // Antigravity
   "**/.agent/rules/",
+  "**/.agent/skills/",
   "**/.agent/workflows/",
   // Augment
   "**/.augmentignore",


### PR DESCRIPTION
## Summary
- Add `**/.agent/skills/` entry to gitignore generation for consistency with PR #816 (feat(antigravity): add skill support)
- Update test file to include the new entry in the expected gitignore content
- Run `pnpm dev gitignore` to update the project's `.gitignore`

## Related
- Follows up on #816 which added skill support for Google Antigravity
- Per review guidance in `tmp/pr-816-review-details.md`

## Test plan
- [x] All existing tests pass (`pnpm cicheck:code`)
- [x] gitignore.test.ts passes with updated expected content
- [x] Project `.gitignore` is updated with the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)