### PR TITLE
fix: read .rulesync source files from cwd instead of baseDir in global mode

### DIFF
--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -106,6 +106,30 @@ describe("HooksProcessor", () => {
         expect.stringContaining("Failed to load Rulesync hooks file"),
       );
     });
+
+    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+      await ensureDir(join(testDir, RULESYNC_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(testDir, RULESYNC_HOOKS_RELATIVE_FILE_PATH),
+        JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: [{ type: "command", command: "echo hello" }] },
+        }),
+      );
+
+      // Use a different baseDir to simulate global mode (baseDir = homeDir)
+      const differentBaseDir = join(testDir, "fake-home");
+      await ensureDir(differentBaseDir);
+
+      const processor = new HooksProcessor({
+        baseDir: differentBaseDir,
+        toolTarget: "claudecode",
+        global: true,
+      });
+      const files = await processor.loadRulesyncFiles();
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(RulesyncHooks);
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -132,7 +132,7 @@ export class HooksProcessor extends FeatureProcessor {
     try {
       return [
         await RulesyncHooks.fromFile({
-          baseDir: this.baseDir,
+          baseDir: process.cwd(),
           validate: true,
         }),
       ];

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -938,6 +938,33 @@ targets: ["*"]
       const rulesyncRule = result[0] as RulesyncRule;
       expect(rulesyncRule.getFrontmatter().root).toBe(true);
     });
