### PR TITLE
chore: add mergeability-first guidance to review prompt

### DIFF
--- a/.github/workflows/comment-to-ai.yml
+++ b/.github/workflows/comment-to-ai.yml
@@ -199,7 +199,7 @@ jobs:
                   - Call code-reviewer subagent to review the code changes in the PR.
                   - Call security-reviewer subagent to review the security issues the PR.
 
-                  最初に、マージ可能かどうかの総合判断を明示すること。原則として medium 以下の指摘はマージブロッカーではない。
+                  First, explicitly state the overall mergeability verdict. By default, issues with severity medium or lower are not merge blockers.
                   Integrate and report the execution results from each subagent. Number each point (1, 2, 3...) for easy reference. Also include the PR number in the result so the user can easily find the PR.
                   ```
               2. Fix the code. Run `pnpm cicheck` to verify code quality. If the environment variable IS_UPSTREAM is true, perform 2-1. If false (fork repository), perform 2-2.


### PR DESCRIPTION
## Summary
- Update `.github/workflows/comment-to-ai.yml` review instruction to require stating the overall mergeability verdict first
- Clarify that, by default, issues with severity medium or lower are not merge blockers
- Keep the change minimal and focused to prompt wording

## Scope
- Workflow prompt text only

## Test
- No additional tests (prompt text change only)