### PR TITLE
fix(hooks): Correct Copilot event mapping from afterSubmitPrompt to beforeSubmitPrompt

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -43,7 +43,7 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
 - **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
-- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `afterSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
+- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 - **Gemini CLI:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `stop`, `beforeAgentResponse`, `afterAgentResponse`, `beforeToolSelection`, `preToolUse`, `postToolUse`, `preCompact`, `notification`
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin, so importing from OpenCode to rulesync is not supported. OpenCode only supports command-type hooks (not prompt-type).

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -43,7 +43,7 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
 - **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
-- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `afterSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
+- **GitHub Copilot:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 - **Gemini CLI:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `stop`, `beforeAgentResponse`, `afterAgentResponse`, `beforeToolSelection`, `preToolUse`, `postToolUse`, `preCompact`, `notification`
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin, so importing from OpenCode to rulesync is not supported. OpenCode only supports command-type hooks (not prompt-type).
@@ -157,6 +157,7 @@ description: >- # skill description
   A sample skill that demonstrates the skill format
 targets: ["*"] # * = all, or specific tools
 claudecode: # for claudecode-specific parameters
+  model: sonnet # opus, sonnet, haiku, or any string
   allowed-tools:
     - "Bash"
     - "Read"

--- a/src/features/hooks/copilot-hooks.test.ts
+++ b/src/features/hooks/copilot-hooks.test.ts
@@ -47,7 +47,7 @@ describe("CopilotHooks", () => {
         hooks: {
           sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
           sessionEnd: [{ command: ".rulesync/hooks/session-end.sh" }],
-          afterSubmitPrompt: [{ command: ".rulesync/hooks/after-prompt.sh" }],
+          beforeSubmitPrompt: [{ command: ".rulesync/hooks/before-prompt.sh" }],
           preToolUse: [{ command: ".rulesync/hooks/pre-tool.sh" }],
           postToolUse: [{ command: ".rulesync/hooks/post-tool.sh" }],
           afterError: [{ command: ".rulesync/hooks/error.sh" }],
@@ -446,8 +446,8 @@ describe("CopilotHooks", () => {
       expect(json.hooks.sessionStart).toHaveLength(1);
       expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
       expect(json.hooks.sessionStart?.[0]?.timeout).toBe(30);
-      expect(json.hooks.afterSubmitPrompt).toHaveLength(1);
-      expect(json.hooks.afterSubmitPrompt?.[0]?.command).toBe("log-prompt.sh");
+      expect(json.hooks.beforeSubmitPrompt).toHaveLength(1);
+      expect(json.hooks.beforeSubmitPrompt?.[0]?.command).toBe("log-prompt.sh");
       expect(json.hooks.afterError).toHaveLength(1);
       expect(json.hooks.afterError?.[0]?.command).toBe("handle-error.sh");
     });

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -68,7 +68,6 @@ export type HookEvent =
   | "permissionRequest"
   | "notification"
   | "setup"
-  | "afterSubmitPrompt"
   | "afterError"
   | "beforeToolSelection";
 
@@ -126,7 +125,7 @@ export const OPENCODE_HOOK_EVENTS: readonly HookEvent[] = [
 export const COPILOT_HOOK_EVENTS: readonly HookEvent[] = [
   "sessionStart",
   "sessionEnd",
-  "afterSubmitPrompt",
+  "beforeSubmitPrompt",
   "preToolUse",
   "postToolUse",
   "afterError",
@@ -281,7 +280,7 @@ export const CANONICAL_TO_OPENCODE_EVENT_NAMES: Record<string, string> = {
 export const CANONICAL_TO_COPILOT_EVENT_NAMES: Record<string, string> = {
   sessionStart: "sessionStart",
   sessionEnd: "sessionEnd",
-  afterSubmitPrompt: "userPromptSubmitted",
+  beforeSubmitPrompt: "userPromptSubmitted",
   preToolUse: "preToolUse",
   postToolUse: "postToolUse",
   afterError: "errorOccurred",


### PR DESCRIPTION
Copilot native event `userPromptSubmitted` was being mapped to
`afterSubmitPrompt`, which was added specifically for Copilot.

All other tools that fire on user prompt submission (Cursor
`beforeSubmitPrompt`, Claude Code `UserPromptSubmit`, Factory Droid
`UserPromptSubmit`) already map to the canonical `beforeSubmitPrompt`
event. This change aligns Copilot with the same canonical event and
removes the unused `afterSubmitPrompt` type.

Changes:
- Remove `afterSubmitPrompt` from the `HookEvent` type union
- Update `COPILOT_HOOK_EVENTS` and `CANONICAL_TO_COPILOT_EVENT_NAMES` to
  use `beforeSubmitPrompt`
- Update tests and documentation to reflect the corrected mapping
