### PR TITLE
fix: preserve Cursor command frontmatter (description, handoffs)

### DIFF
--- a/src/features/commands/cursor-command.test.ts
+++ b/src/features/commands/cursor-command.test.ts
@@ -1,27 +1,20 @@
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type {
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+} from "./tool-command.js";
+
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { writeFileContent } from "../../utils/file.js";
-import { CursorCommand } from "./cursor-command.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { CursorCommand, CursorCommandFrontmatterSchema } from "./cursor-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 
 describe("CursorCommand", () => {
   let testDir: string;
   let cleanup: () => Promise<void>;
-
-  const validMarkdownContent = `This is the body of the cursor command.
-It can be multiline.`;
-
-  const markdownContentWithFrontmatter = `---
-description: Test cursor command description
----
-
-This is the body of the cursor command.
-It can be multiline.`;
-
-  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
 
   beforeEach(async () => {
     const testSetup = await setupTestDirectory();
@@ -50,31 +43,35 @@ It can be multiline.`;
   });
 
   describe("constructor", () => {
-    it("should create instance with valid content", () => {
+    it("should create instance with valid content and frontmatter", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
-        fileContent: "This is the body of the cursor command.\nIt can be multiline.",
+        frontmatter: { description: "Test description" },
+        body: "This is the body of the cursor command.\nIt can be multiline.",
         validate: true,
       });
 
       expect(command).toBeInstanceOf(CursorCommand);
-      expect(command.getFileContent()).toBe(
+      expect(command.getBody()).toBe(
         "This is the body of the cursor command.\nIt can be multiline.",
       );
+      expect(command.getFrontmatter()).toEqual({ description: "Test description" });
     });
 
-    it("should create instance with empty content", () => {
+    it("should create instance with empty frontmatter", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
-        fileContent: "",
+        frontmatter: {},
+        body: "Body content",
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe("");
+      expect(command).toBeInstanceOf(CursorCommand);
+      expect(command.getBody()).toBe("Body content");
     });
 
     it("should create instance without validation when validate is false", () => {
@@ -82,50 +79,67 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
-        fileContent: "Test body",
+        frontmatter: {},
+        body: "Test body",
         validate: false,
       });
 
       expect(command).toBeInstanceOf(CursorCommand);
     });
-  });
 
-  describe("getFileContent", () => {
-    it("should return the file content", () => {
+    it("should generate correct file content with frontmatter", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
-        relativeFilePath: "test-command.md",
-        fileContent: "This is the body content.\nWith multiple lines.",
-        validate: true,
+        relativeFilePath: "test.md",
+        frontmatter: { description: "Test cursor command" },
+        body: "This is a test command body",
       });
 
-      expect(command.getFileContent()).toBe("This is the body content.\nWith multiple lines.");
+      const fileContent = command.getFileContent();
+      expect(fileContent).toContain("---");
+      expect(fileContent).toContain("description: Test cursor command");
+      expect(fileContent).toContain("This is a test command body");
     });
   });
 
   describe("getBody", () => {
-    it("should return the same as getFileContent", () => {
+    it("should return the command body", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
-        fileContent: "This is the body content.\nWith multiple lines.",
-        validate: true,
+        frontmatter: { description: "Test" },
+        body: "This is the body content.\nWith multiple lines.",
       });
 
       expect(command.getBody()).toBe("This is the body content.\nWith multiple lines.");
-      expect(command.getBody()).toBe(command.getFileContent());
+    });
+  });
+
+  describe("getFrontmatter", () => {
+    it("should return the frontmatter", () => {
+      const frontmatter = { description: "Test cursor command description" };
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter,
+        body: "Command body",
+      });
+
+      expect(command.getFrontmatter()).toEqual(frontmatter);
     });
   });
 
   describe("toRulesyncCommand", () => {
-    it("should convert to RulesyncCommand", () => {
+    it("should convert to RulesyncCommand with description", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
-        fileContent: "Test body content",
+        frontmatter: { description: "Test cursor description" },
+        body: "Test body content",
         validate: true,
       });
 
@@ -133,9 +147,61 @@ It can be multiline.`;
       expect(rulesyncCommand).toBeInstanceOf(RulesyncCommand);
       expect(rulesyncCommand.getBody()).toBe("Test body content");
       expect(rulesyncCommand.getFrontmatter().targets).toEqual(["*"]);
-      expect(rulesyncCommand.getFrontmatter().description).toBe("");
+      expect(rulesyncCommand.getFrontmatter().description).toBe("Test cursor description");
       expect(rulesyncCommand.getRelativeFilePath()).toBe("test-command.md");
       expect(rulesyncCommand.getFileContent()).toContain("Test body content");
+    });
+
+    it("should default description to empty string when not set", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {},
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+      expect(rulesyncCommand.getFrontmatter().description).toBe("");
+    });
+
+    it("should preserve handoffs in cursor section", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {
+          description: "Test",
+          handoffs: [
+            { label: "Build Plan", agent: "planner", prompt: "Plan this", send: true },
+          ],
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+      const fm = rulesyncCommand.getFrontmatter();
+      expect(fm.cursor).toEqual({
+        handoffs: [
+          { label: "Build Plan", agent: "planner", prompt: "Plan this", send: true },
+        ],
+      });
+    });
+
+    it("should not include cursor section when no extra fields", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: { description: "Just a description" },
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+      expect(rulesyncCommand.getFrontmatter().cursor).toBeUndefined();
     });
   });
 
