### PR TITLE
refactor: extract init core logic to lib/init.ts

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,31 +1,36 @@
-import { join } from "node:path";
-
-import { ConfigParams } from "../../config/config.js";
 import { SKILL_FILE_NAME } from "../../constants/general.js";
 import {
   RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
-  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
   RULESYNC_HOOKS_RELATIVE_FILE_PATH,
   RULESYNC_MCP_RELATIVE_FILE_PATH,
-  RULESYNC_OVERVIEW_FILE_NAME,
   RULESYNC_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
-import { RulesyncCommand } from "../../features/commands/rulesync-command.js";
-import { RulesyncHooks } from "../../features/hooks/rulesync-hooks.js";
-import { RulesyncIgnore } from "../../features/ignore/rulesync-ignore.js";
-import { RulesyncMcp } from "../../features/mcp/rulesync-mcp.js";
-import { RulesyncRule } from "../../features/rules/rulesync-rule.js";
-import { RulesyncSkill } from "../../features/skills/rulesync-skill.js";
-import { RulesyncSubagent } from "../../features/subagents/rulesync-subagent.js";
-import { ensureDir, fileExists, writeFileContent } from "../../utils/file.js";
+import { init } from "../../lib/init.js";
+import { ensureDir } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
 
 export async function initCommand(): Promise<void> {
   logger.info("Initializing rulesync...");
 
   await ensureDir(RULESYNC_RELATIVE_DIR_PATH);
-  await createSampleFiles();
-  await createConfigFile();
+
+  const result = await init();
+
+  // Log sample file results
+  for (const file of result.sampleFiles) {
+    if (file.created) {
+      logger.success(`Created ${file.path}`);
+    } else {
+      logger.info(`Skipped ${file.path} (already exists)`);
+    }
+  }
+
+  // Log config file result
+  if (result.configFile.created) {
+    logger.success(`Created ${result.configFile.path}`);
+  } else {
+    logger.info(`Skipped ${result.configFile.path} (already exists)`);
+  }
 
   logger.success("rulesync initialized successfully!");
   logger.info("Next steps:");
@@ -33,278 +38,4 @@ export async function initCommand(): Promise<void> {
     `1. Edit ${RULESYNC_RELATIVE_DIR_PATH}/**/*.md, ${RULESYNC_RELATIVE_DIR_PATH}/skills/*/${SKILL_FILE_NAME}, ${RULESYNC_MCP_RELATIVE_FILE_PATH}, ${RULESYNC_HOOKS_RELATIVE_FILE_PATH} and ${RULESYNC_AIIGNORE_RELATIVE_FILE_PATH}`,
   );
   logger.info("2. Run 'rulesync generate' to create configuration files");
-}
-
-async function createConfigFile(): Promise<void> {
-  if (await fileExists(RULESYNC_CONFIG_RELATIVE_FILE_PATH)) {
-    logger.info(`Skipped ${RULESYNC_CONFIG_RELATIVE_FILE_PATH} (already exists)`);
-    return;
-  }
-
-  await writeFileContent(
-    RULESYNC_CONFIG_RELATIVE_FILE_PATH,
-    JSON.stringify(
-      {
-        targets: ["copilot", "cursor", "claudecode", "codexcli"],
-        features: ["rules", "ignore", "mcp", "commands", "subagents", "skills", "hooks"],
-        baseDirs: ["."],
-        delete: true,
-        verbose: false,
-        silent: false,
-        global: false,
-        simulateCommands: false,
-        simulateSubagents: false,
-        simulateSkills: false,
-        modularMcp: false,
-      } satisfies ConfigParams,
-      null,
-      2,
-    ),
-  );
-
-  logger.success(`Created ${RULESYNC_CONFIG_RELATIVE_FILE_PATH}`);
-}
-
-async function createSampleFiles(): Promise<void> {
-  // Create rule sample file
-  const sampleRuleFile = {
-    filename: RULESYNC_OVERVIEW_FILE_NAME,
-    content: `---
-root: true
-targets: ["*"]
-description: "Project overview and general development guidelines"
-globs: ["**/*"]
----
-
-# Project Overview
-
-## General Guidelines
-
-- Use TypeScript for all new code
-- Follow consistent naming conventions
-- Write self-documenting code with clear variable and function names
-- Prefer composition over inheritance
-- Use meaningful comments for complex business logic
-
-## Code Style
-
-- Use 2 spaces for indentation
-- Use semicolons
-- Use double quotes for strings
-- Use trailing commas in multi-line objects and arrays
-
-## Architecture Principles
-
-- Organize code by feature, not by file type
-- Keep related files close together
-- Use dependency injection for better testability
-- Implement proper error handling
-- Follow single responsibility principle
-`,
-  };
-
-  // Create MCP sample file
-  const sampleMcpFile = {
-    filename: "mcp.json",
-    content: `{
-  "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
-      "env": {}
-    },
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ],
-      "env": {}
-    }
-  }
-}
-`,
-  };
-
-  // Create command sample file
-  const sampleCommandFile = {
-    filename: "review-pr.md",
-    content: `---
-description: 'Review a pull request'
-targets: ["*"]
----
-
-target_pr = $ARGUMENTS
-
-If target_pr is not provided, use the PR of the current branch.
-
-Execute the following in parallel:
-
-1. Check code quality and style consistency
-2. Review test coverage
-3. Verify documentation updates
-4. Check for potential bugs or security issues
-
-Then provide a summary of findings and suggestions for improvement.
-`,
-  };
-
-  // Create subagent sample file
-  const sampleSubagentFile = {
-    filename: "planner.md",
-    content: `---
-name: planner
-targets: ["*"]
-description: >-
-  This is the general-purpose planner. The user asks the agent to plan to
-  suggest a specification, implement a new feature, refactor the codebase, or
-  fix a bug. This agent can be called by the user explicitly only.
-claudecode:
-  model: inherit
----
-
-You are the planner for any tasks.
-
-Based on the user's instruction, create a plan while analyzing the related files. Then, report the plan in detail. You can output files to @tmp/ if needed.
-
-Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
-`,
-  };
-
-  // Create skill sample file
-  const sampleSkillFile = {
-    dirName: "project-context",
-    content: `---
-name: project-context
-description: "Summarize the project context and key constraints"
-targets: ["*"]
----
-
-Summarize the project goals, core constraints, and relevant dependencies.
-Call out any architecture decisions, shared conventions, and validation steps.
-Keep the summary concise and ready to reuse in future tasks.`,
-  };
-
-  // Create ignore sample file
-  const sampleIgnoreFile = {
-    content: `credentials/
-`,
-  };
-
-  // Create hooks sample file
-  const sampleHooksFile = {
-    content: `{
-  "version": 1,
-  "hooks": {
-    "postToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "command": ".rulesync/hooks/format.sh"
-      }
-    ]
-  }
-}
-`,
-  };
-
-  // Get paths from settable paths
-  const rulePaths = RulesyncRule.getSettablePaths();
-  const mcpPaths = RulesyncMcp.getSettablePaths();
-  const commandPaths = RulesyncCommand.getSettablePaths();
-  const subagentPaths = RulesyncSubagent.getSettablePaths();
-  const skillPaths = RulesyncSkill.getSettablePaths();
-  const ignorePaths = RulesyncIgnore.getSettablePaths();
-  const hooksPaths = RulesyncHooks.getSettablePaths();
-
-  // Ensure directories
-  await ensureDir(rulePaths.recommended.relativeDirPath);
-  await ensureDir(mcpPaths.recommended.relativeDirPath);
-  await ensureDir(commandPaths.relativeDirPath);
-  await ensureDir(subagentPaths.relativeDirPath);
-  await ensureDir(skillPaths.relativeDirPath);
-  await ensureDir(ignorePaths.recommended.relativeDirPath);
-
-  // Create rule sample file
-  const ruleFilepath = join(rulePaths.recommended.relativeDirPath, sampleRuleFile.filename);
-  if (!(await fileExists(ruleFilepath))) {
-    await writeFileContent(ruleFilepath, sampleRuleFile.content);
-    logger.success(`Created ${ruleFilepath}`);
-  } else {
-    logger.info(`Skipped ${ruleFilepath} (already exists)`);
-  }
-
-  // Create MCP sample file
-  const mcpFilepath = join(
-    mcpPaths.recommended.relativeDirPath,
-    mcpPaths.recommended.relativeFilePath,
-  );
-  if (!(await fileExists(mcpFilepath))) {
-    await writeFileContent(mcpFilepath, sampleMcpFile.content);
-    logger.success(`Created ${mcpFilepath}`);
-  } else {
-    logger.info(`Skipped ${mcpFilepath} (already exists)`);
-  }
-
-  // Create command sample file
-  const commandFilepath = join(commandPaths.relativeDirPath, sampleCommandFile.filename);
-  if (!(await fileExists(commandFilepath))) {
-    await writeFileContent(commandFilepath, sampleCommandFile.content);
-    logger.success(`Created ${commandFilepath}`);
-  } else {
-    logger.info(`Skipped ${commandFilepath} (already exists)`);
-  }
-
-  // Create subagent sample file
-  const subagentFilepath = join(subagentPaths.relativeDirPath, sampleSubagentFile.filename);
-  if (!(await fileExists(subagentFilepath))) {
-    await writeFileContent(subagentFilepath, sampleSubagentFile.content);
-    logger.success(`Created ${subagentFilepath}`);
-  } else {
-    logger.info(`Skipped ${subagentFilepath} (already exists)`);
-  }
-
-  // Create skill sample file
-  const skillDirPath = join(skillPaths.relativeDirPath, sampleSkillFile.dirName);
-  await ensureDir(skillDirPath);
-  const skillFilepath = join(skillDirPath, SKILL_FILE_NAME);
-  if (!(await fileExists(skillFilepath))) {
-    await writeFileContent(skillFilepath, sampleSkillFile.content);
-    logger.success(`Created ${skillFilepath}`);
-  } else {
-    logger.info(`Skipped ${skillFilepath} (already exists)`);
-  }
-
-  // Create ignore sample file
-  const ignoreFilepath = join(
-    ignorePaths.recommended.relativeDirPath,
-    ignorePaths.recommended.relativeFilePath,
-  );
-  if (!(await fileExists(ignoreFilepath))) {
-    await writeFileContent(ignoreFilepath, sampleIgnoreFile.content);
-    logger.success(`Created ${ignoreFilepath}`);
-  } else {
-    logger.info(`Skipped ${ignoreFilepath} (already exists)`);
-  }
-
-  // Create hooks sample file
-  const hooksFilepath = join(hooksPaths.relativeDirPath, hooksPaths.relativeFilePath);
-  if (!(await fileExists(hooksFilepath))) {
-    await writeFileContent(hooksFilepath, sampleHooksFile.content);
-    logger.success(`Created ${hooksFilepath}`);
-  } else {
-    logger.info(`Skipped ${hooksFilepath} (already exists)`);
-  }
 }

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -1,0 +1,303 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SKILL_FILE_NAME } from "../constants/general.js";
+import {
+  RULESYNC_AIIGNORE_FILE_NAME,
+  RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_OVERVIEW_FILE_NAME,
+  RULESYNC_RELATIVE_DIR_PATH,
+  RULESYNC_RULES_RELATIVE_DIR_PATH,
+  RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+  RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+import { RulesyncCommand } from "../features/commands/rulesync-command.js";
+import { RulesyncHooks } from "../features/hooks/rulesync-hooks.js";
+import { RulesyncIgnore } from "../features/ignore/rulesync-ignore.js";
+import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
+import { RulesyncRule } from "../features/rules/rulesync-rule.js";
+import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
+import { RulesyncSubagent } from "../features/subagents/rulesync-subagent.js";
+import { ensureDir, fileExists, writeFileContent } from "../utils/file.js";
+import { init } from "./init.js";
+
+vi.mock("../utils/file.js");
+vi.mock("../features/commands/rulesync-command.js");
+vi.mock("../features/hooks/rulesync-hooks.js");
+vi.mock("../features/ignore/rulesync-ignore.js");
+vi.mock("../features/mcp/rulesync-mcp.js");
+vi.mock("../features/rules/rulesync-rule.js");
+vi.mock("../features/skills/rulesync-skill.js");
+vi.mock("../features/subagents/rulesync-subagent.js");
+
+describe("init", () => {
+  beforeEach(() => {
+    vi.mocked(ensureDir).mockResolvedValue(undefined);
+    vi.mocked(fileExists).mockResolvedValue(false);
+    vi.mocked(writeFileContent).mockResolvedValue(undefined);
+
+    vi.mocked(RulesyncRule.getSettablePaths).mockReturnValue({
+      recommended: { relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH },
+    } as never);
+    vi.mocked(RulesyncMcp.getSettablePaths).mockReturnValue({
+      recommended: {
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "mcp.json",
+      },
+      legacy: {
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+      },
+    } as never);
+    vi.mocked(RulesyncCommand.getSettablePaths).mockReturnValue({
+      relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+    } as never);
+    vi.mocked(RulesyncSubagent.getSettablePaths).mockReturnValue({
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    } as never);
+    vi.mocked(RulesyncSkill.getSettablePaths).mockReturnValue({
+      relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+    } as never);
+    vi.mocked(RulesyncIgnore.getSettablePaths).mockReturnValue({
+      recommended: {
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_AIIGNORE_FILE_NAME,
+      },
+      legacy: {
+        relativeDirPath: ".",
+        relativeFilePath: ".rulesyncignore",
+      },
+    } as never);
+    vi.mocked(RulesyncHooks.getSettablePaths).mockReturnValue({
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: "hooks.json",
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("return value", () => {
+    it("should return InitResult with configFile and sampleFiles", async () => {
+      const result = await init();
+
+      expect(result).toHaveProperty("configFile");
+      expect(result).toHaveProperty("sampleFiles");
+      expect(result.configFile).toHaveProperty("created");
+      expect(result.configFile).toHaveProperty("path");
+      expect(Array.isArray(result.sampleFiles)).toBe(true);
+    });
+
+    it("should return created: true for new files", async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+
+      const result = await init();
+
+      expect(result.configFile.created).toBe(true);
+      expect(result.sampleFiles.every((f) => f.created)).toBe(true);
+    });
+
+    it("should return created: false for existing files", async () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+
+      const result = await init();
+
+      expect(result.configFile.created).toBe(false);
+      expect(result.sampleFiles.every((f) => f.created === false)).toBe(true);
+    });
+
+    it("should return correct paths for all files", async () => {
+      const result = await init();
+
+      expect(result.configFile.path).toBe(RULESYNC_CONFIG_RELATIVE_FILE_PATH);
+
+      const expectedPaths = [
+        join(RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+        join(RULESYNC_RELATIVE_DIR_PATH, "mcp.json"),
+        join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md"),
+        join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
+        join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context", SKILL_FILE_NAME),
+        join(RULESYNC_RELATIVE_DIR_PATH, RULESYNC_AIIGNORE_FILE_NAME),
+        join(RULESYNC_RELATIVE_DIR_PATH, "hooks.json"),
+      ];
+
+      const actualPaths = result.sampleFiles.map((f) => f.path);
+      for (const path of expectedPaths) {
+        expect(actualPaths).toContain(path);
+      }
+    });
+  });
+
+  describe("directory creation", () => {
+    it("should ensure all required directories exist", async () => {
+      await init();
+
+      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RULES_RELATIVE_DIR_PATH);
+      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
+      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
+      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
+      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      expect(ensureDir).toHaveBeenCalledWith(
+        join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
+      );
+    });
+  });
+
+  describe("config file creation", () => {
+    it("should create config file with correct content", async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+
+      await init();
+
+      expect(writeFileContent).toHaveBeenCalledWith(
+        RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+        expect.stringContaining('"targets"'),
+      );
+      expect(writeFileContent).toHaveBeenCalledWith(
+        RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+        expect.stringContaining('"features"'),
+      );
+    });
+
+    it("should not create config file if it already exists", async () => {
+      vi.mocked(fileExists).mockImplementation(async (path) => {
+        return path === RULESYNC_CONFIG_RELATIVE_FILE_PATH;
+      });
+
+      const result = await init();
+
+      expect(result.configFile.created).toBe(false);
+      const configWriteCalls = vi
+        .mocked(writeFileContent)
+        .mock.calls.filter((call) => call[0] === RULESYNC_CONFIG_RELATIVE_FILE_PATH);
+      expect(configWriteCalls.length).toBe(0);
+    });
+  });
+
+  describe("sample file creation", () => {
+    it("should create rule sample file with correct frontmatter", async () => {
+      await init();
+
+      const ruleFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME);
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === ruleFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain("root: true");
+      expect(content).toContain('targets: ["*"]');
+      expect(content).toContain("# Project Overview");
+    });
+
+    it("should create MCP sample file", async () => {
+      await init();
+
+      const mcpFilePath = join(RULESYNC_RELATIVE_DIR_PATH, "mcp.json");
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === mcpFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain('"mcpServers"');
+    });
+
+    it("should create command sample file", async () => {
+      await init();
+
+      const commandFilePath = join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md");
+      const writeCall = vi
+        .mocked(writeFileContent)
+        .mock.calls.find((c) => c[0] === commandFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain("description: 'Review a pull request'");
+    });
+
+    it("should create subagent sample file", async () => {
+      await init();
+
+      const subagentFilePath = join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md");
+      const writeCall = vi
+        .mocked(writeFileContent)
+        .mock.calls.find((c) => c[0] === subagentFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain("name: planner");
+    });
+
+    it("should create skill sample file", async () => {
+      await init();
+
+      const skillFilePath = join(
+        RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        "project-context",
+        SKILL_FILE_NAME,
+      );
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === skillFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain("name: project-context");
+    });
+
+    it("should create ignore sample file", async () => {
+      await init();
+
+      const ignoreFilePath = join(RULESYNC_RELATIVE_DIR_PATH, RULESYNC_AIIGNORE_FILE_NAME);
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === ignoreFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain("credentials/");
+    });
+
+    it("should create hooks sample file", async () => {
+      await init();
+
+      const hooksFilePath = join(RULESYNC_RELATIVE_DIR_PATH, "hooks.json");
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === hooksFilePath);
+
+      expect(writeCall).toBeDefined();
+      const content = writeCall?.[1] ?? "";
+      expect(content).toContain('"hooks"');
+      expect(content).toContain('"postToolUse"');
+    });
+
+    it("should not create files that already exist", async () => {
+      const ruleFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME);
+      vi.mocked(fileExists).mockImplementation(async (path) => {
+        return path === ruleFilePath;
+      });
+
+      const result = await init();
+
+      const ruleResult = result.sampleFiles.find((f) => f.path === ruleFilePath);
+      expect(ruleResult?.created).toBe(false);
+
+      const writeCall = vi.mocked(writeFileContent).mock.calls.find((c) => c[0] === ruleFilePath);
+      expect(writeCall).toBeUndefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should propagate ensureDir errors", async () => {
+      vi.mocked(ensureDir).mockRejectedValueOnce(new Error("Permission denied"));
+
+      await expect(init()).rejects.toThrow("Permission denied");
+    });
+
+    it("should propagate fileExists errors", async () => {
+      vi.mocked(fileExists).mockRejectedValue(new Error("File system error"));
+
+      await expect(init()).rejects.toThrow("File system error");
+    });
+
+    it("should propagate writeFileContent errors", async () => {
+      vi.mocked(writeFileContent).mockRejectedValue(new Error("Write error"));
+
+      await expect(init()).rejects.toThrow("Write error");
+    });
+  });
+});

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,0 +1,287 @@
+import { join } from "node:path";
+
+import { ConfigParams } from "../config/config.js";
+import { SKILL_FILE_NAME } from "../constants/general.js";
+import {
+  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_OVERVIEW_FILE_NAME,
+} from "../constants/rulesync-paths.js";
+import { RulesyncCommand } from "../features/commands/rulesync-command.js";
+import { RulesyncHooks } from "../features/hooks/rulesync-hooks.js";
+import { RulesyncIgnore } from "../features/ignore/rulesync-ignore.js";
+import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
+import { RulesyncRule } from "../features/rules/rulesync-rule.js";
+import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
+import { RulesyncSubagent } from "../features/subagents/rulesync-subagent.js";
+import { ensureDir, fileExists, writeFileContent } from "../utils/file.js";
+
+export type InitFileResult = {
+  created: boolean;
+  path: string;
+};
+
+export type InitResult = {
+  configFile: InitFileResult;
+  sampleFiles: InitFileResult[];
+};
+
+/**
+ * Initialize rulesync configuration and sample files.
+ * This is the core logic without CLI-specific logging.
+ */
+export async function init(): Promise<InitResult> {
+  const sampleFiles = await createSampleFiles();
+  const configFile = await createConfigFile();
+
+  return {
+    configFile,
+    sampleFiles,
+  };
+}
+
+async function createConfigFile(): Promise<InitFileResult> {
+  const path = RULESYNC_CONFIG_RELATIVE_FILE_PATH;
+
+  if (await fileExists(path)) {
+    return { created: false, path };
+  }
+
+  await writeFileContent(
+    path,
+    JSON.stringify(
+      {
+        targets: ["copilot", "cursor", "claudecode", "codexcli"],
+        features: ["rules", "ignore", "mcp", "commands", "subagents", "skills", "hooks"],
+        baseDirs: ["."],
+        delete: true,
+        verbose: false,
+        silent: false,
+        global: false,
+        simulateCommands: false,
+        simulateSubagents: false,
+        simulateSkills: false,
+        modularMcp: false,
+      } satisfies ConfigParams,
+      null,
+      2,
+    ),
+  );
+
+  return { created: true, path };
+}
+
+async function createSampleFiles(): Promise<InitFileResult[]> {
+  const results: InitFileResult[] = [];
+
+  // Sample file contents
+  const sampleRuleFile = {
+    filename: RULESYNC_OVERVIEW_FILE_NAME,
+    content: `---
+root: true
+targets: ["*"]
+description: "Project overview and general development guidelines"
+globs: ["**/*"]
+---
+
+# Project Overview
+
+## General Guidelines
+
+- Use TypeScript for all new code
+- Follow consistent naming conventions
+- Write self-documenting code with clear variable and function names
+- Prefer composition over inheritance
+- Use meaningful comments for complex business logic
+
+## Code Style
+
+- Use 2 spaces for indentation
+- Use semicolons
+- Use double quotes for strings
+- Use trailing commas in multi-line objects and arrays
+
+## Architecture Principles
+
+- Organize code by feature, not by file type
+- Keep related files close together
+- Use dependency injection for better testability
+- Implement proper error handling
+- Follow single responsibility principle
+`,
+  };
+
+  const sampleMcpFile = {
+    filename: "mcp.json",
+    content: `{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide-assistant",
+        "--enable-web-dashboard",
+        "false",
+        "--project",
+        "."
+      ],
+      "env": {}
+    },
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {}
+    }
+  }
+}
+`,
+  };
+
+  const sampleCommandFile = {
+    filename: "review-pr.md",
+    content: `---
+description: 'Review a pull request'
+targets: ["*"]
+---
+
+target_pr = $ARGUMENTS
+
+If target_pr is not provided, use the PR of the current branch.
+
+Execute the following in parallel:
+
+1. Check code quality and style consistency
+2. Review test coverage
+3. Verify documentation updates
+4. Check for potential bugs or security issues
+
+Then provide a summary of findings and suggestions for improvement.
+`,
+  };
+
+  const sampleSubagentFile = {
+    filename: "planner.md",
+    content: `---
+name: planner
+targets: ["*"]
+description: >-
+  This is the general-purpose planner. The user asks the agent to plan to
+  suggest a specification, implement a new feature, refactor the codebase, or
+  fix a bug. This agent can be called by the user explicitly only.
+claudecode:
+  model: inherit
+---
+
+You are the planner for any tasks.
+
+Based on the user's instruction, create a plan while analyzing the related files. Then, report the plan in detail. You can output files to @tmp/ if needed.
+
+Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
+`,
+  };
+
+  const sampleSkillFile = {
+    dirName: "project-context",
+    content: `---
+name: project-context
+description: "Summarize the project context and key constraints"
+targets: ["*"]
+---
+
+Summarize the project goals, core constraints, and relevant dependencies.
+Call out any architecture decisions, shared conventions, and validation steps.
+Keep the summary concise and ready to reuse in future tasks.`,
+  };
+
+  const sampleIgnoreFile = {
+    content: `credentials/
+`,
+  };
+
+  const sampleHooksFile = {
+    content: `{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "command": ".rulesync/hooks/format.sh"
+      }
+    ]
+  }
+}
+`,
+  };
+
+  // Get paths from settable paths
+  const rulePaths = RulesyncRule.getSettablePaths();
+  const mcpPaths = RulesyncMcp.getSettablePaths();
+  const commandPaths = RulesyncCommand.getSettablePaths();
+  const subagentPaths = RulesyncSubagent.getSettablePaths();
+  const skillPaths = RulesyncSkill.getSettablePaths();
+  const ignorePaths = RulesyncIgnore.getSettablePaths();
+  const hooksPaths = RulesyncHooks.getSettablePaths();
+
+  // Ensure directories
+  await ensureDir(rulePaths.recommended.relativeDirPath);
+  await ensureDir(mcpPaths.recommended.relativeDirPath);
+  await ensureDir(commandPaths.relativeDirPath);
+  await ensureDir(subagentPaths.relativeDirPath);
+  await ensureDir(skillPaths.relativeDirPath);
+  await ensureDir(ignorePaths.recommended.relativeDirPath);
+
+  // Create rule sample file
+  const ruleFilepath = join(rulePaths.recommended.relativeDirPath, sampleRuleFile.filename);
+  results.push(await writeIfNotExists(ruleFilepath, sampleRuleFile.content));
+
+  // Create MCP sample file
+  const mcpFilepath = join(
+    mcpPaths.recommended.relativeDirPath,
+    mcpPaths.recommended.relativeFilePath,
+  );
+  results.push(await writeIfNotExists(mcpFilepath, sampleMcpFile.content));
+
+  // Create command sample file
+  const commandFilepath = join(commandPaths.relativeDirPath, sampleCommandFile.filename);
+  results.push(await writeIfNotExists(commandFilepath, sampleCommandFile.content));
+
+  // Create subagent sample file
+  const subagentFilepath = join(subagentPaths.relativeDirPath, sampleSubagentFile.filename);
+  results.push(await writeIfNotExists(subagentFilepath, sampleSubagentFile.content));
+
+  // Create skill sample file
+  const skillDirPath = join(skillPaths.relativeDirPath, sampleSkillFile.dirName);
+  await ensureDir(skillDirPath);
+  const skillFilepath = join(skillDirPath, SKILL_FILE_NAME);
+  results.push(await writeIfNotExists(skillFilepath, sampleSkillFile.content));
+
+  // Create ignore sample file
+  const ignoreFilepath = join(
+    ignorePaths.recommended.relativeDirPath,
+    ignorePaths.recommended.relativeFilePath,
+  );
+  results.push(await writeIfNotExists(ignoreFilepath, sampleIgnoreFile.content));
+
+  // Create hooks sample file
+  const hooksFilepath = join(hooksPaths.relativeDirPath, hooksPaths.relativeFilePath);
+  results.push(await writeIfNotExists(hooksFilepath, sampleHooksFile.content));
+
+  return results;
+}
+
+async function writeIfNotExists(path: string, content: string): Promise<InitFileResult> {
+  if (await fileExists(path)) {
+    return { created: false, path };
+  }
+
+  await writeFileContent(path, content);
+  return { created: true, path };
+}


### PR DESCRIPTION
## Summary

- Move core initialization logic from `cli/commands/init.ts` to `lib/init.ts`, following the existing pattern of `generate.ts` and `import.ts`
- Create `InitResult` and `InitFileResult` types to track created/skipped files
- Keep CLI-specific logging in `cli/commands/init.ts` while core logic returns structured results
- Add comprehensive unit tests for `lib/init.ts`

## Test plan

- [x] Run `pnpm cicheck:code` - all checks pass
- [x] Run `pnpm test -- src/lib/init.test.ts` - 18 tests pass
- [x] Run `pnpm test -- src/cli/commands/init.test.ts` - 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)