### PR TITLE
ci: add release-by-ai workflow and rename release workflows to publish

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -1,4 +1,4 @@
-name: Release Assets
+name: Publish Assets
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 
 on:
   release:

--- a/.github/workflows/release-by-ai.yml
+++ b/.github/workflows/release-by-ai.yml
@@ -1,0 +1,90 @@
+name: Release by AI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., v1.2.3). Leave empty to auto-detect from release-dry-run."
+        required: false
+        default: ""
+      model:
+        description: "OpenRouter model to use"
+        required: false
+        default: "openrouter/z-ai/glm-5"
+        type: choice
+        options:
+          - "openrouter/z-ai/glm-5"
+          - "openrouter/openai/gpt-5.2-codex"
+          - "openrouter/moonshotai/kimi-k2.5"
+
+jobs:
+  release:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (
+          github.actor == github.repository_owner ||
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.sender.login)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name dyoshikawa
+          git config user.email dyoshikawa1993@gmail.com
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run OpenCode to perform release
+        uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        with:
+          model: ${{ inputs.model }}
+          use_github_token: "true"
+          share: false
+          prompt: |
+            You are performing an automated release for this project on the main branch.
+
+            Read the environment variable RELEASE_VERSION to check if a specific version was provided.
+
+            Follow these steps:
+
+            ## Step 1: Determine the release version
+
+            If RELEASE_VERSION is empty or not set:
+            1. Execute the /release-dry-run command to analyze changes since the last release.
+            2. Based on the dry run output, determine the appropriate next version following semantic versioning.
+            3. Assign the determined version to use in the next step.
+
+            If RELEASE_VERSION is set (e.g., "v1.2.3"):
+            1. Use that version directly.
+
+            ## Step 2: Execute the release
+
+            Execute the /release command with the determined version as the argument.
+            For example, if the version is "v1.2.3", run: /release v1.2.3
+
+            IMPORTANT:
+            - You MUST be on the main branch. If not, abort immediately.
+            - Follow the release command instructions exactly.
+            - Do not skip any steps in the release process.
+            - Wait for the publish-assets workflow to complete before publishing the release.

--- a/.rulesync/commands/release.md
+++ b/.rulesync/commands/release.md
@@ -27,7 +27,7 @@ Let's resume the release process.
 7. Since `package.json` will be modified, execute `git commit` and `git push`.
 8. Run `gh pr create` and `gh pr merge --admin` to merge the release branch into the main branch.
 9. As a precaution, verify that `getVersion()` in `src/cli/index.ts` is updated to the ${new_version}.
-10. Create a **draft** release using `gh release create v${new_version} --draft --title v${new_version} --notes-file ./ai-tmp/release-notes.md` command on the `github.com/dyoshikawa/rulesync` repository. This creates a draft release so that the release-assets workflow can upload assets.
-11. Wait for the release-assets workflow to complete successfully. Use `gh run list --workflow="Release Assets" --branch v${new_version} --limit 1 --json status,conclusion,databaseId` to check the status. Poll until the workflow completes (status is "completed"). If it fails, abort the release process and report the failure.
-12. Once the release-assets workflow succeeds, publish the release by running `gh release edit v${new_version} --draft=false`.
+10. Create a **draft** release using `gh release create v${new_version} --draft --title v${new_version} --notes-file ./ai-tmp/release-notes.md` command on the `github.com/dyoshikawa/rulesync` repository. This creates a draft release so that the publish-assets workflow can upload assets.
+11. Wait for the publish-assets workflow to complete successfully. Use `gh run list --workflow="Publish Assets" --branch v${new_version} --limit 1 --json status,conclusion,databaseId` to check the status. Poll until the workflow completes (status is "completed"). If it fails, abort the release process and report the failure.
+12. Once the publish-assets workflow succeeds, publish the release by running `gh release edit v${new_version} --draft=false`.
 13. Clean up the branches. Run `git checkout main`, `git branch -D release/v${new_version}` and `git pull --prune`.


### PR DESCRIPTION
## Summary
- Add a new `release-by-ai.yml` workflow that uses OpenCode to automate the release process via `workflow_dispatch`
  - Runs `/release-dry-run` to determine the next version, then executes `/release` with that version
  - Supports optional manual version input and model selection
- Rename `release.yml` → `publish.yml` and `release-assets.yml` → `publish-assets.yml`
- Update all references in `.rulesync/commands/release.md` and `release-by-ai.yml`

## Test plan
- [ ] Verify `publish.yml` triggers on release published events
- [ ] Verify `publish-assets.yml` triggers on `v*` tag pushes
- [ ] Verify `release-by-ai.yml` can be manually dispatched from the Actions tab
- [ ] Confirm the `/release` command references the correct workflow name (`Publish Assets`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)