### PR TITLE
chore: exclude .serena/project.yml from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,7 @@
     "opencode.json",
     ".zed/settings.json",
     ".vscode/settings.json",
-    ".claude/settings.json"
+    ".claude/settings.json",
+    ".serena/project.yml"
   ]
 }


### PR DESCRIPTION
## Summary
- `.serena/project.yml` を oxfmt の `ignorePatterns` に追加し、フォーマット対象から除外

## Test plan
- [x] `pnpm cicheck` が全て通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)