### PR TITLE
fix: address issue #1266 follow-ups from git-native transport review

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -114,3 +114,7 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/config-schema.json
+++ b/config-schema.json
@@ -50,7 +50,16 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
+            "enum": [
+              "rules",
+              "ignore",
+              "mcp",
+              "subagents",
+              "commands",
+              "skills",
+              "hooks",
+              "*"
+            ]
           }
         },
         {
@@ -62,7 +71,16 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
+              "enum": [
+                "rules",
+                "ignore",
+                "mcp",
+                "subagents",
+                "commands",
+                "skills",
+                "hooks",
+                "*"
+              ]
             }
           }
         }
@@ -112,7 +130,10 @@
           },
           "transport": {
             "type": "string",
-            "enum": ["github", "git"]
+            "enum": [
+              "github",
+              "git"
+            ]
           },
           "ref": {
             "type": "string"
@@ -121,7 +142,9 @@
             "type": "string"
           }
         },
-        "required": ["source"],
+        "required": [
+          "source"
+        ],
         "additionalProperties": false
       }
     }

--- a/config-schema.json
+++ b/config-schema.json
@@ -50,16 +50,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "rules",
-              "ignore",
-              "mcp",
-              "subagents",
-              "commands",
-              "skills",
-              "hooks",
-              "*"
-            ]
+            "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
           }
         },
         {
@@ -71,16 +62,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "rules",
-                "ignore",
-                "mcp",
-                "subagents",
-                "commands",
-                "skills",
-                "hooks",
-                "*"
-              ]
+              "enum": ["rules", "ignore", "mcp", "subagents", "commands", "skills", "hooks", "*"]
             }
           }
         }
@@ -120,31 +102,31 @@
         "properties": {
           "source": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Repository identifier (e.g., 'org/repo' or a full URL)."
           },
           "skills": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Skill names to fetch. Omit to fetch all skills from the source."
           },
           "transport": {
             "type": "string",
-            "enum": [
-              "github",
-              "git"
-            ]
+            "enum": ["github", "git"],
+            "description": "Transport protocol for fetching skills. 'github' uses the GitHub REST API (default). 'git' uses the git CLI and works with any git remote."
           },
           "ref": {
-            "type": "string"
+            "type": "string",
+            "description": "Git ref (branch or tag) to fetch skills from. Defaults to the repository's default branch."
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Path to the skills directory within the repository. Defaults to 'skills'."
           }
         },
-        "required": [
-          "source"
-        ],
+        "required": ["source"],
         "additionalProperties": false
       }
     }

--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -12,9 +12,30 @@ const generatedSchema = z.toJSONSchema(ConfigFileSchema, {
   reused: "ref",
 });
 
