### PR TITLE
fix: inline review steps in PR comment workflow

### DIFF
--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -83,7 +83,15 @@ jobs:
 
             Follow these instructions:
             If the triggering comment is a review request, perform step 1. If it is a fix request, perform step 2. If you cannot determine which, post a comment on this PR stating so and exit immediately.
-              1. Review the changes in this PR using /review-pr (.opencode/command/review-pr.md) and post the results as a comment.
+              1. Review the changes in this PR with the following steps:
+                  ```md
+                  Execute the following steps:
+
+                  - Call code-reviewer subagent to review the code changes in the PR.
+                  - Call security-reviewer subagent to review the security issues the PR.
+
+                  Integrate and report the execution results from each subagent. Additionaly, please output PR number in the result so that the user can easily find the PR.
+                  ```
               2. Fix the code. Run `pnpm cicheck` to verify code quality. If the environment variable IS_UPSTREAM is true, perform 2-1. If false (fork repository), perform 2-2.
                 2-1. Commit and push the fix to this branch.
                 2-2. Carry over the commits from this PR, then commit and push the fix to a new branch. Create a new PR.


### PR DESCRIPTION
## Summary
- PR comment workflowのレビュー手順を `/review-pr` コマンド参照からインライン手順に変更
- `code-reviewer` と `security-reviewer` サブエージェントを直接呼び出す形式に改善
- AIエージェントがスキル参照に依存せず、確実にレビューを実行できるように

## Test plan
- [ ] PR comment workflowが正常にトリガーされることを確認
- [ ] AIエージェントがcode-reviewerとsecurity-reviewerサブエージェントを正しく呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)