### PR TITLE
chore(commands): auto-cleanup local branch after merge

### DIFF
--- a/.rulesync/commands/merge-pr.md
+++ b/.rulesync/commands/merge-pr.md
@@ -68,7 +68,7 @@ After merging:
 
 ## Step 5: Clean Up Local Branch
 
-Ask the user if they want to clean up the local branch. If yes, execute:
+If the local branch exists, please clean up the local branch. Execute:
 
 ```bash
 git checkout main && git pull && git branch -d <branch-name>


### PR DESCRIPTION
## Summary

- Change merge-pr command to automatically delete the local branch after a successful merge
- Previously the command asked the user for confirmation before cleanup
- This streamlines the PR merge workflow by removing the manual confirmation step

## Test plan

- [ ] Verify the merge-pr command automatically deletes the local branch after merge
- [ ] Confirm the cleanup only runs if the local branch exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)