+
+    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+      await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
+        `---
+root: true
+targets: ["*"]
+---
+# Root rule`,
+      );
+
+      // Use a different baseDir to simulate global mode (baseDir = homeDir)
+      const differentBaseDir = join(testDir, "fake-home");
+      await ensureDir(differentBaseDir);
+
+      const processor = new RulesProcessor({
+        baseDir: differentBaseDir,
+        toolTarget: "claudecode",
+        global: true,
+      });
+
+      const result = await processor.loadRulesyncFiles();
+      expect(result).toHaveLength(1);
+      const rulesyncRule = result[0] as RulesyncRule;
+      expect(rulesyncRule.getFrontmatter().root).toBe(true);
+    });
   });
 
   describe("localRoot content generation", () => {

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -753,7 +753,7 @@ export class RulesProcessor extends FeatureProcessor {
    * Load and parse rulesync rule files from .rulesync/rules/ directory
    */
   async loadRulesyncFiles(): Promise<RulesyncFile[]> {
-    const rulesyncBaseDir = join(this.baseDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
+    const rulesyncBaseDir = join(process.cwd(), RULESYNC_RULES_RELATIVE_DIR_PATH);
     const files = await findFilesByGlobs(join(rulesyncBaseDir, "**", "*.md"));
     logger.debug(`Found ${files.length} rulesync files`);
     const rulesyncRules = await Promise.all(

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -394,6 +394,39 @@ Invalid content`;
 
       await expect(processor.loadRulesyncDirs()).rejects.toThrow("SKILL.md not found in");
     });
+
+    it("should load rulesync dirs from cwd even when baseDir is different (global mode)", async () => {
+      const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      await ensureDir(skillsDir);
+
+      const skill1Dir = join(skillsDir, "skill-1");
+      await ensureDir(skill1Dir);
+
+      const skillContent = `---
+name: skill-1
+description: First skill
+---
+This is skill content`;
+
+      await writeFileContent(join(skill1Dir, "SKILL.md"), skillContent);
+
+      // Use a different baseDir to simulate global mode (baseDir = homeDir)
+      const differentBaseDir = join(testDir, "fake-home");
+      await ensureDir(differentBaseDir);
+
+      const globalProcessor = new SkillsProcessor({
+        baseDir: differentBaseDir,
+        toolTarget: "claudecode",
+        global: true,
+      });
+
+      const rulesyncDirs = await globalProcessor.loadRulesyncDirs();
+
+      expect(rulesyncDirs).toHaveLength(1);
+      expect(rulesyncDirs[0]).toBeInstanceOf(RulesyncSkill);
+      const rulesyncSkill = rulesyncDirs[0] as RulesyncSkill;
+      expect(rulesyncSkill.getFrontmatter().name).toBe("skill-1");
+    });
   });
 
   describe("loadToolDirs", () => {

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -304,18 +304,18 @@ export class SkillsProcessor extends DirFeatureProcessor {
    */
   async loadRulesyncDirs(): Promise<AiDir[]> {
     // Load local skills (directly under .rulesync/skills/)
-    const localDirNames = [...(await getLocalSkillDirNames(this.baseDir))];
+    const localDirNames = [...(await getLocalSkillDirNames(process.cwd()))];
 
     const localSkills = await Promise.all(
       localDirNames.map((dirName) =>
-        RulesyncSkill.fromDir({ baseDir: this.baseDir, dirName, global: this.global }),
+        RulesyncSkill.fromDir({ baseDir: process.cwd(), dirName, global: this.global }),
       ),
     );
 
     const localSkillNames = new Set(localDirNames);
 
     // Load curated (remote) skills from .curated/ subdirectory
-    const curatedDirPath = join(this.baseDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+    const curatedDirPath = join(process.cwd(), RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
     let curatedSkills: RulesyncSkill[] = [];
 
     if (await directoryExists(curatedDirPath)) {
@@ -335,7 +335,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       curatedSkills = await Promise.all(
         nonConflicting.map((dirName) =>
           RulesyncSkill.fromDir({
-            baseDir: this.baseDir,
+            baseDir: process.cwd(),
             relativeDirPath: curatedRelativeDirPath,
             dirName,
             global: this.global,

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -516,6 +516,37 @@ Invalid content`;
       const validRulesyncSubagent = rulesyncFiles[0] as RulesyncSubagent;
       expect(validRulesyncSubagent.getFrontmatter().name).toBe("valid-agent");
     });
+
+    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+      const subagentsDir = join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
+      await ensureDir(subagentsDir);
+
+      const validSubagentContent = `---
+name: global-agent
+description: Global agent description
+targets: ["*"]
+---
+Global agent content`;
+
+      await writeFileContent(join(subagentsDir, "global-agent.md"), validSubagentContent);
+
+      // Use a different baseDir to simulate global mode (baseDir = homeDir)
+      const differentBaseDir = join(testDir, "fake-home");
+      await ensureDir(differentBaseDir);
+
+      const globalProcessor = new SubagentsProcessor({
+        baseDir: differentBaseDir,
+        toolTarget: "claudecode",
+        global: true,
+      });
+
+      const rulesyncFiles = await globalProcessor.loadRulesyncFiles();
+
+      expect(rulesyncFiles).toHaveLength(1);
+      expect(rulesyncFiles[0]).toBeInstanceOf(RulesyncSubagent);
+      const rulesyncSubagent = rulesyncFiles[0] as RulesyncSubagent;
+      expect(rulesyncSubagent.getFrontmatter().name).toBe("global-agent");
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -272,7 +272,7 @@ export class SubagentsProcessor extends FeatureProcessor {
    * Load and parse rulesync subagent files from .rulesync/subagents/ directory
    */
   async loadRulesyncFiles(): Promise<RulesyncFile[]> {
-    const subagentsDir = join(this.baseDir, RulesyncSubagent.getSettablePaths().relativeDirPath);
+    const subagentsDir = join(process.cwd(), RulesyncSubagent.getSettablePaths().relativeDirPath);
 
     // Check if directory exists
     const dirExists = await directoryExists(subagentsDir);


### PR DESCRIPTION
## Summary

- Fix 4 processors that incorrectly used `this.baseDir` to read `.rulesync/` source files. When `--global` flag is used, `baseDir` points to the home directory (for output), but `.rulesync/` source files should always be read from `process.cwd()` (the project root).
- Affected processors: `SubagentsProcessor`, `RulesProcessor`, `SkillsProcessor`, `HooksProcessor`
- Add test cases for each processor to verify global mode reads rulesync files from cwd

## Test plan

- [x] All 4 new test cases pass: verify `loadRulesyncFiles`/`loadRulesyncDirs` reads from cwd even when `baseDir` is different
- [x] `pnpm cicheck` passes (3976 tests, lint, typecheck, spell check, secret check)
- [ ] Manual test: `pnpm dev generate --targets claudecode --features subagents --global` should find and generate subagent files from project's `.rulesync/subagents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)