### PR TITLE
fix(ci): remove draft flag from publish-assets workflow

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Upload assets to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          draft: true
           files: |
             install.sh
             dist-bun/rulesync-linux-x64


### PR DESCRIPTION
## Summary

- Remove `draft: true` flag from `softprops/action-gh-release` in publish-assets workflow
- The flag causes `Cannot upload assets to an immutable release` error when the release is already published before the workflow runs

## Test plan

- [ ] Verify that the publish-assets workflow succeeds on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)