### PR TITLE
fix: update GLM model from z-ai/glm-4.7 to z-ai/glm-5

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -23,11 +23,11 @@ runs:
         if [[ "$COMMENT_BODY" == *"codex"* ]]; then
           echo "model=openrouter/openai/gpt-5.2-codex" >> $GITHUB_OUTPUT
         elif [[ "$COMMENT_BODY" == *"glm"* ]]; then
-          echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
+          echo "model=openrouter/z-ai/glm-5" >> $GITHUB_OUTPUT
         elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then
           echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
         else
-          echo "model=openrouter/z-ai/glm-4.7" >> $GITHUB_OUTPUT
+          echo "model=openrouter/z-ai/glm-5" >> $GITHUB_OUTPUT
         fi
         CLEANED_COMMENT_BODY="$COMMENT_BODY"
         CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//\/oc/}"


### PR DESCRIPTION
## Summary
- Update the OpenCode model selector to use `z-ai/glm-5` instead of `z-ai/glm-4.7`
- Both the GLM keyword match and the default fallback model are updated

## Test plan
- [ ] Verify the OpenCode AI workflow triggers correctly with the updated model

🤖 Generated with [Claude Code](https://claude.com/claude-code)