### PR TITLE
chore: align subagent guidance and disable sharing

### DIFF
--- a/.rulesync/subagents/code-reviewer.md
+++ b/.rulesync/subagents/code-reviewer.md
@@ -13,7 +13,7 @@ Reviews code from a general software engineering perspective.
 
 - Adherence to DRY principles
 - Addition and updating of test code in accordance with feature development
-- Adherence to `.claude/memories/coding-guides.md`
+- Adherence to coding-guidelines.md
 
 - When functionality changes are involved, ensure the implementation and documentation align with `feature-change-guidelines.md`.
 

--- a/.rulesync/subagents/security-reviewer.md
+++ b/.rulesync/subagents/security-reviewer.md
@@ -13,4 +13,6 @@ Reviews code specifically for vulnerabilities and malicious code.
 If a GitHub PR URL is provided, it reviews that PR; otherwise, it reviews the PR associated with the current branch.
 
 Please note the following points:
-This project is the CLI tool that is used on the user's local machine. Therefore, its security considerations may differ from those of a web application intended for use by an unspecified large number of users. Please conduct a security review in line with the nature of this project.
+
+- This project is the CLI tool that is used on the user's local machine. Therefore, its security considerations may differ from those of a web application intended for use by an unspecified large number of users. Please conduct a security review in line with the nature of this project.
+- Adherence to github-actions-security.md

--- a/opencode.json
+++ b/opencode.json
@@ -54,5 +54,6 @@
       "enabled": true,
       "environment": {}
     }
-  }
+  },
+  "share": "disabled"
 }


### PR DESCRIPTION
## Summary\n- align subagent guidance references for coding and security rules\n- add github-actions-security reminder for security reviews\n- disable opencode share setting\n\n## Test Plan\n- pnpm cicheck