### PR TITLE
chore: enable experimental agent teams in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
     "BASH_MAX_TIMEOUT_MS": "1200000",
-    "DISABLE_AUTOUPDATER": "0"
+    "DISABLE_AUTOUPDATER": "0",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "sandbox": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable to `.claude/settings.json` to enable the experimental agent teams feature in Claude Code.

## Test plan
- [x] Verify `.claude/settings.json` is valid JSON after the change
- [x] Confirm the environment variable is correctly added

🤖 Generated with [Claude Code](https://claude.com/claude-code)