### PR TITLE
docs: rename "Kiro IDE" to "Kiro" in supported tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Kilo Code          | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |
 | Roo Code           |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |
 | Qwen Code          |  ✅   |   ✅   |          |          |           |        |
-| Kiro IDE           |  ✅   |   ✅   |    ✅    |    ✅    |           |        |
+| Kiro               |  ✅   |   ✅   |    ✅    |    ✅    |           |        |
 | Google Antigravity |  ✅   |        |          |    ✅    |           | ✅ 🌏  |
 | JetBrains Junie    |  ✅   |   ✅   |    ✅    |          |           |        |
 | AugmentCode        |  ✅   |   ✅   |          |          |           |        |


### PR DESCRIPTION
## Summary

- Rename "Kiro IDE" to "Kiro" in the supported tools table to match the official branding

## Test plan

- [x] Verify the change is correct in the README.md table

🤖 Generated with [Claude Code](https://claude.com/claude-code)