### PR TITLE
feat: add git-worktree-runner (gtr) skill

### DIFF
--- a/.rulesync/skills/git-worktree-runner/SKILL.md
+++ b/.rulesync/skills/git-worktree-runner/SKILL.md
@@ -5,9 +5,10 @@ description: >-
   to create, list, remove, or navigate worktrees with `git gtr` commands, open
   editors or AI tools in worktrees, or manage parallel development branches.
 targets:
-  - '*'
-allowed-tools: 'Bash(git-worktree-runner:*)'
+  - "*"
+allowed-tools: "Bash(git-worktree-runner:*)"
 ---
+
 # Git Worktree Runner (gtr)
 
 git-worktree-runner (gtr) is a CLI tool that wraps `git worktree` with quality-of-life features for modern development workflows including editor and AI tool integration.


### PR DESCRIPTION
## Summary
- Add a new skill for git-worktree-runner (gtr), a CLI tool that wraps `git worktree` with editor and AI tool integration
- Includes command reference (create, list, remove, navigate worktrees), configuration guide, and practical examples (parallel AI development, PR review, hotfix workflows)

## Test plan
- [ ] Verify `pnpm dev generate` produces correct output for the new skill
- [ ] Confirm skill is recognized by Claude Code after generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)