@@ -150,7 +216,7 @@ It can be multiline.`;
           description: "Test description from rulesync",
         },
         body: "Test command content",
-        fileContent: "", // Will be generated
+        fileContent: "",
         validate: true,
       });
 
@@ -161,7 +227,10 @@ It can be multiline.`;
       });
 
       expect(cursorCommand).toBeInstanceOf(CursorCommand);
-      expect(cursorCommand.getFileContent()).toBe("Test command content");
+      expect(cursorCommand.getBody()).toBe("Test command content");
+      expect(cursorCommand.getFrontmatter()).toEqual({
+        description: "Test description from rulesync",
+      });
       expect(cursorCommand.getRelativeFilePath()).toBe("test-command.md");
       expect(cursorCommand.getRelativeDirPath()).toBe(".cursor/commands");
     });
@@ -209,7 +278,9 @@ It can be multiline.`;
         validate: true,
       });
 
-      expect(cursorCommand.getFileContent()).toBe("Test content");
+      expect(cursorCommand.getBody()).toBe("Test content");
+      // Empty description should not be included in cursor frontmatter
+      expect(cursorCommand.getFrontmatter()).toEqual({});
     });
 
     it("should use global paths when global is true", () => {
@@ -259,14 +330,77 @@ It can be multiline.`;
       expect(cursorCommand.getRelativeDirPath()).toBe(join(".cursor", "commands"));
       expect(cursorCommand.getBody()).toBe("Local command body");
     });
