### PR TITLE
fix: do not create config files if they dont exist when reading them

### DIFF
--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -11,7 +11,7 @@ import {
   CURSOR_TO_CLAUDE_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -156,10 +156,7 @@ export class ClaudecodeHooks extends ToolHooks {
   }: ToolHooksFromFileParams): Promise<ClaudecodeHooks> {
     const paths = ClaudecodeHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
-    const fileContent = await readOrInitializeFileContent(
-      filePath,
-      JSON.stringify({ hooks: {} }, null, 2),
-    );
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new ClaudecodeHooks({
       baseDir,
       relativeDirPath: paths.relativeDirPath,

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -11,7 +11,7 @@ import {
   CURSOR_TO_CLAUDE_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -150,10 +150,7 @@ export class FactorydroidHooks extends ToolHooks {
   }: ToolHooksFromFileParams): Promise<FactorydroidHooks> {
     const paths = FactorydroidHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
-    const fileContent = await readOrInitializeFileContent(
-      filePath,
-      JSON.stringify({ hooks: {} }, null, 2),
-    );
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new FactorydroidHooks({
       baseDir,
       relativeDirPath: paths.relativeDirPath,

--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -52,10 +52,9 @@ export class ClaudecodeMcp extends ToolMcp {
     global = false,
   }: ToolMcpFromFileParams): Promise<ClaudecodeMcp> {
     const paths = this.getSettablePaths({ global });
-    const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
-      JSON.stringify({ mcpServers: {} }, null, 2),
-    );
+    const fileContent =
+      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
+      '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 

--- a/src/features/mcp/geminicli-mcp.ts
+++ b/src/features/mcp/geminicli-mcp.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -43,10 +43,9 @@ export class GeminiCliMcp extends ToolMcp {
     global = false,
   }: ToolMcpFromFileParams): Promise<GeminiCliMcp> {
     const paths = this.getSettablePaths({ global });
-    const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
-      JSON.stringify({ mcpServers: {} }, null, 2),
-    );
+    const fileContent =
+      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
+      '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 

--- a/src/features/mcp/kilo-mcp.ts
+++ b/src/features/mcp/kilo-mcp.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -36,10 +36,9 @@ export class KiloMcp extends ToolMcp {
     validate = true,
   }: ToolMcpFromFileParams): Promise<KiloMcp> {
     const paths = this.getSettablePaths();
-    const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
-      JSON.stringify({ mcpServers: {} }, null, 2),
-    );
+    const fileContent =
+      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
+      '{"mcpServers":{}}';
 
     return new KiloMcp({
       baseDir,

--- a/src/features/mcp/kiro-mcp.ts
+++ b/src/features/mcp/kiro-mcp.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -36,10 +36,9 @@ export class KiroMcp extends ToolMcp {
     validate = true,
   }: ToolMcpFromFileParams): Promise<KiroMcp> {
     const paths = this.getSettablePaths();
-    const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
-      JSON.stringify({ mcpServers: {} }, null, 2),
-    );
+    const fileContent =
+      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
+      '{"mcpServers":{}}';
 
     return new KiroMcp({
       baseDir,

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -3,7 +3,7 @@ import { z } from "zod/mini";
 
 import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
-import { readOrInitializeFileContent } from "../../utils/file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -178,10 +178,9 @@ export class OpencodeMcp extends ToolMcp {
     global = false,
   }: ToolMcpFromFileParams): Promise<OpencodeMcp> {
     const paths = this.getSettablePaths({ global });
-    const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
-      JSON.stringify({ mcp: {} }, null, 2),
-    );
+    const fileContent =
+      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
+      '{"mcp":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcp: json.mcp ?? {} };
 


### PR DESCRIPTION
Currently, for some features, when reading config files we are using `readOrInitializeFileContent`. This causes empty config files to be created during operations that should not create them, like importing.

This replaces `readOrInitializeFileContent` with `readFileContentOrNull` and defaulting to empty configuration json if it doesn't exist. This maintains the current code's semantics, while avoiding creating files.

closes #1027