### PR TITLE
feat: add Intel Mac (darwin-x64) single binary support

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -43,6 +43,7 @@ jobs:
           bun build --compile --minify --sourcemap --target=bun-linux-x64 --outfile=dist-bun/rulesync-linux-x64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-linux-arm64 --outfile=dist-bun/rulesync-linux-arm64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-darwin-arm64 --outfile=dist-bun/rulesync-darwin-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-x64 --outfile=dist-bun/rulesync-darwin-x64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-windows-x64 --outfile=dist-bun/rulesync-windows-x64.exe ./src/cli/index.ts
 
       - name: Cache binaries
@@ -58,7 +59,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
 
     steps:
       - name: Checkout code
@@ -80,10 +81,14 @@ jobs:
           if [ "$MATRIX_OS" = "ubuntu-latest" ]; then
             chmod +x dist-bun/rulesync-linux-x64
             BINARY_PATH=dist-bun/rulesync-linux-x64
-          else
+          elif [ "$MATRIX_OS" = "macos-latest" ]; then
             # macos-latest is Apple Silicon (arm64)
             chmod +x dist-bun/rulesync-darwin-arm64
             BINARY_PATH=dist-bun/rulesync-darwin-arm64
+          else
+            # macos-15-intel is Intel (x64)
+            chmod +x dist-bun/rulesync-darwin-x64
+            BINARY_PATH=dist-bun/rulesync-darwin-x64
           fi
           echo "BINARY_PATH=$BINARY_PATH" >> $GITHUB_ENV
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -32,6 +32,7 @@ jobs:
           bun build --compile --minify --sourcemap --target=bun-linux-x64 --outfile=dist-bun/rulesync-linux-x64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-linux-arm64 --outfile=dist-bun/rulesync-linux-arm64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-darwin-arm64 --outfile=dist-bun/rulesync-darwin-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-x64 --outfile=dist-bun/rulesync-darwin-x64 ./src/cli/index.ts
           bun build --compile --minify --sourcemap --target=bun-windows-x64 --outfile=dist-bun/rulesync-windows-x64.exe ./src/cli/index.ts
 
       - name: Generate checksums
@@ -47,5 +48,6 @@ jobs:
             dist-bun/rulesync-linux-x64
             dist-bun/rulesync-linux-arm64
             dist-bun/rulesync-darwin-arm64
+            dist-bun/rulesync-darwin-x64
             dist-bun/rulesync-windows-x64.exe
             dist-bun/SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ curl -L https://github.com/dyoshikawa/rulesync/releases/latest/download/rulesync
   sudo mv rulesync /usr/local/bin/
 ```
 
+#### macOS (Intel)
+
+```bash
+curl -L https://github.com/dyoshikawa/rulesync/releases/latest/download/rulesync-darwin-x64 -o rulesync && \
+  chmod +x rulesync && \
+  sudo mv rulesync /usr/local/bin/
+```
+
 #### Windows (x64)
 
 ```powershell


### PR DESCRIPTION
## Summary

- Add `darwin-x64` (Intel Mac) target to single binary builds
- Add E2E tests on `macos-15-intel` runner for Intel Mac binary validation
- Add macOS (Intel) installation instructions to README

## Test plan

- [ ] Verify GitHub Actions builds `rulesync-darwin-x64` binary successfully
- [ ] Verify E2E tests pass on `macos-15-intel` runner
- [ ] Verify README installation instructions are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)