### PR TITLE
fix: create release tag before publishing draft release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,33 @@ jobs:
       - name: Publish to npm
         run: pnpm publish
 
+      - name: Ensure release tag exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          TAG="${HEAD_BRANCH#release/}"
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid release tag derived from branch: $HEAD_BRANCH"
+            exit 1
+          fi
+
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists on origin"
+            exit 0
+          fi
+
+          if [ -z "$TARGET_SHA" ]; then
+            echo "::error::workflow_run.head_sha is empty"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$TARGET_SHA"
+          git push origin "refs/tags/$TAG"
+
       - name: Publish target draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a pre-step in  to ensure the release tag exists on origin
- create and push tag from  when missing
- keep release publish step unchanged ()

## Why
Publishing a draft release failed with  when the tag did not exist yet.
