### PR TITLE
fix: prevent empty descriptions from being serialized as YAML null in frontmatter

### DIFF
--- a/src/features/rules/agentsmd-rule.test.ts
+++ b/src/features/rules/agentsmd-rule.test.ts
@@ -278,7 +278,7 @@ describe("AgentsMdRule", () => {
       expect(rulesyncRule.getFrontmatter()).toEqual({
         root: false,
         targets: ["*"],
-        description: "",
+        description: undefined,
         globs: [],
       });
     });
@@ -298,7 +298,7 @@ describe("AgentsMdRule", () => {
       expect(rulesyncRule.getFrontmatter()).toEqual({
         root: true,
         targets: ["*"],
-        description: "",
+        description: undefined,
         globs: ["**/*"],
       });
     });

--- a/src/features/rules/codexcli-rule.test.ts
+++ b/src/features/rules/codexcli-rule.test.ts
@@ -442,7 +442,7 @@ More detailed instructions here.`;
       expect(rulesyncRule.getBody()).toBe(agentsContent);
       expect(rulesyncRule.getFrontmatter().root).toBe(true);
       expect(rulesyncRule.getFrontmatter().targets).toEqual(["*"]);
-      expect(rulesyncRule.getFrontmatter().description).toBe("");
+      expect(rulesyncRule.getFrontmatter().description).toBeUndefined();
       expect(rulesyncRule.getFrontmatter().globs).toEqual(["**/*"]);
     });
 
@@ -464,7 +464,7 @@ More detailed instructions here.`;
       expect(rulesyncRule.getBody()).toBe(memoryContent);
       expect(rulesyncRule.getFrontmatter().root).toBe(false);
       expect(rulesyncRule.getFrontmatter().targets).toEqual(["*"]);
