### PR TITLE
feat: kiro subagents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,6 +251,7 @@ bun.lock
 **/.kilocodeignore
 **/.kiro/steering/
 **/.kiro/prompts/
+**/.kiro/agents/
 **/.kiro/settings/mcp.json
 **/.aiignore
 **/.opencode/memories/

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Kilo Code          | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |
 | Roo Code           |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |
 | Qwen Code          |  ✅   |   ✅   |          |          |           |        |
-| Kiro               |  ✅   |   ✅   |    ✅    |    ✅    |           |        |
+| Kiro IDE           |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |        |
 | Google Antigravity |  ✅   |        |          |    ✅    |           | ✅ 🌏  |
 | JetBrains Junie    |  ✅   |   ✅   |    ✅    |          |           |        |
 | AugmentCode        |  ✅   |   ✅   |          |          |           |        |

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -236,6 +236,7 @@ dist/`;
 **/.kilocodeignore
 **/.kiro/steering/
 **/.kiro/prompts/
+**/.kiro/agents/
 **/.kiro/settings/mcp.json
 **/.aiignore
 **/.opencode/memories/

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -67,6 +67,7 @@ const RULESYNC_IGNORE_ENTRIES = [
   // Kiro
   "**/.kiro/steering/",
   "**/.kiro/prompts/",
+  "**/.kiro/agents/",
   "**/.kiro/settings/mcp.json",
   "**/.aiignore",
   // OpenCode

--- a/src/features/subagents/kiro-subagent.test.ts
+++ b/src/features/subagents/kiro-subagent.test.ts
@@ -1,0 +1,221 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { writeFileContent } from "../../utils/file.js";
+import { KiroSubagent } from "./kiro-subagent.js";
+import { RulesyncSubagent } from "./rulesync-subagent.js";
+
+describe("KiroSubagent", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should return settable paths for project scope", () => {
+    expect(KiroSubagent.getSettablePaths()).toEqual({
+      relativeDirPath: join(".kiro", "agents"),
+    });
+
+    expect(KiroSubagent.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: join(".kiro", "agents"),
+    });
+  });
+
+  it("should create a RulesyncSubagent with kiro target from JSON", () => {
+    const json = {
+      name: "review",
+      description: "Review agent",
+      prompt: "Review the provided changes",
+      model: "anthropic/claude-sonnet-4",
+      tools: ["read", "write"],
+    };
+    const subagent = new KiroSubagent({
+      baseDir: testDir,
+      relativeDirPath: ".kiro/agents",
+      relativeFilePath: "review.json",
+      body: JSON.stringify(json),
+      fileContent: "",
+      validate: true,
+    });
+
+    const rulesyncSubagent = subagent.toRulesyncSubagent();
+
+    expect(rulesyncSubagent).toBeInstanceOf(RulesyncSubagent);
+    expect(rulesyncSubagent.getFrontmatter()).toMatchObject({
+      targets: ["kiro"],
+      name: "review",
+      description: "Review agent",
+      kiro: {
+        model: "anthropic/claude-sonnet-4",
+        tools: ["read", "write"],
+      },
+    });
+    expect(rulesyncSubagent.getBody()).toBe("Review the provided changes");
+    expect(rulesyncSubagent.getRelativeFilePath()).toBe("review.md");
+  });
+
+  it("should create KiroSubagent from RulesyncSubagent with frontmatter", () => {
+    const rulesyncSubagent = new RulesyncSubagent({
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "reviewer.md",
+      frontmatter: {
+        targets: ["kiro"],
+        name: "reviewer",
+        description: "Code reviewer",
+        kiro: {
+          model: "anthropic/claude-sonnet-4",
+          tools: ["read", "write"],
+        },
+      },
+      body: "Review code changes",
+      validate: true,
+    });
+
+    const kiroSubagent = KiroSubagent.fromRulesyncSubagent({
+      baseDir: testDir,
+      rulesyncSubagent,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    }) as KiroSubagent;
+
+    expect(kiroSubagent).toBeInstanceOf(KiroSubagent);
+    expect(kiroSubagent.getRelativeDirPath()).toBe(join(".kiro", "agents"));
+    expect(kiroSubagent.getRelativeFilePath()).toBe("reviewer.json");
+    const parsed = JSON.parse(kiroSubagent.getBody());
+    expect(parsed).toMatchObject({
+      name: "reviewer",
+      description: "Code reviewer",
+      prompt: "Review code changes",
+      model: "anthropic/claude-sonnet-4",
+      tools: ["read", "write"],
+    });
+  });
+
+  it("should validate JSON successfully", () => {
+    const json = { name: "test", prompt: "Test prompt" };
+    const subagent = new KiroSubagent({
+      baseDir: testDir,
+      relativeDirPath: ".kiro/agents",
+      relativeFilePath: "test.json",
+      body: JSON.stringify(json),
+      fileContent: "",
+      validate: true,
+    });
+
+    expect(subagent.validate()).toEqual({ success: true, error: null });
+  });
+
+  it("should fail validation for invalid JSON", () => {
+    const subagent = new KiroSubagent({
+      baseDir: testDir,
+      relativeDirPath: ".kiro/agents",
+      relativeFilePath: "invalid.json",
+      body: "not json",
+      fileContent: "",
+      validate: false,
+    });
+
+    const result = subagent.validate();
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it("should load from JSON file", async () => {
+    const agentsDir = join(testDir, ".kiro", "agents");
+    const filePath = join(agentsDir, "planner.json");
+    const json = {
+      name: "planner",
+      description: "Planning agent",
+      prompt: "You are a planner agent",
+    };
+
+    await writeFileContent(filePath, JSON.stringify(json, null, 2));
+
+    const subagent = await KiroSubagent.fromFile({
+      baseDir: testDir,
+      relativeFilePath: "planner.json",
+    });
+
+    expect(subagent).toBeInstanceOf(KiroSubagent);
+    expect(JSON.parse(subagent.getBody())).toEqual(json);
+  });
+
+  it("should identify targeted rulesync subagents", () => {
+    const targeted = new RulesyncSubagent({
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "agent.md",
+      frontmatter: { targets: ["kiro"], name: "agent", description: "" },
+      body: "Content",
+      validate: true,
+    });
+
+    const notTargeted = new RulesyncSubagent({
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "other.md",
+      frontmatter: { targets: ["cursor"], name: "other", description: "" },
+      body: "Content",
+      validate: true,
+    });
+
+    expect(KiroSubagent.isTargetedByRulesyncSubagent(targeted)).toBe(true);
+    expect(KiroSubagent.isTargetedByRulesyncSubagent(notTargeted)).toBe(false);
+  });
+
+  it("should create deletable placeholder", () => {
+    const subagent = KiroSubagent.forDeletion({
+      baseDir: testDir,
+      relativeDirPath: ".kiro/agents",
+      relativeFilePath: "obsolete.json",
+    });
+
+    expect(subagent.isDeletable()).toBe(true);
+    expect(subagent.getBody()).toBe("");
+  });
+
+  it("should import JSON file and convert to RulesyncSubagent with frontmatter", async () => {
+    const agentsDir = join(testDir, ".kiro", "agents");
+    const filePath = join(agentsDir, "test-agent.json");
+    const json = {
+      name: "test-agent",
+      description: "Test agent for import",
+      prompt: "You are a test agent",
+      model: "anthropic/claude-sonnet-4",
+      tools: ["read", "write"],
+    };
+
+    await writeFileContent(filePath, JSON.stringify(json, null, 2));
+
+    const kiroSubagent = await KiroSubagent.fromFile({
+      baseDir: testDir,
+      relativeFilePath: "test-agent.json",
+    });
+
+    const rulesyncSubagent = kiroSubagent.toRulesyncSubagent();
+
+    expect(rulesyncSubagent.getFrontmatter()).toMatchObject({
+      targets: ["kiro"],
+      name: "test-agent",
+      description: "Test agent for import",
+      kiro: {
+        model: "anthropic/claude-sonnet-4",
+        tools: ["read", "write"],
+      },
+    });
+    expect(rulesyncSubagent.getBody()).toBe("You are a test agent");
+    expect(rulesyncSubagent.getRelativeFilePath()).toBe("test-agent.md");
+  });
+});

--- a/src/features/subagents/kiro-subagent.ts
+++ b/src/features/subagents/kiro-subagent.ts
@@ -1,0 +1,174 @@
+import { join } from "node:path";
+import { z } from "zod/mini";
+
+import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncSubagent, RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
+import {
+  ToolSubagent,
+  ToolSubagentForDeletionParams,
+  ToolSubagentFromFileParams,
+  ToolSubagentFromRulesyncSubagentParams,
+  ToolSubagentSettablePaths,
+} from "./tool-subagent.js";
+
+const KiroCliSubagentJsonSchema = z.looseObject({
+  name: z.string(),
+  description: z.optional(z.nullable(z.string())),
+  prompt: z.optional(z.nullable(z.string())),
+  tools: z.optional(z.nullable(z.array(z.string()))),
+  toolAliases: z.optional(z.nullable(z.record(z.string(), z.string()))),
+  toolSettings: z.optional(z.nullable(z.unknown())),
+  toolSchema: z.optional(z.nullable(z.unknown())),
+  hooks: z.optional(z.nullable(z.record(z.string(), z.array(z.unknown())))),
+  model: z.optional(z.nullable(z.string())),
+  mcpServers: z.optional(z.nullable(z.record(z.string(), z.unknown()))),
+  useLegacyMcpJson: z.optional(z.nullable(z.boolean())),
+  resources: z.optional(z.nullable(z.array(z.string()))),
+  allowedTools: z.optional(z.nullable(z.array(z.string()))),
+  includeMcpJson: z.optional(z.nullable(z.boolean())),
+});
+
+type KiroCliSubagentJson = z.infer<typeof KiroCliSubagentJsonSchema>;
+
+export type KiroSubagentParams = {
+  body: string;
+} & AiFileParams;
+
+export class KiroSubagent extends ToolSubagent {
+  private readonly body: string;
+
+  constructor({ body, ...rest }: KiroSubagentParams) {
+    super({
+      ...rest,
+    });
+
+    this.body = body;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolSubagentSettablePaths {
+    return {
+      relativeDirPath: join(".kiro", "agents"),
+    };
+  }
+
+  getBody(): string {
+    return this.body;
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    const parsed: KiroCliSubagentJson = JSON.parse(this.body);
+    const { name, description, prompt, ...restFields } = parsed;
+
+    // Build kiro section with all fields except name, description, and prompt
+    const kiroSection: Record<string, unknown> = {
+      ...restFields,
+    };
+
+    const rulesyncFrontmatter: RulesyncSubagentFrontmatter = {
+      targets: ["kiro"],
+      name,
+      description: description ?? "",
+      // Only include kiro section if there are fields
+      ...(Object.keys(kiroSection).length > 0 && { kiro: kiroSection }),
+    };
+
+    return new RulesyncSubagent({
+      baseDir: ".",
+      frontmatter: rulesyncFrontmatter,
+      body: prompt ?? "",
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: this.getRelativeFilePath().replace(/\.json$/, ".md"),
+      validate: true,
+    });
+  }
+
+  static fromRulesyncSubagent({
+    baseDir = process.cwd(),
+    rulesyncSubagent,
+    validate = true,
+    global = false,
+  }: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
+    const frontmatter = rulesyncSubagent.getFrontmatter();
+    const kiroSection = frontmatter.kiro ?? {};
+
+    // Build kiro JSON from rulesync frontmatter + kiro section
+    const json: KiroCliSubagentJson = {
+      name: frontmatter.name,
+      description: frontmatter.description || null,
+      prompt: rulesyncSubagent.getBody() || null,
+      ...kiroSection,
+    };
+
+    const body = JSON.stringify(json, null, 2);
+    const paths = this.getSettablePaths({ global });
+    const relativeFilePath = rulesyncSubagent.getRelativeFilePath().replace(/\.md$/, ".json");
+
+    return new KiroSubagent({
+      baseDir,
+      body,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath,
+      fileContent: body,
+      validate,
+      global,
+    });
+  }
+
+  validate(): ValidationResult {
+    try {
+      const parsed = JSON.parse(this.body);
+      KiroCliSubagentJsonSchema.parse(parsed);
+      return { success: true, error: null };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+  }
+
+  static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
+    return this.isTargetedByRulesyncSubagentDefault({
+      rulesyncSubagent,
+      toolTarget: "kiro",
+    });
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    relativeFilePath,
+    validate = true,
+    global = false,
+  }: ToolSubagentFromFileParams): Promise<KiroSubagent> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const fileContent = await readFileContent(filePath);
+
+    return new KiroSubagent({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath,
+      body: fileContent.trim(),
+      fileContent,
+      validate,
+      global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): KiroSubagent {
+    return new KiroSubagent({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      body: "",
+      fileContent: "",
+      validate: false,
+    });
+  }
+}

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -907,6 +907,7 @@ Second global content`;
           "copilot",
           "cursor",
           "geminicli",
