### PR TITLE
feat: implement hooks for copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | Codex CLI          | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |    ✅     | ✅ 🌏  |       |
 | Gemini CLI         | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    🎮     | ✅ 🌏  |       |
 | Goose              | goose        | ✅ 🌏 |        |          |          |           |        |       |
-| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |       |
+| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | Cursor             | cursor       |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |
 | OpenCode           | opencode     | ✅ 🌏 |        |  ✅ 🔧   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -43,8 +43,11 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
 - **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
+- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `afterSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin, so importing from OpenCode to rulesync is not supported. OpenCode only supports command-type hooks (not prompt-type).
+
+> **Note:** GitHub Copilot's format uses separate `powershell` and `bash` fields for hooks. Rulesync supports only a single `command` field and resolves this by emitting the command under the `powershell` key on Windows, and under the `bash` key on all other platforms.
 
 Use optional **override keys** so tool-specific events and config live in one file without leaking to others: `cursor.hooks` for Cursor-only events, `claudecode.hooks` for Claude-only, `opencode.hooks` for OpenCode-only. Events in shared `hooks` that a tool does not support are skipped for that tool (and a warning is logged at generate time).
 

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -9,7 +9,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Claude Code        | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Codex CLI          | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |    ✅     | ✅ 🌏  |       |
 | Gemini CLI         | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    🎮     | ✅ 🌏  |       |
-| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |       |
+| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | Goose              | goose        | ✅ 🌏 |        |          |          |           |        |       |
 | Cursor             | cursor       |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -43,8 +43,11 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
 - **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
+- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `afterSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin, so importing from OpenCode to rulesync is not supported. OpenCode only supports command-type hooks (not prompt-type).
+
+> **Note:** GitHub Copilot's format uses separate `powershell` and `bash` fields for hooks. Rulesync supports only a single `command` field and resolves this by emitting the command under the `powershell` key on Windows, and under the `bash` key on all other platforms.
 
 Use optional **override keys** so tool-specific events and config live in one file without leaking to others: `cursor.hooks` for Cursor-only events, `claudecode.hooks` for Claude-only, `opencode.hooks` for OpenCode-only. Events in shared `hooks` that a tool does not support are skipped for that tool (and a warning is logged at generate time).
 

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -9,7 +9,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Claude Code        | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Codex CLI          | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |    ✅     | ✅ 🌏  |       |
 | Gemini CLI         | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    🎮     | ✅ 🌏  |       |
-| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |       |
+| GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | Goose              | goose        | ✅ 🌏 |        |          |          |           |        |       |
 | Cursor             | cursor       |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
 | Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |

