### PR TITLE
fix: add release-assets.githubusercontent.com to allowed download domains

### DIFF
--- a/src/lib/update.test.ts
+++ b/src/lib/update.test.ts
@@ -348,6 +348,12 @@ describe("update", () => {
       ).not.toThrow();
     });
 
+    it("should accept release-assets.githubusercontent.com URLs", () => {
+      expect(() =>
+        validateDownloadUrl("https://release-assets.githubusercontent.com/some/path/to/asset"),
+      ).not.toThrow();
+    });
+
     it("should reject HTTP URLs", () => {
       expect(() =>
         validateDownloadUrl("http://github.com/dyoshikawa/rulesync/releases/download/v1.0.0/file"),

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -29,6 +29,7 @@ const ALLOWED_DOWNLOAD_DOMAINS = [
   "github.com",
   "objects.githubusercontent.com",
   "github-releases.githubusercontent.com",
+  "release-assets.githubusercontent.com",
 ];
 
 /**


### PR DESCRIPTION
## Summary

- `rulesync update` が GitHub リリースアセットのダウンロード時に `release-assets.githubusercontent.com` ドメインへのリダイレクトで失敗する問題を修正
- `ALLOWED_DOWNLOAD_DOMAINS` に `release-assets.githubusercontent.com` を追加
- 対応するテストケースを追加

## Test plan

- [x] `validateDownloadUrl` の既存テストが全てパス
- [x] 新しいドメイン `release-assets.githubusercontent.com` の受け入れテストがパス
- [ ] `rulesync update` コマンドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)