### PR TITLE
feat: add programmatic API for generate and importFromTool

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,7 +1,7 @@
 import { type KnipConfig } from "knip";
 
 const config: KnipConfig = {
-  entry: ["src/cli/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"],
+  entry: ["src/cli/index.ts", "src/index.ts", "src/**/*.test.ts", "src/**/*.test-d.ts"],
   project: ["src/**/*.ts"],
   ignore: [
     // Build output and node_modules

--- a/package.json
+++ b/package.json
@@ -23,17 +23,29 @@
   "license": "MIT",
   "author": "dyoshikawa",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "rulesync": "dist/index.js"
+    "rulesync": "dist/cli/index.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/cli/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/cli/index.ts src/index.ts --format cjs,esm --dts --clean",
     "check": "pnpm run fmt:check && pnpm run oxlint && pnpm run eslint && pnpm run typecheck",
     "cicheck": "pnpm run cicheck:code && pnpm run cicheck:content",
     "cicheck:code": "pnpm run check && pnpm run test",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Config } from "./config/config.js";
+import type { GenerateResult } from "./lib/generate.js";
+import type { ImportResult } from "./lib/import.js";
+
+import { ConfigResolver } from "./config/config-resolver.js";
+import { generate, importFromTool } from "./index.js";
+import { checkRulesyncDirExists, generate as coreGenerate } from "./lib/generate.js";
+import { importFromTool as coreImportFromTool } from "./lib/import.js";
+import { logger } from "./utils/logger.js";
+
+vi.mock("./config/config-resolver.js");
+vi.mock("./lib/generate.js");
+vi.mock("./lib/import.js");
+vi.mock("./utils/logger.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./utils/logger.js")>();
+  return {
+    ...actual,
+    logger: {
+      configure: vi.fn(),
+    },
+  };
+});
+
+const mockConfig = {
+  getBaseDirs: () => ["/project"],
+} as unknown as Config;
+
+const mockGenerateResult: GenerateResult = {
+  rulesCount: 1,
+  rulesPaths: ["/project/.cursorrules"],
+  ignoreCount: 0,
+  ignorePaths: [],
+  mcpCount: 0,
+  mcpPaths: [],
+  commandsCount: 0,
+  commandsPaths: [],
+  subagentsCount: 0,
+  subagentsPaths: [],
+  skillsCount: 0,
+  skillsPaths: [],
+  hooksCount: 0,
+  hooksPaths: [],
+  skills: [],
+  hasDiff: false,
+};
+
+const mockImportResult: ImportResult = {
+  rulesCount: 1,
+  ignoreCount: 0,
+  mcpCount: 0,
+  commandsCount: 0,
+  subagentsCount: 0,
+  skillsCount: 0,
+  hooksCount: 0,
+};
+
+beforeEach(() => {
+  vi.mocked(ConfigResolver.resolve).mockResolvedValue(mockConfig as never);
+  vi.mocked(checkRulesyncDirExists).mockResolvedValue(true);
+  vi.mocked(coreGenerate).mockResolvedValue(mockGenerateResult);
+  vi.mocked(coreImportFromTool).mockResolvedValue(mockImportResult);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generate", () => {
+  it("should default silent to true", async () => {
+    await generate();
+
+    expect(logger.configure).toHaveBeenCalledWith({ verbose: false, silent: true });
+  });
+
+  it("should allow overriding silent to false", async () => {
+    await generate({ silent: false });
+
+    expect(logger.configure).toHaveBeenCalledWith({ verbose: false, silent: false });
+  });
+
+  it("should pass options to ConfigResolver.resolve", async () => {
+    await generate({
+      targets: ["claudecode", "cursor"],
+      features: ["rules", "mcp"],
+      verbose: true,
+      silent: false,
+    });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["claudecode", "cursor"],
+        features: ["rules", "mcp"],
+        verbose: true,
+        silent: false,
+      }),
+    );
+  });
+
+  it("should throw if .rulesync directory does not exist", async () => {
+    vi.mocked(checkRulesyncDirExists).mockResolvedValue(false);
+
+    await expect(generate()).rejects.toThrow(".rulesync directory not found");
+  });
+
+  it("should call core generate and return result", async () => {
+    const result = await generate();
+
+    expect(coreGenerate).toHaveBeenCalledWith({ config: mockConfig });
+    expect(result).toEqual(mockGenerateResult);
+  });
+});
+
+describe("importFromTool", () => {
+  it("should default silent to true", async () => {
+    await importFromTool({ target: "claudecode" });
+
+    expect(logger.configure).toHaveBeenCalledWith({ verbose: false, silent: true });
+  });
+
+  it("should wrap target in array for ConfigResolver", async () => {
+    await importFromTool({ target: "cursor" });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["cursor"],
+      }),
+    );
+  });
+
+  it("should call core importFromTool with correct tool", async () => {
+    const result = await importFromTool({ target: "claudecode" });
+
+    expect(coreImportFromTool).toHaveBeenCalledWith({ config: mockConfig, tool: "claudecode" });
+    expect(result).toEqual(mockImportResult);
+  });
+
+  it("should pass features and other options through", async () => {
+    await importFromTool({
+      target: "claudecode",
+      features: ["rules", "commands"],
+      verbose: true,
+      silent: false,
+    });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["claudecode"],
+        features: ["rules", "commands"],
+        verbose: true,
+        silent: false,
+      }),
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,72 @@
+import type { Feature } from "./types/features.js";
+import type { ToolTarget } from "./types/tool-targets.js";
+
+import { ConfigResolver } from "./config/config-resolver.js";
+import { checkRulesyncDirExists, generate as coreGenerate } from "./lib/generate.js";
+import { importFromTool as coreImportFromTool } from "./lib/import.js";
+import { logger } from "./utils/logger.js";
+
+export type { Feature } from "./types/features.js";
+export type { ToolTarget } from "./types/tool-targets.js";
+export { ALL_FEATURES } from "./types/features.js";
+export { ALL_TOOL_TARGETS } from "./types/tool-targets.js";
+export type { GenerateResult } from "./lib/generate.js";
+export type { ImportResult } from "./lib/import.js";
+
+export type GenerateOptions = {
+  targets?: ToolTarget[];
+  features?: Feature[];
+  baseDirs?: string[];
+  configPath?: string;
+  verbose?: boolean;
+  silent?: boolean;
+  delete?: boolean;
+  global?: boolean;
+  simulateCommands?: boolean;
+  simulateSubagents?: boolean;
+  simulateSkills?: boolean;
+  dryRun?: boolean;
+  check?: boolean;
+};
+
+export type ImportOptions = {
+  target: ToolTarget;
+  features?: Feature[];
+  configPath?: string;
+  verbose?: boolean;
+  silent?: boolean;
+  global?: boolean;
+};
+
+export async function generate(options: GenerateOptions = {}) {
+  const { silent = true, verbose = false, ...rest } = options;
+  logger.configure({ verbose, silent });
+
+  const config = await ConfigResolver.resolve({
+    ...rest,
+    verbose,
+    silent,
+  });
+
+  for (const baseDir of config.getBaseDirs()) {
+    if (!(await checkRulesyncDirExists({ baseDir }))) {
+      throw new Error(".rulesync directory not found. Run 'rulesync init' first.");
+    }
+  }
+
+  return coreGenerate({ config });
+}
+
+export async function importFromTool(options: ImportOptions) {
+  const { target, silent = true, verbose = false, ...rest } = options;
+  logger.configure({ verbose, silent });
+
+  const config = await ConfigResolver.resolve({
+    ...rest,
+    targets: [target],
+    verbose,
+    silent,
+  });
+
+  return coreImportFromTool({ config, tool: target });
+}


### PR DESCRIPTION
## Summary

- Add `src/index.ts` as a library entry point exposing `generate()` and `importFromTool()` functions with ergonomic options (defaults `silent: true`, resolves Config internally, throws Error instead of `process.exit`)
- Fix `package.json` build config: dual CJS/ESM exports, correct `bin` path (`dist/cli/index.js`), and `exports` field with proper types conditions
- Add `src/index.test.ts` with 9 unit tests covering both wrapper functions
- Add `src/index.ts` to `knip.ts` entry points

## Usage

```ts
import { generate, importFromTool } from "rulesync";

const result = await generate({
  targets: ["claudecode", "cursor"],
  features: ["rules", "mcp"],
});

const importResult = await importFromTool({
  target: "claudecode",
  features: ["rules", "commands"],
});
```

Closes #377

## Test plan

- [x] All 3819 existing tests pass
- [x] 9 new tests for `src/index.ts` pass
- [x] `pnpm cicheck` passes (fmt, oxlint, eslint, typecheck, test, cspell, secretlint)
- [x] `pnpm build` produces correct outputs (`dist/index.js`, `dist/index.cjs`, `dist/index.d.ts`, `dist/index.d.cts`, `dist/cli/index.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)