### PR TITLE
Replace OCO environment variables with ZHIPU AI in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,9 +47,7 @@
     "OPENAI_API_KEY": "${localEnv:DEVCONTAINER_OPENAI_API_KEY}",
     "GEMINI_API_KEY": "${localEnv:DEVCONTAINER_GEMINI_API_KEY}",
     "OPENROUTER_API_KEY": "${localEnv:DEVCONTAINER_OPENROUTER_API_KEY}",
-    "OCO_API_KEY": "${localEnv:DEVCONTAINER_OPENROUTER_API_KEY}",
-    "OCO_API_URL": "${localEnv:DEVCONTAINER_OCO_API_URL}",
-    "OCO_MODEL": "${localEnv:DEVCONTAINER_OCO_MODEL}"
+    "ZHIPU_API_KEY": "${localEnv:DEVCONTAINER_ZAI_API_KEY}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",


### PR DESCRIPTION
## Summary

- Replaced OCO (OpenCoder) API environment variables with ZHIPU AI API in devcontainer configuration
- Removed: `OCO_API_KEY`, `OCO_API_URL`, `OCO_MODEL` environment variables
- Added: `ZHIPU_API_KEY` environment variable referencing `DEVCONTAINER_ZAI_API_KEY`

## Changes

Updated `.devcontainer/devcontainer.json` to use ZHIPU AI API instead of OCO API for AI-powered coding assistance in the development container.

## Testing

- Manually verified environment variable mappings
- Devcontainer should now use ZHIPU AI API instead of OCO API