### PR TITLE
docs: move JSON Schema support section to file-formats.md

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -189,6 +189,7 @@ Example:
 ```json
 {
   "mcpServers": {
+    "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
     "serena": {
       "description": "Code analysis and semantic search MCP server",
       "type": "stdio",
@@ -215,6 +216,17 @@ Example:
       "env": {}
     }
   }
+}
+```
+
+#### JSON Schema Support
+
+Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:
+
+```json
+{
+  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
+  "mcpServers": {}
 }
 ```
 

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -15,17 +15,6 @@ rulesync mcp
 
 This starts an MCP server using stdio transport that AI agents can communicate with.
 
-### JSON Schema Support
-
-Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:
-
-```json
-{
-  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
-  "mcpServers": {}
-}
-```
-
 ### Configuration
 
 Add the Rulesync MCP server to your `.rulesync/mcp.json`:

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -189,6 +189,7 @@ Example:
 ```json
 {
   "mcpServers": {
+    "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
     "serena": {
       "description": "Code analysis and semantic search MCP server",
       "type": "stdio",
@@ -215,6 +216,17 @@ Example:
       "env": {}
     }
   }
+}
+```
+
+#### JSON Schema Support
+
+Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:
+
+```json
+{
+  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
+  "mcpServers": {}
 }
 ```
 

--- a/skills/rulesync/mcp-server.md
+++ b/skills/rulesync/mcp-server.md
@@ -15,17 +15,6 @@ rulesync mcp
 
 This starts an MCP server using stdio transport that AI agents can communicate with.
 
-### JSON Schema Support
-
-Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:
-
-```json
-{
-  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
-  "mcpServers": {}
-}
-```
-
 ### Configuration
 
 Add the Rulesync MCP server to your `.rulesync/mcp.json`:


### PR DESCRIPTION
## Summary

- JSON Schema サポートセクションを `mcp-server.md` から `file-formats.md` に移動
- MCP設定ファイルフォーマットの説明と同じ場所に配置することで、ドキュメントの文脈的な整合性を改善
- MCP設定JSONの例に `$schema` プロパティを追加

## Test plan

- [x] `pnpm cicheck` パス済み（コード・コンテンツ両方）
- [ ] ドキュメントの表示確認