### PR TITLE
refactor: rename clean-branches command to clean-git

### DIFF
--- a/.rulesync/commands/clean-branches.md
+++ b/.rulesync/commands/clean-branches.md
@@ -1,8 +1,0 @@
----
-description: "Clean branches"
-targets:
-  - "*"
----
-
-1. Delete all local branches except for current branch and main branch.
-2. Run `git pull --prune`

--- a/.rulesync/commands/clean-git.md
+++ b/.rulesync/commands/clean-git.md
@@ -1,0 +1,9 @@
+---
+description: "Clean branches and worktrees"
+targets:
+  - "*"
+---
+
+1. Delete all local branches except for current branch and main branch.
+2. Run `git worktree prune` to clean up stale worktree references.
+3. Run `git pull --prune`


### PR DESCRIPTION
## Summary
- Rename `clean-branches` command to `clean-git` to better reflect its broader scope
- Add `git worktree prune` step to clean up stale worktree references

## Test plan
- [ ] Verify `clean-git` command is recognized by rulesync
- [ ] Confirm old `clean-branches` command file is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)