-      expect(rulesyncRule.getFrontmatter().description).toBe("");
+      expect(rulesyncRule.getFrontmatter().description).toBeUndefined();
       expect(rulesyncRule.getFrontmatter().globs).toEqual([]);
     });
 

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -89,7 +89,7 @@ export class CursorRule extends ToolRule {
     if (frontmatter.alwaysApply !== undefined) {
       lines.push(`alwaysApply: ${frontmatter.alwaysApply}`);
     }
-    if (frontmatter.description !== undefined) {
+    if (frontmatter.description) {
       lines.push(`description: ${frontmatter.description}`);
     }
     if (frontmatter.globs !== undefined) {

--- a/src/features/rules/qwencode-rule.test.ts
+++ b/src/features/rules/qwencode-rule.test.ts
@@ -352,7 +352,7 @@ describe("QwencodeRule", () => {
       const frontmatter = rulesyncRule.getFrontmatter();
       expect(frontmatter.root).toBe(false);
       expect(frontmatter.targets).toEqual(["*"]);
-      expect(frontmatter.description).toBe("");
+      expect(frontmatter.description).toBeUndefined();
       expect(frontmatter.globs).toEqual([]);
     });
 
@@ -375,7 +375,7 @@ describe("QwencodeRule", () => {
       const frontmatter = rulesyncRule.getFrontmatter();
       expect(frontmatter.root).toBe(true);
       expect(frontmatter.targets).toEqual(["*"]);
-      expect(frontmatter.description).toBe("");
+      expect(frontmatter.description).toBeUndefined();
       expect(frontmatter.globs).toEqual(["**/*"]);
     });
 

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -159,7 +159,7 @@ export class RulesyncRule extends RulesyncFile {
       root: result.data.root ?? false,
       localRoot: result.data.localRoot ?? false,
       targets: result.data.targets ?? ["*"],
-      description: result.data.description ?? "",
+      description: result.data.description,
       globs: result.data.globs ?? [],
       agentsmd: result.data.agentsmd,
       cursor: result.data.cursor,

--- a/src/features/rules/tool-rule.test.ts
+++ b/src/features/rules/tool-rule.test.ts
@@ -874,7 +874,7 @@ describe("ToolRule", () => {
       const frontmatter = rulesyncRule.getFrontmatter();
       expect(frontmatter.root).toBe(false);
       expect(frontmatter.targets).toEqual(["*"]);
-      expect(frontmatter.description).toBe("");
+      expect(frontmatter.description).toBeUndefined();
       expect(frontmatter.globs).toEqual([]);
     });
 
@@ -916,7 +916,7 @@ describe("ToolRule", () => {
       const frontmatter = rulesyncRule.getFrontmatter();
       expect(frontmatter.root).toBe(true);
       expect(frontmatter.targets).toEqual(["*"]);
-      expect(frontmatter.description).toBe("");
+      expect(frontmatter.description).toBeUndefined();
       expect(frontmatter.globs).toEqual(["**/*"]);
     });
   });

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -174,7 +174,7 @@ export abstract class ToolRule extends ToolFile {
       frontmatter: {
         root: this.isRoot(),
         targets: ["*"],
-        description: this.description ?? "",
+        description: this.description,
         globs: this.globs ?? (this.isRoot() ? ["**/*"] : []),
       },
       body: this.getFileContent(),

--- a/src/features/rules/windsurf-rule.test.ts
+++ b/src/features/rules/windsurf-rule.test.ts
@@ -259,7 +259,7 @@ describe("WindsurfRule", () => {
       expect(rulesyncRule.getFrontmatter()).toEqual({
         root: false,
         targets: ["*"],
-        description: "",
+        description: undefined,
         globs: [],
       });
     });
@@ -301,7 +301,7 @@ describe("WindsurfRule", () => {
       const rulesyncRule = windsurfRule.toRulesyncRule();
 
       expect(rulesyncRule.getFileContent()).toContain(
-        "---\nroot: false\ntargets:\n  - '*'\ndescription: ''\nglobs: []\n---\n",
+        "---\nroot: false\ntargets:\n  - '*'\nglobs: []\n---\n",
       );
     });
   });

--- a/src/mcp/rules.test.ts
+++ b/src/mcp/rules.test.ts
@@ -90,7 +90,7 @@ description: "Second rule"
         root: false,
         localRoot: false,
         targets: ["*"],
-        description: "",
+        description: undefined,
         globs: [],
       });
     });

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -187,6 +187,42 @@ Body content after empty frontmatter.`;
       expect(result.body).toBe("Body content after empty frontmatter.");
     });
 
+    it("should strip YAML null values from parsed frontmatter", () => {
+      // YAML parses bare keys like "description:" as null
+      const content = `---
+description:
+globs: "*.ts"
+alwaysApply: true
+---
+Body content.`;
+
+      const result = parseFrontmatter(content);
+
+      // null value from "description:" should be stripped
+      expect(result.frontmatter).toEqual({
+        globs: "*.ts",
+        alwaysApply: true,
+      });
+      expect(result.frontmatter).not.toHaveProperty("description");
+    });
+
+    it("should strip nested null values from parsed frontmatter", () => {
+      const content = `---
+cursor:
+  description:
+  alwaysApply: true
+---
+Body content.`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.frontmatter).toEqual({
+        cursor: {
+          alwaysApply: true,
+        },
+      });
+    });
+
     it("should handle malformed YAML gracefully", () => {
       const content = `---
 title: "Valid quote"

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -64,5 +64,11 @@ export function parseFrontmatter(content: string): {
 } {
   const { data: frontmatter, content: body } = matter(content);
 
-  return { frontmatter, body };
+  // Strip null/undefined values from parsed frontmatter for consistency.
+  // YAML parses bare keys (e.g. "description:") as null, which would fail
+  // Zod validation (z.optional(z.string()) does not accept null).
+  // This mirrors the deepRemoveNullishObject cleanup done in stringifyFrontmatter.
+  const cleanFrontmatter = deepRemoveNullishObject(frontmatter);
+
+  return { frontmatter: cleanFrontmatter, body };
 }


### PR DESCRIPTION
closes #1068