### PR TITLE
fix(cli): resolve --base-dir flag being silently ignored in generate command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -179,6 +179,9 @@ const main = async () => {
     .option(
       "-b, --base-dir <paths>",
       "Base directories to generate files (comma-separated for multiple paths)",
+      (value) => {
+        return value.split(",").map((p) => p.trim());
+      },
     )
     .option("-V, --verbose", "Verbose output")
     .option("-s, --silent", "Suppress all output")
@@ -206,7 +209,7 @@ const main = async () => {
           verbose: options.verbose,
           silent: options.silent,
           delete: options.delete,
-          baseDirs: options.baseDirs,
+          baseDirs: options.baseDir,
           configPath: options.config,
           global: options.global,
           simulateCommands: options.simulateCommands,


### PR DESCRIPTION
## Summary

- Fix `--base-dir` CLI flag being silently ignored due to Commander.js camelCase mismatch (`options.baseDirs` → `options.baseDir`)
- Add comma-separated value parser for `--base-dir` to match `--features`/`--targets` pattern

https://github.com/dyoshikawa/rulesync/issues/1168

## Test plan

- [x] pnpm test
- [x] pnpm check
- [x] Manual: `--base-dir "./some-dir"` correctly reflected in verbose output
- [x] Manual: `--base-dir "./dir1,./dir2"` correctly splits into multiple base directories