### PR TITLE
fix(ci): use EOF delimiter for GITHUB_OUTPUT in select-opencode-model

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -34,4 +34,7 @@ runs:
         CLEANED="${CLEANED//codex/}"
         CLEANED="${CLEANED//glm/}"
         CLEANED="${CLEANED//kimi/}"
-        echo "cleaned_text=$CLEANED" >> $GITHUB_OUTPUT
+        EOF_MARKER=$(uuidgen)
+        echo "cleaned_text<<${EOF_MARKER}" >> $GITHUB_OUTPUT
+        echo "$CLEANED" >> $GITHUB_OUTPUT
+        echo "${EOF_MARKER}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `select-opencode-model` アクションの `cleaned_text` 出力を、単一行 `echo` からEOFデリミタパターンに変更
- 入力テキストに改行や特殊文字が含まれる場合の `$GITHUB_OUTPUT` 破損を防止

## Test plan
- [ ] `select-opencode-model` アクションを使用するワークフローが正常に動作することを確認
- [ ] 改行を含む入力テキストで `cleaned_text` が正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)