### PR TITLE
feat: warn when unsupported target-feature combination is specified

### DIFF
--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -10,6 +10,7 @@ import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
 import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
 import { fileExists, readFileContentOrNull } from "../utils/file.js";
+import { logger } from "../utils/logger.js";
 import { checkRulesyncDirExists, generate } from "./generate.js";
 
 vi.mock("../features/rules/rules-processor.js");
@@ -819,6 +820,81 @@ describe("generate", () => {
       const result = await generate({ config: mockConfig as never });
 
       expect(result.hasDiff).toBe(true);
+    });
+  });
+
+  describe("unsupported target-feature warning", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(logger, "warn");
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("should warn when a target does not support an enabled feature", async () => {
+      mockConfig.getTargets.mockReturnValue(["codexcli"]);
+      // getFeatures(target) is called per-target; return "mcp" for codexcli
+      mockConfig.getFeatures.mockImplementation((target?: string) => {
+        if (target === "codexcli") return ["mcp"];
+        return [];
+      });
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      await generate({ config: mockConfig as never });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Target 'codexcli' does not support the feature 'mcp'. Skipping.",
+      );
+    });
+
+    it("should not warn when the target supports the feature", async () => {
+      mockConfig.getTargets.mockReturnValue(["claudecode"]);
+      mockConfig.getFeatures.mockImplementation((target?: string) => {
+        if (target === "claudecode") return ["rules"];
+        return [];
+      });
+      vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      await generate({ config: mockConfig as never });
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("does not support the feature"),
+      );
+    });
+
+    it("should not warn when the feature is not enabled for the unsupported target", async () => {
+      mockConfig.getTargets.mockReturnValue(["codexcli"]);
+      // codexcli has no features enabled, so no warning even though it doesn't support mcp
+      mockConfig.getFeatures.mockImplementation(() => []);
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      await generate({ config: mockConfig as never });
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("does not support the feature"),
+      );
+    });
+
+    it("should warn for each unsupported target-feature combination", async () => {
+      mockConfig.getTargets.mockReturnValue(["codexcli", "cursor"]);
+      // Both unsupported targets have mcp enabled
+      mockConfig.getFeatures.mockImplementation((target?: string) => {
+        if (target === "codexcli" || target === "cursor") return ["mcp"];
+        return [];
+      });
+      vi.mocked(McpProcessor.getToolTargets).mockReturnValue(["claudecode"]);
+
+      await generate({ config: mockConfig as never });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Target 'codexcli' does not support the feature 'mcp'. Skipping.",
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Target 'cursor' does not support the feature 'mcp'. Skipping.",
+      );
     });
   });
 });

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -16,6 +16,8 @@ import { AiDir } from "../types/ai-dir.js";
 import { AiFile } from "../types/ai-file.js";
 import { DirFeatureProcessor } from "../types/dir-feature-processor.js";
 import { FeatureProcessor } from "../types/feature-processor.js";
+import type { Feature } from "../types/features.js";
+import type { ToolTarget } from "../types/tool-targets.js";
 import { formatError } from "../utils/error.js";
 import { fileExists } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
