### PR TITLE
Fix formatting and add agentsskills to cspell dictionary

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -47,16 +47,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "rules",
-          "ignore",
-          "mcp",
-          "subagents",
-          "commands",
-          "skills",
-          "hooks",
-          "*"
-        ]
+        "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
       }
     },
     "verbose": {

--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "agentrequested",
     "agentsignore",
     "agentsmd",
+    "agentsskills",
     "aiexclude",
     "aiglobal",
     "aiignore",


### PR DESCRIPTION
## Summary

- Fix `config-schema.json` formatting detected by oxfmt
- Add "agentsskills" word to cspell.json dictionary for the new tool target added in #917

## Test plan

- [x] `pnpm cicheck` passes (3468 tests, no cspell errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)