### PR TITLE
test: preserve opencode.mode from rulesync subagents

### DIFF
--- a/src/e2e/e2e-subagents.spec.ts
+++ b/src/e2e/e2e-subagents.spec.ts
@@ -36,4 +36,38 @@ You are the planner. Analyze files and create a plan.
     expect(generatedContent).toContain("planner");
     expect(generatedContent).toContain("Analyze files and create a plan.");
   });
+
+  it("should preserve opencode.mode when generating OpenCode subagents", async () => {
+    const testDir = getTestDir();
+
+    // Setup: Create a subagent with opencode.mode: primary
+    const subagentContent = `---
+name: primary-agent
+targets: ["*"]
+description: "A primary mode agent"
+opencode:
+  mode: primary
+  hidden: false
+  tools:
+    bash: true
+    edit: true
+---
+You are a primary agent. You appear in the Tab rotation.
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "primary-agent.md"),
+      subagentContent,
+    );
+
+    // Execute: Generate subagents for opencode
+    await runGenerate({ target: "opencode", features: "subagents" });
+
+    // Verify that the mode is preserved as primary, not defaulting to subagent
+    const generatedContent = await readFileContent(
+      join(testDir, ".opencode", "agent", "primary-agent.md"),
+    );
+    expect(generatedContent).toContain("mode: primary");
+    expect(generatedContent).not.toContain("mode: subagent");
+    expect(generatedContent).toContain("A primary mode agent");
+  });
 });

--- a/src/features/subagents/opencode-subagent.test.ts
+++ b/src/features/subagents/opencode-subagent.test.ts
@@ -131,6 +131,44 @@ describe("OpenCodeSubagent", () => {
     expect(toolSubagent.getRelativeDirPath()).toBe(join(".config", "opencode", "agent"));
   });
 
+  it("should preserve primary mode for OpenCode subagent", () => {
+    // Regression test for: opencode.mode was hardcoded to 'subagent' instead of being preserved
+    const rulesyncSubagent = new RulesyncSubagent({
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "primary-agent.md",
+      frontmatter: {
+        targets: ["*"],
+        name: "primary-agent",
+        description: "A primary mode agent",
+        opencode: {
+          mode: "primary",
+          hidden: false,
+          tools: {
+            bash: true,
+            edit: true,
+          },
+        },
+      },
+      body: "Test body for primary agent",
+      validate: false,
+    });
+
+    const toolSubagent = OpenCodeSubagent.fromRulesyncSubagent({
+      rulesyncSubagent,
+      global: true,
+      baseDir: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    }) as OpenCodeSubagent;
+
+    expect(toolSubagent.getFrontmatter().mode).toBe("primary");
+    expect(toolSubagent.getFrontmatter().name).toBe("primary-agent");
+    expect(toolSubagent.getFrontmatter().tools).toEqual({
+      bash: true,
+      edit: true,
+    });
+  });
+
   it("should load from file and validate frontmatter", async () => {
     const dirPath = join(testDir, ".opencode", "agent");
     const filePath = join(dirPath, "general.md");


### PR DESCRIPTION
## Summary

Fixes bug where `opencode.mode` was hardcoded to `'subagent'` instead of reading the value from the rulesync subagent frontmatter.

## Problem

When generating OpenCode subagents from rulesync files that specified `opencode.mode: primary`, the generated output always had `mode: subagent` regardless of the source configuration.

## Solution

The fix is present in the source code at `src/features/subagents/opencode-subagent.ts:103`:
```typescript
mode: typeof opencodeSection.mode === "string" ? opencodeSection.mode : "subagent",
```

This PR adds comprehensive tests to prevent regression and ensure the fix works correctly.

## Changes

- **src/features/subagents/opencode-subagent.test.ts**: Add unit test for `opencode.mode: primary` preservation
- **src/e2e/e2e-subagents.spec.ts**: Add E2E test covering full generation flow

## Testing

- ✅ All unit tests pass
- ✅ All E2E tests pass
- ✅ Verified `opencode.mode: primary` is preserved in generated output
- ✅ Verified default `mode: subagent` still works when not specified

## Test Case

Create a test agent with this frontmatter:
```yaml
opencode:
  mode: primary
```

Run `rulesync generate --targets opencode` and verify the output has `mode: primary`, not `mode: subagent`.