### PR TITLE
ci: enforce read-only rules in auto AI review prompt

### DIFF
--- a/.github/workflows/pr-auto-ai-review.yml
+++ b/.github/workflows/pr-auto-ai-review.yml
@@ -90,6 +90,13 @@ jobs:
             - Call code-reviewer subagent to review the code changes in the PR.
             - Call security-reviewer subagent to review the security issues in the PR.
 
+            IMPORTANT READ-ONLY RULES:
+            - Review is READ-ONLY.
+            - Do NOT perform any write operations.
+            - Do NOT edit/create/delete files.
+            - Do NOT run git commit, git push, or open PRs.
+            - Do NOT change repository state.
+
             Integrate and report the execution results from each subagent. Additionally, please output PR number in the result so that the user can easily find the PR.
 
       - name: Minimize old github-actions bot issue comments


### PR DESCRIPTION
## Summary
- add explicit read-only rules to the OpenCode review prompt in pr-auto-ai-review.yml
- prohibit write operations during review (file edits, commit/push, PR creation)

## Why
Recent runs attempted to modify repository state during review. This change constrains the agent to review-only behavior.