+
+    it("should preserve cursor-specific fields from rulesync frontmatter", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "passthrough-test.md",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "Test command",
+          cursor: {
+            handoffs: [
+              { label: "Build Plan", agent: "planner", prompt: "Plan this", send: true },
+            ],
+          },
+        },
+        body: "Test body",
+        fileContent: "",
+      });
+
+      const cursorCommand = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+      });
+
+      const frontmatter = cursorCommand.getFrontmatter();
+      expect(frontmatter.description).toBe("Test command");
+      expect(frontmatter.handoffs).toEqual([
+        { label: "Build Plan", agent: "planner", prompt: "Plan this", send: true },
+      ]);
+    });
+
+    it("should handle empty cursor fields in RulesyncCommand", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "empty-test.md",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "Test command",
+          cursor: {},
+        },
+        body: "Test body",
+        fileContent: "",
+      });
+
+      const cursorCommand = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+      });
+
+      const frontmatter = cursorCommand.getFrontmatter();
+      expect(frontmatter.description).toBe("Test command");
+      // No extra fields should be added
+      expect(Object.keys(frontmatter)).toEqual(["description"]);
+    });
   });
 
   describe("fromFile", () => {
-    it("should load CursorCommand from file", async () => {
+    it("should load CursorCommand from file with frontmatter", async () => {
       const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "test-file-command.md");
+      await ensureDir(commandsDir);
 
-      await writeFileContent(filePath, validMarkdownContent);
+      const fileContent = `---
+description: Test cursor command description
+---
+
+This is the body of the cursor command.
+It can be multiline.`;
+
+      const filePath = join(commandsDir, "test-file-command.md");
+      await writeFileContent(filePath, fileContent);
 
       const command = await CursorCommand.fromFile({
         baseDir: testDir,
@@ -275,17 +409,83 @@ It can be multiline.`;
       });
 
       expect(command).toBeInstanceOf(CursorCommand);
-      expect(command.getFileContent()).toBe(
+      expect(command.getBody()).toBe(
         "This is the body of the cursor command.\nIt can be multiline.",
       );
+      expect(command.getFrontmatter()).toEqual({
+        description: "Test cursor command description",
+      });
       expect(command.getRelativeFilePath()).toBe("test-file-command.md");
+    });
+
+    it("should load CursorCommand from file with handoffs", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      await ensureDir(commandsDir);
+
+      const fileContent = `---
+description: Create a spec
+handoffs:
+  - label: Build Plan
+    agent: speckit.plan
+    prompt: Create a plan
+  - label: Clarify
+    agent: speckit.clarify
+    prompt: Clarify requirements
+    send: true
+---
+
+This is the body.`;
+
+      const filePath = join(commandsDir, "with-handoffs.md");
+      await writeFileContent(filePath, fileContent);
+
+      const command = await CursorCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "with-handoffs.md",
+        validate: true,
+      });
+
+      expect(command.getFrontmatter()).toEqual({
+        description: "Create a spec",
+        handoffs: [
+          { label: "Build Plan", agent: "speckit.plan", prompt: "Create a plan" },
+          { label: "Clarify", agent: "speckit.clarify", prompt: "Clarify requirements", send: true },
+        ],
+      });
+      expect(command.getBody()).toBe("This is the body.");
+    });
+
+    it("should handle file without frontmatter", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      await ensureDir(commandsDir);
+
+      await writeFileContent(
+        join(commandsDir, "no-frontmatter.md"),
+        "This is just plain content without frontmatter.",
+      );
+
+      const command = await CursorCommand.fromFile({
+        baseDir: testDir,
+        relativeFilePath: "no-frontmatter.md",
+        validate: true,
+      });
+
+      expect(command.getBody()).toBe("This is just plain content without frontmatter.");
+      expect(command.getFrontmatter()).toEqual({});
     });
 
     it("should handle file path with subdirectories", async () => {
       const commandsDir = join(testDir, ".cursor", "commands", "subdir");
-      const filePath = join(commandsDir, "nested-command.md");
+      await ensureDir(commandsDir);
 
-      await writeFileContent(filePath, validMarkdownContent);
+      await writeFileContent(
+        join(commandsDir, "nested-command.md"),
+        `---
+description: Nested
+---
+
+Body content`,
+      );
 
       const command = await CursorCommand.fromFile({
         baseDir: testDir,
@@ -307,59 +507,42 @@ It can be multiline.`;
       ).rejects.toThrow();
     });
 
-    it("should handle file with frontmatter (stripping it)", async () => {
+    it("should trim whitespace from body", async () => {
       const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "with-frontmatter.md");
+      await ensureDir(commandsDir);
 
-      await writeFileContent(filePath, markdownContentWithFrontmatter);
+      const fileContent = `---
+description: Whitespace test
+---
+
+
+   Body with leading and trailing whitespace
+
+
+`;
+
+      await writeFileContent(join(commandsDir, "whitespace.md"), fileContent);
 
       const command = await CursorCommand.fromFile({
         baseDir: testDir,
-        relativeFilePath: "with-frontmatter.md",
+        relativeFilePath: "whitespace.md",
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe(
-        "This is the body of the cursor command.\nIt can be multiline.",
-      );
-    });
-
-    it("should handle file without frontmatter", async () => {
-      const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "no-frontmatter.md");
-
-      await writeFileContent(filePath, markdownWithoutFrontmatter);
-
-      const command = await CursorCommand.fromFile({
-        baseDir: testDir,
-        relativeFilePath: "no-frontmatter.md",
-        validate: true,
-      });
-
-      expect(command.getFileContent()).toBe("This is just plain content without frontmatter.");
-    });
-
-    it("should trim whitespace from file content", async () => {
-      const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "with-whitespace.md");
-      const contentWithWhitespace = "\n\n  This content has whitespace  \n\n";
-
-      await writeFileContent(filePath, contentWithWhitespace);
-
-      const command = await CursorCommand.fromFile({
-        baseDir: testDir,
-        relativeFilePath: "with-whitespace.md",
-        validate: true,
-      });
-
-      expect(command.getFileContent()).toBe("This content has whitespace");
+      expect(command.getBody()).toBe("Body with leading and trailing whitespace");
     });
 
     it("should load from global path when global is true", async () => {
       const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "global-test.md");
+      await ensureDir(commandsDir);
 
-      await writeFileContent(filePath, "Global command body");
+      await writeFileContent(
+        join(commandsDir, "global-test.md"),
+        `---
+description: Global command
+---
+Global command body`,
+      );
 
       const command = await CursorCommand.fromFile({
         baseDir: testDir,
@@ -374,9 +557,15 @@ It can be multiline.`;
 
     it("should load from local path when global is false", async () => {
       const commandsDir = join(testDir, ".cursor", "commands");
-      const filePath = join(commandsDir, "local-test.md");
+      await ensureDir(commandsDir);
 
-      await writeFileContent(filePath, "Local command body");
+      await writeFileContent(
+        join(commandsDir, "local-test.md"),
+        `---
+description: Local command
+---
+Local command body`,
+      );
 
       const command = await CursorCommand.fromFile({
         baseDir: testDir,
@@ -391,18 +580,63 @@ It can be multiline.`;
   });
 
   describe("validate", () => {
-    it("should always return success", () => {
+    it("should return success for valid frontmatter", () => {
       const command = new CursorCommand({
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "valid-command.md",
-        fileContent: "Valid body",
-        validate: false,
+        frontmatter: { description: "Valid description" },
+        body: "Valid body",
       });
 
       const result = command.validate();
       expect(result.success).toBe(true);
       expect(result.error).toBeNull();
+    });
+
+    it("should return success for empty frontmatter", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "empty-fm.md",
+        frontmatter: {},
+        body: "Body",
+      });
+
+      const result = command.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should return success when frontmatter is undefined", () => {
+      const command = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "test.md",
+        frontmatter: {} as any,
+        body: "Body",
+        validate: false,
+      });
+
+      (command as any).frontmatter = undefined;
+
+      const result = command.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a minimal instance for deletion", () => {
+      const command = CursorCommand.forDeletion({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "to-delete.md",
+      });
+
+      expect(command).toBeInstanceOf(CursorCommand);
+      expect(command.getBody()).toBe("");
+      expect(command.getFrontmatter()).toEqual({});
     });
   });
 
@@ -412,11 +646,12 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "empty-body.md",
-        fileContent: "",
+        frontmatter: {},
+        body: "",
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe("");
+      expect(command.getBody()).toBe("");
     });
 
     it("should handle special characters in content", () => {
@@ -427,14 +662,15 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "special-char.md",
-        fileContent: specialContent,
+        frontmatter: { description: "Special chars" },
+        body: specialContent,
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe(specialContent);
-      expect(command.getFileContent()).toContain("@#$%^&*()");
-      expect(command.getFileContent()).toContain("你好世界 🌍");
-      expect(command.getFileContent()).toContain("\"Hello 'World'\"");
+      expect(command.getBody()).toBe(specialContent);
+      expect(command.getBody()).toContain("@#$%^&*()");
+      expect(command.getBody()).toContain("你好世界 🌍");
+      expect(command.getBody()).toContain("\"Hello 'World'\"");
     });
 
     it("should handle very long content", () => {
@@ -444,12 +680,13 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "long-content.md",
-        fileContent: longContent,
+        frontmatter: {},
+        body: longContent,
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe(longContent);
-      expect(command.getFileContent().length).toBe(10000);
+      expect(command.getBody()).toBe(longContent);
+      expect(command.getBody().length).toBe(10000);
     });
 
     it("should handle Windows-style line endings", () => {
@@ -459,11 +696,12 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "windows-lines.md",
-        fileContent: windowsContent,
+        frontmatter: {},
+        body: windowsContent,
         validate: true,
       });
 
-      expect(command.getFileContent()).toBe(windowsContent);
+      expect(command.getBody()).toBe(windowsContent);
     });
   });
 