--- a/src/features/hooks/copilot-hooks.test.ts
+++ b/src/features/hooks/copilot-hooks.test.ts
@@ -1,0 +1,620 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { CopilotHooks } from "./copilot-hooks.js";
+import { RulesyncHooks } from "./rulesync-hooks.js";
+
+describe("CopilotHooks", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .github/hooks and copilot-hooks.json for project mode", () => {
+      const paths = CopilotHooks.getSettablePaths({ global: false });
+      expect(paths).toEqual({
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+      });
+    });
+
+    it("should return .github/hooks and copilot-hooks.json for global mode", () => {
+      const paths = CopilotHooks.getSettablePaths({ global: true });
+      expect(paths).toEqual({
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+      });
+    });
+  });
+
+  describe("fromRulesyncHooks", () => {
+    it("should filter shared hooks to Copilot-supported events and convert event names", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
+          sessionEnd: [{ command: ".rulesync/hooks/session-end.sh" }],
+          afterSubmitPrompt: [{ command: ".rulesync/hooks/after-prompt.sh" }],
+          preToolUse: [{ command: ".rulesync/hooks/pre-tool.sh" }],
+          postToolUse: [{ command: ".rulesync/hooks/post-tool.sh" }],
+          afterError: [{ command: ".rulesync/hooks/error.sh" }],
+          // This event is NOT supported by Copilot
+          stop: [{ command: ".rulesync/hooks/stop.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.version).toBe(1);
+      expect(parsed.hooks.sessionStart).toBeDefined();
+      expect(parsed.hooks.sessionEnd).toBeDefined();
+      expect(parsed.hooks.userPromptSubmitted).toBeDefined();
+      expect(parsed.hooks.preToolUse).toBeDefined();
+      expect(parsed.hooks.postToolUse).toBeDefined();
+      expect(parsed.hooks.errorOccurred).toBeDefined();
+      // stop is not supported by Copilot
+      expect(parsed.hooks.stop).toBeUndefined();
+    });
+
+    it("should use bash field on non-Windows and timeoutSec instead of timeout", async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "echo hello", timeout: 30 }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      const entry = parsed.hooks.sessionStart[0];
+      expect(entry.type).toBe("command");
+      expect(entry.bash).toBe("echo hello");
+      expect(entry.powershell).toBeUndefined();
+      expect(entry.timeoutSec).toBe(30);
+      // Should NOT have command or timeout fields
+      expect(entry.command).toBeUndefined();
+      expect(entry.timeout).toBeUndefined();
+    });
+
+    it("should use powershell field on Windows", async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "echo hello", timeout: 30 }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      const entry = parsed.hooks.sessionStart[0];
+      expect(entry.type).toBe("command");
+      expect(entry.powershell).toBe("echo hello");
+      expect(entry.bash).toBeUndefined();
+      expect(entry.timeoutSec).toBe(30);
+    });
+
+    it("should not prefix commands with any path variable", async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      const entry = parsed.hooks.sessionStart[0];
+      expect(entry.bash).toBe(".rulesync/hooks/session-start.sh");
+      expect(entry.bash).not.toContain("$CLAUDE_PROJECT_DIR");
+    });
+
+    it("should skip hooks with matcher", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", command: "lint.sh", matcher: "Write" },
+            { type: "command", command: "all-tools.sh" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      // Only the non-matcher hook should be present
+      expect(parsed.hooks.preToolUse).toHaveLength(1);
+      expect(parsed.hooks.preToolUse[0].bash).toBe("all-tools.sh");
+    });
+
+    it("should skip prompt-type hooks", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "prompt", prompt: "Check the code carefully" },
+            { type: "command", command: "lint.sh" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.preToolUse).toHaveLength(1);
+      expect(parsed.hooks.preToolUse[0].type).toBe("command");
+      expect(parsed.hooks.preToolUse[0].bash).toBe("lint.sh");
+    });
+
+    it("should merge config.copilot.hooks on top of shared hooks", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "shared.sh" }],
+        },
+        copilot: {
+          hooks: {
+            sessionStart: [{ type: "command", command: "copilot-override.sh" }],
+            afterError: [{ type: "command", command: "error-handler.sh" }],
+          },
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      // copilot override replaces shared sessionStart
+      expect(parsed.hooks.sessionStart[0].bash).toBe("copilot-override.sh");
+      // copilot-specific afterError is present
+      expect(parsed.hooks.errorOccurred).toBeDefined();
+      expect(parsed.hooks.errorOccurred[0].bash).toBe("error-handler.sh");
+    });
+
+    it("should produce standalone file without merging existing content", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ command: "echo start" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      // Should have exactly version and hooks at top level
+      expect(Object.keys(parsed)).toEqual(["version", "hooks"]);
+      expect(parsed.version).toBe(1);
+    });
+
+    it("should omit events with no valid hooks after filtering", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            // All hooks have matcher or are prompt type — all skipped
+            { type: "prompt", prompt: "Check carefully" },
+            { type: "command", command: "lint.sh", matcher: "Write" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      // preToolUse should be absent since all hooks were filtered out
+      expect(parsed.hooks.preToolUse).toBeUndefined();
+    });
+
+    it("should pass through unknown keys and keep bash/powershell overrides", async () => {
+      const config = {
+        version: 1,
+        hooks: {},
+        copilot: {
+          hooks: {
+            sessionStart: [
+              { type: "command", bash: "run.sh", powershell: "run.ps1", customKey: 123 },
+            ],
+          },
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.sessionStart[0].bash).toBe("run.sh");
+      expect(parsed.hooks.sessionStart[0].powershell).toBe("run.ps1");
+      expect(parsed.hooks.sessionStart[0].customKey).toBe(123);
+    });
+  });
+
+  describe("toRulesyncHooks", () => {
+    it("should throw error with descriptive message when content contains invalid JSON", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: "invalid json {",
+        validate: false,
+      });
+
+      expect(() => copilotHooks.toRulesyncHooks()).toThrow(/Failed to parse Copilot hooks content/);
+    });
+
+    it("should convert Copilot hooks with bash-only to canonical format", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [{ type: "command", bash: "echo start", timeoutSec: 30 }],
+            userPromptSubmitted: [{ type: "command", bash: "log-prompt.sh" }],
+            errorOccurred: [{ type: "command", bash: "handle-error.sh" }],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart).toHaveLength(1);
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(json.hooks.sessionStart?.[0]?.timeout).toBe(30);
+      expect(json.hooks.afterSubmitPrompt).toHaveLength(1);
+      expect(json.hooks.afterSubmitPrompt?.[0]?.command).toBe("log-prompt.sh");
+      expect(json.hooks.afterError).toHaveLength(1);
+      expect(json.hooks.afterError?.[0]?.command).toBe("handle-error.sh");
+    });
+
+    it("should convert Copilot hooks with powershell-only to canonical format", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [{ type: "command", powershell: "Write-Output start", timeoutSec: 15 }],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart).toHaveLength(1);
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("Write-Output start");
+      expect(json.hooks.sessionStart?.[0]?.timeout).toBe(15);
+    });
+
+    it("should use bash when both bash and powershell are present on non-Windows", async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const warnCalls: string[] = [];
+      vi.spyOn(await import("../../utils/logger.js"), "logger", "get").mockReturnValue({
+        warn: (msg: string) => warnCalls.push(msg),
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as never);
+
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [
+              { type: "command", bash: "echo start", powershell: "Write-Output start" },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(warnCalls.some((msg) => msg.includes("bash") && msg.includes("powershell"))).toBe(
+        true,
+      );
+    });
+
+    it("should use powershell when both bash and powershell are present on Windows", async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const warnCalls: string[] = [];
+      vi.spyOn(await import("../../utils/logger.js"), "logger", "get").mockReturnValue({
+        warn: (msg: string) => warnCalls.push(msg),
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as never);
+
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [
+              { type: "command", bash: "echo start", powershell: "Write-Output start" },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("Write-Output start");
+      expect(warnCalls.some((msg) => msg.includes("bash") && msg.includes("powershell"))).toBe(
+        true,
+      );
+    });
+
+    it("should handle empty hooks", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({ version: 1, hooks: {} }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks).toEqual({});
+    });
+
+    it("should skip invalid hook entries", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [
+              { type: "command", bash: "valid.sh" },
+              "not-an-object",
+              { noTypeField: true },
+              { type: 123 },
+              { type: "command", powershell: 456 },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart).toHaveLength(1);
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("valid.sh");
+    });
+
+    it("should not import unknown keys when converting to canonical hooks", () => {
+      const copilotHooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [
+              { type: "command", bash: "run.sh", powershell: "run.ps1", customKey: 123 },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = copilotHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      const entry = json.hooks.sessionStart?.[0] as Record<string, unknown>;
+      expect(entry.command).toBe("run.sh");
+      expect(entry.customKey).toBeUndefined();
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load from .github/hooks/copilot-hooks.json when it exists", async () => {
+      await ensureDir(join(testDir, ".github", "hooks"));
+      await writeFileContent(
+        join(testDir, ".github", "hooks", "copilot-hooks.json"),
+        JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: [{ type: "command", bash: "echo start" }] },
+        }),
+      );
+
+      const copilotHooks = await CopilotHooks.fromFile({
+        baseDir: testDir,
+        validate: false,
+      });
+      expect(copilotHooks).toBeInstanceOf(CopilotHooks);
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.sessionStart).toHaveLength(1);
+    });
+
+    it("should initialize empty hooks when copilot-hooks.json does not exist", async () => {
+      const copilotHooks = await CopilotHooks.fromFile({
+        baseDir: testDir,
+        validate: false,
+      });
+      expect(copilotHooks).toBeInstanceOf(CopilotHooks);
+      const content = copilotHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks).toEqual({});
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("should return true (default from ToolFile)", () => {
+      const hooks = new CopilotHooks({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        fileContent: '{"version":1,"hooks":{}}',
+        validate: false,
+      });
+      // CopilotHooks does NOT override isDeletable, so it uses the default (true)
+      expect(hooks.isDeletable()).toBe(true);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should return CopilotHooks instance with empty hooks for deletion path", () => {
+      const hooks = CopilotHooks.forDeletion({
+        baseDir: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+      });
+      expect(hooks).toBeInstanceOf(CopilotHooks);
+      const parsed = JSON.parse(hooks.getFileContent());
+      expect(parsed.hooks).toEqual({});
+    });
+  });
+});

