### PR TITLE
Update OpenCode comment triggers and model selection

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -1,0 +1,38 @@
+name: Select OpenCode model
+description: Selects OpenRouter model based on comment text
+inputs:
+  comment-body:
+    description: Comment body to inspect for model keywords
+    required: true
+outputs:
+  model:
+    description: Selected OpenRouter model
+    value: ${{ steps.select-model.outputs.model }}
+  comment-body-cleaned:
+    description: Comment body with model keywords removed
+    value: ${{ steps.select-model.outputs.comment_body_cleaned }}
+runs:
+  using: composite
+  steps:
+    - name: Determine model based on comment
+      id: select-model
+      shell: bash
+      env:
+        COMMENT_BODY: ${{ inputs.comment-body }}
+      run: |
+        if [[ "$COMMENT_BODY" == *"codex"* ]]; then
+          echo "model=openai/gpt-5.2-codex" >> $GITHUB_OUTPUT
+        elif [[ "$COMMENT_BODY" == *"glm"* ]]; then
+          echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
+        elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then
+          echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
+        else
+          echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
+        fi
+        CLEANED_COMMENT_BODY="$COMMENT_BODY"
+        CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//\/oc/}"
+        CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//\/opencode/}"
+        CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//codex/}"
+        CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//glm/}"
+        CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//kimi/}"
+        echo "comment_body_cleaned=$CLEANED_COMMENT_BODY" >> $GITHUB_OUTPUT

--- a/.github/workflows/issue-comment-to-ai.yml
+++ b/.github/workflows/issue-comment-to-ai.yml
@@ -8,7 +8,7 @@ jobs:
   handle-issue:
     if: >-
       !github.event.issue.pull_request &&
-      contains(github.event.comment.body, '[ai]') &&
+      (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
           github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
@@ -42,17 +42,9 @@ jobs:
 
       - name: Determine model based on comment
         id: select-model
-        shell: bash
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          if [[ "$COMMENT_BODY" == *"glm"* ]]; then
-            echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
-          elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then
-            echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
-          else
-            echo "model=openrouter/moonshotai/kimi-k2" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/select-opencode-model
+        with:
+          comment-body: ${{ github.event.comment.body }}
 
       - name: Run OpenCode to handle issue
         uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2
@@ -62,7 +54,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ steps.select-model.outputs.comment-body-cleaned }}
         with:
           model: ${{ steps.select-model.outputs.model }}
           use_github_token: "true"

--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -8,7 +8,7 @@ jobs:
   handle-pr-comment:
     if: >-
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '[ai]') &&
+      (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
           github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
@@ -66,17 +66,9 @@ jobs:
 
       - name: Determine model based on comment
         id: select-model
-        shell: bash
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          if [[ "$COMMENT_BODY" == *"glm"* ]]; then
-            echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
-          elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then
-            echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
-          else
-            echo "model=openrouter/moonshotai/kimi-k2" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/select-opencode-model
+        with:
+          comment-body: ${{ github.event.comment.body }}
 
       - name: Run OpenCode to handle PR comment
         uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2
@@ -85,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_UPSTREAM: ${{ github.repository == 'dyoshikawa/rulesync' }}
           PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ steps.select-model.outputs.comment-body-cleaned }}
         with:
           model: ${{ steps.select-model.outputs.model }}
           use_github_token: "true"


### PR DESCRIPTION
## Summary

- Switch comment triggers to /oc and /opencode and strip them from the prompt
- Add codex model selection and default to glm when no keyword is present
- Reuse a shared composite action to select models and clean comment text

## Test plan

- pnpm cicheck