### PR TITLE
feat: add security-scan-diff command

### DIFF
--- a/.rulesync/commands/security-scan-diff.md
+++ b/.rulesync/commands/security-scan-diff.md
@@ -20,7 +20,6 @@ Thoroughly check for malicious code in the diff between `${target_ref}` and the 
    - Categorize changed files into: CI/CD workflows, source code, and config/docs.
 
 2. Execute the following security reviews in parallel using subagents:
-
    - Call security-reviewer subagent to review CI/CD and workflow files (`.github/`, `scripts/`) for:
      - Secret exfiltration
      - Script injection (`${{ github.event.* }}` direct expansion in `run:`)


### PR DESCRIPTION
## Summary

- Add `/security-scan-diff` custom slash command that scans git diffs between a specified tag/commit and HEAD for malicious code
- Runs three parallel security-reviewer subagents covering CI/CD workflows, source code, and config/docs
- Outputs a unified security review report with findings, recommendations, and positive observations

## Usage

```
/security-scan-diff v7.0.0
```

## Test plan

- [ ] Verify `rulesync generate` produces command files for Claude Code, GitHub Copilot, and OpenCode
- [ ] Run `/security-scan-diff` with a valid tag to confirm it triggers parallel security reviews
- [ ] Confirm the integrated report format matches the expected template

🤖 Generated with [Claude Code](https://claude.com/claude-code)