### PR TITLE
fix(hooks): keep executable hook commands unprefixed

### DIFF
--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -68,14 +68,17 @@ describe("ClaudecodeHooks", () => {
       expect(parsed.hooks.afterFileEdit).toBeUndefined();
     });
 
-    it("should prefix non-absolute commands with $CLAUDE_PROJECT_DIR", async () => {
+    it("should only prefix dot-relative commands with $CLAUDE_PROJECT_DIR", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
 
       const config = {
         version: 1,
         hooks: {
-          sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
+          sessionStart: [
+            { type: "command", command: ".rulesync/hooks/session-start.sh" },
+            { type: "command", command: "npx prettier --write ./src/hooks/format.ts" },
+          ],
         },
       };
       const rulesyncHooks = new RulesyncHooks({
@@ -99,6 +102,7 @@ describe("ClaudecodeHooks", () => {
       expect(sessionStartEntry.matcher).toBeUndefined();
       expect(sessionStartEntry.hooks[0].command).toContain("$CLAUDE_PROJECT_DIR");
       expect(sessionStartEntry.hooks[0].command).toContain(".rulesync/hooks/session-start.sh");
+      expect(sessionStartEntry.hooks[1].command).toBe("npx prettier --write ./src/hooks/format.ts");
     });
 
     it("should merge config.claudecode.hooks on top of shared hooks", async () => {

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -25,6 +25,7 @@ const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   canonicalToToolEventNames: CANONICAL_TO_CLAUDE_EVENT_NAMES,
   toolToCanonicalEventNames: CLAUDE_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "$CLAUDE_PROJECT_DIR",
+  prefixDotRelativeCommandsOnly: true,
 };
 
 export class ClaudecodeHooks extends ToolHooks {

--- a/src/features/hooks/geminicli-hooks.test.ts
+++ b/src/features/hooks/geminicli-hooks.test.ts
@@ -55,10 +55,33 @@ describe("GeminicliHooks", () => {
       const parsed = JSON.parse(geminiHooks.getFileContent());
       expect(parsed.hooks).toBeDefined();
       expect(parsed.hooks.SessionStart).toBeDefined();
-      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe("$GEMINI_PROJECT_DIR/echo start");
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe("echo start");
       expect(parsed.hooks.SessionStart[0].hooks[0].name).toBe("Start Hook");
       expect(parsed.hooks.SessionStart[0].hooks[0].description).toBe("Runs on start");
       expect(parsed.hooks.UnsupportedEvent).toBeUndefined();
+    });
+
+    it("should prefix dot-relative commands with $GEMINI_PROJECT_DIR", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [{ command: "./hooks/start.sh" }],
+            },
+          }),
+        }),
+      );
+
+      const geminiHooks = await GeminicliHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(geminiHooks.getFileContent());
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
+        "$GEMINI_PROJECT_DIR/hooks/start.sh",
+      );
     });
 
     it("should merge with existing settings.json", async () => {
@@ -119,10 +142,8 @@ describe("GeminicliHooks", () => {
       });
 
       const parsed = JSON.parse(geminiHooks.getFileContent());
-      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
-        "$GEMINI_PROJECT_DIR/echo override",
-      );
-      expect(parsed.hooks.SessionEnd[0].hooks[0].command).toBe("$GEMINI_PROJECT_DIR/echo end");
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe("echo override");
+      expect(parsed.hooks.SessionEnd[0].hooks[0].command).toBe("echo end");
     });
   });
 

--- a/src/features/hooks/geminicli-hooks.ts
+++ b/src/features/hooks/geminicli-hooks.ts
@@ -51,9 +51,17 @@ function canonicalToGeminicliHooks(config: HooksConfig): Record<string, unknown[
     const entries: unknown[] = [];
     for (const [matcherKey, defs] of byMatcher) {
       const hooks = defs.map((def) => {
+        const commandText = def.command;
+        const trimmedCommand =
+          typeof commandText === "string" ? commandText.trimStart() : undefined;
+        const shouldPrefix =
+          typeof trimmedCommand === "string" &&
+          !trimmedCommand.startsWith("$") &&
+          trimmedCommand.startsWith(".");
+
         const command =
-          def.command !== undefined && def.command !== null && !def.command.startsWith("$")
-            ? `$GEMINI_PROJECT_DIR/${def.command.replace(/^\.\//, "")}`
+          shouldPrefix && typeof trimmedCommand === "string"
+            ? `$GEMINI_PROJECT_DIR/${trimmedCommand.replace(/^\.\//, "")}`
             : def.command;
         return {
           type: def.type ?? "command",

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -23,6 +23,11 @@ export type ToolHooksConverterConfig = {
   canonicalToToolEventNames: Record<string, string>;
   toolToCanonicalEventNames: Record<string, string>;
   projectDirVar: string;
+  /**
+   * When true, only dot-relative commands (e.g. ./script.sh, ../script.sh, .rulesync/hooks/x.sh)
+   * are prefixed with projectDirVar. Bare executable commands like `npx prettier ...` are left intact.
+   */
+  prefixDotRelativeCommandsOnly?: boolean;
 };
 
 /**
@@ -64,9 +69,17 @@ export function canonicalToToolHooks({
     const entries: unknown[] = [];
     for (const [matcherKey, defs] of byMatcher) {
       const hooks = defs.map((def) => {
+        const commandText = def.command;
+        const trimmedCommand =
+          typeof commandText === "string" ? commandText.trimStart() : undefined;
+        const shouldPrefix =
+          typeof trimmedCommand === "string" &&
+          !trimmedCommand.startsWith("$") &&
+          (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
+
         const command =
-          def.command !== undefined && def.command !== null && !def.command.startsWith("$")
-            ? `${converterConfig.projectDirVar}/${def.command.replace(/^\.\//, "")}`
+          shouldPrefix && typeof trimmedCommand === "string"
+            ? `${converterConfig.projectDirVar}/${trimmedCommand.replace(/^\.\//, "")}`
             : def.command;
         return {
           type: def.type ?? "command",


### PR DESCRIPTION
## Summary
- stop auto-prefixing bare executable commands (e.g. `npx prettier --write ./src/hooks/format.ts`) with project-dir env vars for Claude Code and Gemini CLI hooks
- keep prefixing dot-relative script paths (e.g. `./hooks/start.sh`, `.rulesync/hooks/session-start.sh`) so repo-local script references still work
- add regression tests for both tools and keep Factory Droid behavior unchanged

## Why
`rulesync` currently rewrites commands like `npx prettier --write ./src/hooks/format.ts` to `$CLAUDE_PROJECT_DIR/npx prettier --write ./src/hooks/format.ts`, which produces invalid commands.

This PR addresses #1229 by making prefixing path-aware instead of unconditional.

Closes #1229

## Validation
- `pnpm test src/features/hooks/claudecode-hooks.test.ts src/features/hooks/geminicli-hooks.test.ts src/features/hooks/factorydroid-hooks.test.ts`
- `pnpm run typecheck`
- `pnpm run fmt:check`
