### PR TITLE
feat: warn when importing from non-existent config files

### DIFF
--- a/src/lib/import.test.ts
+++ b/src/lib/import.test.ts
@@ -142,6 +142,9 @@ describe("importFromTool", () => {
       expect(result.rulesCount).toBe(0);
       expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
       expect(mockProcessor.writeAiFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No rule files found for claudecode"),
+      );
     });
   });
 
@@ -203,6 +206,9 @@ describe("importFromTool", () => {
 
       expect(result.ignoreCount).toBe(0);
       expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No ignore files found for claudecode"),
+      );
     });
   });
 
@@ -255,6 +261,9 @@ describe("importFromTool", () => {
 
       expect(result.mcpCount).toBe(0);
       expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No MCP files found for claudecode"),
+      );
     });
   });
 
@@ -318,6 +327,9 @@ describe("importFromTool", () => {
 
       expect(result.commandsCount).toBe(0);
       expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No command files found for claudecode"),
+      );
     });
   });
 
@@ -381,6 +393,9 @@ describe("importFromTool", () => {
 
       expect(result.subagentsCount).toBe(0);
       expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No subagent files found for claudecode"),
+      );
     });
   });
 
@@ -433,6 +448,9 @@ describe("importFromTool", () => {
 
       expect(result.skillsCount).toBe(0);
       expect(mockProcessor.convertToolDirsToRulesyncDirs).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No skill directories found for claudecode"),
+      );
     });
   });
 
@@ -467,6 +485,28 @@ describe("importFromTool", () => {
         toolTarget: "claudecode",
         global: false,
       });
+    });
+
+    it("should return 0 when no tool files found", async () => {
+      mockConfig.getFeatures.mockReturnValue(["hooks"]);
+      vi.mocked(HooksProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      const mockProcessor = {
+        loadToolFiles: vi.fn().mockResolvedValue([]),
+        convertToolFilesToRulesyncFiles: vi.fn(),
+        writeAiFiles: vi.fn(),
+      };
+      vi.mocked(HooksProcessor).mockImplementation(function () {
+        return mockProcessor as unknown as HooksProcessor;
+      });
+
+      const result = await importFromTool({ config: mockConfig as never, tool: "claudecode" });
+
+      expect(result.hooksCount).toBe(0);
+      expect(mockProcessor.convertToolFilesToRulesyncFiles).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No hooks files found for claudecode"),
+      );
     });
 
     it("should return 0 hooks when feature is not enabled", async () => {

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -70,6 +70,7 @@ async function importRulesCore(params: { config: Config; tool: ToolTarget }): Pr
 
   const toolFiles = await rulesProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No rule files found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -106,6 +107,7 @@ async function importIgnoreCore(params: { config: Config; tool: ToolTarget }): P
 
   const toolFiles = await ignoreProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No ignore files found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -146,6 +148,7 @@ async function importMcpCore(params: { config: Config; tool: ToolTarget }): Prom
 
   const toolFiles = await mcpProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No MCP files found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -182,6 +185,7 @@ async function importCommandsCore(params: { config: Config; tool: ToolTarget }):
 
   const toolFiles = await commandsProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No command files found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -217,6 +221,7 @@ async function importSubagentsCore(params: { config: Config; tool: ToolTarget })
 
   const toolFiles = await subagentsProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No subagent files found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -253,6 +258,7 @@ async function importSkillsCore(params: { config: Config; tool: ToolTarget }): P
 
   const toolDirs = await skillsProcessor.loadToolDirs();
   if (toolDirs.length === 0) {
+    logger.warn(`No skill directories found for ${tool}. Skipping import.`);
     return 0;
   }
 
@@ -294,6 +300,7 @@ async function importHooksCore(params: { config: Config; tool: ToolTarget }): Pr
 
   const toolFiles = await hooksProcessor.loadToolFiles();
   if (toolFiles.length === 0) {
+    logger.warn(`No hooks files found for ${tool}. Skipping import.`);
     return 0;
   }
 


### PR DESCRIPTION
## Summary

- Add `logger.warn()` in each `import*Core` function when `loadToolFiles()`/`loadToolDirs()` returns empty, informing users that no config files were found for the specified tool target during import
- Covers all 7 features: rules, ignore, mcp, commands, subagents, skills, hooks

Closes https://github.com/dyoshikawa/rulesync/issues/1040

## References

- https://github.com/dyoshikawa/rulesync/issues/1027
- https://github.com/dyoshikawa/rulesync/pull/1037

## Test plan

- [x] pnpm check
- [x] pnpm test (4096 passed)