### PR TITLE
feat: downgrade verbose logs to debug and show file paths in generate summary

### DIFF
--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -18,7 +18,7 @@ export async function fetchCommand(options: FetchCommandOptions): Promise<void> 
     silent: fetchOptions.silent ?? false,
   });
 
-  logger.info(`Fetching files from ${source}...`);
+  logger.debug(`Fetching files from ${source}...`);
 
   try {
     const summary = await fetchFiles({

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -63,6 +63,7 @@ describe("generateCommand", () => {
     // Setup logger mocks
     vi.mocked(logger.configure).mockImplementation(() => {});
     vi.mocked(logger.info).mockImplementation(() => {});
+    vi.mocked(logger.debug).mockImplementation(() => {});
     vi.mocked(logger.error).mockImplementation(() => {});
     vi.mocked(logger.success).mockImplementation(() => {});
     vi.mocked(logger.warn).mockImplementation(() => {});
@@ -76,7 +77,7 @@ describe("generateCommand", () => {
       removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
       loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
       convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-      writeAiFiles: vi.fn().mockResolvedValue(1),
+      writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
     };
 
     // Setup processor static method mocks
@@ -93,7 +94,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       } as any;
     });
     vi.mocked(IgnoreProcessor).mockImplementation(function () {
@@ -102,7 +103,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       } as any;
     });
     vi.mocked(McpProcessor).mockImplementation(function () {
@@ -111,7 +112,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       } as any;
     });
     vi.mocked(SubagentsProcessor).mockImplementation(function () {
@@ -120,7 +121,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       } as any;
     });
     vi.mocked(CommandsProcessor).mockImplementation(function () {
@@ -129,7 +130,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       } as any;
     });
   });
@@ -162,7 +163,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating files...");
     });
   });
 
