### PR TITLE
fix(docs): correct OGP image paths and use absolute URLs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   lastUpdated: true,
 
   head: [
-    ["link", { rel: "icon", href: "/rulesync/logo.jpg" }],
+    ["link", { rel: "icon", href: "/logo.jpg" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:title", content: "Rulesync" }],
     [
@@ -19,7 +19,13 @@ export default defineConfig({
           "A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files.",
       },
     ],
-    ["meta", { property: "og:image", content: "/rulesync/logo.jpg" }],
+    [
+      "meta",
+      {
+        property: "og:image",
+        content: "https://rulesync.dyoshikawa.com/logo.jpg",
+      },
+    ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
     ["meta", { name: "twitter:title", content: "Rulesync" }],
     [
@@ -30,7 +36,13 @@ export default defineConfig({
           "A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files.",
       },
     ],
-    ["meta", { name: "twitter:image", content: "/rulesync/logo.jpg" }],
+    [
+      "meta",
+      {
+        name: "twitter:image",
+        content: "https://rulesync.dyoshikawa.com/logo.jpg",
+      },
+    ],
   ],
 
   themeConfig: {


### PR DESCRIPTION
## Summary

- Fix favicon path from `/rulesync/logo.jpg` to `/logo.jpg` to match the current `base: "/"` setting
- Fix `og:image` and `twitter:image` to use absolute URLs (`https://rulesync.dyoshikawa.com/logo.jpg`) as required by the OGP and Twitter Card specifications

These paths were left pointing to `/rulesync/` after #1090 changed the VitePress `base` from `/rulesync/` to `/`.

## Test plan

- [ ] Verify favicon loads correctly on the deployed docs site
- [ ] Verify OGP image renders when sharing the docs site URL on social media (use https://opengraph.dev or similar tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)