### PR TITLE
docs(commands): add English language requirement to create-issue command

### DIFF
--- a/.rulesync/commands/create-issue.md
+++ b/.rulesync/commands/create-issue.md
@@ -27,6 +27,8 @@ Before writing the issue, investigate the relevant parts of the codebase to unde
 
 ## Step 3: Draft the Issue
 
+**Important: All issue content (title, body, labels) must be written in English**, regardless of the language used in the conversation with the user.
+
 Create a well-structured issue with the following sections:
 
 ```markdown


### PR DESCRIPTION
## Summary

- Add instruction to the `create-issue` command that all issue content (title, body, labels) must be written in English, regardless of the conversation language

## Test plan

- [ ] Verify the create-issue command file renders correctly
- [ ] Confirm the instruction is clear and placed in the appropriate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)