### PR TITLE
feat: add dyoshikawa-openclaw to comment-to-ai workflow allowed users

### DIFF
--- a/.github/workflows/comment-to-ai.yml
+++ b/.github/workflows/comment-to-ai.yml
@@ -11,7 +11,8 @@ jobs:
       (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
           github.event.comment.user.login == 'dyoshikawa' ||
-          github.event.comment.user.login == 'cm-dyoshikawa'
+          github.event.comment.user.login == 'cm-dyoshikawa' ||
+          github.event.comment.user.login == 'dyoshikawa-claw'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -85,7 +86,8 @@ jobs:
       (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) &&
       (
           github.event.comment.user.login == 'dyoshikawa' ||
-          github.event.comment.user.login == 'cm-dyoshikawa'
+          github.event.comment.user.login == 'cm-dyoshikawa' ||
+          github.event.comment.user.login == 'dyoshikawa-claw'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Add `dyoshikawa-openclaw` to the list of users who can trigger the comment-to-ai workflow
- This allows the OpenClaw bot account to use `/oc` and `/opencode` commands on issues and PRs

## Changes
- Updated `.github/workflows/comment-to-ai.yml` to include `dyoshikawa-openclaw` in both `handle-issue` and `handle-pr-comment` jobs