### PR TITLE
chore: simplify rulesync config targets and remove unused globs

### DIFF
--- a/.rulesync/rules/feature-change-guidelines.md
+++ b/.rulesync/rules/feature-change-guidelines.md
@@ -2,7 +2,6 @@
 root: false
 targets: ["*"]
 description: "When you add or change features, must follow these guidelines."
-globs: ["**/*"]
 ---
 
 # Guidelines for Adding or Modifying Features

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -2,15 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
 
   // List of tools to generate configurations for
-  "targets": [
-    "cursor",
-    "claudecode-legacy",
-    "geminicli",
-    "codexcli",
-    "copilot",
-    "opencode",
-    "antigravity",
-  ],
+  "targets": ["copilot", "claudecode"],
 
   "features": ["rules", "ignore", "mcp", "commands", "subagents", "skills"],
 
@@ -20,6 +12,7 @@
   // Delete existing files before generating
   "delete": true,
   "verbose": true,
+  "silent": false,
 
   "simulateCommands": true,
   "simulateSubagents": true,


### PR DESCRIPTION
## Summary
- `rulesync.jsonc`のtargetsリストを`copilot`と`claudecode`のみに簡略化
- `feature-change-guidelines.md`から不要な`globs`フロントマターを削除
- `silent: false`オプションを明示的に追加

## Test plan
- [ ] `pnpm cicheck`が通ることを確認
- [ ] `npx rulesync generate`が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)