### PR TITLE
feat: add silent option to init command config template

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -48,6 +48,7 @@ async function createConfigFile(): Promise<void> {
         baseDirs: ["."],
         delete: true,
         verbose: false,
+        silent: false,
         global: false,
         simulateCommands: false,
         simulateSubagents: false,


### PR DESCRIPTION
## Summary
- Added `silent: false` to the `rulesync.jsonc` template generated by the `init` command
- This aligns the init output with the existing `ConfigParams` type which already supports the `silent` option

## Test plan
- [x] `pnpm cicheck` passes
- [ ] Run `rulesync init` in a fresh directory and verify `rulesync.jsonc` includes `silent: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)