### PR TITLE
chore(fmt): ignore .claude/settings.json in oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -16,6 +16,7 @@
     "dist*/**",
     "opencode.json",
     ".zed/settings.json",
-    ".vscode/settings.json"
+    ".vscode/settings.json",
+    ".claude/settings.json"
   ]
 }


### PR DESCRIPTION
## Summary
- add .claude/settings.json to oxfmt ignorePatterns

## Why
- avoid recurrent CI formatting noise caused by editor-specific settings file updates
- keep formatter focused on source/content files
