### PR TITLE
docs(contributing): add note about maintainer commits on PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Issues and Pull Requests are welcome!
 ## Pull Request Guidelines
 
 - For external contributors, keep the number of changed lines in a PR under 400-500 whenever possible.
+- Please note that the maintainer may add additional commits on top of your commits before merging at their discretion. In such cases, your original commits will still be preserved as your contribution.
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

- Add clarification in CONTRIBUTING.md that maintainers may add additional commits on top of contributor's commits before merging
- Note that original commits will still be preserved as contributions

## Test plan

- [x] Verify the note is clear and properly formatted in the Pull Request Guidelines section

🤖 Generated with [Claude Code](https://claude.com/claude-code)