### PR TITLE
fix(ci): support workflow_dispatch for publish-assets

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v7.6.2)"
+        required: true
+        type: string
 
 permissions:
   contents: write # Required for uploading release assets
@@ -48,9 +54,22 @@ jobs:
       - name: Bundle TOON files into zip
         run: zip repomix-toon.zip repomix-output-*.toon
 
+      - name: Determine tag name
+        id: tag
+        run: |
+          if [ -n "$TAG_INPUT" ]; then
+            echo "tag=$TAG_INPUT" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+
       - name: Upload assets to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          draft: true
           files: |
             install.sh
             dist-bun/rulesync-linux-x64


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger with tag input to publish-assets workflow
- Restore `draft: true` in `softprops/action-gh-release` so assets can be uploaded to draft releases
- Add tag name determination step to support both tag push and manual dispatch triggers

This fixes the `Cannot upload assets to an immutable release` error caused by GitHub's immutable releases feature, which prevents uploading assets to published releases.

## New release flow

1. Create draft release: `gh release create vX.Y.Z --draft`
2. Manually trigger workflow: `gh workflow run "Publish Assets" -f tag=vX.Y.Z`
3. Wait for workflow to complete
4. Publish release: `gh release edit vX.Y.Z --draft=false`

## Test plan

- [ ] Verify publish-assets workflow succeeds via manual dispatch for v7.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)