### PR TITLE
chore: remove ENABLE_TOOL_SEARCH env from claude alias in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -134,7 +134,7 @@ RUN curl -fsSL https://opencode.ai/install | bash
 RUN echo 'PATH=/home/node/.opencode/bin:$PATH' >> "/home/node/.bashrc"
 
 # Aliases
-ENV CLAUDE_COMMAND="alias claude=\"ENABLE_TOOL_SEARCH=1 claude --dangerously-skip-permissions\""
+ENV CLAUDE_COMMAND="alias claude=\"claude --dangerously-skip-permissions\""
 RUN echo ${CLAUDE_COMMAND} >> "/home/node/.zshrc"
 RUN echo ${CLAUDE_COMMAND} >> "/home/node/.bashrc"
 


### PR DESCRIPTION
## Summary
- Remove the `ENABLE_TOOL_SEARCH=1` environment variable from the claude CLI alias in the devcontainer Dockerfile, as it is no longer needed.

## Test plan
- [ ] Verify devcontainer builds successfully
- [ ] Verify claude CLI alias works correctly without the env variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)