### PR TITLE
fix: avoid YAML block scalars in Cursor frontmatter output

### DIFF
--- a/src/features/commands/cursor-command.ts
+++ b/src/features/commands/cursor-command.ts
@@ -54,7 +54,7 @@ export class CursorCommand extends ToolCommand {
 
     super({
       ...rest,
-      fileContent: stringifyFrontmatter(body, frontmatter),
+      fileContent: stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true }),
     });
 
     this.frontmatter = frontmatter;

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -265,7 +265,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     getFactory?: GetFactory;
     dryRun?: boolean;
   }) {
-    super({ baseDir, dryRun });
+    super({ baseDir, dryRun, avoidBlockScalars: toolTarget === "cursor" });
     const result = SkillsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -102,7 +102,7 @@ export class CursorSubagent extends ToolSubagent {
     };
 
     const body = rulesyncSubagent.getBody();
-    const fileContent = stringifyFrontmatter(body, cursorFrontmatter);
+    const fileContent = stringifyFrontmatter(body, cursorFrontmatter, { avoidBlockScalars: true });
     const paths = this.getSettablePaths({ global });
 
     return new CursorSubagent({

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -16,10 +16,20 @@ import { ToolTarget } from "./tool-targets.js";
 export abstract class DirFeatureProcessor {
   protected readonly baseDir: string;
   protected readonly dryRun: boolean;
+  protected readonly avoidBlockScalars: boolean;
 
-  constructor({ baseDir = process.cwd(), dryRun = false }: { baseDir?: string; dryRun?: boolean }) {
+  constructor({
+    baseDir = process.cwd(),
+    dryRun = false,
+    avoidBlockScalars = false,
+  }: {
+    baseDir?: string;
+    dryRun?: boolean;
+    avoidBlockScalars?: boolean;
+  }) {
     this.baseDir = baseDir;
     this.dryRun = dryRun;
+    this.avoidBlockScalars = avoidBlockScalars;
   }
 
   abstract loadRulesyncDirs(): Promise<AiDir[]>;
@@ -61,7 +71,9 @@ export abstract class DirFeatureProcessor {
       let mainFileContent: string | undefined;
       if (mainFile) {
         const mainFilePath = join(dirPath, mainFile.name);
-        const content = stringifyFrontmatter(mainFile.body, mainFile.frontmatter);
+        const content = stringifyFrontmatter(mainFile.body, mainFile.frontmatter, {
+          avoidBlockScalars: this.avoidBlockScalars,
+        });
         mainFileContent = addTrailingNewline(content);
         const existingContent = await readFileContentOrNull(mainFilePath);
         if (existingContent !== mainFileContent) {

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -124,6 +124,84 @@ describe("frontmatter utilities", () => {
       expect(result).toContain("- 42");
       expect(result).toContain("- true");
     });
+
+    it("should allow block scalars by default for long strings", () => {
+      const body = "Body content";
+      const longDescription =
+        "Use this agent when the user wants to commit current changes, push them, " +
+        "and create or update a pull request with an English summary for the repository " +
+        "including all changed files and their descriptions in a well-structured format";
+      const frontmatter = { name: "test", description: longDescription };
+
+      const result = stringifyFrontmatter(body, frontmatter);
+
+      expect(result).toContain(">-");
+
+      const parsed = parseFrontmatter(result);
+      expect(parsed.frontmatter.description).toBe(longDescription);
+    });
+
+    it("should preserve embedded newlines in strings by default", () => {
+      const body = "Body content";
+      const frontmatter = { description: "Line one\nLine two\nLine three" };
+
+      const result = stringifyFrontmatter(body, frontmatter);
+
+      expect(result).toContain("|-");
+
+      const parsed = parseFrontmatter(result);
+      expect(parsed.frontmatter.description).toBe("Line one\nLine two\nLine three");
+    });
+
+    describe("with avoidBlockScalars option", () => {
+      it("should not emit block scalar indicators for long strings", () => {
+        const body = "Body content";
+        const longDescription =
+          "Use this agent when the user wants to commit current changes, push them, " +
+          "and create or update a pull request with an English summary for the repository " +
+          "including all changed files and their descriptions in a well-structured format";
+        const frontmatter = { name: "test", description: longDescription };
+
+        const result = stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true });
+
+        expect(result).not.toContain(">-");
+        expect(result).not.toContain("|-");
+        expect(result).toContain(longDescription);
+
+        const parsed = parseFrontmatter(result);
+        expect(parsed.frontmatter.description).toBe(longDescription);
+      });
+
+      it("should collapse newlines in string values", () => {
+        const body = "Body content";
+        const frontmatter = {
+          description: "Line one\nLine two\nLine three",
+        };
+
+        const result = stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true });
+
+        expect(result).not.toContain("|-");
+        expect(result).not.toContain(">-");
+        expect(result).toContain("description: Line one Line two Line three");
+      });
+
+      it("should collapse newlines in nested string values", () => {
+        const body = "Body content";
+        const frontmatter = {
+          config: {
+            label: "First line\nSecond line",
+          },
+          items: ["item\nwith\nnewlines"],
+        };
+
+        const result = stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true });
+
+        expect(result).not.toContain("|-");
+        expect(result).not.toContain(">-");
+        expect(result).toContain("label: First line Second line");
+        expect(result).toContain("- item with newlines");
+      });
+    });
   });
 
   describe("parseFrontmatter", () => {

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,4 +1,5 @@
 import matter from "gray-matter";
+import { dump, load } from "js-yaml";
 
 import { formatError } from "./error.js";
 
@@ -51,11 +52,86 @@ function deepRemoveNullishObject(
   return result;
 }
 
+function deepFlattenStringsValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value.replace(/\n+/g, " ").trim();
+  }
+
+  if (Array.isArray(value)) {
+    const cleanedArray = value
+      .map((item) => deepFlattenStringsValue(item))
+      .filter((item) => item !== undefined);
+    return cleanedArray;
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      const cleaned = deepFlattenStringsValue(val);
+      if (cleaned !== undefined) {
+        result[key] = cleaned;
+      }
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function deepFlattenStringsObject(
+  obj: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!obj || typeof obj !== "object") {
+    return {};
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(obj)) {
+    const cleaned = deepFlattenStringsValue(val);
+    if (cleaned !== undefined) {
+      result[key] = cleaned;
+    }
+  }
+  return result;
+}
+
+export type StringifyFrontmatterOptions = {
+  /**
+   * When true, ensures output avoids YAML block scalar indicators (>-, |-)
+   * that simplified frontmatter parsers (e.g. Cursor) cannot handle.
+   * Collapses newlines in string values and disables line wrapping.
+   */
+  avoidBlockScalars?: boolean;
+};
+
 export function stringifyFrontmatter(
   body: string,
   frontmatter: Record<string, unknown> | null | undefined,
+  options?: StringifyFrontmatterOptions,
 ): string {
-  const cleanFrontmatter = deepRemoveNullishObject(frontmatter);
+  const { avoidBlockScalars = false } = options ?? {};
+
+  const cleanFrontmatter = avoidBlockScalars
+    ? deepFlattenStringsObject(frontmatter)
+    : deepRemoveNullishObject(frontmatter);
+
+  if (avoidBlockScalars) {
+    // Use a custom YAML engine with lineWidth disabled to prevent js-yaml from
+    // emitting block scalars (>- or |-). Some tools use simplified frontmatter
+    // parsers that interpret these indicators as literal string values.
+    return matter.stringify(body, cleanFrontmatter, {
+      engines: {
+        yaml: {
+          parse: (input: string) => load(input) ?? {},
+          stringify: (data: object) => dump(data, { lineWidth: -1 }),
+        },
+      },
+    });
+  }
 
   return matter.stringify(body, cleanFrontmatter);
 }
@@ -85,7 +161,6 @@ export function parseFrontmatter(
   // Strip null/undefined values from parsed frontmatter for consistency.
   // YAML parses bare keys (e.g. "description:") as null, which would fail
   // Zod validation (z.optional(z.string()) does not accept null).
-  // This mirrors the deepRemoveNullishObject cleanup done in stringifyFrontmatter.
   const cleanFrontmatter = deepRemoveNullishObject(frontmatter);
 
   return { frontmatter: cleanFrontmatter, body };


### PR DESCRIPTION
## Summary

- Cursor's frontmatter parser doesn't support YAML block scalar indicators (`>-`, `|-`), causing descriptions to display as literal `>-` in the Settings UI and the Cursor agent probably not using the actual description of a subagent during runtime
- `gray-matter` / `js-yaml` automatically emits block scalars for long or multiline strings, triggering this issue
- Added `avoidBlockScalars` option to `stringifyFrontmatter()` that disables line wrapping (`lineWidth: -1`) and collapses embedded newlines in string values
- Enabled the option only for Cursor subagents, commands, and skills; other tools are unaffected

## Changes

- `src/utils/frontmatter.ts` — Added `StringifyFrontmatterOptions` with `avoidBlockScalars` flag; added `deepFlattenStringsObject` for newline collapsing; custom YAML engine with `lineWidth: -1`
- `src/features/commands/cursor-command.ts` — Pass `{ avoidBlockScalars: true }` in constructor
- `src/features/subagents/cursor-subagent.ts` — Pass `{ avoidBlockScalars: true }` in `fromRulesyncSubagent`
- `src/types/dir-feature-processor.ts` — Added `avoidBlockScalars` constructor parameter, threaded to `writeAiDirs`
- `src/features/skills/skills-processor.ts` — Set `avoidBlockScalars: true` when `toolTarget === "cursor"`

## Test plan

- [x] Added tests verifying default behavior preserves block scalars (backward compat)
- [x] Added tests verifying `avoidBlockScalars: true` prevents `>-` and `|-` indicators
- [x] All existing tests pass (102 tests across cursor-command, cursor-subagent, cursor-skill)
- [x] Full `pnpm cicheck` passes