### PR TITLE
chore: fix oxfmt formatting across codebase

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -14,7 +14,7 @@
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
-- typescript
+  - typescript
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+
 import * as z from "zod";
 
 // Import schema directly from source - zod and zod/mini schemas are compatible in Zod v4

--- a/scripts/generate-repomix-toon.ts
+++ b/scripts/generate-repomix-toon.ts
@@ -1,6 +1,7 @@
-import { encode } from "@toon-format/toon";
 import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+import { encode } from "@toon-format/toon";
 import { runCli } from "repomix";
 
 type Variant = {

--- a/scripts/security-scan-lib.test.ts
+++ b/scripts/security-scan-lib.test.ts
@@ -1,10 +1,10 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { OpenRouterClient, SecurityScanResult } from "./security-scan-lib.js";
-
 import { setupTestDirectory } from "../src/test-utils/test-directories.js";
+import type { OpenRouterClient, SecurityScanResult } from "./security-scan-lib.js";
 import {
   SecurityScanResultSchema,
   formatEmailBody,

--- a/scripts/security-scan-lib.ts
+++ b/scripts/security-scan-lib.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+
 import { Resend } from "resend";
 import { z } from "zod";
 

--- a/scripts/security-scan-toon.ts
+++ b/scripts/security-scan-toon.ts
@@ -1,12 +1,12 @@
 // oxlint-disable no-console
 
-import { OpenRouter } from "@openrouter/sdk";
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 
-import type { SecurityScanResult } from "./security-scan-lib.js";
+import { OpenRouter } from "@openrouter/sdk";
 
 import { formatError } from "../src/utils/error.js";
+import type { SecurityScanResult } from "./security-scan-lib.js";
 import {
   formatEmailBody,
   getToonFiles,

--- a/src/cli/commands/fetch.test.ts
+++ b/src/cli/commands/fetch.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { FetchSummary } from "../../types/fetch.js";
-
 import { fetchFiles, formatFetchSummary } from "../../lib/fetch.js";
 import { GitHubClientError } from "../../lib/github-client.js";
+import type { FetchSummary } from "../../types/fetch.js";
 import { logger } from "../../utils/logger.js";
 import { fetchCommand } from "./fetch.js";
 

--- a/src/cli/commands/fetch.ts
+++ b/src/cli/commands/fetch.ts
@@ -1,7 +1,6 @@
-import type { FetchOptions } from "../../types/fetch.js";
-
 import { fetchFiles, formatFetchSummary } from "../../lib/fetch.js";
 import { GitHubClientError, logGitHubAuthHints } from "../../lib/github-client.js";
+import type { FetchOptions } from "../../types/fetch.js";
 import { formatError } from "../../utils/error.js";
 import { logger } from "../../utils/logger.js";
 

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -1,8 +1,6 @@
 import { intersection } from "es-toolkit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GenerateOptions } from "./generate.js";
-
 import { ConfigResolver } from "../../config/config-resolver.js";
 import { CommandsProcessor } from "../../features/commands/commands-processor.js";
 import { IgnoreProcessor } from "../../features/ignore/ignore-processor.js";
@@ -11,6 +9,7 @@ import { RulesProcessor } from "../../features/rules/rules-processor.js";
 import { SubagentsProcessor } from "../../features/subagents/subagents-processor.js";
 import { fileExists } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";
+import type { GenerateOptions } from "./generate.js";
 import { generateCommand } from "./generate.js";
 
 // Mock all dependencies

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ImportOptions } from "./import.js";
-
 import { ConfigResolver } from "../../config/config-resolver.js";
 import { CommandsProcessor } from "../../features/commands/commands-processor.js";
 import { IgnoreProcessor } from "../../features/ignore/ignore-processor.js";
@@ -9,6 +7,7 @@ import { McpProcessor } from "../../features/mcp/mcp-processor.js";
 import { RulesProcessor } from "../../features/rules/rules-processor.js";
 import { SubagentsProcessor } from "../../features/subagents/subagents-processor.js";
 import { logger } from "../../utils/logger.js";
+import type { ImportOptions } from "./import.js";
 import { importCommand } from "./import.js";
 
 // Mock all dependencies

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { SourceEntry } from "../../config/config.js";
-
 import { ConfigResolver } from "../../config/config-resolver.js";
+import type { SourceEntry } from "../../config/config.js";
 import { Config } from "../../config/config.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import { logger } from "../../utils/logger.js";

--- a/src/cli/commands/mcp.test.ts
+++ b/src/cli/commands/mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../test-utils/test-directories.js";

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -1,5 +1,6 @@
-import { parse as parseJsonc } from "jsonc-parser";
 import { dirname, join, resolve } from "node:path";
+
+import { parse as parseJsonc } from "jsonc-parser";
 
 import {
   RULESYNC_CONFIG_RELATIVE_FILE_PATH,

--- a/src/e2e/e2e-commands.spec.ts
+++ b/src/e2e/e2e-commands.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/e2e/e2e-helper.ts
+++ b/src/e2e/e2e-helper.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
+
 import { afterEach, beforeEach } from "vitest";
 
 import { setupTestDirectory } from "../test-utils/test-directories.js";

--- a/src/e2e/e2e-hooks.spec.ts
+++ b/src/e2e/e2e-hooks.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_HOOKS_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_AIIGNORE_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/e2e/e2e-import.spec.ts
+++ b/src/e2e/e2e-import.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { readFileContent, writeFileContent } from "../utils/file.js";

--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { join } from "node:path";
 import { setTimeout } from "node:timers/promises";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_MCP_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/e2e/e2e-subagents.spec.ts
+++ b/src/e2e/e2e-subagents.spec.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/features/commands/agentsmd-command.test.ts
+++ b/src/features/commands/agentsmd-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/antigravity-command.test.ts
+++ b/src/features/commands/antigravity-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/antigravity-command.ts
+++ b/src/features/commands/antigravity-command.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/claudecode-command.test.ts
+++ b/src/features/commands/claudecode-command.test.ts
@@ -1,16 +1,16 @@
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type {
-  ToolCommandFromFileParams,
-  ToolCommandFromRulesyncCommandParams,
-} from "./tool-command.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { ClaudecodeCommand, ClaudecodeCommandFrontmatterSchema } from "./claudecode-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
+import type {
+  ToolCommandFromFileParams,
+  ToolCommandFromRulesyncCommandParams,
+} from "./tool-command.js";
 
 describe("ClaudecodeCommand", () => {
   let testDir: string;

--- a/src/features/commands/claudecode-command.ts
+++ b/src/features/commands/claudecode-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/cline-command.test.ts
+++ b/src/features/commands/cline-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/codexcli-command.test.ts
+++ b/src/features/commands/codexcli-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, MockedFunction, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -1,11 +1,11 @@
 import { basename, join, relative } from "node:path";
-import { z } from "zod/mini";
 
-import type { ToolTarget } from "../../types/tool-targets.js";
+import { z } from "zod/mini";
 
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
+import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { checkPathTraversal, findFilesByGlobs } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";

--- a/src/features/commands/copilot-command.test.ts
+++ b/src/features/commands/copilot-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/copilot-command.ts
+++ b/src/features/commands/copilot-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/cursor-command.test.ts
+++ b/src/features/commands/cursor-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/factorydroid-command.test.ts
+++ b/src/features/commands/factorydroid-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -1,9 +1,9 @@
 import { join } from "node:path";
+
 import { parse as parseToml } from "smol-toml";
 import { z } from "zod/mini";
 
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
-
 import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
 import { stringifyFrontmatter } from "../../utils/frontmatter.js";

--- a/src/features/commands/kilo-command.test.ts
+++ b/src/features/commands/kilo-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/kiro-command.test.ts
+++ b/src/features/commands/kiro-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/opencode-command.test.ts
+++ b/src/features/commands/opencode-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/opencode-command.ts
+++ b/src/features/commands/opencode-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { optional, z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/roo-command.test.ts
+++ b/src/features/commands/roo-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/roo-command.ts
+++ b/src/features/commands/roo-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { optional, z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/rulesync-command.test.ts
+++ b/src/features/commands/rulesync-command.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/rulesync-command.ts
+++ b/src/features/commands/rulesync-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/commands/simulated-command.ts
+++ b/src/features/commands/simulated-command.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/commands/tool-command.ts
+++ b/src/features/commands/tool-command.ts
@@ -1,7 +1,6 @@
+import { AiFile, AiFileFromFileParams, AiFileParams } from "../../types/ai-file.js";
 import type { ToolTarget } from "../../types/tool-targets.js";
 import type { RulesyncCommand } from "./rulesync-command.js";
-
-import { AiFile, AiFileFromFileParams, AiFileParams } from "../../types/ai-file.js";
 
 export type ToolCommandFromRulesyncCommandParams = Omit<
   AiFileParams,

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -3,8 +3,6 @@ import { join } from "node:path";
 import type { AiFileParams } from "../../types/ai-file.js";
 import type { ValidationResult } from "../../types/ai-file.js";
 import type { HooksConfig } from "../../types/hooks.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-
 import {
   CLAUDE_HOOK_EVENTS,
   CLAUDE_TO_CANONICAL_EVENT_NAMES,
@@ -12,6 +10,7 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,

--- a/src/features/hooks/cursor-hooks.test.ts
+++ b/src/features/hooks/cursor-hooks.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/hooks/cursor-hooks.ts
+++ b/src/features/hooks/cursor-hooks.ts
@@ -3,14 +3,13 @@ import { join } from "node:path";
 import type { AiFileParams } from "../../types/ai-file.js";
 import type { ValidationResult } from "../../types/ai-file.js";
 import type { HooksConfig } from "../../types/hooks.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-
 import {
   CURSOR_HOOK_EVENTS,
   CURSOR_TO_CANONICAL_EVENT_NAMES,
   CANONICAL_TO_CURSOR_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { readFileContent } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,

--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -3,8 +3,6 @@ import { join } from "node:path";
 import type { AiFileParams } from "../../types/ai-file.js";
 import type { ValidationResult } from "../../types/ai-file.js";
 import type { HooksConfig } from "../../types/hooks.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-
 import {
   FACTORYDROID_HOOK_EVENTS,
   FACTORYDROID_TO_CANONICAL_EVENT_NAMES,
@@ -12,6 +10,7 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_HOOKS_RELATIVE_FILE_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -1,14 +1,5 @@
 import { z } from "zod/mini";
 
-import type { RulesyncFile } from "../../types/rulesync-file.js";
-import type { ToolFile } from "../../types/tool-file.js";
-import type { ToolTarget } from "../../types/tool-targets.js";
-import type {
-  ToolHooksForDeletionParams,
-  ToolHooksFromFileParams,
-  ToolHooksFromRulesyncHooksParams,
-} from "./tool-hooks.js";
-
 import { RULESYNC_HOOKS_RELATIVE_FILE_PATH } from "../../constants/rulesync-paths.js";
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import {
@@ -19,6 +10,9 @@ import {
   type HookEvent,
   type HookType,
 } from "../../types/hooks.js";
+import type { RulesyncFile } from "../../types/rulesync-file.js";
+import type { ToolFile } from "../../types/tool-file.js";
+import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { logger } from "../../utils/logger.js";
 import { ClaudecodeHooks } from "./claudecode-hooks.js";
@@ -26,6 +20,11 @@ import { CursorHooks } from "./cursor-hooks.js";
 import { FactorydroidHooks } from "./factorydroid-hooks.js";
 import { OpencodeHooks } from "./opencode-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
+import type {
+  ToolHooksForDeletionParams,
+  ToolHooksFromFileParams,
+  ToolHooksFromRulesyncHooksParams,
+} from "./tool-hooks.js";
 import { ToolHooks } from "./tool-hooks.js";
 
 const hooksProcessorToolTargetTuple = ["cursor", "claudecode", "opencode", "factorydroid"] as const;

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/hooks/opencode-hooks.ts
+++ b/src/features/hooks/opencode-hooks.ts
@@ -2,14 +2,13 @@ import { join } from "node:path";
 
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import type { HooksConfig } from "../../types/hooks.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-
 import {
   CANONICAL_TO_OPENCODE_EVENT_NAMES,
   CONTROL_CHARS,
   OPENCODE_HOOK_EVENTS,
 } from "../../types/hooks.js";
 import { readFileContent } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,

--- a/src/features/hooks/rulesync-hooks.ts
+++ b/src/features/hooks/rulesync-hooks.ts
@@ -1,13 +1,12 @@
 import { join } from "node:path";
 
-import type { ValidationResult } from "../../types/ai-file.js";
-import type { RulesyncFileFromFileParams, RulesyncFileParams } from "../../types/rulesync-file.js";
-
 import {
   RULESYNC_HOOKS_RELATIVE_FILE_PATH,
   RULESYNC_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
+import type { ValidationResult } from "../../types/ai-file.js";
 import { type HooksConfig, HooksConfigSchema } from "../../types/hooks.js";
+import type { RulesyncFileFromFileParams, RulesyncFileParams } from "../../types/rulesync-file.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { fileExists, readFileContent } from "../../utils/file.js";
 

--- a/src/features/hooks/tool-hooks.ts
+++ b/src/features/hooks/tool-hooks.ts
@@ -1,6 +1,5 @@
-import type { AiFileFromFileParams, AiFileParams } from "../../types/ai-file.js";
-
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import type { AiFileFromFileParams, AiFileParams } from "../../types/ai-file.js";
 import { ToolFile } from "../../types/tool-file.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 

--- a/src/features/ignore/augmentcode-ignore.test.ts
+++ b/src/features/ignore/augmentcode-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/claudecode-ignore.test.ts
+++ b/src/features/ignore/claudecode-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -1,5 +1,6 @@
-import { uniq } from "es-toolkit";
 import { join } from "node:path";
+
+import { uniq } from "es-toolkit";
 
 import { fileExists, readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";

--- a/src/features/ignore/cline-ignore.test.ts
+++ b/src/features/ignore/cline-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/cursor-ignore.test.ts
+++ b/src/features/ignore/cursor-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_AIIGNORE_RELATIVE_FILE_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/ignore/geminicli-ignore.test.ts
+++ b/src/features/ignore/geminicli-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/geminicli-ignore.ts
+++ b/src/features/ignore/geminicli-ignore.ts
@@ -1,14 +1,13 @@
 import { join } from "node:path";
 
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
   ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
-
-import { readFileContent } from "../../utils/file.js";
-import { RulesyncIgnore } from "./rulesync-ignore.js";
 import { ToolIgnore } from "./tool-ignore.js";
 
 export class GeminiCliIgnore extends ToolIgnore {

--- a/src/features/ignore/goose-ignore.test.ts
+++ b/src/features/ignore/goose-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/junie-ignore.test.ts
+++ b/src/features/ignore/junie-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/kilo-ignore.test.ts
+++ b/src/features/ignore/kilo-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/kiro-ignore.test.ts
+++ b/src/features/ignore/kiro-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/qwencode-ignore.test.ts
+++ b/src/features/ignore/qwencode-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/qwencode-ignore.ts
+++ b/src/features/ignore/qwencode-ignore.ts
@@ -1,14 +1,13 @@
 import { join } from "node:path";
 
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
   ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
-
-import { readFileContent } from "../../utils/file.js";
-import { RulesyncIgnore } from "./rulesync-ignore.js";
 import { ToolIgnore } from "./tool-ignore.js";
 
 export class QwencodeIgnore extends ToolIgnore {

--- a/src/features/ignore/roo-ignore.test.ts
+++ b/src/features/ignore/roo-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/rulesync-ignore.test.ts
+++ b/src/features/ignore/rulesync-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/tool-ignore.test.ts
+++ b/src/features/ignore/tool-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/windsurf-ignore.test.ts
+++ b/src/features/ignore/windsurf-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/windsurf-ignore.ts
+++ b/src/features/ignore/windsurf-ignore.ts
@@ -1,14 +1,13 @@
 import { join } from "node:path";
 
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
   ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
-
-import { readFileContent } from "../../utils/file.js";
-import { RulesyncIgnore } from "./rulesync-ignore.js";
 import { ToolIgnore } from "./tool-ignore.js";
 
 /**

--- a/src/features/ignore/zed-ignore.test.ts
+++ b/src/features/ignore/zed-ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/ignore/zed-ignore.ts
+++ b/src/features/ignore/zed-ignore.ts
@@ -1,5 +1,6 @@
-import { uniq } from "es-toolkit";
 import { join } from "node:path";
+
+import { uniq } from "es-toolkit";
 
 import { fileExists, readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";

--- a/src/features/mcp/claudecode-mcp.test.ts
+++ b/src/features/mcp/claudecode-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/cline-mcp.test.ts
+++ b/src/features/mcp/cline-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import * as smolToml from "smol-toml";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/copilot-mcp.test.ts
+++ b/src/features/mcp/copilot-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/factorydroid-mcp.test.ts
+++ b/src/features/mcp/factorydroid-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";

--- a/src/features/mcp/geminicli-mcp.test.ts
+++ b/src/features/mcp/geminicli-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/junie-mcp.test.ts
+++ b/src/features/mcp/junie-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/kilo-mcp.test.ts
+++ b/src/features/mcp/kilo-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/kiro-mcp.test.ts
+++ b/src/features/mcp/kiro-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { ValidationResult } from "../../types/ai-file.js";

--- a/src/features/mcp/roo-mcp.test.ts
+++ b/src/features/mcp/roo-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -1,5 +1,6 @@
-import { omit } from "es-toolkit/object";
 import { join } from "node:path";
+
+import { omit } from "es-toolkit/object";
 import { z } from "zod/mini";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/mcp/tool-mcp.test.ts
+++ b/src/features/mcp/tool-mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/agentsmd-rule.test.ts
+++ b/src/features/rules/agentsmd-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/antigravity-rule.test.ts
+++ b/src/features/rules/antigravity-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/antigravity-rule.ts
+++ b/src/features/rules/antigravity-rule.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { ValidationResult } from "../../types/ai-file.js";

--- a/src/features/rules/augmentcode-legacy-rule.test.ts
+++ b/src/features/rules/augmentcode-legacy-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/augmentcode-rule.test.ts
+++ b/src/features/rules/augmentcode-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/claudecode-legacy-rule.test.ts
+++ b/src/features/rules/claudecode-legacy-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/claudecode-rule.test.ts
+++ b/src/features/rules/claudecode-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/cline-rule.test.ts
+++ b/src/features/rules/cline-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";

--- a/src/features/rules/cline-rule.ts
+++ b/src/features/rules/cline-rule.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { ValidationResult } from "../../types/ai-file.js";

--- a/src/features/rules/codexcli-rule.test.ts
+++ b/src/features/rules/codexcli-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -1,10 +1,10 @@
 import { join } from "node:path";
-import { z } from "zod/mini";
 
-import type { RulesyncTargets } from "../../types/tool-targets.js";
+import { z } from "zod/mini";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import type { RulesyncTargets } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
 import { parseFrontmatter } from "../../utils/frontmatter.js";

--- a/src/features/rules/factorydroid-rule.test.ts
+++ b/src/features/rules/factorydroid-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/geminicli-rule.test.ts
+++ b/src/features/rules/geminicli-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/goose-rule.test.ts
+++ b/src/features/rules/goose-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/junie-rule.test.ts
+++ b/src/features/rules/junie-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/kilo-rule.test.ts
+++ b/src/features/rules/kilo-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/opencode-rule.test.ts
+++ b/src/features/rules/opencode-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/qwencode-rule.test.ts
+++ b/src/features/rules/qwencode-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/replit-rule.test.ts
+++ b/src/features/rules/replit-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/roo-rule.test.ts
+++ b/src/features/rules/roo-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1,5 +1,6 @@
-import { encode } from "@toon-format/toon";
 import { basename, join, relative } from "node:path";
+
+import { encode } from "@toon-format/toon";
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/rules/rulesync-rule.test.ts
+++ b/src/features/rules/rulesync-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import {

--- a/src/features/rules/tool-rule.test.ts
+++ b/src/features/rules/tool-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/warp-rule.test.ts
+++ b/src/features/rules/warp-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/features/rules/windsurf-rule.test.ts
+++ b/src/features/rules/windsurf-rule.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/skills/agentsmd-skill.test.ts
+++ b/src/features/skills/agentsmd-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/agentsskills-skill.test.ts
+++ b/src/features/skills/agentsskills-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/agentsskills-skill.ts
+++ b/src/features/skills/agentsskills-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/antigravity-skill.test.ts
+++ b/src/features/skills/antigravity-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/antigravity-skill.ts
+++ b/src/features/skills/antigravity-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/codexcli-skill.test.ts
+++ b/src/features/skills/codexcli-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/codexcli-skill.ts
+++ b/src/features/skills/codexcli-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/copilot-skill.test.ts
+++ b/src/features/skills/copilot-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/copilot-skill.ts
+++ b/src/features/skills/copilot-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/cursor-skill.test.ts
+++ b/src/features/skills/cursor-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/cursor-skill.ts
+++ b/src/features/skills/cursor-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/factorydroid-skill.test.ts
+++ b/src/features/skills/factorydroid-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/geminicli-skill.test.ts
+++ b/src/features/skills/geminicli-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/geminicli-skill.ts
+++ b/src/features/skills/geminicli-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/kilo-skill.test.ts
+++ b/src/features/skills/kilo-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/kilo-skill.ts
+++ b/src/features/skills/kilo-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/kiro-skill.test.ts
+++ b/src/features/skills/kiro-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/kiro-skill.ts
+++ b/src/features/skills/kiro-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/opencode-skill.test.ts
+++ b/src/features/skills/opencode-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/opencode-skill.ts
+++ b/src/features/skills/opencode-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/replit-skill.test.ts
+++ b/src/features/skills/replit-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/replit-skill.ts
+++ b/src/features/skills/replit-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/roo-skill.test.ts
+++ b/src/features/skills/roo-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/roo-skill.ts
+++ b/src/features/skills/roo-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/rulesync-skill.test.ts
+++ b/src/features/skills/rulesync-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/simulated-skill.test.ts
+++ b/src/features/skills/simulated-skill.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/simulated-skill.ts
+++ b/src/features/skills/simulated-skill.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/agentsmd-subagent.test.ts
+++ b/src/features/subagents/agentsmd-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/claudecode-subagent.test.ts
+++ b/src/features/subagents/claudecode-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/claudecode-subagent.ts
+++ b/src/features/subagents/claudecode-subagent.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/codexcli-subagent.test.ts
+++ b/src/features/subagents/codexcli-subagent.test.ts
@@ -1,13 +1,13 @@
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ToolSubagent } from "./tool-subagent.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { writeFileContent } from "../../utils/file.js";
 import { CodexCliSubagent, CodexCliSubagentTomlSchema } from "./codexcli-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
+import type { ToolSubagent } from "./tool-subagent.js";
 
 describe("CodexCliSubagent", () => {
   let testDir: string;

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import * as smolToml from "smol-toml";
 import { z } from "zod/mini";
 

--- a/src/features/subagents/copilot-subagent.test.ts
+++ b/src/features/subagents/copilot-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/cursor-subagent.test.ts
+++ b/src/features/subagents/cursor-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/factorydroid-subagent.test.ts
+++ b/src/features/subagents/factorydroid-subagent.test.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ToolSubagent } from "./tool-subagent.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
@@ -9,6 +8,7 @@ import { writeFileContent } from "../../utils/file.js";
 import { FactorydroidSubagent } from "./factorydroid-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 import { SimulatedSubagentFrontmatter } from "./simulated-subagent.js";
+import type { ToolSubagent } from "./tool-subagent.js";
 
 describe("FactorydroidSubagent", () => {
   let testDir: string;

--- a/src/features/subagents/geminicli-subagent.test.ts
+++ b/src/features/subagents/geminicli-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/kiro-subagent.test.ts
+++ b/src/features/subagents/kiro-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/kiro-subagent.ts
+++ b/src/features/subagents/kiro-subagent.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/opencode-subagent.test.ts
+++ b/src/features/subagents/opencode-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/opencode-subagent.ts
+++ b/src/features/subagents/opencode-subagent.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/roo-subagent.test.ts
+++ b/src/features/subagents/roo-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/rulesync-subagent.test.ts
+++ b/src/features/subagents/rulesync-subagent.test.ts
@@ -1,11 +1,11 @@
 import { basename, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { writeFileContent } from "../../utils/file.js";
+import type { RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
 import { RulesyncSubagent, RulesyncSubagentFrontmatterSchema } from "./rulesync-subagent.js";
 
 describe("RulesyncSubagentFrontmatterSchema", () => {

--- a/src/features/subagents/rulesync-subagent.ts
+++ b/src/features/subagents/rulesync-subagent.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/simulated-subagent.test.ts
+++ b/src/features/subagents/simulated-subagent.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/simulated-subagent.ts
+++ b/src/features/subagents/simulated-subagent.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -1,11 +1,11 @@
 import { basename, join } from "node:path";
-import { z } from "zod/mini";
 
-import type { ToolTarget } from "../../types/tool-targets.js";
+import { z } from "zod/mini";
 
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
+import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { directoryExists, findFilesByGlobs, listDirectoryFiles } from "../../utils/file.js";
 import { logger } from "../../utils/logger.js";

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Config } from "./config/config.js";
-import type { GenerateResult } from "./lib/generate.js";
-import type { ImportResult } from "./lib/import.js";
-
 import { ConfigResolver } from "./config/config-resolver.js";
+import type { Config } from "./config/config.js";
 import { generate, importFromTool } from "./index.js";
+import type { GenerateResult } from "./lib/generate.js";
 import { checkRulesyncDirExists, generate as coreGenerate } from "./lib/generate.js";
+import type { ImportResult } from "./lib/import.js";
 import { importFromTool as coreImportFromTool } from "./lib/import.js";
 import { logger } from "./utils/logger.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
-import type { Feature } from "./types/features.js";
-import type { ToolTarget } from "./types/tool-targets.js";
-
 import { ConfigResolver } from "./config/config-resolver.js";
 import { checkRulesyncDirExists, generate as coreGenerate } from "./lib/generate.js";
 import { importFromTool as coreImportFromTool } from "./lib/import.js";
+import type { Feature } from "./types/features.js";
+import type { ToolTarget } from "./types/tool-targets.js";
 import { logger } from "./utils/logger.js";
 
 export type { Feature } from "./types/features.js";

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../test-utils/test-directories.js";

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,17 +1,6 @@
-import { Semaphore } from "es-toolkit/promise";
 import { join } from "node:path";
 
-import type { Feature } from "../types/features.js";
-import type { FetchTarget } from "../types/fetch-targets.js";
-import type {
-  ConflictStrategy,
-  FetchFileResult,
-  FetchOptions,
-  FetchSummary,
-  GitHubFileEntry,
-  ParsedSource,
-} from "../types/fetch.js";
-import type { ToolTarget } from "../types/tool-targets.js";
+import { Semaphore } from "es-toolkit/promise";
 
 import {
   FETCH_CONCURRENCY_LIMIT,
@@ -28,7 +17,18 @@ import { McpProcessor } from "../features/mcp/mcp-processor.js";
 import { RulesProcessor } from "../features/rules/rules-processor.js";
 import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
+import type { Feature } from "../types/features.js";
 import { ALL_FEATURES } from "../types/features.js";
+import type { FetchTarget } from "../types/fetch-targets.js";
+import type {
+  ConflictStrategy,
+  FetchFileResult,
+  FetchOptions,
+  FetchSummary,
+  GitHubFileEntry,
+  ParsedSource,
+} from "../types/fetch.js";
+import type { ToolTarget } from "../types/tool-targets.js";
 import {
   checkPathTraversal,
   createTempDirectory,

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,7 +1,6 @@
-import { intersection } from "es-toolkit";
 import { join } from "node:path";
 
-import type { FeatureGenerateResult } from "../utils/result.js";
+import { intersection } from "es-toolkit";
 
 import { Config } from "../config/config.js";
 import { RULESYNC_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";
@@ -20,6 +19,7 @@ import { FeatureProcessor } from "../types/feature-processor.js";
 import { formatError } from "../utils/error.js";
 import { fileExists } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
+import type { FeatureGenerateResult } from "../utils/result.js";
 
 export type GenerateResult = {
   rulesCount: number;

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -1,6 +1,7 @@
 import { RequestError } from "@octokit/request-error";
 import { Octokit } from "@octokit/rest";
 
+import { MAX_FILE_SIZE } from "../constants/rulesync-paths.js";
 import type {
   GitHubApiError,
   GitHubClientConfig,
@@ -8,8 +9,6 @@ import type {
   GitHubRelease,
   GitHubRepoInfo,
 } from "../types/fetch.js";
-
-import { MAX_FILE_SIZE } from "../constants/rulesync-paths.js";
 import {
   GitHubFileEntrySchema,
   GitHubReleaseSchema,

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -1,5 +1,3 @@
-import type { ToolTarget } from "../types/tool-targets.js";
-
 import { Config } from "../config/config.js";
 import { CommandsProcessor } from "../features/commands/commands-processor.js";
 import { HooksProcessor } from "../features/hooks/hooks-processor.js";
@@ -8,6 +6,7 @@ import { McpProcessor } from "../features/mcp/mcp-processor.js";
 import { RulesProcessor } from "../features/rules/rules-processor.js";
 import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
+import type { ToolTarget } from "../types/tool-targets.js";
 import { logger } from "../utils/logger.js";
 
 export type ImportResult = {

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../constants/general.js";

--- a/src/lib/source-parser.ts
+++ b/src/lib/source-parser.ts
@@ -1,6 +1,5 @@
 import type { ParsedSource } from "../types/fetch.js";
 import type { GitProvider } from "../types/git-provider.js";
-
 import { ALL_GIT_PROVIDERS } from "../types/git-provider.js";
 
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);

--- a/src/lib/sources-lock.test.ts
+++ b/src/lib/sources-lock.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/lib/sources-lock.ts
+++ b/src/lib/sources-lock.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
+
 import { optional, z } from "zod/mini";
 
 import { RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -1,8 +1,8 @@
-import { Semaphore } from "es-toolkit/promise";
 import { join, resolve, sep } from "node:path";
 
-import type { SourceEntry } from "../config/config.js";
+import { Semaphore } from "es-toolkit/promise";
 
+import type { SourceEntry } from "../config/config.js";
 import {
   FETCH_CONCURRENCY_LIMIT,
   MAX_FILE_SIZE,

--- a/src/lib/update.test.ts
+++ b/src/lib/update.test.ts
@@ -1,11 +1,11 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GitHubRelease } from "../types/fetch.js";
-
 import { setupTestDirectory } from "../test-utils/test-directories.js";
+import type { GitHubRelease } from "../types/fetch.js";
 import {
   checkForUpdate,
   compareVersions,

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -6,7 +6,6 @@ import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import type { GitHubRelease, GitHubReleaseAsset } from "../types/fetch.js";
-
 import { GitHubClient } from "./github-client.js";
 
 const RULESYNC_REPO_OWNER = "dyoshikawa";

--- a/src/mcp/commands.test.ts
+++ b/src/mcp/commands.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/commands.ts
+++ b/src/mcp/commands.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/generate.test.ts
+++ b/src/mcp/generate.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/mcp/ignore.test.ts
+++ b/src/mcp/ignore.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/mcp/ignore.ts
+++ b/src/mcp/ignore.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import {

--- a/src/mcp/import.test.ts
+++ b/src/mcp/import.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_CONFIG_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/mcp.test.ts
+++ b/src/mcp/mcp.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/mcp/mcp.ts
+++ b/src/mcp/mcp.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_MCP_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/rules.test.ts
+++ b/src/mcp/rules.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/src/mcp/rules.ts
+++ b/src/mcp/rules.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/skills.test.ts
+++ b/src/mcp/skills.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SKILL_FILE_NAME } from "../constants/general.js";

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../constants/general.js";

--- a/src/mcp/subagents.test.ts
+++ b/src/mcp/subagents.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/subagents.ts
+++ b/src/mcp/subagents.ts
@@ -1,4 +1,5 @@
 import { basename, join } from "node:path";
+
 import { z } from "zod/mini";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../test-utils/test-directories.js";

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -1,7 +1,5 @@
 import { join } from "node:path";
 
-import type { WriteResult } from "../utils/result.js";
-
 import {
   addTrailingNewline,
   ensureDir,
@@ -11,6 +9,7 @@ import {
 } from "../utils/file.js";
 import { stringifyFrontmatter } from "../utils/frontmatter.js";
 import { logger } from "../utils/logger.js";
+import type { WriteResult } from "../utils/result.js";
 import { AiDir, AiDirFile } from "./ai-dir.js";
 import { ToolTarget } from "./tool-targets.js";
 

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -1,5 +1,3 @@
-import type { WriteResult } from "../utils/result.js";
-
 import {
   addTrailingNewline,
   readFileContentOrNull,
@@ -7,6 +5,7 @@ import {
   writeFileContent,
 } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
+import type { WriteResult } from "../utils/result.js";
 import { AiFile } from "./ai-file.js";
 import { RulesyncFile } from "./rulesync-file.js";
 import { ToolFile } from "./tool-file.js";

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,9 +1,8 @@
 import { z } from "zod/mini";
 
-import type { GitProvider } from "./git-provider.js";
-
 import { ALL_FEATURES_WITH_WILDCARD } from "./features.js";
 import { FetchTargetSchema } from "./fetch-targets.js";
+import type { GitProvider } from "./git-provider.js";
 
 /**
  * Conflict resolution strategies for fetch command

--- a/src/types/tool-file.test.ts
+++ b/src/types/tool-file.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../test-utils/test-directories.js";

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -1,4 +1,5 @@
 import { join, resolve } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,8 +1,9 @@
-import { kebabCase } from "es-toolkit";
-import { globbySync } from "globby";
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
+
+import { kebabCase } from "es-toolkit";
+import { globbySync } from "globby";
 
 import { logger } from "./logger.js";
 import { isEnvTest } from "./vitest.js";


### PR DESCRIPTION
## Summary
- Apply `oxfmt` auto-formatting to fix formatting issues in 222 files detected by `oxfmt --check`
- No logic changes — formatting only (268 insertions, 111 deletions)
- All `pnpm cicheck` checks pass (formatting, oxlint, eslint, typecheck, tests, cspell, secretlint)

## Test plan
- [x] `pnpm cicheck` passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)