### PR TITLE
docs(rules): add note about docs/ and skills/rulesync/ auto-sync

### DIFF
--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -31,3 +31,4 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - This directory contains official skills that are distributed for users to install via the `rulesync fetch` command (e.g., `npx rulesync fetch dyoshikawa/rulesync --features skills`).
   - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.
   - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
+- The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.


### PR DESCRIPTION
## Summary
- Add a note to `.rulesync/rules/overview.md` that `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`, and their content may overlap.

## Test plan
- [x] Verify the added note is clear and correctly placed

🤖 Generated with [Claude Code](https://claude.com/claude-code)