### PR TITLE
fix: disable share setting in AI workflow actions

### DIFF
--- a/.github/workflows/issue-comment-to-ai.yml
+++ b/.github/workflows/issue-comment-to-ai.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           model: ${{ steps.select-model.outputs.model }}
           use_github_token: "true"
+          share: false
           prompt: |
             You are working on a GitHub Issue. Read the following environment variables to get context:
             - ISSUE_NUMBER: The issue number

--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           model: ${{ steps.select-model.outputs.model }}
           use_github_token: "true"
+          share: false
           prompt: |
             You are working on a GitHub pull request. Read the following environment variables to get context:
             - PR_NUMBER: The pull request number


### PR DESCRIPTION
## Summary
- Add `share: false` to the Claude action configuration in both `issue-comment-to-ai.yml` and `pr-comment-to-ai.yml` GitHub Actions workflows
- Prevents conversations from being shared when AI responds to issue and PR comments

## Test plan
- [ ] Verify issue comment workflow runs correctly with share disabled
- [ ] Verify PR comment workflow runs correctly with share disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)