### PR TITLE
fix: respect user-specified opencode.mode in subagent frontmatter

### DIFF
--- a/src/features/subagents/opencode-subagent.test.ts
+++ b/src/features/subagents/opencode-subagent.test.ts
@@ -62,7 +62,7 @@ describe("OpenCodeSubagent", () => {
     expect(rulesync.getBody()).toBe("Review the provided changes");
   });
 
-  it("should build OpenCode subagent from Rulesync subagent and force subagent mode", () => {
+  it("should build OpenCode subagent from Rulesync subagent and preserve mode", () => {
     const rulesyncSubagent = new RulesyncSubagent({
       baseDir: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -72,7 +72,41 @@ describe("OpenCodeSubagent", () => {
         name: "docs-writer",
         description: "Writes documentation",
         opencode: {
-          mode: "primary", // should be overridden
+          mode: "primary", // should be preserved
+          model: "model-x",
+        },
+      },
+      body: "Document the APIs",
+      validate: false,
+    });
+
+    const toolSubagent = OpenCodeSubagent.fromRulesyncSubagent({
+      rulesyncSubagent,
+      global: true,
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    }) as OpenCodeSubagent;
+
+    expect(toolSubagent).toBeInstanceOf(OpenCodeSubagent);
+    expect(toolSubagent.getFrontmatter()).toEqual({
+      name: "docs-writer",
+      description: "Writes documentation",
+      model: "model-x",
+      mode: "primary",
+    });
+    expect(toolSubagent.getRelativeDirPath()).toBe(join(".config", "opencode", "agent"));
+  });
+
+  it("should build OpenCode subagent with default mode when not specified", () => {
+    const rulesyncSubagent = new RulesyncSubagent({
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "docs-writer.md",
+      frontmatter: {
+        targets: ["opencode"],
+        name: "docs-writer",
+        description: "Writes documentation",
+        opencode: {
           model: "model-x",
         },
       },

--- a/src/features/subagents/opencode-subagent.ts
+++ b/src/features/subagents/opencode-subagent.ts
@@ -100,7 +100,7 @@ export class OpenCodeSubagent extends ToolSubagent {
     const opencodeFrontmatter: OpenCodeSubagentFrontmatter = {
       ...opencodeSection,
       description: rulesyncFrontmatter.description,
-      mode: "subagent",
+      mode: typeof opencodeSection.mode === "string" ? opencodeSection.mode : "subagent",
       ...(rulesyncFrontmatter.name && { name: rulesyncFrontmatter.name }),
     };
 


### PR DESCRIPTION
## Summary

Fixes a bug where the OpenCode agent mode was hardcoded to `"subagent"`, ignoring the `mode` value specified in the Rulesync subagent frontmatter.

## The Problem

When a Rulesync subagent specifies `opencode.mode: "primary"`, RuleSync was ignoring it and always outputting `mode: "subagent"` in the generated OpenCode agent file.

## The Fix

Changed line 103 in `src/features/subagents/opencode-subagent.ts` from:
```typescript
mode: "subagent",
```

To:
```typescript
mode: opencodeSection.mode ?? "subagent",
```

This preserves the user's specified mode while defaulting to "subagent" if not specified.

## Why This Matters

OpenCode has two agent modes:
- **primary**: Appears in Tab cycling (main agent rotation)
- **subagent**: Invoked via @mention only

Users need to set `mode: "primary"` in their Rulesync subagents to make them appear as main agents in OpenCode's Tab interface.

## Testing

1. Create a test subagent with `opencode.mode: "primary"`
2. Run: `rulesync generate --targets opencode`
3. Check the generated file - it should now contain `mode: "primary"`

## Backward Compatibility

The fix maintains backward compatibility - if no mode is specified, it defaults to `"subagent"`.