### PR TITLE
chore: add git-gtr support to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -133,6 +133,13 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN curl -fsSL https://opencode.ai/install | bash
 RUN echo 'PATH=/home/node/.opencode/bin:$PATH' >> "/home/node/.bashrc"
 
+# Install git-gtr
+RUN mkdir -p /home/node/.local/bin /home/node/.local/src && \
+    git clone https://github.com/coderabbitai/git-worktree-runner /home/node/.local/src/git-worktree-runner && \
+    ln -s /home/node/.local/src/git-worktree-runner/bin/git-gtr /home/node/.local/bin/git-gtr && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "/home/node/.bashrc" && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "/home/node/.zshrc"
+
 # Aliases
 ENV CLAUDE_COMMAND="alias claude=\"claude --dangerously-skip-permissions\""
 RUN echo ${CLAUDE_COMMAND} >> "/home/node/.zshrc"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,9 @@
     "source=${localWorkspaceFolderBasename}-claude-code-bashhistory,target=/commandhistory,type=volume,consistency=delegated",
     "source=${localWorkspaceFolderBasename}-claude-code-config,target=/home/node/.claude,type=volume,consistency=delegated",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume,consistency=delegated",
-    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/home/node/.pnpm-store,type=volume,consistency=delegated"
+    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/home/node/.pnpm-store,type=volume,consistency=delegated",
+    "source=${localWorkspaceFolderBasename}-workspace-worktrees,target=/workspace-worktrees,type=volume,consistency=delegated",
+    "source=${localWorkspaceFolderBasename}-local-share-opencode,target=/home/node/.local/share/opencode,type=volume,consistency=delegated"
   ],
   "remoteEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -4,6 +4,10 @@
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
 sudo chown -R node:node /home/node/.pnpm-store 2>/dev/null || true
 
+# Ensure workspace-worktrees volume has correct ownership for non-root user to use gtr
+sudo mkdir -p /workspace-worktrees
+sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
+
 # Configure pnpm store directory for devcontainer
 pnpm config set store-dir /home/node/.pnpm-store
 


### PR DESCRIPTION
## Summary
- Install git-gtr in the devcontainer image.
- Add workspace worktrees and opencode share volumes to the devcontainer.
- Ensure the worktrees volume has the correct ownership during init.

## Test Plan
- pnpm cicheck