### PR TITLE
Refactor: extract FeatureGenerateResult type and add path assertion tests

### DIFF
--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,6 +1,8 @@
 import { intersection } from "es-toolkit";
 import { join } from "node:path";
 
+import type { FeatureGenerateResult } from "../utils/result.js";
+
 import { Config } from "../config/config.js";
 import { RULESYNC_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";
 import { CommandsProcessor } from "../features/commands/commands-processor.js";
@@ -42,7 +44,7 @@ async function processFeatureGeneration<T extends AiFile>(params: {
   config: Config;
   processor: FeatureProcessor;
   toolFiles: T[];
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+}): Promise<FeatureGenerateResult> {
   const { config, processor, toolFiles } = params;
 
   let totalCount = 0;
@@ -67,7 +69,7 @@ async function processDirFeatureGeneration(params: {
   config: Config;
   processor: DirFeatureProcessor;
   toolDirs: AiDir[];
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+}): Promise<FeatureGenerateResult> {
   const { config, processor, toolDirs } = params;
 
   let totalCount = 0;
@@ -92,7 +94,7 @@ async function processDirFeatureGeneration(params: {
 async function processEmptyFeatureGeneration(params: {
   config: Config;
   processor: FeatureProcessor;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+}): Promise<FeatureGenerateResult> {
   const { config, processor } = params;
 
   const totalCount = 0;
@@ -161,7 +163,7 @@ export async function generate(params: { config: Config }): Promise<GenerateResu
 async function generateRulesCore(params: {
   config: Config;
   skills?: RulesyncSkill[];
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+}): Promise<FeatureGenerateResult> {
   const { config, skills } = params;
 
   let totalCount = 0;
@@ -209,9 +211,7 @@ async function generateRulesCore(params: {
   return { count: totalCount, paths: allPaths, hasDiff };
 }
 
-async function generateIgnoreCore(params: {
-  config: Config;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+async function generateIgnoreCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
   if (config.getGlobal()) {
@@ -268,9 +268,7 @@ async function generateIgnoreCore(params: {
   return { count: totalCount, paths: allPaths, hasDiff };
 }
 
-async function generateMcpCore(params: {
-  config: Config;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+async function generateMcpCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
   let totalCount = 0;
@@ -314,9 +312,7 @@ async function generateMcpCore(params: {
   return { count: totalCount, paths: allPaths, hasDiff };
 }
 
-async function generateCommandsCore(params: {
-  config: Config;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+async function generateCommandsCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
   let totalCount = 0;
@@ -363,9 +359,7 @@ async function generateCommandsCore(params: {
   return { count: totalCount, paths: allPaths, hasDiff };
 }
 
-async function generateSubagentsCore(params: {
-  config: Config;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+async function generateSubagentsCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
   let totalCount = 0;
@@ -469,9 +463,7 @@ async function generateSkillsCore(params: {
   return { count: totalCount, paths: allPaths, skills: allSkills, hasDiff };
 }
 
-async function generateHooksCore(params: {
-  config: Config;
-}): Promise<{ count: number; paths: string[]; hasDiff: boolean }> {
+async function generateHooksCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
   let totalCount = 0;

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -175,7 +175,10 @@ describe("DirFeatureProcessor", () => {
 
       const result = await processor.writeAiDirs(dirs);
 
-      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
+      expect(result).toEqual({
+        count: 2,
+        paths: ["/path/to/dir1/SKILL.md", "/path/to/dir2/SKILL.md"],
+      });
       expect(ensureDir).toHaveBeenCalledTimes(2);
       expect(writeFileContent).toHaveBeenCalledTimes(2);
     });
@@ -205,7 +208,7 @@ describe("DirFeatureProcessor", () => {
 
       const result = await processor.writeAiDirs(dirs);
 
-      expect(result).toEqual({ count: 1, paths: expect.any(Array) });
+      expect(result).toEqual({ count: 1, paths: ["/path/to/dir1/extra.txt"] });
       expect(ensureDir).toHaveBeenCalledTimes(1);
       expect(writeFileContent).toHaveBeenCalledTimes(1);
     });
@@ -221,7 +224,10 @@ describe("DirFeatureProcessor", () => {
 
       const result = await processor.writeAiDirs(dirs);
 
-      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
+      expect(result).toEqual({
+        count: 2,
+        paths: ["/path/to/dir1/SKILL.md", "/path/to/dir2/SKILL.md"],
+      });
       expect(ensureDir).not.toHaveBeenCalled();
       expect(writeFileContent).not.toHaveBeenCalled();
     });

--- a/src/types/feature-processor.test.ts
+++ b/src/types/feature-processor.test.ts
@@ -152,7 +152,7 @@ describe("FeatureProcessor", () => {
 
       const result = await processor.writeAiFiles(files);
 
-      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
+      expect(result).toEqual({ count: 2, paths: ["/path/to/file1.md", "/path/to/file2.md"] });
       expect(writeFileContent).toHaveBeenCalledTimes(2);
     });
 
@@ -178,7 +178,7 @@ describe("FeatureProcessor", () => {
 
       const result = await processor.writeAiFiles(files);
 
-      expect(result).toEqual({ count: 1, paths: expect.any(Array) });
+      expect(result).toEqual({ count: 1, paths: ["/path/to/file2.md"] });
       expect(writeFileContent).toHaveBeenCalledTimes(1);
     });
 
@@ -190,7 +190,7 @@ describe("FeatureProcessor", () => {
 
       const result = await processor.writeAiFiles(files);
 
-      expect(result).toEqual({ count: 2, paths: expect.any(Array) });
+      expect(result).toEqual({ count: 2, paths: ["/path/to/file1.md", "/path/to/file2.md"] });
       expect(writeFileContent).not.toHaveBeenCalled();
     });
   });

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -7,6 +7,11 @@ export type WriteResult = {
 };
 
 /**
+ * Result of feature generation, extending WriteResult with hasDiff
+ */
+export type FeatureGenerateResult = WriteResult & { hasDiff: boolean };
+
+/**
  * Common count fields shared by ImportResult and GenerateResult
  */
 export type CountableResult = {


### PR DESCRIPTION
### Summary
Refactored `generate.ts` to use a named type for generation results and improved test assertions in processor tests, addressing #1031.

### Changes
- **Refactor:** Extracted `FeatureGenerateResult` type in `src/utils/result.ts`.
- **Refactor:** Replaced inline type definition with `FeatureGenerateResult` in 9 occurrences within `src/lib/generate.ts`.
- **Test:** Updated `feature-processor.test.ts` and `dir-feature-processor.test.ts` to use specific path assertions instead of `expect.any(Array)`.

### Verification
- Ran `npm test` and all 20 tests passed.

Closes #1031