### PR TITLE
ci: update OpenCode workflow config

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -27,7 +27,7 @@ runs:
         elif [[ "$COMMENT_BODY" == *"kimi"* ]]; then
           echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
         else
-          echo "model=openrouter/z-ai/glm-5" >> $GITHUB_OUTPUT
+          echo "model=zai-coding-plan/glm-5" >> $GITHUB_OUTPUT
         fi
         CLEANED_COMMENT_BODY="$COMMENT_BODY"
         CLEANED_COMMENT_BODY="${CLEANED_COMMENT_BODY//\/oc/}"

--- a/.github/workflows/issue-comment-to-ai.yml
+++ b/.github/workflows/issue-comment-to-ai.yml
@@ -10,9 +10,8 @@ jobs:
       !github.event.issue.pull_request &&
       (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.comment.user.login == 'dyoshikawa' ||
+          github.event.comment.user.login == 'cm-dyoshikawa'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -50,6 +49,7 @@ jobs:
         uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}

--- a/.github/workflows/pr-comment-to-ai.yml
+++ b/.github/workflows/pr-comment-to-ai.yml
@@ -10,9 +10,8 @@ jobs:
       github.event.issue.pull_request &&
       (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.comment.user.login == 'dyoshikawa' ||
+          github.event.comment.user.login == 'cm-dyoshikawa'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -66,6 +65,7 @@ jobs:
         uses: anomalyco/opencode/github@4d187af9d20b04e4fbd77ad04eaaea241b8e25bf # v1.1.2
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_UPSTREAM: ${{ github.repository == 'dyoshikawa/rulesync' }}
           PR_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

- デフォルトモデルを `zai-coding-plan/glm-5` に変更
- `ZHIPU_API_KEY` シークレットを両ワークフローの env に追加
- トリガー可能なユーザーを `dyoshikawa` と `cm-dyoshikawa` に限定（`author_association` ベースから `user.login` ベースに変更）

## Test plan

- [ ] Issue コメントで `/oc` トリガー時に正しいモデルが選択されることを確認
- [ ] `dyoshikawa` / `cm-dyoshikawa` 以外のユーザーではワークフローが実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)