### PR TITLE
fix: update banner spacing in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -248,7 +248,7 @@ print_uninstall_instructions() {
 main() {
     echo ""
     printf '%b\n' "${BLUE}╔════════════════════════════════════════╗${NC}"
-    printf '%b\n' "${BLUE}║      Rulesync Binary Installer        ║${NC}"
+    printf '%b\n' "${BLUE}║      Rulesync Binary Installer         ║${NC}"
     printf '%b\n' "${BLUE}╚════════════════════════════════════════╝${NC}"
     echo ""
 


### PR DESCRIPTION
## Summary
- Update spacing in the banner text of `install.sh` installer script

## Test plan
- [ ] Verify the install script banner displays correctly by running `bash install.sh --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)