@@ -109,6 +111,19 @@ async function processEmptyFeatureGeneration(params: {
   return { count: totalCount, paths: [], hasDiff };
 }
 
+function warnUnsupportedTargets(params: {
+  config: Config;
+  supportedTargets: ToolTarget[];
+  featureName: Feature;
+}): void {
+  const { config, supportedTargets, featureName } = params;
+  for (const target of config.getTargets()) {
+    if (!supportedTargets.includes(target) && config.getFeatures(target).includes(featureName)) {
+      logger.warn(`Target '${target}' does not support the feature '${featureName}'. Skipping.`);
+    }
+  }
+}
+
 /**
  * Check if .rulesync directory exists.
  */
@@ -170,10 +185,9 @@ async function generateRulesCore(params: {
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    RulesProcessor.getToolTargets({ global: config.getGlobal() }),
-  );
+  const supportedTargets = RulesProcessor.getToolTargets({ global: config.getGlobal() });
+  const toolTargets = intersection(config.getTargets(), supportedTargets);
+  warnUnsupportedTargets({ config, supportedTargets, featureName: "rules" });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -214,6 +228,13 @@ async function generateRulesCore(params: {
 async function generateIgnoreCore(params: { config: Config }): Promise<FeatureGenerateResult> {
   const { config } = params;
 
+  const supportedIgnoreTargets = IgnoreProcessor.getToolTargets();
+  warnUnsupportedTargets({
+    config,
+    supportedTargets: supportedIgnoreTargets,
+    featureName: "ignore",
+  });
+
   if (config.getGlobal()) {
     return { count: 0, paths: [], hasDiff: false };
   }
@@ -222,7 +243,7 @@ async function generateIgnoreCore(params: { config: Config }): Promise<FeatureGe
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  for (const toolTarget of intersection(config.getTargets(), IgnoreProcessor.getToolTargets())) {
+  for (const toolTarget of intersection(config.getTargets(), supportedIgnoreTargets)) {
     // Check if ignore feature is enabled for this specific target
     if (!config.getFeatures(toolTarget).includes("ignore")) {
       continue;
@@ -275,10 +296,9 @@ async function generateMcpCore(params: { config: Config }): Promise<FeatureGener
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    McpProcessor.getToolTargets({ global: config.getGlobal() }),
-  );
+  const supportedMcpTargets = McpProcessor.getToolTargets({ global: config.getGlobal() });
+  const toolTargets = intersection(config.getTargets(), supportedMcpTargets);
+  warnUnsupportedTargets({ config, supportedTargets: supportedMcpTargets, featureName: "mcp" });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -319,13 +339,16 @@ async function generateCommandsCore(params: { config: Config }): Promise<Feature
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    CommandsProcessor.getToolTargets({
-      global: config.getGlobal(),
-      includeSimulated: config.getSimulateCommands(),
-    }),
-  );
+  const supportedCommandsTargets = CommandsProcessor.getToolTargets({
+    global: config.getGlobal(),
+    includeSimulated: config.getSimulateCommands(),
+  });
+  const toolTargets = intersection(config.getTargets(), supportedCommandsTargets);
+  warnUnsupportedTargets({
+    config,
+    supportedTargets: supportedCommandsTargets,
+    featureName: "commands",
+  });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -366,13 +389,16 @@ async function generateSubagentsCore(params: { config: Config }): Promise<Featur
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    SubagentsProcessor.getToolTargets({
-      global: config.getGlobal(),
-      includeSimulated: config.getSimulateSubagents(),
-    }),
-  );
+  const supportedSubagentsTargets = SubagentsProcessor.getToolTargets({
+    global: config.getGlobal(),
+    includeSimulated: config.getSimulateSubagents(),
+  });
+  const toolTargets = intersection(config.getTargets(), supportedSubagentsTargets);
+  warnUnsupportedTargets({
+    config,
+    supportedTargets: supportedSubagentsTargets,
+    featureName: "subagents",
+  });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -416,13 +442,16 @@ async function generateSkillsCore(params: {
   let hasDiff = false;
   const allSkills: RulesyncSkill[] = [];
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    SkillsProcessor.getToolTargets({
-      global: config.getGlobal(),
-      includeSimulated: config.getSimulateSkills(),
-    }),
-  );
+  const supportedSkillsTargets = SkillsProcessor.getToolTargets({
+    global: config.getGlobal(),
+    includeSimulated: config.getSimulateSkills(),
+  });
+  const toolTargets = intersection(config.getTargets(), supportedSkillsTargets);
+  warnUnsupportedTargets({
+    config,
+    supportedTargets: supportedSkillsTargets,
+    featureName: "skills",
+  });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {
@@ -470,10 +499,9 @@ async function generateHooksCore(params: { config: Config }): Promise<FeatureGen
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  const toolTargets = intersection(
-    config.getTargets(),
-    HooksProcessor.getToolTargets({ global: config.getGlobal() }),
-  );
+  const supportedHooksTargets = HooksProcessor.getToolTargets({ global: config.getGlobal() });
+  const toolTargets = intersection(config.getTargets(), supportedHooksTargets);
+  warnUnsupportedTargets({ config, supportedTargets: supportedHooksTargets, featureName: "hooks" });
 
   for (const baseDir of config.getBaseDirs()) {
     for (const toolTarget of toolTargets) {


### PR DESCRIPTION
> Accidentally closed PR #1214 by deleting the fork. Recreating with the same diff.

## Summary

- Add `warnUnsupportedTargets()` helper function in `generate.ts` that checks if a target does not support a given feature and logs `logger.warn()` with a clear message
- Call `warnUnsupportedTargets()` in all 7 `generate*Core` functions (rules, ignore, mcp, commands, subagents, skills, hooks) right after `intersection()` computation
- Add 4 test cases covering: warning on unsupported target-feature, no warning on supported target, no warning when feature is disabled, and warning for multiple unsupported targets

Closes https://github.com/dyoshikawa/rulesync/issues/1026

## References

- https://github.com/dyoshikawa/rulesync/issues/1026

## Test plan

- [ ] pnpm check
- [ ] pnpm test