### PR TITLE
feat(skills): add Replit Agent skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | AugmentCode        |  ✅   |   ✅   |          |          |           |        |
 | Windsurf           |  ✅   |   ✅   |          |          |           |        |
 | Warp               |  ✅   |        |          |          |           |        |
-| Replit             |  ✅   |        |          |          |           |        |
+| Replit             |  ✅   |        |          |          |           |   ✅   |
 | Zed                |       |   ✅   |          |          |           |        |
 
 - ✅: Supports project mode

--- a/src/features/skills/replit-skill.test.ts
+++ b/src/features/skills/replit-skill.test.ts
@@ -1,0 +1,243 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { ReplitSkill } from "./replit-skill.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+
+describe("ReplitSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .agent/skills as relativeDirPath", () => {
+      const paths = ReplitSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(join(".agent", "skills"));
+    });
+
+    it("should throw error when global is true", () => {
+      expect(() => ReplitSkill.getSettablePaths({ global: true })).toThrow(
+        "ReplitSkill does not support global mode.",
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new ReplitSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agent", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "This is the body of the replit skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(ReplitSkill);
+      expect(skill.getBody()).toBe("This is the body of the replit skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from valid skill directory", async () => {
+      const skillDir = join(testDir, ".agent", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: Test Skill
+description: Test skill description
+---
+
+This is the body of the replit skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await ReplitSkill.fromDir({
+        baseDir: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill).toBeInstanceOf(ReplitSkill);
+      expect(skill.getBody()).toBe("This is the body of the replit skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".agent", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        ReplitSkill.fromDir({
+          baseDir: testDir,
+          dirName: "empty-skill",
+        }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const replitSkill = ReplitSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(replitSkill).toBeInstanceOf(ReplitSkill);
+      expect(replitSkill.getBody()).toBe("Test body content");
+      expect(replitSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should return true when targets includes '*'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "all-targets-skill",
+        frontmatter: {
+          name: "All Targets Skill",
+          description: "Skill for all targets",
+          targets: ["*"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(ReplitSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return true when targets includes 'replit'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "replit-skill",
+        frontmatter: {
+          name: "Replit Skill",
+          description: "Skill for replit",
+          targets: ["copilot", "replit"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(ReplitSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return false when targets does not include 'replit'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "claudecode-only-skill",
+        frontmatter: {
+          name: "ClaudeCode Only Skill",
+          description: "Skill for claudecode only",
+          targets: ["claudecode"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(ReplitSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should convert to RulesyncSkill", () => {
+      const skill = new ReplitSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agent", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill).toBeInstanceOf(RulesyncSkill);
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test description",
+        targets: ["*"],
+      });
+      expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create minimal instance for deletion", () => {
+      const skill = ReplitSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: join(".agent", "skills"),
+      });
+
+      expect(skill.getDirName()).toBe("cleanup");
+      expect(skill.getRelativeDirPath()).toBe(join(".agent", "skills"));
+      expect(skill.getGlobal()).toBe(false);
+    });
+
+    it("should use process.cwd() as default baseDir", () => {
+      const skill = ReplitSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: join(".agent", "skills"),
+      });
+
+      expect(skill).toBeInstanceOf(ReplitSkill);
+      expect(skill.getBaseDir()).toBe(testDir);
+    });
+
+    it("should create instance with empty frontmatter for deletion", () => {
+      const skill = ReplitSkill.forDeletion({
+        dirName: "to-delete",
+        relativeDirPath: join(".agent", "skills"),
+      });
+
+      expect(skill.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+      expect(skill.getBody()).toBe("");
+    });
+  });
+});

--- a/src/features/skills/replit-skill.ts
+++ b/src/features/skills/replit-skill.ts
@@ -1,0 +1,208 @@
+import { join } from "node:path";
+import { z } from "zod/mini";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { ValidationResult } from "../../types/ai-dir.js";
+import { formatError } from "../../utils/error.js";
+import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  ToolSkill,
+  ToolSkillForDeletionParams,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+export const ReplitSkillFrontmatterSchema = z.looseObject({
+  name: z.string(),
+  description: z.string(),
+});
+
+export type ReplitSkillFrontmatter = z.infer<typeof ReplitSkillFrontmatterSchema>;
+
+export type ReplitSkillParams = {
+  baseDir?: string;
+  relativeDirPath?: string;
+  dirName: string;
+  frontmatter: ReplitSkillFrontmatter;
+  body: string;
+  otherFiles?: SkillFile[];
+  validate?: boolean;
+  global?: boolean;
+};
+
+/**
+ * Represents a Replit Agent skill directory.
+ * Skills are stored under the .agent/skills directory with SKILL.md files.
+ * Follows the open Agent Skills standard with name and description frontmatter.
+ */
+export class ReplitSkill extends ToolSkill {
+  constructor({
+    baseDir = process.cwd(),
+    relativeDirPath = join(".agent", "skills"),
+    dirName,
+    frontmatter,
+    body,
+    otherFiles = [],
+    validate = true,
+    global = false,
+  }: ReplitSkillParams) {
+    super({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      mainFile: {
+        name: SKILL_FILE_NAME,
+        body,
+        frontmatter: { ...frontmatter },
+      },
+      otherFiles,
+      global,
+    });
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
+    if (options?.global) {
+      throw new Error("ReplitSkill does not support global mode.");
+    }
+    return {
+      relativeDirPath: join(".agent", "skills"),
+    };
+  }
+
+  getFrontmatter(): ReplitSkillFrontmatter {
+    if (!this.mainFile?.frontmatter) {
+      throw new Error("Frontmatter is not defined");
+    }
+    const result = ReplitSkillFrontmatterSchema.parse(this.mainFile.frontmatter);
+    return result;
+  }
+
+  getBody(): string {
+    return this.mainFile?.body ?? "";
+  }
+
+  validate(): ValidationResult {
+    if (!this.mainFile) {
+      return {
+        success: false,
+        error: new Error(`${this.getDirPath()}: ${SKILL_FILE_NAME} file does not exist`),
+      };
+    }
+
+    const result = ReplitSkillFrontmatterSchema.safeParse(this.mainFile.frontmatter);
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${this.getDirPath()}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+
+    return { success: true, error: null };
+  }
+
+  toRulesyncSkill(): RulesyncSkill {
+    const frontmatter = this.getFrontmatter();
+    const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      targets: ["*"],
+    };
+
+    return new RulesyncSkill({
+      baseDir: this.baseDir,
+      relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+      dirName: this.getDirName(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.getBody(),
+      otherFiles: this.getOtherFiles(),
+      validate: true,
+      global: this.global,
+    });
+  }
+
+  static fromRulesyncSkill({
+    rulesyncSkill,
+    validate = true,
+    global = false,
+  }: ToolSkillFromRulesyncSkillParams): ReplitSkill {
+    const settablePaths = ReplitSkill.getSettablePaths({ global });
+    const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+    const replitFrontmatter: ReplitSkillFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    return new ReplitSkill({
+      baseDir: rulesyncSkill.getBaseDir(),
+      relativeDirPath: settablePaths.relativeDirPath,
+      dirName: rulesyncSkill.getDirName(),
+      frontmatter: replitFrontmatter,
+      body: rulesyncSkill.getBody(),
+      otherFiles: rulesyncSkill.getOtherFiles(),
+      validate,
+      global,
+    });
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    const targets = rulesyncSkill.getFrontmatter().targets;
+    return targets.includes("*") || targets.includes("replit");
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<ReplitSkill> {
+    const loaded = await this.loadSkillDirContent({
+      ...params,
+      getSettablePaths: ReplitSkill.getSettablePaths,
+    });
+
+    const result = ReplitSkillFrontmatterSchema.safeParse(loaded.frontmatter);
+    if (!result.success) {
+      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      throw new Error(
+        `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
+      );
+    }
+
+    return new ReplitSkill({
+      baseDir: loaded.baseDir,
+      relativeDirPath: loaded.relativeDirPath,
+      dirName: loaded.dirName,
+      frontmatter: result.data,
+      body: loaded.body,
+      otherFiles: loaded.otherFiles,
+      validate: true,
+      global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): ReplitSkill {
+    const settablePaths = ReplitSkill.getSettablePaths({ global });
+    return new ReplitSkill({
+      baseDir,
+      relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -638,6 +638,7 @@ Content that would fail parsing`;
           "kilo",
           "kiro",
           "opencode",
+          "replit",
           "roo",
         ]),
       );
@@ -658,6 +659,7 @@ Content that would fail parsing`;
           "kilo",
           "kiro",
           "opencode",
+          "replit",
           "roo",
         ]),
       );
@@ -676,6 +678,7 @@ Content that would fail parsing`;
           "kilo",
           "kiro",
           "opencode",
+          "replit",
           "roo",
         ]),
       );

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -17,6 +17,7 @@ import { GeminiCliSkill } from "./geminicli-skill.js";
 import { KiloSkill } from "./kilo-skill.js";
 import { KiroSkill } from "./kiro-skill.js";
 import { OpenCodeSkill } from "./opencode-skill.js";
+import { ReplitSkill } from "./replit-skill.js";
 import { RooSkill } from "./roo-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill } from "./simulated-skill.js";
@@ -66,6 +67,7 @@ const skillsProcessorToolTargetTuple = [
   "kilo",
   "kiro",
   "opencode",
+  "replit",
   "roo",
 ] as const;
 
@@ -154,6 +156,13 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
     {
       class: OpenCodeSkill,
       meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
+    },
+  ],
+  [
+    "replit",
+    {
+      class: ReplitSkill,
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: false },
     },
   ],
   [


### PR DESCRIPTION
Add native skills support for Replit Agent following the open Agent Skills standard. Skills are stored at .agent/skills with SKILL.md files containing name and description frontmatter.

- Add ReplitSkill class extending ToolSkill with .agent/skills path
- Register ReplitSkill in SkillsProcessor factory map
- Add comprehensive unit tests for ReplitSkill
- Update README to reflect Replit skills support

---

オープンな Agent Skills 標準に準拠し、Replit Agent にネイティブなスキルサポートを追加します。スキルは .agent/skills に保存され、SKILL.md ファイルには名前および説明を含むフロントマターを記載します。

- .agent/skills パスを使用する ToolSkill を継承した ReplitSkill クラスを追加します
- SkillsProcessor のファクトリマップに ReplitSkill を登録します
- ReplitSkill に対する包括的なユニットテストを追加します
- Replit のスキル対応を反映するため、README を更新します