### PR TITLE
fix: add openrouter prefix to codex model in select-opencode-model action

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -21,7 +21,7 @@ runs:
         COMMENT_BODY: ${{ inputs.comment-body }}
       run: |
         if [[ "$COMMENT_BODY" == *"codex"* ]]; then
-          echo "model=openai/gpt-5.2-codex" >> $GITHUB_OUTPUT
+          echo "model=openrouter/openai/gpt-5.2-codex" >> $GITHUB_OUTPUT
         elif [[ "$COMMENT_BODY" == *"glm"* ]]; then
           echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
         elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then


### PR DESCRIPTION
## Summary
- Fix the codex model identifier in the `select-opencode-model` GitHub Action to include the `openrouter/` prefix
- Changed `openai/gpt-5.2-codex` to `openrouter/openai/gpt-5.2-codex` for consistency with other models (glm, kimi) that already use the OpenRouter prefix

## Test plan
- [ ] Verify the OpenCode CI workflow correctly selects the codex model when triggered with the `codex` keyword in the comment body

Generated with [Claude Code](https://claude.com/claude-code)