--- a/src/features/hooks/copilot-hooks.ts
+++ b/src/features/hooks/copilot-hooks.ts
@@ -1,0 +1,243 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import type { AiFileParams } from "../../types/ai-file.js";
+import type { ValidationResult } from "../../types/ai-file.js";
+import type { HooksConfig } from "../../types/hooks.js";
+import {
+  COPILOT_TO_CANONICAL_EVENT_NAMES,
+  CANONICAL_TO_COPILOT_EVENT_NAMES,
+  COPILOT_HOOK_EVENTS,
+} from "../../types/hooks.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import { logger } from "../../utils/logger.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import {
+  ToolHooks,
+  type ToolHooksForDeletionParams,
+  type ToolHooksFromFileParams,
+  type ToolHooksFromRulesyncHooksParams,
+  type ToolHooksSettablePaths,
+} from "./tool-hooks.js";
+
+/**
+ * Copilot hook entry as stored in .github/hooks/copilot-hooks.json.
+ *
+ * On Windows, commands are emitted under `powershell`; on other platforms, under `bash`.
+ */
+const CopilotHookEntrySchema = z.looseObject({
+  type: z.string(),
+  bash: z.optional(z.string()),
+  powershell: z.optional(z.string()),
+  timeoutSec: z.optional(z.number()),
+});
+
+type CopilotHookEntry = z.infer<typeof CopilotHookEntrySchema>;
+
+/**
+ * Convert canonical hooks config to Copilot format.
+ * Filters shared hooks to COPILOT_HOOK_EVENTS, merges config.copilot?.hooks,
+ * then converts to Copilot event names and field format.
+ *
+ * On Windows the command is emitted under the `powershell` key;
+ * on all other platforms it is emitted under `bash`.
+ */
+function canonicalToCopilotHooks(config: HooksConfig): Record<string, CopilotHookEntry[]> {
+  const isWindows = process.platform === "win32";
+  const commandField = isWindows ? "powershell" : "bash";
+  const supported: Set<string> = new Set(COPILOT_HOOK_EVENTS);
+  const sharedConfigHooks: HooksConfig["hooks"] = {};
+  for (const [event, defs] of Object.entries(config.hooks)) {
+    if (supported.has(event)) {
+      sharedConfigHooks[event] = defs;
+    }
+  }
+  const effectiveHooks: HooksConfig["hooks"] = {
+    ...sharedConfigHooks,
+    ...config.copilot?.hooks,
+  };
+  const copilot: Record<string, CopilotHookEntry[]> = {};
+  for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
+    const copilotEventName = CANONICAL_TO_COPILOT_EVENT_NAMES[eventName] ?? eventName;
+    const entries: CopilotHookEntry[] = [];
+    for (const def of definitions) {
+      const hookType = def.type ?? "command";
+
+      // Not supported
+      if (def.matcher) continue;
+      if (hookType !== "command") continue;
+
+      const command = def.command;
+      const timeout = def.timeout;
+
+      const rest = Object.fromEntries(
+        Object.entries(def).filter(
+          ([k]) => !["type", "matcher", "command", "prompt", "timeout"].includes(k),
+        ),
+      );
+
+      entries.push({
+        type: hookType,
+        ...(command !== undefined && command !== null && { [commandField]: command }),
+        ...(timeout !== undefined && timeout !== null && { timeoutSec: timeout }),
+        ...rest,
+      });
+    }
+
+    if (entries.length > 0) {
+      copilot[copilotEventName] = entries;
+    }
+  }
+  return copilot;
+}
+
+/**
+ * Resolve the command string from a Copilot hook entry.
+ *
+ * - If only `bash` is present, use it.
+ * - If only `powershell` is present, use it.
+ * - If both are present, use `powershell` on Windows, `bash` otherwise,
+ *   and log a warning that the other value was ignored.
+ */
+function resolveImportCommand(entry: CopilotHookEntry): string | undefined {
+  const hasBash = typeof entry.bash === "string";
+  const hasPowershell = typeof entry.powershell === "string";
+  if (hasBash && hasPowershell) {
+    const isWindows = process.platform === "win32";
+    const chosen = isWindows ? "powershell" : "bash";
+    const ignored = isWindows ? "bash" : "powershell";
+    logger.warn(
+      `Copilot hook has both bash and powershell commands; using ${chosen} and ignoring ${ignored} on this platform.`,
+    );
+    return isWindows ? entry.powershell : entry.bash;
+  } else if (hasBash) {
+    return entry.bash;
+  } else if (hasPowershell) {
+    return entry.powershell;
+  }
+  return undefined;
+}
+
+/**
+ * Extract hooks from Copilot hooks JSON into canonical format.
+ * Copilot format: { version: 1, hooks: { eventName: [...hookEntries] } }
+ */
+function copilotHooksToCanonical(copilotHooks: unknown): HooksConfig["hooks"] {
+  if (copilotHooks === null || copilotHooks === undefined || typeof copilotHooks !== "object") {
+    return {};
+  }
+
+  const canonical: HooksConfig["hooks"] = {};
+  for (const [copilotEventName, hookEntries] of Object.entries(copilotHooks)) {
+    const eventName = COPILOT_TO_CANONICAL_EVENT_NAMES[copilotEventName] ?? copilotEventName;
+    if (!Array.isArray(hookEntries)) continue;
+    const defs: HooksConfig["hooks"][string] = [];
+    for (const rawEntry of hookEntries) {
+      const parseResult = CopilotHookEntrySchema.safeParse(rawEntry);
+      if (!parseResult.success) continue;
+      const entry = parseResult.data;
+      const command = resolveImportCommand(entry);
+      const timeout = entry.timeoutSec;
+      defs.push({
+        type: "command",
+        ...(command !== undefined && { command }),
+        ...(timeout !== undefined && { timeout }),
+      });
+    }
+    if (defs.length > 0) {
+      canonical[eventName] = defs;
+    }
+  }
+  return canonical;
+}
+
+export class CopilotHooks extends ToolHooks {
+  constructor(params: AiFileParams) {
+    super({
+      ...params,
+      fileContent: params.fileContent ?? "{}",
+    });
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
+    return {
+      relativeDirPath: join(".github", "hooks"),
+      relativeFilePath: "copilot-hooks.json",
+    };
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolHooksFromFileParams): Promise<CopilotHooks> {
+    const paths = CopilotHooks.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
+    return new CopilotHooks({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncHooks({
+    baseDir = process.cwd(),
+    rulesyncHooks,
+    validate = true,
+  }: ToolHooksFromRulesyncHooksParams & {
+    global?: boolean;
+  }): Promise<CopilotHooks> {
+    const paths = CopilotHooks.getSettablePaths();
+    const config = rulesyncHooks.getJson();
+    const copilotHooks = canonicalToCopilotHooks(config);
+    const fileContent = JSON.stringify({ version: 1, hooks: copilotHooks }, null, 2);
+    return new CopilotHooks({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  toRulesyncHooks(): RulesyncHooks {
+    let parsed: { version?: number; hooks?: unknown };
+    try {
+      parsed = JSON.parse(this.getFileContent());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Copilot hooks content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    const hooks = copilotHooksToCanonical(parsed.hooks);
+    return this.toRulesyncHooksDefault({
+      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolHooksForDeletionParams): CopilotHooks {
+    return new CopilotHooks({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({ hooks: {} }, null, 2),
+      validate: false,
+    });
+  }
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -64,7 +64,9 @@ export type HookEvent =
   | "afterTabFileEdit"
   | "permissionRequest"
   | "notification"
-  | "setup";
+  | "setup"
+  | "afterSubmitPrompt"
+  | "afterError";
 
 /** Hook events supported by Cursor. */
 export const CURSOR_HOOK_EVENTS: readonly HookEvent[] = [
@@ -116,6 +118,16 @@ export const OPENCODE_HOOK_EVENTS: readonly HookEvent[] = [
   "permissionRequest",
 ];
 
+/** Hook events supported by Copilot. */
+export const COPILOT_HOOK_EVENTS: readonly HookEvent[] = [
+  "sessionStart",
+  "sessionEnd",
+  "afterSubmitPrompt",
+  "preToolUse",
+  "postToolUse",
+  "afterError",
+];
+
 /** Hook events supported by Factory Droid. */
 export const FACTORYDROID_HOOK_EVENTS: readonly HookEvent[] = [
   "sessionStart",
@@ -141,6 +153,7 @@ export const HooksConfigSchema = z.looseObject({
   hooks: hooksRecordSchema,
   cursor: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   claudecode: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
+  copilot: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   opencode: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   factorydroid: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
 });
@@ -241,3 +254,22 @@ export const CANONICAL_TO_OPENCODE_EVENT_NAMES: Record<string, string> = {
   afterShellExecution: "command.executed",
   permissionRequest: "permission.asked",
 };
+
+/**
+ * Map canonical camelCase event names to Copilot camelCase.
+ */
+export const CANONICAL_TO_COPILOT_EVENT_NAMES: Record<string, string> = {
+  sessionStart: "sessionStart",
+  sessionEnd: "sessionEnd",
+  afterSubmitPrompt: "userPromptSubmitted",
+  preToolUse: "preToolUse",
+  postToolUse: "postToolUse",
+  afterError: "errorOccurred",
+};
+
+/**
+ * Map Copilot camelCase event names to canonical camelCase.
+ */
+export const COPILOT_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_COPILOT_EVENT_NAMES).map(([k, v]) => [v, k]),
+);


### PR DESCRIPTION
This:
- adds hooks feature for copilot

Notes:
Copilot has an unique hooks format, where it allows for defining the command through `bash` or `powershell` fields. Depending on the platform you're on, either `powershell` or `bash` are required. There are different ways in which this mismatch could be resolved. This chooses to read the user's platform and generate bash or powershell accordingly. If the user wants to maintain both, then they'll need to use copilot-specific overrides.

Closes #1006 