### PR TITLE
ci: update Codex model from gpt-5.2 to gpt-5.3

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -21,7 +21,7 @@ runs:
         INPUT_TEXT: ${{ inputs.input-text }}
       run: |
         if [[ "$INPUT_TEXT" == *"codex"* ]]; then
-          echo "model=openrouter/openai/gpt-5.2-codex" >> $GITHUB_OUTPUT
+          echo "model=openrouter/openai/gpt-5.3-codex" >> $GITHUB_OUTPUT
         elif [[ "$INPUT_TEXT" == *"glm"* ]]; then
           echo "model=openrouter/z-ai/glm-5" >> $GITHUB_OUTPUT
         elif [[ "$INPUT_TEXT" == *"kimi"* ]]; then


### PR DESCRIPTION
## Summary
- Update OpenRouter Codex model from `gpt-5.2-codex` to `gpt-5.3-codex` in the `select-opencode-model` GitHub Action

## Test plan
- [x] `pnpm cicheck` passed (lint, typecheck, 4059 tests, cspell, secretlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)