### PR TITLE
chore(deps): consolidate dependabot groups into single group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,7 @@ updates:
       default-days: 1
     open-pull-requests-limit: 2
     groups:
-      dev-dependencies:
-        dependency-type: "development"
-        patterns:
-          - "*"
-      production-dependencies:
-        dependency-type: "production"
+      all-dependencies:
         patterns:
           - "*"
     commit-message:


### PR DESCRIPTION
## Summary

- Merge `dev-dependencies` and `production-dependencies` groups into a single `all-dependencies` group
- Simplifies dependabot configuration for npm dependencies

## Test plan

- [ ] Verify dependabot.yml syntax is valid
- [ ] Confirm dependabot behavior in next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)