### PR TITLE
fix: correct Serena project.yml indentation and add language_backend

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -14,7 +14,7 @@
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
-  - typescript
+- typescript
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
@@ -107,3 +107,10 @@ fixed_tools: []
 # override of the corresponding setting in serena_config.yml, see the documentation there.
 # If null or missing, the value from the global config is used.
 symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:


### PR DESCRIPTION
## Summary
- `.serena/project.yml` の `languages` リストのYAMLインデントを修正
- `language_backend` 設定セクションを追加

## Test plan
- [x] `pnpm cicheck` passed (lint, typecheck, 4059 tests, cspell, secretlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)