### PR TITLE
ci: soften additions limit enforcement to comment-only

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -47,11 +47,9 @@ jobs:
 
           Please split your changes into smaller PRs. See [CONTRIBUTING.md](https://github.com/${GH_REPO}/blob/main/CONTRIBUTING.md) for details.
 
-          This PR has been automatically closed.
           EOF
             )
             gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
-            gh pr close "$PR_NUMBER"
             echo "::error::PR exceeds the addition line limit for external contributors ($PR_ADDITIONS > $MAX_ADDITIONS)."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- change additions limit enforcement from automatic PR close to comment-only
- keep automatic PR close only for open PR count limit (3+ PRs)
- update comment message to remove "automatically closed" text

## Why
Automatic PR closure for large diffs is too aggressive. Comment-only feedback allows contributors to split changes without losing work.

## Validation
- `pnpm cicheck` passed before PR creation