@@ -473,11 +711,11 @@ It can be multiline.`;
         baseDir: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
-        fileContent: "Body",
+        frontmatter: { description: "Test" },
+        body: "Body",
         validate: true,
       });
 
-      // Check that it's an instance of parent classes
       expect(command).toBeInstanceOf(CursorCommand);
       expect(command.getRelativeDirPath()).toBe(".cursor/commands");
       expect(command.getRelativeFilePath()).toBe("test.md");
@@ -489,7 +727,8 @@ It can be multiline.`;
         baseDir: customBaseDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
-        fileContent: "Body",
+        frontmatter: {},
+        body: "Body",
         validate: true,
       });
 
@@ -569,7 +808,6 @@ It can be multiline.`;
     });
 
     it("should return true for rulesync command with undefined targets (defaults to true)", () => {
-      // Create a RulesyncCommand with undefined targets by bypassing validation
       const rulesyncCommand = new RulesyncCommand({
         baseDir: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
@@ -577,11 +815,242 @@ It can be multiline.`;
         frontmatter: { targets: undefined as any, description: "Test" },
         body: "Body",
         fileContent: "",
-        validate: false, // Skip validation to allow undefined targets
+        validate: false,
       });
 
       const result = CursorCommand.isTargetedByRulesyncCommand(rulesyncCommand);
       expect(result).toBe(true);
