### PR TITLE
fix(ci): simplify release-by-ai job condition to prevent skipped runs

### DIFF
--- a/.github/workflows/release-by-ai.yml
+++ b/.github/workflows/release-by-ai.yml
@@ -19,12 +19,7 @@ on:
 
 jobs:
   release:
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      (
-          github.actor == github.repository_owner ||
-          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.sender.login)
-      )
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary

- `release-by-ai.yml` の `if` 条件を簡略化し、`workflow_dispatch` 実行時にジョブがスキップされる問題を修正
- 旧条件は `github.event.sender.login` をロール名 (`OWNER`/`MEMBER`/`COLLABORATOR`) と比較していたが、`sender.login` はユーザー名を返すため常に不一致だった
- `workflow_dispatch` は元々リポジトリへの write 権限を持つユーザーのみがトリガーできるため、`github.ref == 'refs/heads/main'` のブランチ制限のみで十分

## Test plan

- [ ] `workflow_dispatch` で Release by AI ワークフローを手動実行し、ジョブがスキップされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)