### PR TITLE
docs: add GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,25 @@
+# Governance
+
+## Roles
+
+### Owner
+
+The project Owner has full authority over all aspects of the project, including but not limited to:
+
+- Project direction and roadmap
+- Collaborator management (invitation and removal)
+- Final decision-making on all matters
+
+### Collaborator
+
+Collaborators are trusted contributors who have been granted write access to the repository. Collaborators may:
+
+- Review and merge pull requests
+- Triage issues
+- Participate in project discussions and decision-making
+
+## Collaborator Invitation and Removal
+
+Invitation and removal of Collaborators are at the sole discretion of the Owner.
+
+The Owner will make best efforts to provide reasoning for these decisions. However, there may be cases where full disclosure is not possible.


### PR DESCRIPTION
## Summary
- Add `GOVERNANCE.md` defining project roles (Owner, Collaborator) and governance policy
- Collaborator invitation and removal are at the Owner's sole discretion
- Owner will make best efforts to provide reasoning, but full disclosure may not always be possible

## Test plan
- [x] Verify `GOVERNANCE.md` content is accurate and complete
- [x] Confirm CI passes (`pnpm cicheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)