+          "kiro",
           "opencode",
           "roo",
         ]),

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -15,6 +15,7 @@ import { CodexCliSubagent } from "./codexcli-subagent.js";
 import { CopilotSubagent } from "./copilot-subagent.js";
 import { CursorSubagent } from "./cursor-subagent.js";
 import { GeminiCliSubagent } from "./geminicli-subagent.js";
+import { KiroSubagent } from "./kiro-subagent.js";
 import { OpenCodeSubagent } from "./opencode-subagent.js";
 import { RooSubagent } from "./roo-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
@@ -44,6 +45,8 @@ type ToolSubagentFactory = {
     supportsSimulated: boolean;
     /** Whether the tool supports global (user-level) subagents */
     supportsGlobal: boolean;
+    /** File pattern for import (e.g., "*.md", "*.json") */
+    filePattern: string;
   };
 };
 
@@ -59,6 +62,7 @@ const subagentsProcessorToolTargetTuple = [
   "copilot",
   "cursor",
   "geminicli",
+  "kiro",
   "opencode",
   "roo",
 ] as const;
@@ -75,34 +79,74 @@ export const SubagentsProcessorToolTargetSchema = z.enum(subagentsProcessorToolT
 const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolSubagentFactory>([
   [
     "agentsmd",
-    { class: AgentsmdSubagent, meta: { supportsSimulated: true, supportsGlobal: false } },
+    {
+      class: AgentsmdSubagent,
+      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+    },
   ],
   [
     "claudecode",
-    { class: ClaudecodeSubagent, meta: { supportsSimulated: false, supportsGlobal: true } },
+    {
+      class: ClaudecodeSubagent,
+      meta: { supportsSimulated: false, supportsGlobal: true, filePattern: "*.md" },
+    },
   ],
   [
     "claudecode-legacy",
-    { class: ClaudecodeSubagent, meta: { supportsSimulated: false, supportsGlobal: true } },
+    {
+      class: ClaudecodeSubagent,
+      meta: { supportsSimulated: false, supportsGlobal: true, filePattern: "*.md" },
+    },
   ],
   [
     "codexcli",
-    { class: CodexCliSubagent, meta: { supportsSimulated: true, supportsGlobal: false } },
+    {
+      class: CodexCliSubagent,
+      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+    },
   ],
   [
     "copilot",
-    { class: CopilotSubagent, meta: { supportsSimulated: false, supportsGlobal: false } },
+    {
+      class: CopilotSubagent,
+      meta: { supportsSimulated: false, supportsGlobal: false, filePattern: "*.md" },
+    },
   ],
-  ["cursor", { class: CursorSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  [
+    "cursor",
+    {
+      class: CursorSubagent,
+      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+    },
+  ],
   [
     "geminicli",
-    { class: GeminiCliSubagent, meta: { supportsSimulated: true, supportsGlobal: false } },
+    {
+      class: GeminiCliSubagent,
+      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+    },
+  ],
+  [
+    "kiro",
+    {
+      class: KiroSubagent,
+      meta: { supportsSimulated: false, supportsGlobal: false, filePattern: "*.json" },
+    },
   ],
   [
     "opencode",
-    { class: OpenCodeSubagent, meta: { supportsSimulated: false, supportsGlobal: true } },
+    {
+      class: OpenCodeSubagent,
+      meta: { supportsSimulated: false, supportsGlobal: true, filePattern: "*.md" },
+    },
   ],
-  ["roo", { class: RooSubagent, meta: { supportsSimulated: true, supportsGlobal: false } }],
+  [
+    "roo",
+    {
+      class: RooSubagent,
+      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+    },
+  ],
 ]);
 
 /**
@@ -279,7 +323,7 @@ export class SubagentsProcessor extends FeatureProcessor {
     const paths = factory.class.getSettablePaths({ global: this.global });
 
     const subagentFilePaths = await findFilesByGlobs(
-      join(this.baseDir, paths.relativeDirPath, "*.md"),
+      join(this.baseDir, paths.relativeDirPath, factory.meta.filePattern),
     );
 
     if (forDeletion) {


### PR DESCRIPTION
### Summary

- Supporting `subagents` for Kiro CLI.

### Features Added

| Tool               | rules | ignore |   mcp    | commands | subagents | skills |
| ------------------ | :---: | :----: | :------: | :------: | :-------: | :----: |
| Kiro IDE   |  ✅   |   ✅   |    ✅    |     ✅      |     ✅ (new)      |        |


### Implementation Details

- subagents output to .kiro/agents/*.json
- added logic to handle json is added since current subagents expects md

### Testing

All tests passing. `pnpm cicheck` passes.