### PR TITLE
chore: track Copilot generated files and exclude from oxfmt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github/copilot-instructions.md linguist-generated=true
+.github/instructions/** linguist-generated=true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Rulesync Project Overview
+
+This is Rulesync, a Node.js CLI tool that automatically generates configuration files for various AI coding tools from unified AI rule files. The project enables teams to maintain consistent AI coding assistant rules across multiple tools.
+
+- Read `README.md` and `docs/**/*.md` if you want to know Rulesync specification.
+- Manage runtimes and package managers with @mise.toml .
+- When you want to check entire codebase:
+  - You can use:
+    - `pnpm cicheck:code` to check code style, type safety, and tests.
+    - `pnpm cicheck:content` to check content style, spelling, and secrets.
+    - `pnpm cicheck` to check both code and content.
+  - Basically, I recommend you to run `pnpm cicheck` to daily checks.
+- When doing `git commit`:
+  - You must run `pnpm cicheck` before committing to verify quality.
+  - You must not use here documents because it causes a sandbox error.
+  - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.
+- When you read or search the codebase:
+  - You should check Serena MCP server tools, and use those actively.
+- About the `skills/` directory at the repository root:
+  - This directory contains official skills that are distributed for users to install via the `rulesync fetch` command (e.g., `npx rulesync fetch dyoshikawa/rulesync --features skills`).
+  - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.
+  - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
+- The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.

--- a/.github/instructions/coding-guidelines.instructions.md
+++ b/.github/instructions/coding-guidelines.instructions.md
@@ -1,0 +1,21 @@
+---
+description: "When you write any code, must follow these guidelines."
+applyTo: "**/*.ts"
+---
+
+# Coding Guidelines
+
+- If the arguments are multiple, you should use object as the argument.
+  - Not only function arguments, but also class constructor those.
+- If you have to write validation logics, please consider using `zod/mini` to do it actively.
+  - `zod/mini` is a subset of `zod` to minimize the bundle size.
+- To import codes, you should always use static imports. You should not use dynamic imports.
+  - Because static imports are easier to analyze and optimize by bundlers such as tree-shaking.
+- TypeScript file names should be in kebab-case, even for class implementation files.
+- Don't create ballel files. Please always direct import the implementation file.
+  - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.
+- The default value of `baseDir` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `baseDir`.
+- When logging errors, you must use `formatError` function in `src/utils/error.ts` to format the error message.
+- When writing any path, you must always use `join` function in `node:path` to join the path because it must support both Windows and Unix-like paths.
+- When writing Rulesync file paths, you must condsider using constants in `src/constants/rulesync-paths.ts` to avoid hardcoding paths.
+- You should always use `z.looseObject()` for zod schemas representing frontmatter keys. This is because various AI tools update very quickly and parameters are constantly being added.

--- a/.github/instructions/feature-change-guidelines.instructions.md
+++ b/.github/instructions/feature-change-guidelines.instructions.md
@@ -1,0 +1,11 @@
+---
+description: "When you add or change features, must follow these guidelines."
+---
+
+# Guidelines for Adding or Modifying Features
+
+- Check whether `rules-processor.ts` needs an updated Additional Convention, especially values within `additionalConvention`. For example, if you remove support for Cursor's Skill feature simulation, remove `skills: { skillClass: CursorSkill }` within convention entry for Cursor.
+- Review frontmatter in both rulesync files (`rulesync-{feature}.ts`) and tool files (`{tool}-{feature}.ts`). For overlapping parameters (e.g., `description`), prefer the rulesync value by default, but if the tool file defines the parameter, that tool-specific value takes precedence.
+- Evaluate whether `gitignore.ts` needs additions or changes in its generated output. And `pnpm dev gitignore` should be run to update `.gitignore` in the project.
+- Consider project scope and global scope support. Simulated support should cover project scope only. For native support, implement both project and global scope when the target tool supports them. Consult the tool’s official documentation to decide scope support.
+- Keep `Supported Tools and Features` section and `Each File Format` section in `README.md` and `docs/**/*.md` synchronized with the implemented functionality.

--- a/.github/instructions/github-actions-security.instructions.md
+++ b/.github/instructions/github-actions-security.instructions.md
@@ -1,0 +1,15 @@
+---
+description: Guidelines to avoid GitHub Actions script injection vulnerabilities.
+applyTo: .github/workflows/*.yml
+---
+
+# GitHub Actions Security: Script Injection
+
+When working with GitHub Actions workflows, ensure that untrusted inputs are never interpolated directly into `run` scripts or other execution contexts. Follow GitHub's guidance on avoiding script injection vulnerabilities.
+
+- Do not use expressions that inject untrusted inputs into shell commands (for example, `run: echo ${{ inputs.name }}` or `run: echo ${{ github.event.issue.title }}`)
+- Prefer passing untrusted data through environment variables and reference them safely within scripts
+- Use explicit quoting and safe parameter handling
+- Validate or sanitize inputs before use when feasible
+
+Reference: https://docs.github.com/ja/actions/concepts/security/script-injections

--- a/.github/instructions/testing-guidelines.instructions.md
+++ b/.github/instructions/testing-guidelines.instructions.md
@@ -1,0 +1,85 @@
+---
+description: "When you write tests, must follow these guidelines."
+applyTo: "**/*.test.ts"
+---
+
+# Testing Guidelines
+
+- Test code files should be placed next to the implementation. This is called the co-location pattern.
+  - For example, if the implementation file is `src/a.ts`, the test code file should be `src/a.test.ts`.
+- For all test code, to avoid polluting the git managed files, must use the unified pattern of targeting ./tmp/tests/projects/{RANDOM_STRING} as the project directory or ./tmp/tests/home/{RANDOM_STRING} as the pseudo-home directory.
+  - To use the unified test directory, you should use the `setupTestDirectory` function from `src/test-utils/test-directories.ts` and mock `process.cwd()` to return the test directory. You must not use `process.chdir()` instead of mocking `process.cwd()` because `process.chdir()` changes the current working directory globally and affects other tests. If you want to test some behavior in global mode, use the pseudo-home directory by `setupTestDirectory({ home: true })` and mock `getHomeDirectory()` to return the pseudo-home directory.
+
+    ```typescript
+    // Example with project directory
+    describe("Test Name", () => {
+      let testDir: string;
+      let cleanup: () => Promise<void>;
+
+      beforeEach(async () => {
+        ({ testDir, cleanup } = await setupTestDirectory());
+        vi.spyOn(process, "cwd").mockReturnValue(testDir);
+      });
+
+      afterEach(async () => {
+        await cleanup();
+      });
+
+      it("Test Case", async () => {
+        // Run test using testDir
+        await RulesyncRule.fromFile({
+          baseDir: testDir,
+          relativeFilePath: "test.md",
+        });
+        // ...
+      });
+    });
+    ```
+
+    ```typescript
+    // Example with pseudo-home directory
+    const { getHomeDirectoryMock } = vi.hoisted(() => {
+      return {
+        getHomeDirectoryMock: vi.fn(),
+      };
+    });
+    vi.mock("../utils/file.js", async () => {
+      const actual = await vi.importActual<typeof import("../utils/file.js")>("../utils/file.js");
+      return {
+        ...actual,
+        getHomeDirectory: getHomeDirectoryMock,
+      };
+    });
+
+    describe("Test Name", () => {
+      let testDir: string;
+      let cleanup: () => Promise<void>;
+
+      beforeEach(async () => {
+        ({ testDir, cleanup } = await setupTestDirectory({ home: true }));
+        getHomeDirectoryMock.mockReturnValue(testDir);
+      });
+
+      afterEach(async () => {
+        await cleanup();
+        getHomeDirectoryMock.mockClear();
+      });
+
+      it("Test Case", async () => {
+        // Run test using testDir
+        const subDir = join(testDir, "subdir");
+        await ensureDir(subDir);
+        // ...
+      });
+    });
+    ```
+
+  - Exceptionally, in E2E testing, you can use process.chdir() to change the current working directory to the test directory because E2E tests are intended to simulate conditions that are as close as possible to real user operations.
+
+- In test, don't change dirs or files out of the project directory even though it's in global mode to make it easier to test some behavior and avoid polluting those.
+- `getHomeDirectory()` in `src/utils/file.ts` respects the `HOME_DIR` environment variable regardless of `NODE_ENV`. When `HOME_DIR` is set, it always returns that value. This is used by E2E tests to specify a pseudo-home directory for global mode testing without depending on `NODE_ENV` (which may not be available in compiled binaries).
+- When `NODE_ENV` is `test`:
+  - All logs by `Logger` in `src/utils/logger.ts` are suppressed.
+    - When you want to log in test, use `console.log` and run `npx vitest run --silent=false` to see the logs.
+  - `getHomeDirectory()` in `src/utils/file.ts` throws an error if `HOME_DIR` is not set, to enforce explicit mocking.
+  - `isEnvTest()` in `src/utils/vitest.ts` is a function that dynamically checks `process.env.NODE_ENV === "test"` at call time. Note: bun compiled binaries may not respect runtime `NODE_ENV` changes, so prefer `HOME_DIR` for E2E tests.

--- a/.gitignore
+++ b/.gitignore
@@ -264,8 +264,6 @@ docs/.vitepress/cache
 **/.goosehints
 **/.goose/
 **/.gooseignore
-**/.github/copilot-instructions.md
-**/.github/instructions/
 **/.github/prompts/
 **/.github/agents/
 **/.github/skills/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -18,6 +18,8 @@
     ".zed/settings.json",
     ".vscode/settings.json",
     ".claude/settings.json",
-    ".serena/project.yml"
+    ".serena/project.yml",
+    ".github/copilot-instructions.md",
+    ".github/instructions/**"
   ]
 }


### PR DESCRIPTION
## Summary
- `.gitignore` から Copilot 生成ファイル（`.github/copilot-instructions.md`, `.github/instructions/`）のignoreパターンを削除し、リポジトリで追跡するようにした
- `.gitattributes` を追加し、Copilot 生成ファイルを `linguist-generated` としてマーク
- Copilot 生成ファイルを oxfmt のフォーマット対象から除外（`.oxfmtrc.json` の `ignorePatterns` に追加）

## Test plan
- [x] `pnpm cicheck` が全て通過することを確認済み