+    });
+  });
+
+  describe("CursorCommandFrontmatterSchema", () => {
+    it("should validate frontmatter with description", () => {
+      const result = CursorCommandFrontmatterSchema.safeParse({ description: "Test" });
+      expect(result.success).toBe(true);
+    });
+
+    it("should validate empty frontmatter", () => {
+      const result = CursorCommandFrontmatterSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it("should validate frontmatter with handoffs", () => {
+      const result = CursorCommandFrontmatterSchema.safeParse({
+        description: "Test",
+        handoffs: [
+          { label: "Build Plan", agent: "planner", prompt: "Do it" },
+          { label: "Clarify", agent: "clarifier", prompt: "Ask", send: true },
+        ],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.handoffs).toHaveLength(2);
+        expect(result.data.handoffs![1].send).toBe(true);
+      }
+    });
+
+    it("should reject non-string description", () => {
+      const result = CursorCommandFrontmatterSchema.safeParse({ description: 123 });
+      expect(result.success).toBe(false);
+    });
+
+    it("should allow additional properties via looseObject", () => {
+      const result = CursorCommandFrontmatterSchema.safeParse({
+        description: "Test",
+        unknownField: "should pass through",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("tool-specific field passthrough", () => {
+    it("round-trip should preserve description + handoffs", () => {
+      const original = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "roundtrip.md",
+        frontmatter: {
+          targets: ["cursor"],
+          description: "Roundtrip test",
+          cursor: {
+            handoffs: [
+              { label: "Build Plan", agent: "speckit.plan", prompt: "Plan this" },
+              { label: "Clarify", agent: "speckit.clarify", prompt: "Clarify", send: true },
+            ],
+          },
+        },
+        body: "Body content",
+        fileContent: "",
+      });
+
+      const cursor = CursorCommand.fromRulesyncCommand({
+        rulesyncCommand: original,
+      });
+
+      // Verify the cursor command has the right frontmatter
+      expect(cursor.getFrontmatter()).toEqual({
+        description: "Roundtrip test",
+        handoffs: [
+          { label: "Build Plan", agent: "speckit.plan", prompt: "Plan this" },
+          { label: "Clarify", agent: "speckit.clarify", prompt: "Clarify", send: true },
+        ],
+      });
+
+      const backToRulesync = cursor.toRulesyncCommand();
+
+      expect(backToRulesync.getFrontmatter().description).toBe("Roundtrip test");
+      expect(backToRulesync.getFrontmatter().cursor).toEqual({
+        handoffs: [
+          { label: "Build Plan", agent: "speckit.plan", prompt: "Plan this" },
+          { label: "Clarify", agent: "speckit.clarify", prompt: "Clarify", send: true },
+        ],
+      });
+    });
+
+    it("round-trip should preserve description-only (no cursor section)", () => {
+      const original = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "desc-only.md",
+        frontmatter: { description: "Just a description" },
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncCommand = original.toRulesyncCommand();
+      const back = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+      });
+
+      expect(back.getBody()).toBe("Body");
+      expect(back.getFrontmatter()).toEqual({ description: "Just a description" });
+    });
+
+    it("round-trip should work for commands with no frontmatter", () => {
+      const original = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "no-fm.md",
+        frontmatter: {},
+        body: "Plain body content",
+        validate: true,
+      });
+
+      const rulesyncCommand = original.toRulesyncCommand();
+      const back = CursorCommand.fromRulesyncCommand({
+        baseDir: testDir,
+        rulesyncCommand,
+      });
+
+      expect(back.getBody()).toBe("Plain body content");
+    });
+
+    it("unknown fields should pass through via looseObject", () => {
+      const original = new CursorCommand({
+        baseDir: testDir,
+        relativeDirPath: ".cursor/commands",
+        relativeFilePath: "unknown.md",
+        frontmatter: {
+          description: "Test",
+          handoffs: [{ label: "Test", agent: "test" }],
+          someNewField: "value",
+        } as any,
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncCommand = original.toRulesyncCommand();
+      const fm = rulesyncCommand.getFrontmatter();
+
+      // Both handoffs and someNewField should be in cursor section
+      expect(fm.cursor).toEqual({
+        handoffs: [{ label: "Test", agent: "test" }],
+        someNewField: "value",
+      });
+
+      // Round-trip back
+      const back = CursorCommand.fromRulesyncCommand({
+        rulesyncCommand,
+      });
+
+      const backFm = back.getFrontmatter();
+      expect(backFm.description).toBe("Test");
+      expect(backFm.handoffs).toEqual([{ label: "Test", agent: "test" }]);
+      expect((backFm as any).someNewField).toBe("value");
+    });
+
+    it("double round-trip should produce stable output", () => {
+      const original = new RulesyncCommand({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "stable.md",
+        frontmatter: {
+          targets: ["*"],
+          description: "Stable test",
+          cursor: {
+            handoffs: [
+              { label: "Plan", agent: "planner", prompt: "Plan", send: false },
+            ],
+          },
+        },
+        body: "Stable body",
+        fileContent: "",
+      });
+
+      // First round-trip
+      const cursor1 = CursorCommand.fromRulesyncCommand({ rulesyncCommand: original });
+      const rulesync1 = cursor1.toRulesyncCommand();
+
+      // Second round-trip
+      const cursor2 = CursorCommand.fromRulesyncCommand({ rulesyncCommand: rulesync1 });
+      const rulesync2 = cursor2.toRulesyncCommand();
+
+      // Output should be identical
+      expect(rulesync2.getFrontmatter().description).toBe(rulesync1.getFrontmatter().description);
+      expect(rulesync2.getFrontmatter().cursor).toEqual(rulesync1.getFrontmatter().cursor);
+      expect(rulesync2.getBody()).toBe(rulesync1.getBody());
+    });
+  });
+
+  describe("type definitions", () => {
+    it("should work with ToolCommandFromFileParams", async () => {
+      const commandsDir = join(testDir, ".cursor", "commands");
+      await ensureDir(commandsDir);
+
+      await writeFileContent(
+        join(commandsDir, "type-test.md"),
+        `---
+description: Type test
+---
+Body`,
+      );
+
+      const params: ToolCommandFromFileParams = {
+        baseDir: testDir,
+        relativeFilePath: "type-test.md",
+      };
+
+      const command = await CursorCommand.fromFile(params);
+      expect(command).toBeInstanceOf(CursorCommand);
+    });
+
+    it("should work with ToolCommandFromRulesyncCommandParams", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "type-test.md",
+        frontmatter: { targets: ["*"], description: "Type test" },
+        body: "Body",
+        fileContent: "",
+      });
+
+      const params: ToolCommandFromRulesyncCommandParams = {
+        baseDir: testDir,
+        rulesyncCommand,
+      };
+
+      const command = CursorCommand.fromRulesyncCommand(params);
+      expect(command).toBeInstanceOf(CursorCommand);
     });
   });
 });

