### PR TITLE
fix: a warn log when there is not a root rule file  #445

### DIFF
--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -612,7 +612,7 @@ export class RulesProcessor extends FeatureProcessor {
 
     if (rootRules.length === 0 && rulesyncRules.length > 0) {
       logger.warn(
-        `No root rulesync rule file found. Consider adding 'root: true' to one of your rule files in .rulesync/rules/.`
+        `No root rulesync rule file found. Consider adding 'root: true' to one of your rule files in .rulesync/rules/.`,
       );
     }
 


### PR DESCRIPTION
<img width="938" height="211" alt="Screenshot 2026-01-22 at 14 43 56" src="https://github.com/user-attachments/assets/e8cd44c7-e646-4e9e-b51e-8fa9c5c9bd9f" />

FIX #445 