### PR TITLE
feat: add AgentsSkills support for .agents/skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Tool               | rules | ignore |   mcp    | commands | subagents | skills | hooks |
 | ------------------ | :---: | :----: | :------: | :------: | :-------: | :----: | :---: |
 | AGENTS.md          |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |
+| AgentsSkills       |       |        |          |          |           |   ✅   |       |
 | Claude Code        | ✅ 🌏 |   ✅   | ✅ 🌏 📦 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Codex CLI          | ✅ 🌏 |        |    🌏    |    🌏    |    🎮     | ✅ 🌏  |       |
 | Gemini CLI         | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    🎮     |   🎮   |       |

--- a/config-schema.json
+++ b/config-schema.json
@@ -17,6 +17,7 @@
         "type": "string",
         "enum": [
           "agentsmd",
+          "agentsskills",
           "antigravity",
           "augmentcode",
           "augmentcode-legacy",
@@ -46,7 +47,16 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
+        "enum": [
+          "rules",
+          "ignore",
+          "mcp",
+          "subagents",
+          "commands",
+          "skills",
+          "hooks",
+          "*"
+        ]
       }
     },
     "verbose": {

--- a/src/features/skills/agentsskills-skill.test.ts
+++ b/src/features/skills/agentsskills-skill.test.ts
@@ -1,0 +1,243 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AgentsSkillsSkill } from "./agentsskills-skill.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+
+describe("AgentsSkillsSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .agents/skills as relativeDirPath", () => {
+      const paths = AgentsSkillsSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(join(".agents", "skills"));
+    });
+
+    it("should throw error when global is true", () => {
+      expect(() => AgentsSkillsSkill.getSettablePaths({ global: true })).toThrow(
+        "AgentsSkillsSkill does not support global mode.",
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new AgentsSkillsSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "This is the body of the agent skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(AgentsSkillsSkill);
+      expect(skill.getBody()).toBe("This is the body of the agent skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from valid skill directory", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: Test Skill
+description: Test skill description
+---
+
+This is the body of the agent skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await AgentsSkillsSkill.fromDir({
+        baseDir: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill).toBeInstanceOf(AgentsSkillsSkill);
+      expect(skill.getBody()).toBe("This is the body of the agent skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        AgentsSkillsSkill.fromDir({
+          baseDir: testDir,
+          dirName: "empty-skill",
+        }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const agentsSkillsSkill = AgentsSkillsSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(agentsSkillsSkill).toBeInstanceOf(AgentsSkillsSkill);
+      expect(agentsSkillsSkill.getBody()).toBe("Test body content");
+      expect(agentsSkillsSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should return true when targets includes '*'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "all-targets-skill",
+        frontmatter: {
+          name: "All Targets Skill",
+          description: "Skill for all targets",
+          targets: ["*"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsSkillsSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return true when targets includes 'agentsskills'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "agentsskills-skill",
+        frontmatter: {
+          name: "AgentsSkills Skill",
+          description: "Skill for agentsskills",
+          targets: ["copilot", "agentsskills"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsSkillsSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return false when targets does not include 'agentsskills'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "claudecode-only-skill",
+        frontmatter: {
+          name: "ClaudeCode Only Skill",
+          description: "Skill for claudecode only",
+          targets: ["claudecode"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AgentsSkillsSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should convert to RulesyncSkill", () => {
+      const skill = new AgentsSkillsSkill({
+        baseDir: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill).toBeInstanceOf(RulesyncSkill);
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test description",
+        targets: ["*"],
+      });
+      expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create minimal instance for deletion", () => {
+      const skill = AgentsSkillsSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: join(".agents", "skills"),
+      });
+
+      expect(skill.getDirName()).toBe("cleanup");
+      expect(skill.getRelativeDirPath()).toBe(join(".agents", "skills"));
+      expect(skill.getGlobal()).toBe(false);
+    });
+
+    it("should use process.cwd() as default baseDir", () => {
+      const skill = AgentsSkillsSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: join(".agents", "skills"),
+      });
+
+      expect(skill).toBeInstanceOf(AgentsSkillsSkill);
+      expect(skill.getBaseDir()).toBe(testDir);
+    });
+
+    it("should create instance with empty frontmatter for deletion", () => {
+      const skill = AgentsSkillsSkill.forDeletion({
+        dirName: "to-delete",
+        relativeDirPath: join(".agents", "skills"),
+      });
+
+      expect(skill.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+      expect(skill.getBody()).toBe("");
+    });
+  });
+});

--- a/src/features/skills/agentsskills-skill.ts
+++ b/src/features/skills/agentsskills-skill.ts
@@ -1,0 +1,208 @@
+import { join } from "node:path";
+import { z } from "zod/mini";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { ValidationResult } from "../../types/ai-dir.js";
+import { formatError } from "../../utils/error.js";
+import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  ToolSkill,
+  ToolSkillForDeletionParams,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+export const AgentsSkillsSkillFrontmatterSchema = z.looseObject({
+  name: z.string(),
+  description: z.string(),
+});
+
+export type AgentsSkillsSkillFrontmatter = z.infer<typeof AgentsSkillsSkillFrontmatterSchema>;
+
+export type AgentsSkillsSkillParams = {
+  baseDir?: string;
+  relativeDirPath?: string;
+  dirName: string;
+  frontmatter: AgentsSkillsSkillFrontmatter;
+  body: string;
+  otherFiles?: SkillFile[];
+  validate?: boolean;
+  global?: boolean;
+};
+
+/**
+ * Represents an Agent Skills directory following the open standard.
+ * Skills are stored under the .agents/skills directory with SKILL.md files.
+ * This is becoming a de facto standard for agent skills across multiple tools.
+ */
+export class AgentsSkillsSkill extends ToolSkill {
+  constructor({
+    baseDir = process.cwd(),
+    relativeDirPath = join(".agents", "skills"),
+    dirName,
+    frontmatter,
+    body,
+    otherFiles = [],
+    validate = true,
+    global = false,
+  }: AgentsSkillsSkillParams) {
+    super({
+      baseDir,
+      relativeDirPath,
+      dirName,
+      mainFile: {
+        name: SKILL_FILE_NAME,
+        body,
+        frontmatter: { ...frontmatter },
+      },
+      otherFiles,
+      global,
+    });
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
+    if (options?.global) {
+      throw new Error("AgentsSkillsSkill does not support global mode.");
+    }
+    return {
+      relativeDirPath: join(".agents", "skills"),
+    };
+  }
+
+  getFrontmatter(): AgentsSkillsSkillFrontmatter {
+    if (!this.mainFile?.frontmatter) {
+      throw new Error("Frontmatter is not defined");
+    }
+    const result = AgentsSkillsSkillFrontmatterSchema.parse(this.mainFile.frontmatter);
+    return result;
+  }
+
+  getBody(): string {
+    return this.mainFile?.body ?? "";
+  }
+
+  validate(): ValidationResult {
+    if (!this.mainFile) {
+      return {
+        success: false,
+        error: new Error(`${this.getDirPath()}: ${SKILL_FILE_NAME} file does not exist`),
+      };
+    }
+
+    const result = AgentsSkillsSkillFrontmatterSchema.safeParse(this.mainFile.frontmatter);
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${this.getDirPath()}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+
+    return { success: true, error: null };
+  }
+
+  toRulesyncSkill(): RulesyncSkill {
+    const frontmatter = this.getFrontmatter();
+    const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      targets: ["*"],
+    };
+
+    return new RulesyncSkill({
+      baseDir: this.baseDir,
+      relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+      dirName: this.getDirName(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.getBody(),
+      otherFiles: this.getOtherFiles(),
+      validate: true,
+      global: this.global,
+    });
+  }
+
+  static fromRulesyncSkill({
+    rulesyncSkill,
+    validate = true,
+    global = false,
+  }: ToolSkillFromRulesyncSkillParams): AgentsSkillsSkill {
+    const settablePaths = AgentsSkillsSkill.getSettablePaths({ global });
+    const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+    const agentsSkillsFrontmatter: AgentsSkillsSkillFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    return new AgentsSkillsSkill({
+      baseDir: rulesyncSkill.getBaseDir(),
+      relativeDirPath: settablePaths.relativeDirPath,
+      dirName: rulesyncSkill.getDirName(),
+      frontmatter: agentsSkillsFrontmatter,
+      body: rulesyncSkill.getBody(),
+      otherFiles: rulesyncSkill.getOtherFiles(),
+      validate,
+      global,
+    });
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    const targets = rulesyncSkill.getFrontmatter().targets;
+    return targets.includes("*") || targets.includes("agentsskills");
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<AgentsSkillsSkill> {
+    const loaded = await this.loadSkillDirContent({
+      ...params,
+      getSettablePaths: AgentsSkillsSkill.getSettablePaths,
+    });
+
+    const result = AgentsSkillsSkillFrontmatterSchema.safeParse(loaded.frontmatter);
+    if (!result.success) {
+      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      throw new Error(
+        `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
+      );
+    }
+
+    return new AgentsSkillsSkill({
+      baseDir: loaded.baseDir,
+      relativeDirPath: loaded.relativeDirPath,
+      dirName: loaded.dirName,
+      frontmatter: result.data,
+      body: loaded.body,
+      otherFiles: loaded.otherFiles,
+      validate: true,
+      global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): AgentsSkillsSkill {
+    const settablePaths = AgentsSkillsSkill.getSettablePaths({ global });
+    return new AgentsSkillsSkill({
+      baseDir,
+      relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -629,6 +629,7 @@ Content that would fail parsing`;
       const targets = SkillsProcessor.getToolTargets();
       expect(new Set(targets)).toEqual(
         new Set([
+          "agentsskills",
           "antigravity",
           "claudecode",
           "claudecode-legacy",
@@ -649,6 +650,7 @@ Content that would fail parsing`;
       expect(new Set(targets)).toEqual(
         new Set([
           "agentsmd",
+          "agentsskills",
           "antigravity",
           "claudecode",
           "claudecode-legacy",
@@ -670,6 +672,7 @@ Content that would fail parsing`;
       const targets = SkillsProcessor.getToolTargets({ includeSimulated: false });
       expect(new Set(targets)).toEqual(
         new Set([
+          "agentsskills",
           "antigravity",
           "claudecode",
           "claudecode-legacy",

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -8,6 +8,7 @@ import { formatError } from "../../utils/error.js";
 import { findFilesByGlobs } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
 import { AgentsmdSkill } from "./agentsmd-skill.js";
+import { AgentsSkillsSkill } from "./agentsskills-skill.js";
 import { AntigravitySkill } from "./antigravity-skill.js";
 import { ClaudecodeSkill } from "./claudecode-skill.js";
 import { CodexCliSkill } from "./codexcli-skill.js";
@@ -58,6 +59,7 @@ type ToolSkillFactory = {
  */
 const skillsProcessorToolTargetTuple = [
   "agentsmd",
+  "agentsskills",
   "antigravity",
   "claudecode",
   "claudecode-legacy",
@@ -88,6 +90,13 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
     {
       class: AgentsmdSkill,
       meta: { supportsProject: true, supportsSimulated: true, supportsGlobal: false },
+    },
+  ],
+  [
+    "agentsskills",
+    {
+      class: AgentsSkillsSkill,
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: false },
     },
   ],
   [

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -13,6 +13,7 @@ describe("tool targets", () => {
     it("should contain expected AI tool targets", () => {
       const expectedTargets = [
         "agentsmd",
+        "agentsskills",
         "antigravity",
         "augmentcode",
         "augmentcode-legacy",

--- a/src/types/tool-targets.ts
+++ b/src/types/tool-targets.ts
@@ -2,6 +2,7 @@ import { z } from "zod/mini";
 
 export const ALL_TOOL_TARGETS = [
   "agentsmd",
+  "agentsskills",
   "antigravity",
   "augmentcode",
   "augmentcode-legacy",


### PR DESCRIPTION
## Summary

- Add support for the **AgentsSkills** open standard, which uses `.agents/skills` directory with `SKILL.md` files
- This is becoming a de facto standard for agent skills across multiple AI coding tools
- The new `agentsskills` target generates skills in the same format as Replit (name and description frontmatter)

## Changes

- Add `"agentsskills"` to `ALL_TOOL_TARGETS`
- Create `AgentsSkillsSkill` class in `src/features/skills/agentsskills-skill.ts`
- Register `AgentsSkillsSkill` in `skills-processor.ts` with project-only support (no global mode)
- Add comprehensive unit tests

## Test plan

- [x] All existing tests pass (`pnpm cicheck:code`)
- [x] New `agentsskills-skill.test.ts` tests pass
- [x] Updated `skills-processor.test.ts` tests pass
- [x] Updated `tool-targets.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)