--- a/src/features/commands/cursor-command.ts
+++ b/src/features/commands/cursor-command.ts
@@ -1,8 +1,10 @@
 import { join } from "node:path";
+import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
-import { parseFrontmatter } from "../../utils/frontmatter.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
@@ -12,28 +14,86 @@ import {
   ToolCommandSettablePaths,
 } from "./tool-command.js";
 
-export type CursorCommandParams = AiFileParams;
+// looseObject preserves unknown keys during parsing (like passthrough in Zod 3)
+export const CursorCommandFrontmatterSchema = z.looseObject({
+  description: z.optional(z.string()),
+  handoffs: z.optional(
+    z.array(
+      z.looseObject({
+        label: z.string(),
+        agent: z.optional(z.string()),
+        prompt: z.optional(z.string()),
+        send: z.optional(z.boolean()),
+      }),
+    ),
+  ),
+});
+
+export type CursorCommandFrontmatter = z.infer<typeof CursorCommandFrontmatterSchema>;
+
+export type CursorCommandParams = {
+  frontmatter: CursorCommandFrontmatter;
+  body: string;
+} & Omit<AiFileParams, "fileContent">;
 
 export class CursorCommand extends ToolCommand {
+  private readonly frontmatter: CursorCommandFrontmatter;
+  private readonly body: string;
+
+  constructor({ frontmatter, body, ...rest }: CursorCommandParams) {
+    // Validate frontmatter before calling super to avoid validation order issues
+    if (rest.validate) {
+      const result = CursorCommandFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw new Error(
+          `Invalid frontmatter in ${join(rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyFrontmatter(body, frontmatter),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
   static getSettablePaths(_options: { global?: boolean } = {}): ToolCommandSettablePaths {
     return {
       relativeDirPath: join(".cursor", "commands"),
     };
   }
 
+  getBody(): string {
+    return this.body;
+  }
+
+  getFrontmatter(): Record<string, unknown> {
+    return this.frontmatter;
+  }
+
   toRulesyncCommand(): RulesyncCommand {
+    const { description = "", ...restFields } = this.frontmatter;
+
     const rulesyncFrontmatter: RulesyncCommandFrontmatter = {
       targets: ["*"],
-      description: "",
+      description,
+      // Preserve extra fields in cursor section
+      ...(Object.keys(restFields).length > 0 && { cursor: restFields }),
     };
 
+    // Generate proper file content with Rulesync specific frontmatter
+    const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
+
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
       frontmatter: rulesyncFrontmatter,
-      body: this.getFileContent(),
+      body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
       relativeFilePath: this.relativeFilePath,
-      fileContent: this.getFileContent(),
+      fileContent,
       validate: true,
     });
   }
@@ -44,11 +104,25 @@ export class CursorCommand extends ToolCommand {
     validate = true,
     global = false,
   }: ToolCommandFromRulesyncCommandParams): CursorCommand {
+    const rulesyncFrontmatter = rulesyncCommand.getFrontmatter();
+
+    // Merge cursor-specific fields from rulesync frontmatter
+    const cursorFields = rulesyncFrontmatter.cursor ?? {};
+
+    const cursorFrontmatter: CursorCommandFrontmatter = {
+      ...(rulesyncFrontmatter.description && { description: rulesyncFrontmatter.description }),
+      ...cursorFields,
+    };
+
+    // Generate proper file content with Cursor specific frontmatter
+    const body = rulesyncCommand.getBody();
+
     const paths = this.getSettablePaths({ global });
 
     return new CursorCommand({
       baseDir: baseDir,
-      fileContent: rulesyncCommand.getBody(),
+      frontmatter: cursorFrontmatter,
+      body,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath(),
       validate,
@@ -56,11 +130,22 @@ export class CursorCommand extends ToolCommand {
   }
 
   validate(): ValidationResult {
-    return { success: true, error: null };
-  }
+    // Check if frontmatter is set (may be undefined during construction)
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
 
-  getBody(): string {
-    return this.getFileContent();
+    const result = CursorCommandFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+        ),
+      };
+    }
   }
 
   static isTargetedByRulesyncCommand(rulesyncCommand: RulesyncCommand): boolean {
@@ -80,13 +165,20 @@ export class CursorCommand extends ToolCommand {
     const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
-    const { body: content } = parseFrontmatter(fileContent);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent);
+
+    // Validate using CursorCommandFrontmatterSchema (soft — allows unknown fields)
+    const result = CursorCommandFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${formatError(result.error)}`);
+    }
 
     return new CursorCommand({
       baseDir: baseDir,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
-      fileContent: content.trim(),
+      frontmatter: result.data,
+      body: content.trim(),
       validate,
     });
   }
@@ -100,7 +192,8 @@ export class CursorCommand extends ToolCommand {
       baseDir,
       relativeDirPath,
       relativeFilePath,
-      fileContent: "",
+      frontmatter: {},
+      body: "",
       validate: false,
     });
   }


