### PR TITLE
fix: add GitHub Copilot hooks to gitignore output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,7 @@ docs/.vitepress/cache
 **/.github/prompts/
 **/.github/agents/
 **/.github/skills/
+**/.github/hooks/
 **/.vscode/mcp.json
 **/.junie/guidelines.md
 **/.junie/mcp.json

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -63,6 +63,7 @@ describe("gitignoreCommand", () => {
       expect(content).toContain("**/.aiignore");
       expect(content).toContain("**/.mcp.json");
       expect(content).toContain("**/.github/agents/");
+      expect(content).toContain("**/.github/hooks/");
       expect(content).toContain("**/.github/prompts/");
       expect(content).toContain("**/.warp/");
       expect(content).toContain("**/.codex/memories/");
@@ -237,6 +238,7 @@ dist/`;
 **/.github/prompts/
 **/.github/agents/
 **/.github/skills/
+**/.github/hooks/
 **/.vscode/mcp.json
 **/.junie/guidelines.md
 **/.junie/mcp.json
@@ -365,6 +367,7 @@ rulesync.local.jsonc
 **/.github/prompts/
 **/.github/agents/
 **/.github/skills/
+**/.github/hooks/
 **/.vscode/mcp.json
 **/.junie/guidelines.md
 **/.junie/mcp.json

--- a/src/cli/commands/gitignore.ts
+++ b/src/cli/commands/gitignore.ts
@@ -66,6 +66,7 @@ const RULESYNC_IGNORE_ENTRIES = [
   "**/.github/prompts/",
   "**/.github/agents/",
   "**/.github/skills/",
+  "**/.github/hooks/",
   "**/.vscode/mcp.json",
   // Junie
   "**/.junie/guidelines.md",


### PR DESCRIPTION
Hello,
I always appreciate your work on rulesync.

Following up on Issue #1207, I have created a Pull Request to fix the `.gitignore` output for GitHub Copilot hooks.

## Description
Closes #1207

This PR updates the `rulesync gitignore` command to ensure that the GitHub Copilot hooks generated files (`**/.github/hooks/`) are properly added to the `.gitignore` file.

## Changes Made
- Added `**/.github/hooks/` to the ignore pattern list in the gitignore command implementation.
- Updated the corresponding tests in `src/cli/commands/gitignore.test.ts`.

## Checklist
- [x] Code style check, type check, and tests passed via `pnpm cicheck`.
- [x] Tested manually by running `pnpm dev gitignore`.

Since this is my very first OSS contribution, please let me know if there are any formatting issues or if I missed anything in the contribution guidelines. I would be happy to fix them.

There is no rush at all for the review. Your time and consideration are greatly appreciated.