### PR TITLE
Fix jq syntax error and hide all bot comments in pr-comment workflow

### DIFF
--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -34,21 +34,13 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
         run: |
-          COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-            -H "Accept: application/vnd.github+json" \
-            --jq '.[].url' | grep '/comments/')
-
-          LATEST_URL=$(echo "$COMMENTS" | tail -n 1)
-
           gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
             -H "Accept: application/vnd.github+json" \
-            --jq '.[] | select(.user.login == "opencode-agent" || .user.login == "github-actions") | .url' | \
+            --jq '.[] | select(.user.login == "opencode-agent" or .user.login == "github-actions") | .url' | \
           while read -r COMMENT_URL; do
-            if [ "$COMMENT_URL" != "$LATEST_URL" ]; then
-              gh api --method PATCH "$COMMENT_URL" \
-                -H "Accept: application/vnd.github+json" \
-                -f state='OUTDATED'
-            fi
+            gh api --method PATCH "$COMMENT_URL" \
+              -H "Accept: application/vnd.github+json" \
+              -f state='OUTDATED'
           done
 
       - name: Configure git


### PR DESCRIPTION
## Summary
- Fix invalid jq operator (`||` -> `or`) in the "Hide outdated opencode-agent comments" step that caused a syntax error
- Simplify logic to hide all opencode-agent/github-actions bot comments instead of keeping the latest one visible

## Test plan
- [ ] Trigger the pr-comment-to-ai workflow and verify all bot comments are correctly hidden
- [ ] Verify the jq filter correctly selects both `opencode-agent` and `github-actions` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)