### PR DESCRIPTION
## Summary

`CursorCommand` currently strips all frontmatter (e.g., `description`, `handoffs`) during the import/generate round-trip, while `ClaudecodeCommand` and `CopilotCommand` both correctly preserve tool-specific frontmatter via a nested section pattern.

This PR brings `CursorCommand` in line with the other tool commands by:

- Adding a `CursorCommandFrontmatterSchema` (using `z.looseObject()` for forward-compatibility)
- Storing `frontmatter` and `body` as separate properties (matching `ClaudecodeCommand` pattern)
- Preserving cursor-specific fields (e.g., `handoffs`) in a `cursor:` section in the rulesync intermediate format
- Restoring those fields when generating back to `.cursor/commands/` format

## Changes

- **`src/features/commands/cursor-command.ts`** — Rewrote to mirror `ClaudecodeCommand` pattern with frontmatter schema, constructor validation, and `cursor:` section passthrough
- **`src/features/commands/cursor-command.test.ts`** — Expanded from 18 tests to 55 tests covering frontmatter preservation, round-trips, schema validation, handoffs, and unknown field passthrough

## Test plan

- [x] All 3998 existing tests pass (`pnpm run test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Stress-tested against a real project with 9 Cursor commands (speckit) — all `description` and `handoffs` arrays survive import→generate round-trip
- [x] Commands without `handoffs` (e.g., `speckit.analyze`) work with just `description`
- [x] Commands without any frontmatter (e.g., `review-pr.md`) still generate correctly
- [x] Double round-trip (import→generate→import→generate) produces stable output (no drift)
- [x] `rulesync generate --check` passes after generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)