### PR TITLE
docs: add Bun executable bundler reference to Single Binary section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rulesync --help
 
 ### Single Binary (Experimental)
 
-Download pre-built binaries from the [latest release](https://github.com/dyoshikawa/rulesync/releases/latest).
+Download pre-built binaries from the [latest release](https://github.com/dyoshikawa/rulesync/releases/latest). These binaries are built using [Bun's single-file executable bundler](https://bun.sh/docs/bundler/executables).
 
 <details>
 <summary>Commands to install a binary for your platform</summary>


### PR DESCRIPTION
## Summary

- Add information that single binaries are built using Bun's single-file executable bundler
- Include a markdown link to the official Bun documentation: https://bun.sh/docs/bundler/executables

## Test plan

- [ ] Verify the markdown link renders correctly in GitHub
- [ ] Confirm the link points to the correct Bun documentation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)