### PR TITLE
chore: mark low-only review findings as mergeable

### DIFF
--- a/.github/workflows/comment-to-ai.yml
+++ b/.github/workflows/comment-to-ai.yml
@@ -199,7 +199,7 @@ jobs:
                   - Call code-reviewer subagent to review the code changes in the PR.
                   - Call security-reviewer subagent to review the security issues the PR.
 
-                  First, explicitly state the overall mergeability verdict. By default, issues with severity medium or lower are not merge blockers.
+                  First, explicitly state the overall mergeability verdict. The verdict is "mergeable" when issues are only low severity or lower (no medium/high/critical blockers).
                   Integrate and report the execution results from each subagent. Number each point (1, 2, 3...) for easy reference. Also include the PR number in the result so the user can easily find the PR.
                   ```
               2. Fix the code. Run `pnpm cicheck` to verify code quality. If the environment variable IS_UPSTREAM is true, perform 2-1. If false (fork repository), perform 2-2.


### PR DESCRIPTION
## Summary
- update `comment-to-ai` workflow review instruction so the overall verdict is **mergeable** when findings are only low severity or below
- keep medium/high/critical as merge blockers

## Validation
- `pnpm cicheck` passed before PR creation
