### PR TITLE
Hide outdated opencode-agent comments in PR review workflow

### DIFF
--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -27,6 +27,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Hide outdated opencode-agent comments
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[].url' | grep '/comments/')
+
+          LATEST_URL=$(echo "$COMMENTS" | tail -n 1)
+
+          gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[] | select(.user.login == "opencode-agent") | .url' | \
+          while read -r COMMENT_URL; do
+            if [ "$COMMENT_URL" != "$LATEST_URL" ]; then
+              gh api --method PATCH "$COMMENT_URL" \
+                -H "Accept: application/vnd.github+json" \
+                -f state='OUTDATED'
+            fi
+          done
+
       - name: Configure git
         run: |
           git config user.name dyoshikawa


### PR DESCRIPTION
## Summary
- Add step to hide outdated opencode-agent comments before PR review
- Pass GitHub context variables via env for security and consistency

## Test plan
The workflow will automatically mark outdated opencode-agent comments as OUTDATED when a new PR review is triggered.