### PR TITLE
refactor(zed): use language server formatter instead of external command

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,9 +1,8 @@
 {
-  "format_on_save": "on",
-  "formatter": {
-    "external": {
-      "command": "pnpm",
-      "arguments": ["exec", "oxfmt", "--stdin-filepath", "{buffer_path}"]
+    "format_on_save": "on",
+    "formatter": {
+        "language_server": {
+            "name": "oxfmt"
+        }
     }
-  }
 }


### PR DESCRIPTION
## Summary

- Switch Zed editor formatter configuration from external pnpm command to native language server integration for oxfmt
- Simplifies the formatter configuration by using Zed's built-in language server support

## Test plan

- [x] Verify the Zed settings.json syntax is valid
- [ ] Open a file in Zed and verify format-on-save works correctly with the new configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)