@@ -201,7 +202,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating rule files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating rule files...");
       expect(RulesProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         global: false,
@@ -243,7 +244,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return customMockInstance as any;
@@ -305,7 +306,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating MCP files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating MCP files...");
       expect(McpProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -337,7 +338,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(McpProcessor).mockImplementation(function () {
         return customMockInstance as any;
@@ -371,7 +372,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating command files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating command files...");
       expect(CommandsProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -413,7 +414,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating ignore files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating ignore files...");
       expect(IgnoreProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -471,7 +472,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating subagent files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating subagent files...");
       expect(SubagentsProcessor).toHaveBeenCalledWith({
         baseDir: ".",
         toolTarget: "claudecode",
@@ -577,7 +578,7 @@ describe("generateCommand", () => {
           removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
 
@@ -597,21 +598,21 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(2),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 2, paths: [] }),
       };
       const mcpMock = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(3),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
       };
       const commandsMock = {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
 
       vi.mocked(RulesProcessor).mockImplementation(function () {
@@ -637,7 +638,7 @@ describe("generateCommand", () => {
       mockConfig.getFeatures.mockReturnValue(["rules", "ignore", "mcp", "commands", "subagents"]);
       mockProcessorInstance.loadRulesyncFiles.mockResolvedValue([{ file: "test" }]); // For ignore to process
 
-      mockProcessorInstance.writeAiFiles.mockResolvedValue(1);
+      mockProcessorInstance.writeAiFiles.mockResolvedValue({ count: 1, paths: [] });
 
       const options: GenerateOptions = {};
 
@@ -654,7 +655,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Base directories: dir1, dir2");
+      expect(logger.debug).toHaveBeenCalledWith("Base directories: dir1, dir2");
     });
 
     it("should log success for each processor type", async () => {
@@ -666,7 +667,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(3),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return customMockInstance as any;
@@ -770,7 +771,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return customMockInstance as any;
@@ -833,7 +834,7 @@ describe("generateCommand", () => {
 
       await generateCommand(options);
 
-      expect(logger.info).toHaveBeenCalledWith("Generating MCP files...");
+      expect(logger.debug).toHaveBeenCalledWith("Generating MCP files...");
       // McpProcessor should not be called because intersection of targets is empty
       expect(McpProcessor).not.toHaveBeenCalled();
     });
@@ -890,7 +891,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(5),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 5, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return customMockInstance as any;
@@ -923,7 +924,7 @@ describe("generateCommand", () => {
           removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(3),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
         } as any;
       });
       vi.mocked(McpProcessor).mockImplementation(function () {
@@ -932,7 +933,7 @@ describe("generateCommand", () => {
           removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(3),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
         } as any;
       });
       vi.mocked(CommandsProcessor).mockImplementation(function () {
@@ -941,7 +942,7 @@ describe("generateCommand", () => {
           removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(3),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
         } as any;
       });
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
@@ -950,7 +951,7 @@ describe("generateCommand", () => {
           removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
           loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
           convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(3),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
         } as any;
       });
 
@@ -979,7 +980,7 @@ describe("generateCommand", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([{ tool: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(2),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 2, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockRulesProcessor as any;
@@ -1004,7 +1005,7 @@ describe("generateCommand", () => {
       mockConfig.getTargets.mockReturnValue(["claudecode", "cursor"]);
       vi.mocked(intersection).mockReturnValue(["claudecode", "cursor"]);
 
-      mockProcessorInstance.writeAiFiles.mockResolvedValue(1);
+      mockProcessorInstance.writeAiFiles.mockResolvedValue({ count: 1, paths: [] });
       const options: GenerateOptions = {};
 
       await generateCommand(options);

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -10,16 +10,20 @@ export type GenerateOptions = ConfigResolverResolveParams;
  */
 function logFeatureResult(params: {
   count: number;
+  paths: string[];
   featureName: string;
   isPreview: boolean;
   modePrefix: string;
 }): void {
-  const { count, featureName, isPreview, modePrefix } = params;
+  const { count, paths, featureName, isPreview, modePrefix } = params;
   if (count > 0) {
     if (isPreview) {
       logger.info(`${modePrefix} Would write ${count} ${featureName}`);
     } else {
       logger.success(`Written ${count} ${featureName}`);
+    }
+    for (const p of paths) {
+      logger.info(`    ${p}`);
     }
   }
 }
@@ -37,79 +41,86 @@ export async function generateCommand(options: GenerateOptions): Promise<void> {
   const isPreview = config.isPreviewMode();
   const modePrefix = isPreview ? "[DRY RUN]" : "";
 
-  logger.info("Generating files...");
+  logger.debug("Generating files...");
 
   if (!(await checkRulesyncDirExists({ baseDir: process.cwd() }))) {
     logger.error("❌ .rulesync directory not found. Run 'rulesync init' first.");
     process.exit(1);
   }
 
-  logger.info(`Base directories: ${config.getBaseDirs().join(", ")}`);
+  logger.debug(`Base directories: ${config.getBaseDirs().join(", ")}`);
 
   const features = config.getFeatures();
 
   if (features.includes("ignore")) {
-    logger.info("Generating ignore files...");
+    logger.debug("Generating ignore files...");
   }
   if (features.includes("mcp")) {
-    logger.info("Generating MCP files...");
+    logger.debug("Generating MCP files...");
   }
   if (features.includes("commands")) {
-    logger.info("Generating command files...");
+    logger.debug("Generating command files...");
   }
   if (features.includes("subagents")) {
-    logger.info("Generating subagent files...");
+    logger.debug("Generating subagent files...");
   }
   if (features.includes("skills")) {
-    logger.info("Generating skill files...");
+    logger.debug("Generating skill files...");
   }
   if (features.includes("hooks")) {
-    logger.info("Generating hooks...");
+    logger.debug("Generating hooks...");
   }
   if (features.includes("rules")) {
-    logger.info("Generating rule files...");
+    logger.debug("Generating rule files...");
   }
 
   const result = await generate({ config });
 
   logFeatureResult({
     count: result.ignoreCount,
+    paths: result.ignorePaths,
     featureName: "ignore file(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.mcpCount,
+    paths: result.mcpPaths,
     featureName: "MCP configuration(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.commandsCount,
+    paths: result.commandsPaths,
     featureName: "command(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.subagentsCount,
+    paths: result.subagentsPaths,
     featureName: "subagent(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.skillsCount,
+    paths: result.skillsPaths,
     featureName: "skill(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.hooksCount,
+    paths: result.hooksPaths,
     featureName: "hooks file(s)",
     isPreview,
     modePrefix,
   });
   logFeatureResult({
     count: result.rulesCount,
+    paths: result.rulesPaths,
     featureName: "rule(s)",
     isPreview,
     modePrefix,

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -57,35 +57,35 @@ describe("importCommand", () => {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       } as any;
     });
     vi.mocked(IgnoreProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       } as any;
     });
     vi.mocked(McpProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       } as any;
     });
     vi.mocked(SubagentsProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       } as any;
     });
     vi.mocked(CommandsProcessor).mockImplementation(function () {
       return {
         loadToolFiles: vi.fn().mockResolvedValue([]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       } as any;
     });
   });
@@ -119,7 +119,7 @@ describe("importCommand", () => {
       const mockRulesProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "rule1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ rule: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockRulesProcessor as any;
@@ -145,7 +145,7 @@ describe("importCommand", () => {
       const mockIgnoreProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "ignore1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ ignore: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return mockIgnoreProcessor as any;
@@ -170,7 +170,7 @@ describe("importCommand", () => {
       const mockMcpProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "mcp1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ mcp: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(McpProcessor).mockImplementation(function () {
         return mockMcpProcessor as any;
@@ -196,7 +196,7 @@ describe("importCommand", () => {
       const mockSubagentsProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "subagent1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ subagent: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return mockSubagentsProcessor as any;
@@ -228,7 +228,7 @@ describe("importCommand", () => {
       const mockCommandsProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "command1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ command: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return mockCommandsProcessor as any;
@@ -304,7 +304,7 @@ describe("importCommand", () => {
       const mockRulesProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "rule1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ rule: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(2),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 2, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockRulesProcessor as any;
@@ -313,7 +313,7 @@ describe("importCommand", () => {
       const mockIgnoreProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "ignore1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ ignore: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return mockIgnoreProcessor as any;
@@ -322,7 +322,7 @@ describe("importCommand", () => {
       const mockMcpProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "mcp1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ mcp: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(3),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 3, paths: [] }),
       };
       vi.mocked(McpProcessor).mockImplementation(function () {
         return mockMcpProcessor as any;
@@ -331,7 +331,7 @@ describe("importCommand", () => {
       const mockSubagentsProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "subagent1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ subagent: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(4),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 4, paths: [] }),
       };
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return mockSubagentsProcessor as any;
@@ -340,7 +340,7 @@ describe("importCommand", () => {
       const mockCommandsProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "command1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ command: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(5),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 5, paths: [] }),
       };
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return mockCommandsProcessor as any;
@@ -371,35 +371,35 @@ describe("importCommand", () => {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(McpProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
 
@@ -427,7 +427,7 @@ describe("importCommand", () => {
       const mockSubagentsProcessor = {
         loadToolFiles: vi.fn().mockResolvedValue([{ file: "subagent1" }]),
         convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ subagent: "converted" }]),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return mockSubagentsProcessor as any;
@@ -452,35 +452,35 @@ describe("importCommand", () => {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([{ file: "test1" }]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ test: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(1),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
         } as any;
       });
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(McpProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([{ file: "test1" }]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ test: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(1),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
         } as any;
       });
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([{ file: "test1" }]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ test: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(1),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
         } as any;
       });
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([{ file: "test1" }]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ test: "converted" }]),
-          writeAiFiles: vi.fn().mockResolvedValue(1),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
         } as any;
       });
 
@@ -522,35 +522,35 @@ describe("importCommand", () => {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(McpProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(CommandsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
       vi.mocked(SubagentsProcessor).mockImplementation(function () {
         return {
           loadToolFiles: vi.fn().mockResolvedValue([]),
           convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: vi.fn().mockResolvedValue(0),
+          writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
         } as any;
       });
 

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -27,7 +27,7 @@ export async function importCommand(options: ImportOptions): Promise<void> {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const tool = config.getTargets()[0]!;
 
-  logger.info(`Importing files from ${tool}...`);
+  logger.debug(`Importing files from ${tool}...`);
 
   const result = await importFromTool({ config, tool });
 

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -39,6 +39,7 @@ describe("initCommand", () => {
   beforeEach(() => {
     // Setup logger mocks
     vi.mocked(logger.info).mockImplementation(() => {});
+    vi.mocked(logger.debug).mockImplementation(() => {});
     vi.mocked(logger.success).mockImplementation(() => {});
 
     // Setup file utility mocks
@@ -93,7 +94,7 @@ describe("initCommand", () => {
     it("should initialize rulesync successfully", async () => {
       await initCommand();
 
-      expect(logger.info).toHaveBeenCalledWith("Initializing rulesync...");
+      expect(logger.debug).toHaveBeenCalledWith("Initializing rulesync...");
       expect(logger.success).toHaveBeenCalledWith("rulesync initialized successfully!");
       expect(logger.info).toHaveBeenCalledWith("Next steps:");
       expect(logger.info).toHaveBeenCalledWith(
@@ -222,7 +223,7 @@ describe("initCommand", () => {
 
       await expect(initCommand()).rejects.toThrow("Permission denied");
 
-      expect(logger.info).toHaveBeenCalledWith("Initializing rulesync...");
+      expect(logger.debug).toHaveBeenCalledWith("Initializing rulesync...");
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(logger.success).not.toHaveBeenCalled();
     });
@@ -243,7 +244,7 @@ describe("initCommand", () => {
 
       await expect(initCommand()).rejects.toThrow("File system error");
 
-      expect(logger.info).toHaveBeenCalledWith("Initializing rulesync...");
+      expect(logger.debug).toHaveBeenCalledWith("Initializing rulesync...");
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
     });
 
@@ -252,7 +253,7 @@ describe("initCommand", () => {
 
       await expect(initCommand()).rejects.toThrow("Write permission denied");
 
-      expect(logger.info).toHaveBeenCalledWith("Initializing rulesync...");
+      expect(logger.debug).toHaveBeenCalledWith("Initializing rulesync...");
       expect(writeFileContent).toHaveBeenCalled();
       expect(logger.success).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
     });
@@ -322,8 +323,8 @@ describe("initCommand", () => {
     it("should log initialization start message first", async () => {
       await initCommand();
 
-      const loggerInfoCalls = vi.mocked(logger.info).mock.calls;
-      expect(loggerInfoCalls[0]?.[0]).toBe("Initializing rulesync...");
+      const loggerDebugCalls = vi.mocked(logger.debug).mock.calls;
+      expect(loggerDebugCalls[0]?.[0]).toBe("Initializing rulesync...");
     });
 
     it("should log success message after completion", async () => {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -10,7 +10,7 @@ import { ensureDir } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
 
 export async function initCommand(): Promise<void> {
-  logger.info("Initializing rulesync...");
+  logger.debug("Initializing rulesync...");
 
   await ensureDir(RULESYNC_RELATIVE_DIR_PATH);
 

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -29,6 +29,7 @@ vi.mock("../../utils/file.js");
 vi.mock("../../utils/logger.js", () => ({
   logger: {
     info: vi.fn(),
+    debug: vi.fn(),
   },
 }));
 // Mock RulesyncCommand after importing it
@@ -591,7 +592,7 @@ describe("CommandsProcessor", () => {
       expect(RulesyncCommand.fromFile).toHaveBeenCalledTimes(2);
       expect(RulesyncCommand.fromFile).toHaveBeenCalledWith({ relativeFilePath: "test1.md" });
       expect(RulesyncCommand.fromFile).toHaveBeenCalledWith({ relativeFilePath: "test2.md" });
-      expect(logger.info).toHaveBeenCalledWith("Successfully loaded 2 rulesync commands");
+      expect(logger.debug).toHaveBeenCalledWith("Successfully loaded 2 rulesync commands");
       expect(result).toEqual(mockRulesyncCommands);
     });
 
@@ -623,7 +624,7 @@ describe("CommandsProcessor", () => {
       const result = await processor.loadRulesyncFiles();
 
       expect(result).toEqual([]);
-      expect(logger.info).toHaveBeenCalledWith("Successfully loaded 0 rulesync commands");
+      expect(logger.debug).toHaveBeenCalledWith("Successfully loaded 0 rulesync commands");
     });
   });
 
@@ -658,7 +659,7 @@ describe("CommandsProcessor", () => {
         relativeFilePath: "test.md",
         global: false,
       });
-      expect(logger.info).toHaveBeenCalledWith("Successfully loaded 1 .claude/commands commands");
+      expect(logger.debug).toHaveBeenCalledWith("Successfully loaded 1 .claude/commands commands");
       expect(result).toEqual([mockCommand]);
     });
 

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -305,7 +305,7 @@ export class CommandsProcessor extends FeatureProcessor {
       ),
     );
 
-    logger.info(`Successfully loaded ${rulesyncCommands.length} rulesync commands`);
+    logger.debug(`Successfully loaded ${rulesyncCommands.length} rulesync commands`);
     return rulesyncCommands;
   }
 
@@ -337,7 +337,7 @@ export class CommandsProcessor extends FeatureProcessor {
         )
         .filter((cmd) => cmd.isDeletable());
 
-      logger.info(`Successfully loaded ${toolCommands.length} ${paths.relativeDirPath} commands`);
+      logger.debug(`Successfully loaded ${toolCommands.length} ${paths.relativeDirPath} commands`);
       return toolCommands;
     }
 
@@ -351,7 +351,7 @@ export class CommandsProcessor extends FeatureProcessor {
       ),
     );
 
-    logger.info(`Successfully loaded ${toolCommands.length} ${paths.relativeDirPath} commands`);
+    logger.debug(`Successfully loaded ${toolCommands.length} ${paths.relativeDirPath} commands`);
     return toolCommands;
   }
 

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -157,7 +157,7 @@ export class HooksProcessor extends FeatureProcessor {
           global: this.global,
         });
         const list = toolHooks.isDeletable?.() !== false ? [toolHooks] : [];
-        logger.info(
+        logger.debug(
           `Successfully loaded ${list.length} ${this.toolTarget} hooks files for deletion`,
         );
         return list;
@@ -168,7 +168,7 @@ export class HooksProcessor extends FeatureProcessor {
         validate: true,
         global: this.global,
       });
-      logger.info(`Successfully loaded 1 ${this.toolTarget} hooks file`);
+      logger.debug(`Successfully loaded 1 ${this.toolTarget} hooks file`);
       return [toolHooks];
     } catch (error) {
       const msg = `Failed to load hooks files for tool target: ${this.toolTarget}: ${formatError(error)}`;

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -264,7 +264,7 @@ export class McpProcessor extends FeatureProcessor {
         });
 
         const toolMcps = toolMcp.isDeletable() ? [toolMcp] : [];
-        logger.info(`Successfully loaded ${toolMcps.length} ${this.toolTarget} MCP files`);
+        logger.debug(`Successfully loaded ${toolMcps.length} ${this.toolTarget} MCP files`);
         return toolMcps;
       }
 
@@ -275,7 +275,7 @@ export class McpProcessor extends FeatureProcessor {
           global: this.global,
         }),
       ];
-      logger.info(`Successfully loaded ${toolMcps.length} ${this.toolTarget} MCP files`);
+      logger.debug(`Successfully loaded ${toolMcps.length} ${this.toolTarget} MCP files`);
       return toolMcps;
     } catch (error) {
       const errorMessage = `Failed to load MCP files for tool target: ${this.toolTarget}: ${formatError(error)}`;

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -310,7 +310,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       ),
     );
 
-    logger.info(`Successfully loaded ${rulesyncSkills.length} rulesync skills`);
+    logger.debug(`Successfully loaded ${rulesyncSkills.length} rulesync skills`);
     return rulesyncSkills;
   }
 
@@ -336,7 +336,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       ),
     );
 
-    logger.info(`Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills`);
+    logger.debug(`Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills`);
     return toolSkills;
   }
 
@@ -357,7 +357,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       }),
     );
 
-    logger.info(
+    logger.debug(
       `Successfully loaded ${toolSkills.length} ${paths.relativeDirPath} skills for deletion`,
     );
     return toolSkills;

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -290,7 +290,7 @@ export class SubagentsProcessor extends FeatureProcessor {
       return [];
     }
 
-    logger.info(`Found ${mdFiles.length} subagent files in ${subagentsDir}`);
+    logger.debug(`Found ${mdFiles.length} subagent files in ${subagentsDir}`);
 
     // Parse all files and create RulesyncSubagent instances using fromFilePath
     const rulesyncSubagents: RulesyncSubagent[] = [];
@@ -317,7 +317,7 @@ export class SubagentsProcessor extends FeatureProcessor {
       return [];
     }
 
-    logger.info(`Successfully loaded ${rulesyncSubagents.length} rulesync subagents`);
+    logger.debug(`Successfully loaded ${rulesyncSubagents.length} rulesync subagents`);
     return rulesyncSubagents;
   }
 
@@ -349,7 +349,9 @@ export class SubagentsProcessor extends FeatureProcessor {
         )
         .filter((subagent) => subagent.isDeletable());
 
-      logger.info(`Successfully loaded ${toolSubagents.length} ${paths.relativeDirPath} subagents`);
+      logger.debug(
+        `Successfully loaded ${toolSubagents.length} ${paths.relativeDirPath} subagents`,
+      );
       return toolSubagents;
     }
 
@@ -363,7 +365,7 @@ export class SubagentsProcessor extends FeatureProcessor {
       ),
     );
 
-    logger.info(`Successfully loaded ${toolSubagents.length} ${paths.relativeDirPath} subagents`);
+    logger.debug(`Successfully loaded ${toolSubagents.length} ${paths.relativeDirPath} subagents`);
     return toolSubagents;
   }
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -817,7 +817,7 @@ async function fetchAndConvertToolFiles(params: {
       status: "created" as const,
     }));
 
-    logger.info(`Converted ${converted} files from ${target} format to rulesync format`);
+    logger.debug(`Converted ${converted} files from ${target} format to rulesync format`);
 
     return {
       source: `${parsed.owner}/${parsed.repo}`,

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -112,7 +112,7 @@ describe("generate", () => {
       convertRulesyncFilesToToolFiles: vi
         .fn()
         .mockResolvedValue([createMockAiFile("/path/to/file", "content")]),
-      writeAiFiles: vi.fn().mockResolvedValue(1),
+      writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
     });
 
     const createMockSkillsProcessor = () => ({
@@ -120,7 +120,7 @@ describe("generate", () => {
       removeAiDirs: vi.fn().mockResolvedValue(undefined),
       loadRulesyncDirs: vi.fn().mockResolvedValue([]),
       convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
-      writeAiDirs: vi.fn().mockResolvedValue(0),
+      writeAiDirs: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
     });
 
     vi.mocked(RulesProcessor).mockImplementation(function () {
@@ -193,7 +193,7 @@ describe("generate", () => {
         removeAiDirs: vi.fn().mockResolvedValue(undefined),
         loadRulesyncDirs: vi.fn().mockResolvedValue([mockSkill]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
-        writeAiDirs: vi.fn().mockResolvedValue(1),
+        writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return mockSkillsProcessor as unknown as SkillsProcessor;
@@ -219,7 +219,7 @@ describe("generate", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue(generatedFiles),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -244,7 +244,7 @@ describe("generate", () => {
         removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
         loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue(generatedFiles),
-        writeAiFiles: vi.fn().mockResolvedValue(1),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -321,7 +321,7 @@ describe("generate", () => {
         removeAiFiles: vi.fn().mockResolvedValue(undefined),
         loadRulesyncFiles: vi.fn().mockResolvedValue([]),
         convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
-        writeAiFiles: vi.fn().mockResolvedValue(0),
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }),
       };
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
         return mockProcessor as unknown as IgnoreProcessor;
@@ -443,7 +443,7 @@ describe("generate", () => {
         removeAiDirs: vi.fn().mockResolvedValue(undefined),
         loadRulesyncDirs: vi.fn().mockResolvedValue([]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([{ dir: "skill" }]),
-        writeAiDirs: vi.fn().mockResolvedValue(1),
+        writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return mockSkillsProcessor as unknown as SkillsProcessor;
@@ -485,7 +485,7 @@ describe("generate", () => {
         removeAiDirs: vi.fn().mockResolvedValue(undefined),
         loadRulesyncDirs: vi.fn().mockResolvedValue([mockSkill]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
-        writeAiDirs: vi.fn().mockResolvedValue(1),
+        writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return mockSkillsProcessor as unknown as SkillsProcessor;
@@ -507,7 +507,7 @@ describe("generate", () => {
         removeOrphanAiDirs: vi.fn().mockResolvedValue(0),
         loadRulesyncDirs: vi.fn().mockResolvedValue([]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue(generatedDirs),
-        writeAiDirs: vi.fn().mockResolvedValue(1),
+        writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return mockSkillsProcessor as unknown as SkillsProcessor;
@@ -544,7 +544,7 @@ describe("generate", () => {
         removeAiDirs: vi.fn().mockResolvedValue(undefined),
         loadRulesyncDirs: vi.fn().mockResolvedValue([]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
-        writeAiDirs: vi.fn().mockResolvedValue(1),
+        writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
       };
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return mockSkillsProcessor as unknown as SkillsProcessor;
@@ -716,7 +716,7 @@ describe("generate", () => {
         convertRulesyncFilesToToolFiles: vi
           .fn()
           .mockResolvedValue([createMockAiFile("/path/to/file", "content")]),
-        writeAiFiles: vi.fn().mockResolvedValue(0), // No changes
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }), // No changes
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -740,7 +740,7 @@ describe("generate", () => {
         convertRulesyncFilesToToolFiles: vi
           .fn()
           .mockResolvedValue([createMockAiFile("/path/to/file", "content")]),
-        writeAiFiles: vi.fn().mockResolvedValue(1), // Has changes
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }), // Has changes
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -764,7 +764,7 @@ describe("generate", () => {
         convertRulesyncFilesToToolFiles: vi
           .fn()
           .mockResolvedValue([createMockAiFile("/path/to/file", "new content")]),
-        writeAiFiles: vi.fn().mockResolvedValue(1), // Has changes (content differs)
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }), // Has changes (content differs)
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -787,7 +787,7 @@ describe("generate", () => {
         convertRulesyncFilesToToolFiles: vi
           .fn()
           .mockResolvedValue([createMockAiFile("/path/to/file", "content")]),
-        writeAiFiles: vi.fn().mockResolvedValue(0), // No changes (content matches)
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 0, paths: [] }), // No changes (content matches)
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;
@@ -810,7 +810,7 @@ describe("generate", () => {
         convertRulesyncFilesToToolFiles: vi
           .fn()
           .mockResolvedValue([createMockAiFile("/path/to/file", "content")]),
-        writeAiFiles: vi.fn().mockResolvedValue(1), // Has changes (file doesn't exist)
+        writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }), // Has changes (file doesn't exist)
       };
       vi.mocked(RulesProcessor).mockImplementation(function () {
         return mockProcessor as unknown as RulesProcessor;

--- a/src/lib/import.test.ts
+++ b/src/lib/import.test.ts
@@ -56,13 +56,13 @@ describe("importFromTool", () => {
     const createMockProcessor = () => ({
       loadToolFiles: vi.fn().mockResolvedValue([{ file: "tool" }]),
       convertToolFilesToRulesyncFiles: vi.fn().mockResolvedValue([{ file: "rulesync" }]),
-      writeAiFiles: vi.fn().mockResolvedValue(1),
+      writeAiFiles: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
     });
 
     const createMockSkillsProcessor = () => ({
       loadToolDirs: vi.fn().mockResolvedValue([{ dir: "tool" }]),
       convertToolDirsToRulesyncDirs: vi.fn().mockResolvedValue([{ dir: "rulesync" }]),
-      writeAiDirs: vi.fn().mockResolvedValue(1),
+      writeAiDirs: vi.fn().mockResolvedValue({ count: 1, paths: [] }),
     });
 
     vi.mocked(RulesProcessor).mockImplementation(function () {

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -75,7 +75,7 @@ async function importRulesCore(params: { config: Config; tool: ToolTarget }): Pr
   }
 
   const rulesyncFiles = await rulesProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await rulesProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await rulesProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} rule files`);
@@ -111,7 +111,7 @@ async function importIgnoreCore(params: { config: Config; tool: ToolTarget }): P
   }
 
   const rulesyncFiles = await ignoreProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await ignoreProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await ignoreProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose()) {
     logger.success(`Created ignore files from ${toolFiles.length} tool ignore configurations`);
@@ -151,7 +151,7 @@ async function importMcpCore(params: { config: Config; tool: ToolTarget }): Prom
   }
 
   const rulesyncFiles = await mcpProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await mcpProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await mcpProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} MCP files`);
@@ -187,7 +187,7 @@ async function importCommandsCore(params: { config: Config; tool: ToolTarget }):
   }
 
   const rulesyncFiles = await commandsProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await commandsProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await commandsProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} command files`);
@@ -222,7 +222,7 @@ async function importSubagentsCore(params: { config: Config; tool: ToolTarget })
   }
 
   const rulesyncFiles = await subagentsProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await subagentsProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await subagentsProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} subagent files`);
@@ -258,7 +258,7 @@ async function importSkillsCore(params: { config: Config; tool: ToolTarget }): P
   }
 
   const rulesyncDirs = await skillsProcessor.convertToolDirsToRulesyncDirs(toolDirs);
-  const writtenCount = await skillsProcessor.writeAiDirs(rulesyncDirs);
+  const { count: writtenCount } = await skillsProcessor.writeAiDirs(rulesyncDirs);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} skill directories`);
@@ -299,7 +299,7 @@ async function importHooksCore(params: { config: Config; tool: ToolTarget }): Pr
   }
 
   const rulesyncFiles = await hooksProcessor.convertToolFilesToRulesyncFiles(toolFiles);
-  const writtenCount = await hooksProcessor.writeAiFiles(rulesyncFiles);
+  const { count: writtenCount } = await hooksProcessor.writeAiFiles(rulesyncFiles);
 
   if (config.getVerbose() && writtenCount > 0) {
     logger.success(`Created ${writtenCount} hooks file(s)`);

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -26,6 +26,7 @@ function createMockDir(dirPath: string): AiDir {
     getDirPath: () => dirPath,
     getMainFile: () => undefined,
     getOtherFiles: () => [],
+    getRelativePathFromCwd: () => dirPath,
   } as unknown as AiDir;
 }
 
@@ -159,6 +160,7 @@ describe("DirFeatureProcessor", () => {
             ? { name: "SKILL.md", body: mainFileBody, frontmatter: {} }
             : undefined,
         getOtherFiles: () => otherFiles,
+        getRelativePathFromCwd: () => dirPath,
       } as unknown as AiDir;
     }
 
@@ -171,9 +173,9 @@ describe("DirFeatureProcessor", () => {
         createMockDirWithFiles({ dirPath: "/path/to/dir2", mainFileBody: "body2" }),
       ];
 
-      const count = await processor.writeAiDirs(dirs);
+      const result = await processor.writeAiDirs(dirs);
 
-      expect(count).toBe(2);
+      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
       expect(ensureDir).toHaveBeenCalledTimes(2);
       expect(writeFileContent).toHaveBeenCalledTimes(2);
     });
@@ -184,9 +186,9 @@ describe("DirFeatureProcessor", () => {
 
       const dirs = [createMockDirWithFiles({ dirPath: "/path/to/dir1", mainFileBody: "body1" })];
 
-      const count = await processor.writeAiDirs(dirs);
+      const result = await processor.writeAiDirs(dirs);
 
-      expect(count).toBe(0);
+      expect(result).toEqual({ count: 0, paths: [] });
       expect(ensureDir).not.toHaveBeenCalled();
       expect(writeFileContent).not.toHaveBeenCalled();
     });
@@ -201,9 +203,9 @@ describe("DirFeatureProcessor", () => {
       };
       const dirs = [createMockDirWithFiles({ dirPath: "/path/to/dir1", otherFiles: [otherFile] })];
 
-      const count = await processor.writeAiDirs(dirs);
+      const result = await processor.writeAiDirs(dirs);
 
-      expect(count).toBe(1);
+      expect(result).toEqual({ count: 1, paths: expect.any(Array) });
       expect(ensureDir).toHaveBeenCalledTimes(1);
       expect(writeFileContent).toHaveBeenCalledTimes(1);
     });
@@ -217,9 +219,9 @@ describe("DirFeatureProcessor", () => {
         createMockDirWithFiles({ dirPath: "/path/to/dir2", mainFileBody: "body2" }),
       ];
 
-      const count = await processor.writeAiDirs(dirs);
+      const result = await processor.writeAiDirs(dirs);
 
-      expect(count).toBe(2);
+      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
       expect(ensureDir).not.toHaveBeenCalled();
       expect(writeFileContent).not.toHaveBeenCalled();
     });

--- a/src/types/feature-processor.test.ts
+++ b/src/types/feature-processor.test.ts
@@ -21,6 +21,7 @@ function createMockFile(filePath: string): AiFile {
   return {
     getFilePath: () => filePath,
     getFileContent: () => "content",
+    getRelativePathFromCwd: () => filePath,
   } as AiFile;
 }
 
@@ -149,9 +150,9 @@ describe("FeatureProcessor", () => {
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
-      const count = await processor.writeAiFiles(files);
+      const result = await processor.writeAiFiles(files);
 
-      expect(count).toBe(2);
+      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
       expect(writeFileContent).toHaveBeenCalledTimes(2);
     });
 
@@ -161,9 +162,9 @@ describe("FeatureProcessor", () => {
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
-      const count = await processor.writeAiFiles(files);
+      const result = await processor.writeAiFiles(files);
 
-      expect(count).toBe(0);
+      expect(result).toEqual({ count: 0, paths: [] });
       expect(writeFileContent).not.toHaveBeenCalled();
     });
 
@@ -175,9 +176,9 @@ describe("FeatureProcessor", () => {
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
-      const count = await processor.writeAiFiles(files);
+      const result = await processor.writeAiFiles(files);
 
-      expect(count).toBe(1);
+      expect(result).toEqual({ count: 1, paths: expect.any(Array) });
       expect(writeFileContent).toHaveBeenCalledTimes(1);
     });
 
@@ -187,9 +188,9 @@ describe("FeatureProcessor", () => {
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
-      const count = await processor.writeAiFiles(files);
+      const result = await processor.writeAiFiles(files);
 
-      expect(count).toBe(2);
+      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
       expect(writeFileContent).not.toHaveBeenCalled();
     });
   });

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -1,3 +1,5 @@
+import type { WriteResult } from "../utils/result.js";
+
 import {
   addTrailingNewline,
   readFileContentOrNull,
@@ -38,10 +40,11 @@ export abstract class FeatureProcessor {
 
   /**
    * Once converted to rulesync/tool files, write them to the filesystem.
-   * Returns the number of files written.
+   * Returns the count and paths of files written.
    */
-  async writeAiFiles(aiFiles: AiFile[]): Promise<number> {
+  async writeAiFiles(aiFiles: AiFile[]): Promise<WriteResult> {
     let changedCount = 0;
+    const changedPaths: string[] = [];
     for (const aiFile of aiFiles) {
       const filePath = aiFile.getFilePath();
       const contentWithNewline = addTrailingNewline(aiFile.getFileContent());
@@ -57,9 +60,10 @@ export abstract class FeatureProcessor {
         await writeFileContent(filePath, contentWithNewline);
       }
       changedCount++;
+      changedPaths.push(aiFile.getRelativePathFromCwd());
     }
 
-    return changedCount;
+    return { count: changedCount, paths: changedPaths };
   }
 
   async removeAiFiles(aiFiles: AiFile[]): Promise<void> {

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,4 +1,12 @@
 /**
+ * Result of writing AI files, including both count and file paths
+ */
+export type WriteResult = {
+  count: number;
+  paths: string[];
+};
+
+/**
  * Common count fields shared by ImportResult and GenerateResult
  */
 export type CountableResult = {


### PR DESCRIPTION
## Summary

- Downgrade internal progress messages (`logger.info` → `logger.debug`) so they only appear with `--verbose`, reducing log noise during normal usage
- Add `WriteResult` type that returns both count and file paths from `writeAiFiles`/`writeAiDirs`
- Display written file paths in the generate command summary, making it easy to see exactly which files were created or updated

### Example output after this change

```
✔ Written 2 rule(s)
    .cursorrules
    .cursor/rules/overview.md
✔ Written 1 MCP configuration(s)
    .mcp.json
🎉 All done! Written 3 file(s) total (2 rules + 1 MCP files)
```

## Test plan

- [x] `pnpm cicheck` passes (lint, type check, 3701 tests, spelling, secrets)
- [ ] `pnpm dev generate --targets "*" --features "*"` shows file paths in summary
- [ ] `pnpm dev generate --targets "*" --features "*" --verbose` shows debug logs
- [ ] `pnpm dev generate --targets "*" --features "*" --dry-run` shows DRY RUN output with file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)