### PR TITLE
fix: improve e2e test robustness with stderr diagnostics and safe cleanup default

### DIFF
--- a/src/e2e/e2e-helper.ts
+++ b/src/e2e/e2e-helper.ts
@@ -67,7 +67,8 @@ export async function runGenerate({
  */
 export function useTestDirectory(): { getTestDir: () => string } {
   let testDir = "";
-  let cleanup: () => Promise<void>;
+  // oxlint-disable-next-line unicorn/consistent-function-scoping -- default avoids undefined if beforeEach fails
+  let cleanup: () => Promise<void> = async () => {};
 
   beforeEach(async () => {
     ({ testDir, cleanup } = await setupTestDirectory());

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -53,10 +53,12 @@ describe("E2E: mcp", () => {
     });
 
     let hasError = false;
+    let stderrOutput = "";
 
     // Collect stderr output and check for actual errors
     mcpProcess.stderr?.on("data", (data) => {
       const output = data.toString();
+      stderrOutput += output;
       // Check if the output contains actual error messages (not just warnings)
       if (output.toLowerCase().includes("error") && !output.includes("warning")) {
         hasError = true;
@@ -75,6 +77,6 @@ describe("E2E: mcp", () => {
     });
 
     // Verify that there were no actual errors (warnings are acceptable)
-    expect(hasError).toBe(false);
+    expect(hasError, `MCP daemon produced errors: ${stderrOutput}`).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Surface stderr output in MCP daemon test assertion message for better failure diagnostics
- Initialize `cleanup` variable with safe default (`async () => {}`) to prevent runtime errors if `beforeEach` fails

## Details

### MCP daemon test stderr diagnostics (`e2e-mcp.spec.ts`)
When the MCP daemon test fails (`hasError` becomes `true`), the assertion previously gave no information about what the actual error was. Now `stderrOutput` is captured and included in the assertion message.

### Safe cleanup default (`e2e-helper.ts`)
The `cleanup` variable was declared without initialization. If `beforeEach` fails before assigning `cleanup`, the `afterEach` would throw a confusing runtime error. Now initialized with a no-op async function.

Closes #969

## Test plan

- [x] `pnpm cicheck` — all checks pass (format, lint, typecheck, 3685 unit tests, spell check, secret lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)