### PR TITLE
refactor(generate): use FeatureGenerateResult in generateSkillsCore return type

### DIFF
--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -408,7 +408,7 @@ async function generateSubagentsCore(params: { config: Config }): Promise<Featur
 
 async function generateSkillsCore(params: {
   config: Config;
-}): Promise<{ count: number; paths: string[]; skills: RulesyncSkill[]; hasDiff: boolean }> {
+}): Promise<FeatureGenerateResult & { skills: RulesyncSkill[] }> {
   const { config } = params;
 
   let totalCount = 0;


### PR DESCRIPTION
## Summary

- Replace inline return type of `generateSkillsCore` with `FeatureGenerateResult & { skills: RulesyncSkill[] }` for consistency with other `generate*Core` functions

Related: https://github.com/dyoshikawa/rulesync/issues/1038

## Test plan

- [x] pnpm check
- [x] pnpm test