### PR TITLE
fix: change delete option to remove only orphan files

### DIFF
--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -71,7 +71,7 @@ describe("generateCommand", () => {
     // Setup default processor mock instance
     mockProcessorInstance = {
       loadToolFiles: vi.fn().mockResolvedValue([]),
-      removeAiFiles: vi.fn().mockResolvedValue(undefined),
+      removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
       loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
       convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
       writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -88,7 +88,7 @@ describe("generateCommand", () => {
     vi.mocked(RulesProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -97,7 +97,7 @@ describe("generateCommand", () => {
     vi.mocked(IgnoreProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -106,7 +106,7 @@ describe("generateCommand", () => {
     vi.mocked(McpProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -115,7 +115,7 @@ describe("generateCommand", () => {
     vi.mocked(SubagentsProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -124,7 +124,7 @@ describe("generateCommand", () => {
     vi.mocked(CommandsProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -236,7 +236,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance for this test
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue(oldFiles),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -250,7 +250,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(customMockInstance.loadToolFiles).toHaveBeenCalledWith({ forDeletion: true });
-      expect(customMockInstance.removeAiFiles).toHaveBeenCalledWith(oldFiles);
+      expect(customMockInstance.removeOrphanAiFiles).toHaveBeenCalled();
     });
 
     it("should process multiple base directories", async () => {
@@ -328,7 +328,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance for this test
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue(oldFiles),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -342,7 +342,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(customMockInstance.loadToolFiles).toHaveBeenCalledWith({ forDeletion: true });
-      expect(customMockInstance.removeAiFiles).toHaveBeenCalledWith(oldFiles);
+      expect(customMockInstance.removeOrphanAiFiles).toHaveBeenCalled();
     });
 
     it("should skip MCP when feature is not enabled", async () => {
@@ -562,7 +562,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance that returns 0
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(0),
@@ -586,21 +586,21 @@ describe("generateCommand", () => {
       // Create custom mock instances with specific return values
       const rulesMock = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(2),
       };
       const mcpMock = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(3),
       };
       const commandsMock = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -655,7 +655,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance that returns 3
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(3),
@@ -758,7 +758,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance to track calls
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "old" }]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(1),
@@ -772,7 +772,7 @@ describe("generateCommand", () => {
       await generateCommand(options);
 
       expect(customMockInstance.loadToolFiles).toHaveBeenCalledWith({ forDeletion: true });
-      expect(customMockInstance.removeAiFiles).toHaveBeenCalled();
+      expect(customMockInstance.removeOrphanAiFiles).toHaveBeenCalled();
     });
 
     it("should use each baseDir in global mode", async () => {
@@ -873,7 +873,7 @@ describe("generateCommand", () => {
       // Create a custom mock instance that returns 5
       const customMockInstance = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(5),
@@ -908,7 +908,7 @@ describe("generateCommand", () => {
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeAiFiles: vi.fn().mockResolvedValue(undefined),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
           writeAiFiles: vi.fn().mockResolvedValue(3),
@@ -917,7 +917,7 @@ describe("generateCommand", () => {
       vi.mocked(McpProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeAiFiles: vi.fn().mockResolvedValue(undefined),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
           writeAiFiles: vi.fn().mockResolvedValue(3),
@@ -926,7 +926,7 @@ describe("generateCommand", () => {
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeAiFiles: vi.fn().mockResolvedValue(undefined),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
           writeAiFiles: vi.fn().mockResolvedValue(3),
@@ -935,7 +935,7 @@ describe("generateCommand", () => {
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeAiFiles: vi.fn().mockResolvedValue(undefined),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
           writeAiFiles: vi.fn().mockResolvedValue(3),
@@ -964,7 +964,7 @@ describe("generateCommand", () => {
       // Set up rules processor to succeed
       const mockRulesProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
-        removeAiFiles: vi.fn().mockResolvedValue(undefined),
+        removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
         writeAiFiles: vi.fn().mockResolvedValue(2),

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -89,15 +89,15 @@ async function generateRulesCore(params: {
         skills: skills,
       });
 
-      if (config.getDelete()) {
-        const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-        await processor.removeAiFiles(oldToolFiles);
-      }
-
       const rulesyncFiles = await processor.loadRulesyncFiles();
       const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
       const writtenCount = await processor.writeAiFiles(toolFiles);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+        await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+      }
     }
   }
 
@@ -125,16 +125,20 @@ async function generateIgnoreCore(params: { config: Config }): Promise<number> {
           toolTarget,
         });
 
-        if (config.getDelete()) {
-          const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-          await processor.removeAiFiles(oldToolFiles);
-        }
-
         const rulesyncFiles = await processor.loadRulesyncFiles();
         if (rulesyncFiles.length > 0) {
           const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
           const writtenCount = await processor.writeAiFiles(toolFiles);
           totalCount += writtenCount;
+
+          if (config.getDelete()) {
+            const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+            await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+          }
+        } else if (config.getDelete()) {
+          // No rulesync files, so all existing tool files are orphans
+          const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+          await processor.removeOrphanAiFiles(existingToolFiles, []);
         }
       } catch (error) {
         logger.warn(
@@ -171,15 +175,15 @@ async function generateMcpCore(params: { config: Config }): Promise<number> {
         modularMcp: config.getModularMcp(),
       });
 
-      if (config.getDelete()) {
-        const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-        await processor.removeAiFiles(oldToolFiles);
-      }
-
       const rulesyncFiles = await processor.loadRulesyncFiles();
       const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
       const writtenCount = await processor.writeAiFiles(toolFiles);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+        await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+      }
     }
   }
 
@@ -211,15 +215,15 @@ async function generateCommandsCore(params: { config: Config }): Promise<number>
         global: config.getGlobal(),
       });
 
-      if (config.getDelete()) {
-        const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-        await processor.removeAiFiles(oldToolFiles);
-      }
-
       const rulesyncFiles = await processor.loadRulesyncFiles();
       const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
       const writtenCount = await processor.writeAiFiles(toolFiles);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+        await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+      }
     }
   }
 
@@ -251,15 +255,15 @@ async function generateSubagentsCore(params: { config: Config }): Promise<number
         global: config.getGlobal(),
       });
 
-      if (config.getDelete()) {
-        const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-        await processor.removeAiFiles(oldToolFiles);
-      }
-
       const rulesyncFiles = await processor.loadRulesyncFiles();
       const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
       const writtenCount = await processor.writeAiFiles(toolFiles);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+        await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+      }
     }
   }
 
@@ -294,11 +298,6 @@ async function generateSkillsCore(params: {
         global: config.getGlobal(),
       });
 
-      if (config.getDelete()) {
-        const oldToolDirs = await processor.loadToolDirsToDelete();
-        await processor.removeAiDirs(oldToolDirs);
-      }
-
       const rulesyncDirs = await processor.loadRulesyncDirs();
 
       for (const rulesyncDir of rulesyncDirs) {
@@ -310,6 +309,11 @@ async function generateSkillsCore(params: {
       const toolDirs = await processor.convertRulesyncDirsToToolDirs(rulesyncDirs);
       const writtenCount = await processor.writeAiDirs(toolDirs);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolDirs = await processor.loadToolDirsToDelete();
+        await processor.removeOrphanAiDirs(existingToolDirs, toolDirs);
+      }
     }
   }
 
@@ -338,19 +342,24 @@ async function generateHooksCore(params: { config: Config }): Promise<number> {
         global: config.getGlobal(),
       });
 
-      if (config.getDelete()) {
-        const oldToolFiles = await processor.loadToolFiles({ forDeletion: true });
-        await processor.removeAiFiles(oldToolFiles);
-      }
-
       const rulesyncFiles = await processor.loadRulesyncFiles();
       if (rulesyncFiles.length === 0) {
+        if (config.getDelete()) {
+          // No rulesync files, so all existing tool files are orphans
+          const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+          await processor.removeOrphanAiFiles(existingToolFiles, []);
+        }
         continue;
       }
 
       const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
       const writtenCount = await processor.writeAiFiles(toolFiles);
       totalCount += writtenCount;
+
+      if (config.getDelete()) {
+        const existingToolFiles = await processor.loadToolFiles({ forDeletion: true });
+        await processor.removeOrphanAiFiles(existingToolFiles, toolFiles);
+      }
     }
   }
 

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { removeDirectory } from "../utils/file.js";
+import { AiDir } from "./ai-dir.js";
+import { DirFeatureProcessor } from "./dir-feature-processor.js";
+
+vi.mock("../utils/file.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils/file.js")>("../utils/file.js");
+  return {
+    ...actual,
+    removeDirectory: vi.fn(),
+    ensureDir: vi.fn(),
+    writeFileContent: vi.fn(),
+  };
+});
+
+function createMockDir(dirPath: string): AiDir {
+  return {
+    getDirPath: () => dirPath,
+    getMainFile: () => undefined,
+    getOtherFiles: () => [],
+  } as unknown as AiDir;
+}
+
+class TestDirProcessor extends DirFeatureProcessor {
+  loadRulesyncDirs(): Promise<AiDir[]> {
+    return Promise.resolve([]);
+  }
+
+  loadToolDirs(): Promise<AiDir[]> {
+    return Promise.resolve([]);
+  }
+
+  loadToolDirsToDelete(): Promise<AiDir[]> {
+    return Promise.resolve([]);
+  }
+
+  convertRulesyncDirsToToolDirs(): Promise<AiDir[]> {
+    return Promise.resolve([]);
+  }
+
+  convertToolDirsToRulesyncDirs(): Promise<AiDir[]> {
+    return Promise.resolve([]);
+  }
+}
+
+describe("DirFeatureProcessor", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("removeOrphanAiDirs", () => {
+    it("should remove dirs that exist in existing but not in generated", async () => {
+      const processor = new TestDirProcessor({ baseDir: testDir });
+
+      const existingDirs = [
+        createMockDir("/path/to/orphan1"),
+        createMockDir("/path/to/orphan2"),
+        createMockDir("/path/to/kept"),
+      ];
+
+      const generatedDirs = [createMockDir("/path/to/kept")];
+
+      await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
+
+      expect(removeDirectory).toHaveBeenCalledTimes(2);
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/orphan1");
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/orphan2");
+    });
+
+    it("should not remove any dirs when all existing dirs are in generated", async () => {
+      const processor = new TestDirProcessor({ baseDir: testDir });
+
+      const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+
+      const generatedDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+
+      await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
+
+      expect(removeDirectory).not.toHaveBeenCalled();
+    });
+
+    it("should remove all dirs when generated is empty", async () => {
+      const processor = new TestDirProcessor({ baseDir: testDir });
+
+      const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+
+      const generatedDirs: AiDir[] = [];
+
+      await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
+
+      expect(removeDirectory).toHaveBeenCalledTimes(2);
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir1");
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir2");
+    });
+
+    it("should not remove any dirs when existing is empty", async () => {
+      const processor = new TestDirProcessor({ baseDir: testDir });
+
+      const existingDirs: AiDir[] = [];
+      const generatedDirs = [createMockDir("/path/to/dir1")];
+
+      await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
+
+      expect(removeDirectory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeAiDirs", () => {
+    it("should remove all dirs", async () => {
+      const processor = new TestDirProcessor({ baseDir: testDir });
+
+      const dirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+
+      await processor.removeAiDirs(dirs);
+
+      expect(removeDirectory).toHaveBeenCalledTimes(2);
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir1");
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir2");
+    });
+  });
+});

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -68,4 +68,17 @@ export abstract class DirFeatureProcessor {
       await removeDirectory(aiDir.getDirPath());
     }
   }
+
+  /**
+   * Remove orphan directories that exist in the tool directory but not in the generated directories.
+   * This only deletes directories that are no longer in the rulesync source, not directories that will be overwritten.
+   */
+  async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<void> {
+    const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
+    const orphanDirs = existingDirs.filter((d) => !generatedPaths.has(d.getDirPath()));
+
+    for (const aiDir of orphanDirs) {
+      await removeDirectory(aiDir.getDirPath());
+    }
+  }
 }

--- a/src/types/feature-processor.test.ts
+++ b/src/types/feature-processor.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { removeFile, writeFileContent } from "../utils/file.js";
+import { AiFile } from "./ai-file.js";
+import { FeatureProcessor } from "./feature-processor.js";
+import { RulesyncFile } from "./rulesync-file.js";
+import { ToolFile } from "./tool-file.js";
+
+vi.mock("../utils/file.js", async () => {
+  const actual = await vi.importActual<typeof import("../utils/file.js")>("../utils/file.js");
+  return {
+    ...actual,
+    removeFile: vi.fn(),
+    writeFileContent: vi.fn(),
+  };
+});
+
+function createMockFile(filePath: string): AiFile {
+  return {
+    getFilePath: () => filePath,
+    getFileContent: () => "content",
+  } as AiFile;
+}
+
+class TestProcessor extends FeatureProcessor {
+  loadRulesyncFiles(): Promise<RulesyncFile[]> {
+    return Promise.resolve([]);
+  }
+
+  loadToolFiles(): Promise<ToolFile[]> {
+    return Promise.resolve([]);
+  }
+
+  convertRulesyncFilesToToolFiles(): Promise<ToolFile[]> {
+    return Promise.resolve([]);
+  }
+
+  convertToolFilesToRulesyncFiles(): Promise<RulesyncFile[]> {
+    return Promise.resolve([]);
+  }
+}
+
+describe("FeatureProcessor", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("removeOrphanAiFiles", () => {
+    it("should remove files that exist in existing but not in generated", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const existingFiles = [
+        createMockFile("/path/to/orphan1.md"),
+        createMockFile("/path/to/orphan2.md"),
+        createMockFile("/path/to/kept.md"),
+      ];
+
+      const generatedFiles = [createMockFile("/path/to/kept.md")];
+
+      await processor.removeOrphanAiFiles(existingFiles, generatedFiles);
+
+      expect(removeFile).toHaveBeenCalledTimes(2);
+      expect(removeFile).toHaveBeenCalledWith("/path/to/orphan1.md");
+      expect(removeFile).toHaveBeenCalledWith("/path/to/orphan2.md");
+    });
+
+    it("should not remove any files when all existing files are in generated", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const existingFiles = [
+        createMockFile("/path/to/file1.md"),
+        createMockFile("/path/to/file2.md"),
+      ];
+
+      const generatedFiles = [
+        createMockFile("/path/to/file1.md"),
+        createMockFile("/path/to/file2.md"),
+      ];
+
+      await processor.removeOrphanAiFiles(existingFiles, generatedFiles);
+
+      expect(removeFile).not.toHaveBeenCalled();
+    });
+
+    it("should remove all files when generated is empty", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const existingFiles = [
+        createMockFile("/path/to/file1.md"),
+        createMockFile("/path/to/file2.md"),
+      ];
+
+      const generatedFiles: AiFile[] = [];
+
+      await processor.removeOrphanAiFiles(existingFiles, generatedFiles);
+
+      expect(removeFile).toHaveBeenCalledTimes(2);
+      expect(removeFile).toHaveBeenCalledWith("/path/to/file1.md");
+      expect(removeFile).toHaveBeenCalledWith("/path/to/file2.md");
+    });
+
+    it("should not remove any files when existing is empty", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const existingFiles: AiFile[] = [];
+      const generatedFiles = [createMockFile("/path/to/file1.md")];
+
+      await processor.removeOrphanAiFiles(existingFiles, generatedFiles);
+
+      expect(removeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("writeAiFiles", () => {
+    it("should write all files and return count", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
+
+      const count = await processor.writeAiFiles(files);
+
+      expect(count).toBe(2);
+      expect(writeFileContent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("removeAiFiles", () => {
+    it("should remove all files", async () => {
+      const processor = new TestProcessor({ baseDir: testDir });
+
+      const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
+
+      await processor.removeAiFiles(files);
+
+      expect(removeFile).toHaveBeenCalledTimes(2);
+      expect(removeFile).toHaveBeenCalledWith("/path/to/file1.md");
+      expect(removeFile).toHaveBeenCalledWith("/path/to/file2.md");
+    });
+  });
+});

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -46,4 +46,17 @@ export abstract class FeatureProcessor {
       await removeFile(aiFile.getFilePath());
     }
   }
+
+  /**
+   * Remove orphan files that exist in the tool directory but not in the generated files.
+   * This only deletes files that are no longer in the rulesync source, not files that will be overwritten.
+   */
+  async removeOrphanAiFiles(existingFiles: AiFile[], generatedFiles: AiFile[]): Promise<void> {
+    const generatedPaths = new Set(generatedFiles.map((f) => f.getFilePath()));
+    const orphanFiles = existingFiles.filter((f) => !generatedPaths.has(f.getFilePath()));
+
+    for (const aiFile of orphanFiles) {
+      await removeFile(aiFile.getFilePath());
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Changed the `delete` option behavior to remove only orphan files instead of all existing tool files before regeneration
- Added `removeOrphanAiFiles` method to `FeatureProcessor` for file-based features
- Added `removeOrphanAiDirs` method to `DirFeatureProcessor` for directory-based features (skills)
- Updated all 7 `generate*Core` functions to use the new orphan removal logic
- Added unit tests for the new methods

## Before
1. Load existing tool files
2. **Delete all existing files** ← Files that would be regenerated were unnecessarily deleted
3. Generate new files

## After
1. Generate new files (overwrite existing)
2. Compare generated files with existing files
3. **Delete only orphan files** (existing - generated)

## Test plan
- [x] `pnpm cicheck:code` passes
- [x] Unit tests for `removeOrphanAiFiles` and `removeOrphanAiDirs` added
- [x] Existing generate tests updated and passing

🤖 Generated with [Claude Code](https://claude.ai/code)