### PR TITLE
fix(sources): drop renamed/deleted skills from lockfile on re-fetch

### DIFF
--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -953,4 +953,42 @@ describe("resolveAndFetchSources", () => {
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("not installed"));
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Hint"));
   });
+
+  it("should drop renamed/deleted skills from lockfile when upstream removes them", async () => {
+    const { readLockFile, writeLockFile } = await import("./sources-lock.js");
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+
+    // Lock has "old-skill" from a previous install
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "https://dev.azure.com/org/_git/repo": {
+          resolvedRef: "a".repeat(40),
+          requestedRef: "main",
+          skills: { "old-skill": { integrity: "sha256-old" } },
+        },
+      },
+    });
+
+    // Remote now has "new-skill" instead of "old-skill" (renamed upstream)
+    vi.mocked(resolveDefaultRef).mockResolvedValue({ ref: "main", sha: "b".repeat(40) });
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "new-skill/SKILL.md", content: "renamed", size: 10 },
+    ]);
+
+    vi.mocked(directoryExists).mockResolvedValue(false);
+
+    await resolveAndFetchSources({
+      sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
+      baseDir: testDir,
+    });
+
+    // The lockfile should contain only "new-skill", not "old-skill"
+    const writeCalls = vi.mocked(writeLockFile).mock.calls;
+    expect(writeCalls).toHaveLength(1);
+    const writtenLock = writeCalls[0]![0].lock;
+    const sourceEntry = Object.values(writtenLock.sources)[0]!;
+    expect(sourceEntry.skills).toHaveProperty("new-skill");
+    expect(sourceEntry.skills).not.toHaveProperty("old-skill");
+  });
 });

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -308,16 +308,20 @@ function buildLockUpdate(params: {
   locked: LockedSource | undefined;
   requestedRef: string | undefined;
   resolvedSha: string;
+  remoteSkillNames: string[];
 }): { updatedLock: SourcesLock; fetchedNames: string[] } {
-  const { lock, sourceKey, fetchedSkills, locked, requestedRef, resolvedSha } = params;
+  const { lock, sourceKey, fetchedSkills, locked, requestedRef, resolvedSha, remoteSkillNames } =
+    params;
   const fetchedNames = Object.keys(fetchedSkills);
 
-  // Merge newly fetched skills with existing locked skills that were skipped
-  // (due to local precedence, already-fetched, etc.) to prevent overwriting their entries
+  // Merge back locked skills that still exist in the remote but were skipped
+  // (due to local precedence, already-fetched, etc.). Skills no longer present
+  // in the remote (e.g. renamed or deleted upstream) are intentionally dropped.
+  const remoteSet = new Set(remoteSkillNames);
   const mergedSkills: Record<string, LockedSkill> = { ...fetchedSkills };
   if (locked) {
     for (const [skillName, skillEntry] of Object.entries(locked.skills)) {
-      if (!(skillName in mergedSkills)) {
+      if (!(skillName in mergedSkills) && remoteSet.has(skillName)) {
         mergedSkills[skillName] = skillEntry;
       }
     }
@@ -502,6 +506,7 @@ async function fetchSource(params: {
     locked,
     requestedRef,
     resolvedSha,
+    remoteSkillNames: filteredDirs.map((d) => d.name),
   });
 
   return {
@@ -617,6 +622,7 @@ async function fetchSourceViaGit(params: {
     locked,
     requestedRef,
     resolvedSha,
+    remoteSkillNames: filteredNames,
   });
   return {
     skillCount: result.fetchedNames.length,


### PR DESCRIPTION
Fixes #1299

## Summary

- Added `remoteSkillNames` parameter to `buildLockUpdate` so only skills that still exist in the remote are preserved; renamed/deleted skills are dropped
- Updated both GitHub and git transport call sites

## Test plan

- [x] Added test: "should drop renamed/deleted skills from lockfile when upstream removes them"
- [x] All 4306 existing tests pass
- [x] `pnpm cicheck` passes