+// Add descriptions to source entry fields (zod/mini lacks .describe())
+// Round-trip through JSON to get a plain object we can mutate without type assertions
+const schemaObj = JSON.parse(JSON.stringify(generatedSchema));
+const sourceProps = schemaObj?.properties?.sources?.items?.properties;
+if (sourceProps) {
+  if (sourceProps.source)
+    sourceProps.source.description = "Repository identifier (e.g., 'org/repo' or a full URL).";
+  if (sourceProps.skills)
+    sourceProps.skills.description =
+      "Skill names to fetch. Omit to fetch all skills from the source.";
+  if (sourceProps.transport)
+    sourceProps.transport.description =
+      "Transport protocol for fetching skills. 'github' uses the GitHub REST API (default). 'git' uses the git CLI and works with any git remote.";
+  if (sourceProps.ref)
+    sourceProps.ref.description =
+      "Git ref (branch or tag) to fetch skills from. Defaults to the repository's default branch.";
+  if (sourceProps.path)
+    sourceProps.path.description =
+      "Path to the skills directory within the repository. Defaults to 'skills'.";
+}
+
 // Add JSON Schema meta properties (override Zod's default $schema with draft-07 for broader compatibility)
 const jsonSchema = {
-  ...generatedSchema,
+  ...schemaObj,
   $schema: "http://json-schema.org/draft-07/schema#",
   $id: "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
   title: "Rulesync Configuration",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,14 +17,7 @@ import {
   ToolTarget,
   ToolTargets,
 } from "../types/tool-targets.js";
-
-function hasControlCharacters(value: string): boolean {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) return true;
-  }
-  return false;
-}
+import { hasControlCharacters } from "../utils/validation.js";
 
 /**
  * Schema for a single source entry in the sources array.

--- a/src/lib/git-client.test.ts
+++ b/src/lib/git-client.test.ts
@@ -197,6 +197,35 @@ describe("git-client", () => {
       expect(removeTempDirectory).toHaveBeenCalledWith("/tmp/test");
     });
 
+    it("rejects skillsPath with path traversal", async () => {
+      await expect(
+        fetchSkillFiles({ url: "https://example.com/repo.git", ref: "main", skillsPath: "../etc" }),
+      ).rejects.toThrow(GitClientError);
+      await expect(
+        fetchSkillFiles({ url: "https://example.com/repo.git", ref: "main", skillsPath: "../etc" }),
+      ).rejects.toThrow("must be a relative path");
+    });
+
+    it("rejects absolute skillsPath", async () => {
+      await expect(
+        fetchSkillFiles({
+          url: "https://example.com/repo.git",
+          ref: "main",
+          skillsPath: "/etc/passwd",
+        }),
+      ).rejects.toThrow(GitClientError);
+    });
+
+    it("rejects skillsPath with control characters", async () => {
+      await expect(
+        fetchSkillFiles({
+          url: "https://example.com/repo.git",
+          ref: "main",
+          skillsPath: "skills\x00",
+        }),
+      ).rejects.toThrow("control character");
+    });
+
     it("returns empty when skills dir missing", async () => {
       mockExecFileAsync.mockResolvedValue({ stdout: "" });
       vi.mocked(createTempDirectory).mockResolvedValue("/tmp/test");

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -13,6 +13,7 @@ import {
   removeTempDirectory,
 } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
+import { findControlCharacter } from "../utils/validation.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -23,20 +24,6 @@ const ALLOWED_URL_SCHEMES =
   /^(https?:\/\/|ssh:\/\/|git:\/\/|file:\/\/\/|[a-zA-Z0-9_.+-]+@[a-zA-Z0-9.-]+:[a-zA-Z0-9_.+/~-]+)/;
 
 const INSECURE_URL_SCHEMES = /^(git:\/\/|http:\/\/)/;
-
-/**
- * Check for control characters and return the position and hex code of the first one found.
- * Returns null if no control characters are found.
- */
-function findControlCharacter(value: string): { position: number; hex: string } | null {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) {
-      return { position: i, hex: `0x${code.toString(16).padStart(2, "0")}` };
-    }
-  }
-  return null;
-}
 
 export class GitClientError extends Error {
   constructor(message: string, cause?: unknown) {

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -21,7 +21,7 @@ const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 60_000;
 
 const ALLOWED_URL_SCHEMES =
-  /^(https?:\/\/|ssh:\/\/|git:\/\/|file:\/\/\/|[a-zA-Z0-9_.+-]+@[a-zA-Z0-9.-]+:[a-zA-Z0-9_.+/~-]+)/;
+  /^(https?:\/\/|ssh:\/\/|git:\/\/|file:\/\/\/).+$|^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9.-]+:[a-zA-Z0-9_.+/~-]+$/;
 
 const INSECURE_URL_SCHEMES = /^(git:\/\/|http:\/\/)/;
 

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 
 import { MAX_FILE_SIZE } from "../constants/rulesync-paths.js";
@@ -132,6 +132,17 @@ export async function fetchSkillFiles(params: {
   const { url, ref, skillsPath } = params;
   validateGitUrl(url);
   validateRef(ref);
+  if (skillsPath.includes("..") || isAbsolute(skillsPath)) {
+    throw new GitClientError(
+      `Invalid skillsPath "${skillsPath}": must be a relative path without ".."`,
+    );
+  }
+  const ctrl = findControlCharacter(skillsPath);
+  if (ctrl) {
+    throw new GitClientError(
+      `skillsPath contains control character ${ctrl.hex} at position ${ctrl.position}`,
+    );
+  }
   await checkGitAvailable();
   const tmpDir = await createTempDirectory("rulesync-git-");
   try {

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -178,11 +178,17 @@ export async function fetchSkillFiles(params: {
 }
 
 const MAX_WALK_DEPTH = 20;
+const MAX_TOTAL_FILES = 10_000;
+const MAX_TOTAL_SIZE = 100 * 1024 * 1024; // 100 MB
+
+/** Mutable context for tracking totals across recursive walkDirectory calls. */
+type WalkContext = { totalFiles: number; totalSize: number };
 
 async function walkDirectory(
   dir: string,
   baseDir: string,
   depth: number = 0,
+  ctx: WalkContext = { totalFiles: 0, totalSize: 0 },
 ): Promise<Array<{ relativePath: string; content: string; size: number }>> {
   if (depth > MAX_WALK_DEPTH) {
     throw new GitClientError(
@@ -198,7 +204,7 @@ async function walkDirectory(
       continue;
     }
     if (await directoryExists(fullPath)) {
-      results.push(...(await walkDirectory(fullPath, baseDir, depth + 1)));
+      results.push(...(await walkDirectory(fullPath, baseDir, depth + 1, ctx)));
     } else {
       const size = await getFileSize(fullPath);
       if (size > MAX_FILE_SIZE) {
@@ -206,6 +212,18 @@ async function walkDirectory(
           `Skipping file "${fullPath}" (${(size / 1024 / 1024).toFixed(2)}MB exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit).`,
         );
         continue;
+      }
+      ctx.totalFiles++;
+      ctx.totalSize += size;
+      if (ctx.totalFiles > MAX_TOTAL_FILES) {
+        throw new GitClientError(
+          `Repository exceeds max file count of ${MAX_TOTAL_FILES}. Aborting to prevent resource exhaustion.`,
+        );
+      }
+      if (ctx.totalSize > MAX_TOTAL_SIZE) {
+        throw new GitClientError(
+          `Repository exceeds max total size of ${MAX_TOTAL_SIZE / 1024 / 1024}MB. Aborting to prevent resource exhaustion.`,
+        );
       }
       const content = await readFileContent(fullPath);
       results.push({ relativePath: relative(baseDir, fullPath), content, size });

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -132,7 +132,7 @@ export async function fetchSkillFiles(params: {
   const { url, ref, skillsPath } = params;
   validateGitUrl(url);
   validateRef(ref);
-  if (skillsPath.includes("..") || isAbsolute(skillsPath)) {
+  if (skillsPath.split(/[/\\]/).includes("..") || isAbsolute(skillsPath)) {
     throw new GitClientError(
       `Invalid skillsPath "${skillsPath}": must be a relative path without ".."`,
     );
@@ -215,12 +215,12 @@ async function walkDirectory(
       }
       ctx.totalFiles++;
       ctx.totalSize += size;
-      if (ctx.totalFiles > MAX_TOTAL_FILES) {
+      if (ctx.totalFiles >= MAX_TOTAL_FILES) {
         throw new GitClientError(
           `Repository exceeds max file count of ${MAX_TOTAL_FILES}. Aborting to prevent resource exhaustion.`,
         );
       }
-      if (ctx.totalSize > MAX_TOTAL_SIZE) {
+      if (ctx.totalSize >= MAX_TOTAL_SIZE) {
         throw new GitClientError(
           `Repository exceeds max total size of ${MAX_TOTAL_SIZE / 1024 / 1024}MB. Aborting to prevent resource exhaustion.`,
         );

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import { promisify } from "node:util";
 
 import { MAX_FILE_SIZE } from "../constants/rulesync-paths.js";
@@ -208,7 +208,7 @@ async function walkDirectory(
         continue;
       }
       const content = await readFileContent(fullPath);
-      results.push({ relativePath: fullPath.substring(baseDir.length + 1), content, size });
+      results.push({ relativePath: relative(baseDir, fullPath), content, size });
     }
   }
   return results;

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -94,6 +94,7 @@ export async function resolveDefaultRef(url: string): Promise<{ ref: string; sha
     const ref = stdout.match(/^ref: refs\/heads\/(.+)\tHEAD$/m)?.[1];
     const sha = stdout.match(/^([0-9a-f]{40})\tHEAD$/m)?.[1];
     if (!ref || !sha) throw new GitClientError(`Could not parse default branch from: ${url}`);
+    validateRef(ref);
     return { ref, sha };
   } catch (error) {
     if (error instanceof GitClientError) throw error;

--- a/src/lib/sources-lock.test.ts
+++ b/src/lib/sources-lock.test.ts
@@ -29,6 +29,8 @@ vi.mock("../utils/logger.js", () => ({
 
 const { logger } = await vi.importMock<typeof import("../utils/logger.js")>("../utils/logger.js");
 
+const VALID_SHA = "a".repeat(40);
+
 describe("sources-lock", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -64,7 +66,7 @@ describe("sources-lock", () => {
         lockfileVersion: 1,
         sources: {
           "https://github.com/org/repo": {
-            resolvedRef: "abc123",
+            resolvedRef: VALID_SHA,
             skills: {
               "skill-a": { integrity: "sha256-abc" },
               "skill-b": { integrity: "sha256-def" },
@@ -78,7 +80,7 @@ describe("sources-lock", () => {
       const lock = await readLockFile({ baseDir: testDir });
 
       expect(lock.sources["https://github.com/org/repo"]).toEqual({
-        resolvedRef: "abc123",
+        resolvedRef: VALID_SHA,
         skills: {
           "skill-a": { integrity: "sha256-abc" },
           "skill-b": { integrity: "sha256-def" },

--- a/src/lib/sources-lock.ts
+++ b/src/lib/sources-lock.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 
-import { optional, z } from "zod/mini";
+import { optional, refine, z } from "zod/mini";
 
 import { RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
 import { fileExists, readFileContent, writeFileContent } from "../utils/file.js";
@@ -23,7 +23,9 @@ export type LockedSkill = z.infer<typeof LockedSkillSchema>;
  */
 export const LockedSourceSchema = z.object({
   requestedRef: optional(z.string()),
-  resolvedRef: z.string(),
+  resolvedRef: z.string().check(
+    refine((v) => /^[0-9a-f]{40}$/.test(v), "resolvedRef must be a 40-character hex SHA"),
+  ),
   resolvedAt: optional(z.string()),
   skills: z.record(z.string(), LockedSkillSchema),
 });

--- a/src/lib/sources-lock.ts
+++ b/src/lib/sources-lock.ts
@@ -23,9 +23,9 @@ export type LockedSkill = z.infer<typeof LockedSkillSchema>;
  */
 export const LockedSourceSchema = z.object({
   requestedRef: optional(z.string()),
-  resolvedRef: z.string().check(
-    refine((v) => /^[0-9a-f]{40}$/.test(v), "resolvedRef must be a 40-character hex SHA"),
-  ),
+  resolvedRef: z
+    .string()
+    .check(refine((v) => /^[0-9a-f]{40}$/.test(v), "resolvedRef must be a 40-character hex SHA")),
   resolvedAt: optional(z.string()),
   skills: z.record(z.string(), LockedSkillSchema),
 });

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -770,4 +770,197 @@ describe("resolveAndFetchSources", () => {
       skillsPath: "exports/skills",
     });
   });
+
+  it("should error in frozen mode when git source lockfile entry lacks requestedRef", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "https://dev.azure.com/org/_git/repo": {
+          resolvedRef: "a".repeat(40),
+          skills: { "my-skill": { integrity: "sha256-x" } },
+        },
+      },
+    });
+
+    // Skill dir missing so SHA-match skip fails
+    vi.mocked(directoryExists).mockResolvedValue(false);
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
+      ],
+      baseDir: testDir,
+      options: { frozen: true },
+    });
+
+    expect(result.fetchedSkillCount).toBe(0);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("missing requestedRef"));
+  });
+
+  it("should skip re-fetch for git transport when locked SHA matches and skills exist", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    const { fetchSkillFiles } = await import("./git-client.js");
+    const curatedDir = join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "https://dev.azure.com/org/_git/repo": {
+          resolvedRef: "b".repeat(40),
+          requestedRef: "main",
+          skills: { "cached-skill": { integrity: "sha256-cached" } },
+        },
+      },
+    });
+
+    vi.mocked(directoryExists).mockImplementation(async (path: string) => {
+      if (path === join(curatedDir, "cached-skill")) return true;
+      return false;
+    });
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
+      ],
+      baseDir: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(0);
+    expect(vi.mocked(fetchSkillFiles)).not.toHaveBeenCalled();
+  });
+
+  it("should apply skill filter for git transport", async () => {
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+    vi.mocked(resolveDefaultRef).mockResolvedValue({ ref: "main", sha: "c".repeat(40) });
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "skill-a/SKILL.md", content: "A", size: 10 },
+      { relativePath: "skill-b/SKILL.md", content: "B", size: 10 },
+    ]);
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        {
+          source: "https://dev.azure.com/org/_git/repo",
+          transport: "git",
+          skills: ["skill-a"],
+        },
+      ],
+      baseDir: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(1);
+    const writeArgs = vi.mocked(writeFileContent).mock.calls.map((call) => call[0]);
+    expect(writeArgs.some((p) => p.includes("skill-a"))).toBe(true);
+    expect(writeArgs.some((p) => p.includes("skill-b"))).toBe(false);
+  });
+
+  it("should skip git transport skill when local skill takes precedence", async () => {
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+    vi.mocked(resolveDefaultRef).mockResolvedValue({ ref: "main", sha: "d".repeat(40) });
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "local-skill/SKILL.md", content: "remote", size: 10 },
+    ]);
+
+    // local-skill exists locally
+    vi.mocked(directoryExists).mockImplementation(async (path: string) => {
+      if (path.endsWith("skills")) return true;
+      return false;
+    });
+    vi.mocked(findFilesByGlobs).mockResolvedValue([
+      join(testDir, ".rulesync/skills/local-skill"),
+    ]);
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
+      ],
+      baseDir: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(0);
+    expect(writeFileContent).not.toHaveBeenCalled();
+  });
+
+  it("should skip duplicate git transport skill from later source", async () => {
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+    vi.mocked(resolveDefaultRef).mockResolvedValue({ ref: "main", sha: "e".repeat(40) });
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "shared-skill/SKILL.md", content: "content", size: 10 },
+    ]);
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/repo-a", transport: "git" },
+        { source: "https://dev.azure.com/org/_git/repo-b", transport: "git" },
+      ],
+      baseDir: testDir,
+    });
+
+    // First source fetches it, second source skips it
+    expect(result.fetchedSkillCount).toBe(1);
+  });
+
+  it("should warn on integrity mismatch for git transport skill", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    const { fetchSkillFiles } = await import("./git-client.js");
+    const lockedSha = "f".repeat(40);
+
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "https://dev.azure.com/org/_git/repo": {
+          resolvedRef: lockedSha,
+          requestedRef: "main",
+          skills: { "my-skill": { integrity: "sha256-original" } },
+        },
+      },
+    });
+
+    // Skill dir missing so re-fetch is triggered
+    vi.mocked(directoryExists).mockResolvedValue(false);
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "my-skill/SKILL.md", content: "tampered", size: 10 },
+    ]);
+
+    await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
+      ],
+      baseDir: testDir,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Integrity mismatch"));
+  });
+
+  it("should handle GitClientError gracefully and continue processing", async () => {
+    const { GitClientError } = await import("./git-client.js");
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+
+    let callCount = 0;
+    vi.mocked(resolveDefaultRef).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new GitClientError("git is not installed or not found in PATH");
+      }
+      return { ref: "main", sha: "a".repeat(40) };
+    });
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "good-skill/SKILL.md", content: "ok", size: 10 },
+    ]);
+
+    const result = await resolveAndFetchSources({
+      sources: [
+        { source: "https://dev.azure.com/org/_git/failing", transport: "git" },
+        { source: "https://dev.azure.com/org/_git/good", transport: "git" },
+      ],
+      baseDir: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(1);
+    expect(result.sourcesProcessed).toBe(2);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("not installed"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Hint"));
+  });
 });

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -788,9 +788,7 @@ describe("resolveAndFetchSources", () => {
     vi.mocked(directoryExists).mockResolvedValue(false);
 
     const result = await resolveAndFetchSources({
-      sources: [
-        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
-      ],
+      sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
       baseDir: testDir,
       options: { frozen: true },
     });
@@ -821,9 +819,7 @@ describe("resolveAndFetchSources", () => {
     });
 
     const result = await resolveAndFetchSources({
-      sources: [
-        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
-      ],
+      sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
       baseDir: testDir,
     });
 
@@ -868,14 +864,10 @@ describe("resolveAndFetchSources", () => {
       if (path.endsWith("skills")) return true;
       return false;
     });
-    vi.mocked(findFilesByGlobs).mockResolvedValue([
-      join(testDir, ".rulesync/skills/local-skill"),
-    ]);
+    vi.mocked(findFilesByGlobs).mockResolvedValue([join(testDir, ".rulesync/skills/local-skill")]);
 
     const result = await resolveAndFetchSources({
-      sources: [
-        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
-      ],
+      sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
       baseDir: testDir,
     });
 
@@ -925,9 +917,7 @@ describe("resolveAndFetchSources", () => {
     ]);
 
     await resolveAndFetchSources({
-      sources: [
-        { source: "https://dev.azure.com/org/_git/repo", transport: "git" },
-      ],
+      sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
       baseDir: testDir,
     });
 

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -23,6 +23,7 @@ import { listDirectoryRecursive, withSemaphore } from "./github-utils.js";
 import { parseSource } from "./source-parser.js";
 import {
   type LockedSkill,
+  type LockedSource,
   type SourcesLock,
   computeSkillIntegrity,
   createEmptyLock,
@@ -180,8 +181,148 @@ async function checkLockedSkillsExist(curatedDir: string, skillNames: string[]):
   return true;
 }
 
+// ---------------------------------------------------------------------------
+// Shared helpers for fetchSource and fetchSourceViaGit
+// ---------------------------------------------------------------------------
+
 /**
- * Fetch skills from a single source entry.
+ * Remove previously curated skill directories for a source before re-fetching.
+ * Validates that each path resolves within the curated directory to prevent traversal.
+ */
+async function cleanPreviousCuratedSkills(
+  curatedDir: string,
+  lockedSkillNames: string[],
+): Promise<void> {
+  const resolvedCuratedDir = resolve(curatedDir);
+  for (const prevSkill of lockedSkillNames) {
+    const prevDir = join(curatedDir, prevSkill);
+    if (!resolve(prevDir).startsWith(resolvedCuratedDir + sep)) {
+      logger.warn(
+        `Skipping removal of "${prevSkill}": resolved path is outside the curated directory.`,
+      );
+      continue;
+    }
+    if (await directoryExists(prevDir)) {
+      await removeDirectory(prevDir);
+    }
+  }
+}
+
+/**
+ * Check whether a skill should be skipped during fetching.
+ * Returns true (with appropriate logging) if the skill should be skipped.
+ */
+function shouldSkipSkill(
+  skillName: string,
+  sourceKey: string,
+  localSkillNames: Set<string>,
+  alreadyFetchedSkillNames: Set<string>,
+): boolean {
+  if (skillName.includes("..") || skillName.includes("/") || skillName.includes("\\")) {
+    logger.warn(
+      `Skipping skill with invalid name "${skillName}" from ${sourceKey}: contains path traversal characters.`,
+    );
+    return true;
+  }
+  if (localSkillNames.has(skillName)) {
+    logger.debug(
+      `Skipping remote skill "${skillName}" from ${sourceKey}: local skill takes precedence.`,
+    );
+    return true;
+  }
+  if (alreadyFetchedSkillNames.has(skillName)) {
+    logger.warn(
+      `Skipping duplicate skill "${skillName}" from ${sourceKey}: already fetched from another source.`,
+    );
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Write skill files to disk, compute integrity, and check against the lockfile.
+ * Returns the computed LockedSkill entry.
+ */
+async function writeSkillAndComputeIntegrity(params: {
+  skillName: string;
+  files: Array<{ relativePath: string; content: string }>;
+  curatedDir: string;
+  locked: LockedSource | undefined;
+  resolvedSha: string;
+  sourceKey: string;
+}): Promise<LockedSkill> {
+  const { skillName, files, curatedDir, locked, resolvedSha, sourceKey } = params;
+  const written: Array<{ path: string; content: string }> = [];
+
+  for (const file of files) {
+    checkPathTraversal({
+      relativePath: file.relativePath,
+      intendedRootDir: join(curatedDir, skillName),
+    });
+    await writeFileContent(join(curatedDir, skillName, file.relativePath), file.content);
+    written.push({ path: file.relativePath, content: file.content });
+  }
+
+  const integrity = computeSkillIntegrity(written);
+  const lockedSkillEntry = locked?.skills[skillName];
+  if (
+    lockedSkillEntry?.integrity &&
+    lockedSkillEntry.integrity !== integrity &&
+    resolvedSha === locked?.resolvedRef
+  ) {
+    logger.warn(
+      `Integrity mismatch for skill "${skillName}" from ${sourceKey}: expected "${lockedSkillEntry.integrity}", got "${integrity}". Content may have been tampered with.`,
+    );
+  }
+
+  return { integrity };
+}
+
+/**
+ * Merge newly fetched skills with existing locked skills and update the lockfile.
+ */
+function buildLockUpdate(params: {
+  lock: SourcesLock;
+  sourceKey: string;
+  fetchedSkills: Record<string, LockedSkill>;
+  locked: LockedSource | undefined;
+  requestedRef: string | undefined;
+  resolvedSha: string;
+}): { updatedLock: SourcesLock; fetchedNames: string[] } {
+  const { lock, sourceKey, fetchedSkills, locked, requestedRef, resolvedSha } = params;
+  const fetchedNames = Object.keys(fetchedSkills);
+
+  // Merge newly fetched skills with existing locked skills that were skipped
+  // (due to local precedence, already-fetched, etc.) to prevent overwriting their entries
+  const mergedSkills: Record<string, LockedSkill> = { ...fetchedSkills };
+  if (locked) {
+    for (const [skillName, skillEntry] of Object.entries(locked.skills)) {
+      if (!(skillName in mergedSkills)) {
+        mergedSkills[skillName] = skillEntry;
+      }
+    }
+  }
+
+  const updatedLock = setLockedSource(lock, sourceKey, {
+    requestedRef,
+    resolvedRef: resolvedSha,
+    resolvedAt: new Date().toISOString(),
+    skills: mergedSkills,
+  });
+
+  logger.info(
+    `Fetched ${fetchedNames.length} skill(s) from ${sourceKey}: ${fetchedNames.join(", ") || "(none)"}`,
+  );
+
+  return { updatedLock, fetchedNames };
+}
+
+// ---------------------------------------------------------------------------
+// Transport-specific fetch functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch skills from a single source entry via the GitHub REST API.
  */
 async function fetchSource(params: {
   sourceEntry: SourceEntry;
@@ -276,50 +417,12 @@ async function fetchSource(params: {
   const semaphore = new Semaphore(FETCH_CONCURRENCY_LIMIT);
   const fetchedSkills: Record<string, LockedSkill> = {};
 
-  // Clean previously curated skills for this source before re-fetching
   if (locked) {
-    const resolvedCuratedDir = resolve(curatedDir);
-    for (const prevSkill of lockedSkillNames) {
-      const prevDir = join(curatedDir, prevSkill);
-      // Verify the resolved path is within the curated directory to prevent traversal
-      if (!resolve(prevDir).startsWith(resolvedCuratedDir + sep)) {
-        logger.warn(
-          `Skipping removal of "${prevSkill}": resolved path is outside the curated directory.`,
-        );
-        continue;
-      }
-      if (await directoryExists(prevDir)) {
-        await removeDirectory(prevDir);
-      }
-    }
+    await cleanPreviousCuratedSkills(curatedDir, lockedSkillNames);
   }
 
   for (const skillDir of filteredDirs) {
-    // Validate skill directory name to prevent path traversal
-    if (
-      skillDir.name.includes("..") ||
-      skillDir.name.includes("/") ||
-      skillDir.name.includes("\\")
-    ) {
-      logger.warn(
-        `Skipping skill with invalid name "${skillDir.name}" from ${sourceKey}: contains path traversal characters.`,
-      );
-      continue;
-    }
-
-    // Skip skills that exist locally (local takes precedence)
-    if (localSkillNames.has(skillDir.name)) {
-      logger.debug(
-        `Skipping remote skill "${skillDir.name}" from ${sourceKey}: local skill takes precedence.`,
-      );
-      continue;
-    }
-
-    // Skip skills already fetched from an earlier source (first-declared wins)
-    if (alreadyFetchedSkillNames.has(skillDir.name)) {
-      logger.warn(
-        `Skipping duplicate skill "${skillDir.name}" from ${sourceKey}: already fetched from another source.`,
-      );
+    if (shouldSkipSkill(skillDir.name, sourceKey, localSkillNames, alreadyFetchedSkillNames)) {
       continue;
     }
 
@@ -344,75 +447,40 @@ async function fetchSource(params: {
       return true;
     });
 
-    // Fetch all file contents and compute integrity hash
-    const skillFiles: Array<{ path: string; content: string }> = [];
-
+    // Fetch all file contents
+    const skillFiles: Array<{ relativePath: string; content: string }> = [];
     for (const file of files) {
-      // Calculate relative path within the skill directory
       const relativeToSkill = file.path.substring(skillDir.path.length + 1);
-      const localFilePath = join(curatedDir, skillDir.name, relativeToSkill);
-
-      // Validate path to prevent traversal attacks
-      checkPathTraversal({
-        relativePath: relativeToSkill,
-        intendedRootDir: join(curatedDir, skillDir.name),
-      });
-
       const content = await withSemaphore(semaphore, () =>
         client.getFileContent(parsed.owner, parsed.repo, file.path, ref),
       );
-      await writeFileContent(localFilePath, content);
-      skillFiles.push({ path: relativeToSkill, content });
+      skillFiles.push({ relativePath: relativeToSkill, content });
     }
 
-    const integrity = computeSkillIntegrity(skillFiles);
-
-    // Verify integrity against lockfile hash when available
-    const lockedSkillEntry = locked?.skills[skillDir.name];
-    if (
-      lockedSkillEntry &&
-      lockedSkillEntry.integrity &&
-      lockedSkillEntry.integrity !== integrity &&
-      resolvedSha === locked?.resolvedRef
-    ) {
-      logger.warn(
-        `Integrity mismatch for skill "${skillDir.name}" from ${sourceKey}: expected "${lockedSkillEntry.integrity}", got "${integrity}". Content may have been tampered with.`,
-      );
-    }
-
-    fetchedSkills[skillDir.name] = { integrity };
+    fetchedSkills[skillDir.name] = await writeSkillAndComputeIntegrity({
+      skillName: skillDir.name,
+      files: skillFiles,
+      curatedDir,
+      locked,
+      resolvedSha,
+      sourceKey,
+    });
     logger.debug(`Fetched skill "${skillDir.name}" from ${sourceKey}`);
   }
 
-  const fetchedNames = Object.keys(fetchedSkills);
-
-  // Merge newly fetched skills with existing locked skills that were skipped
-  // (due to local precedence, already-fetched, etc.) to prevent overwriting their entries
-  const mergedSkills: Record<string, LockedSkill> = { ...fetchedSkills };
-  if (locked) {
-    for (const [skillName, skillEntry] of Object.entries(locked.skills)) {
-      if (!(skillName in mergedSkills)) {
-        mergedSkills[skillName] = skillEntry;
-      }
-    }
-  }
-
-  // Update lockfile entry
-  lock = setLockedSource(lock, sourceKey, {
+  const result = buildLockUpdate({
+    lock,
+    sourceKey,
+    fetchedSkills,
+    locked,
     requestedRef,
-    resolvedRef: resolvedSha,
-    resolvedAt: new Date().toISOString(),
-    skills: mergedSkills,
+    resolvedSha,
   });
 
-  logger.info(
-    `Fetched ${fetchedNames.length} skill(s) from ${sourceKey}: ${fetchedNames.join(", ") || "(none)"}`,
-  );
-
   return {
-    skillCount: fetchedNames.length,
-    fetchedSkillNames: fetchedNames,
-    updatedLock: lock,
+    skillCount: result.fetchedNames.length,
+    fetchedSkillNames: result.fetchedNames,
+    updatedLock: result.updatedLock,
   };
 }
 
@@ -496,76 +564,36 @@ async function fetchSourceViaGit(params: {
   const filteredNames = isWildcard ? allNames : allNames.filter((n) => skillFilter.includes(n));
 
   if (locked) {
-    const base = resolve(curatedDir);
-    for (const prev of lockedSkillNames) {
-      const dir = join(curatedDir, prev);
-      if (resolve(dir).startsWith(base + sep) && (await directoryExists(dir))) {
-        await removeDirectory(dir);
-      }
-    }
+    await cleanPreviousCuratedSkills(curatedDir, lockedSkillNames);
   }
 
   const fetchedSkills: Record<string, LockedSkill> = {};
   for (const skillName of filteredNames) {
-    if (skillName.includes("..") || skillName.includes("/") || skillName.includes("\\")) {
-      logger.warn(
-        `Skipping skill with invalid name "${skillName}" from ${url}: contains path traversal characters.`,
-      );
-      continue;
-    }
-    if (localSkillNames.has(skillName)) {
-      logger.debug(
-        `Skipping remote skill "${skillName}" from ${url}: local skill takes precedence.`,
-      );
-      continue;
-    }
-    if (alreadyFetchedSkillNames.has(skillName)) {
-      logger.warn(
-        `Skipping duplicate skill "${skillName}" from ${url}: already fetched from another source.`,
-      );
+    if (shouldSkipSkill(skillName, url, localSkillNames, alreadyFetchedSkillNames)) {
       continue;
     }
 
-    const files = skillFileMap.get(skillName) ?? [];
-    const written: Array<{ path: string; content: string }> = [];
-    for (const file of files) {
-      checkPathTraversal({
-        relativePath: file.relativePath,
-        intendedRootDir: join(curatedDir, skillName),
-      });
-      await writeFileContent(join(curatedDir, skillName, file.relativePath), file.content);
-      written.push({ path: file.relativePath, content: file.content });
-    }
-
-    const integrity = computeSkillIntegrity(written);
-    const lockedSkillEntry = locked?.skills[skillName];
-    if (
-      lockedSkillEntry?.integrity &&
-      lockedSkillEntry.integrity !== integrity &&
-      resolvedSha === locked?.resolvedRef
-    ) {
-      logger.warn(`Integrity mismatch for skill "${skillName}" from ${url}.`);
-    }
-    fetchedSkills[skillName] = { integrity };
+    fetchedSkills[skillName] = await writeSkillAndComputeIntegrity({
+      skillName,
+      files: skillFileMap.get(skillName) ?? [],
+      curatedDir,
+      locked,
+      resolvedSha,
+      sourceKey: url,
+    });
   }
 
-  const fetchedNames = Object.keys(fetchedSkills);
-  const mergedSkills: Record<string, LockedSkill> = { ...fetchedSkills };
-  if (locked) {
-    for (const [k, v] of Object.entries(locked.skills)) {
-      if (!(k in mergedSkills)) mergedSkills[k] = v;
-    }
-  }
-
-  lock = setLockedSource(lock, url, {
+  const result = buildLockUpdate({
+    lock,
+    sourceKey: url,
+    fetchedSkills,
+    locked,
     requestedRef,
-    resolvedRef: resolvedSha,
-    resolvedAt: new Date().toISOString(),
-    skills: mergedSkills,
+    resolvedSha,
   });
-
-  logger.info(
-    `Fetched ${fetchedNames.length} skill(s) from ${url}: ${fetchedNames.join(", ") || "(none)"}`,
-  );
-  return { skillCount: fetchedNames.length, fetchedSkillNames: fetchedNames, updatedLock: lock };
+  return {
+    skillCount: result.fetchedNames.length,
+    fetchedSkillNames: result.fetchedNames,
+    updatedLock: result.updatedLock,
+  };
 }

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -17,7 +17,13 @@ import {
   writeFileContent,
 } from "../utils/file.js";
 import { logger } from "../utils/logger.js";
-import { fetchSkillFiles, resolveDefaultRef, resolveRefToSha, validateRef } from "./git-client.js";
+import {
+  GitClientError,
+  fetchSkillFiles,
+  resolveDefaultRef,
+  resolveRefToSha,
+  validateRef,
+} from "./git-client.js";
 import { GitHubClient, GitHubClientError, logGitHubAuthHints } from "./github-client.js";
 import { listDirectoryRecursive, withSemaphore } from "./github-utils.js";
 import { parseSource } from "./source-parser.js";
@@ -142,6 +148,8 @@ export async function resolveAndFetchSources(params: {
       logger.error(`Failed to fetch source "${sourceEntry.source}": ${formatError(error)}`);
       if (error instanceof GitHubClientError) {
         logGitHubAuthHints(error);
+      } else if (error instanceof GitClientError) {
+        logGitClientHints(error);
       }
     }
   }
@@ -166,6 +174,19 @@ export async function resolveAndFetchSources(params: {
   }
 
   return { fetchedSkillCount: totalSkillCount, sourcesProcessed: sources.length };
+}
+
+/**
+ * Log contextual hints for GitClientError to help users troubleshoot.
+ */
+function logGitClientHints(error: GitClientError): void {
+  if (error.message.includes("not installed")) {
+    logger.info("Hint: Install git and ensure it is available on your PATH.");
+  } else {
+    logger.info(
+      "Hint: Check your git credentials (SSH keys, credential helper, or access token).",
+    );
+  }
 }
 
 /**

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -183,9 +183,7 @@ function logGitClientHints(error: GitClientError): void {
   if (error.message.includes("not installed")) {
     logger.info("Hint: Install git and ensure it is available on your PATH.");
   } else {
-    logger.info(
-      "Hint: Check your git credentials (SSH keys, credential helper, or access token).",
-    );
+    logger.info("Hint: Check your git credentials (SSH keys, credential helper, or access token).");
   }
 }
 
@@ -360,7 +358,7 @@ async function fetchSource(params: {
 }> {
   const { sourceEntry, client, baseDir, localSkillNames, alreadyFetchedSkillNames, updateSources } =
     params;
-  let { lock } = params;
+  const { lock } = params;
 
   const parsed = parseSource(sourceEntry.source);
 
@@ -519,7 +517,7 @@ async function fetchSourceViaGit(params: {
 }): Promise<{ skillCount: number; fetchedSkillNames: string[]; updatedLock: SourcesLock }> {
   const { sourceEntry, baseDir, localSkillNames, alreadyFetchedSkillNames, updateSources, frozen } =
     params;
-  let { lock } = params;
+  const { lock } = params;
   const url = sourceEntry.source;
   const locked = getLockedSource(lock, url);
   const lockedSkillNames = locked ? getLockedSkillNames(locked) : [];

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -231,12 +231,13 @@ async function cleanPreviousCuratedSkills(
  * Check whether a skill should be skipped during fetching.
  * Returns true (with appropriate logging) if the skill should be skipped.
  */
-function shouldSkipSkill(
-  skillName: string,
-  sourceKey: string,
-  localSkillNames: Set<string>,
-  alreadyFetchedSkillNames: Set<string>,
-): boolean {
+function shouldSkipSkill(params: {
+  skillName: string;
+  sourceKey: string;
+  localSkillNames: Set<string>;
+  alreadyFetchedSkillNames: Set<string>;
+}): boolean {
+  const { skillName, sourceKey, localSkillNames, alreadyFetchedSkillNames } = params;
   if (skillName.includes("..") || skillName.includes("/") || skillName.includes("\\")) {
     logger.warn(
       `Skipping skill with invalid name "${skillName}" from ${sourceKey}: contains path traversal characters.`,
@@ -441,7 +442,14 @@ async function fetchSource(params: {
   }
 
   for (const skillDir of filteredDirs) {
-    if (shouldSkipSkill(skillDir.name, sourceKey, localSkillNames, alreadyFetchedSkillNames)) {
+    if (
+      shouldSkipSkill({
+        skillName: skillDir.name,
+        sourceKey,
+        localSkillNames,
+        alreadyFetchedSkillNames,
+      })
+    ) {
       continue;
     }
 
@@ -588,7 +596,7 @@ async function fetchSourceViaGit(params: {
 
   const fetchedSkills: Record<string, LockedSkill> = {};
   for (const skillName of filteredNames) {
-    if (shouldSkipSkill(skillName, url, localSkillNames, alreadyFetchedSkillNames)) {
+    if (shouldSkipSkill({ skillName, sourceKey: url, localSkillNames, alreadyFetchedSkillNames })) {
       continue;
     }
 

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { findControlCharacter, hasControlCharacters } from "./validation.js";
+
+describe("findControlCharacter", () => {
+  it("returns null for clean strings", () => {
+    expect(findControlCharacter("hello world")).toBeNull();
+    expect(findControlCharacter("path/to/file.ts")).toBeNull();
+    expect(findControlCharacter("")).toBeNull();
+  });
+
+  it("detects null byte (0x00)", () => {
+    const result = findControlCharacter("abc\x00def");
+    expect(result).toEqual({ position: 3, hex: "0x00" });
+  });
+
+  it("detects newline (0x0a)", () => {
+    const result = findControlCharacter("line\nbreak");
+    expect(result).toEqual({ position: 4, hex: "0x0a" });
+  });
+
+  it("detects tab (0x09)", () => {
+    const result = findControlCharacter("\tfoo");
+    expect(result).toEqual({ position: 0, hex: "0x09" });
+  });
+
+  it("detects DEL (0x7f)", () => {
+    const result = findControlCharacter("foo\x7fbar");
+    expect(result).toEqual({ position: 3, hex: "0x7f" });
+  });
+
+  it("detects boundary value 0x1f", () => {
+    const result = findControlCharacter("x\x1fy");
+    expect(result).toEqual({ position: 1, hex: "0x1f" });
+  });
+
+  it("returns the first control character when multiple exist", () => {
+    const result = findControlCharacter("a\x01b\x02c");
+    expect(result).toEqual({ position: 1, hex: "0x01" });
+  });
+
+  it("does not flag printable characters like space (0x20) or tilde (0x7e)", () => {
+    expect(findControlCharacter(" ")).toBeNull();
+    expect(findControlCharacter("~")).toBeNull();
+  });
+});
+
+describe("hasControlCharacters", () => {
+  it("returns false for clean strings", () => {
+    expect(hasControlCharacters("hello")).toBe(false);
+    expect(hasControlCharacters("")).toBe(false);
+  });
+
+  it("returns true when control characters are present", () => {
+    expect(hasControlCharacters("abc\x00")).toBe(true);
+    expect(hasControlCharacters("\x7f")).toBe(true);
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared validation utilities for input sanitization.
+ */
+
+/**
+ * Find the first control character in a string.
+ * Returns the position and hex code, or null if none found.
+ * Control characters: 0x00-0x1f and 0x7f (DEL).
+ */
+export function findControlCharacter(value: string): { position: number; hex: string } | null {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) {
+      return { position: i, hex: `0x${code.toString(16).padStart(2, "0")}` };
+    }
+  }
+  return null;
+}
+
+/**
+ * Check whether a string contains any control characters.
+ */
+export function hasControlCharacters(value: string): boolean {
+  return findControlCharacter(value) !== null;
+}


### PR DESCRIPTION
## Summary

Addresses all 11 items from #1266 (follow-up improvements from the git-native transport PR #1249), plus fixes from code and security review.

**Refactoring:**
- Extract shared helpers from `fetchSource` and `fetchSourceViaGit` to eliminate ~150 lines of duplication (`cleanPreviousCuratedSkills`, `shouldSkipSkill`, `writeSkillAndComputeIntegrity`, `buildLockUpdate`)
- Deduplicate `findControlCharacter`/`hasControlCharacters` into `src/utils/validation.ts`
- Use `path.relative()` instead of manual substring in `walkDirectory`
- Use `const` for non-reassigned lock destructuring

**Security hardening:**
- Validate `skillsPath` in `fetchSkillFiles` (path traversal, absolute paths, control characters)
- Validate ref returned by `resolveDefaultRef` to prevent argument injection
- Anchor SCP-style URL regex to prevent trailing junk bypass
- Add total file count (10,000) and size (100MB) limits to `walkDirectory`
- Validate `resolvedRef` in lockfile schema as 40-character hex SHA
- Use segment-based path traversal check instead of substring match

**Observability:**
- Add `GitClientError` hints in error handler for troubleshooting
- Add descriptions to source entry fields in JSON schema

**Tests:**
- 7 new git transport tests in `sources.test.ts` (frozen mode, SHA cache-hit, skill filter, local precedence, duplicate detection, integrity mismatch, GitClientError handling)
- 3 new `skillsPath` validation tests in `git-client.test.ts`
- 10 new unit tests for `src/utils/validation.ts`

## Test plan

- [x] `pnpm cicheck` passes (4262 tests, format, lint, types, spelling, secrets)
- [x] Code review subagent: approved
- [x] Security review subagent: approved, no issues medium or above

Closes #1266