### PR TITLE
feat: support Claude Code worktree hook events

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -324,6 +324,8 @@
     "KAKEHASHI",
     "redirs",
     "symref",
-    "TOCTOU"
+    "TOCTOU",
+    "worktree",
+    "Worktree"
   ]
 }

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -41,7 +41,10 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 **Event support:**
 
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
-- **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
+- **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`, `worktreeCreate`, `worktreeRemove`
+
+> **Note:** `worktreeCreate` and `worktreeRemove` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config will be ignored for these events.
+
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
 - **GitHub Copilot:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 - **Gemini CLI:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `stop`, `beforeAgentResponse`, `afterAgentResponse`, `beforeToolSelection`, `preToolUse`, `postToolUse`, `preCompact`, `notification`

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -41,7 +41,10 @@ Hooks run scripts at lifecycle events (e.g. session start, before tool use). Eve
 **Event support:**
 
 - **Cursor:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `afterFileEdit`, `afterShellExecution`, `postToolUseFailure`, `subagentStart`, `beforeShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`
-- **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`
+- **Claude Code:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `sessionEnd`, `beforeSubmitPrompt`, `subagentStop`, `preCompact`, `permissionRequest`, `notification`, `setup`, `worktreeCreate`, `worktreeRemove`
+
+> **Note:** `worktreeCreate` and `worktreeRemove` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config will be ignored for these events.
+
 - **OpenCode:** `sessionStart`, `preToolUse`, `postToolUse`, `stop`, `afterFileEdit`, `afterShellExecution`, `permissionRequest`
 - **GitHub Copilot:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `afterError`
 - **Gemini CLI:** `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `stop`, `beforeAgentResponse`, `afterAgentResponse`, `beforeToolSelection`, `preToolUse`, `postToolUse`, `preCompact`, `notification`

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { logger } from "../../utils/logger.js";
 import { ClaudecodeHooks } from "./claudecode-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 
@@ -281,6 +282,202 @@ describe("ClaudecodeHooks", () => {
         validate: false,
       });
       expect(hooks.isDeletable()).toBe(false);
+    });
+  });
+
+  describe("fromRulesyncHooks - worktree events", () => {
+    it("should generate WorktreeCreate and WorktreeRemove events", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          worktreeCreate: [{ type: "command", command: ".rulesync/hooks/worktree-create.sh" }],
+          worktreeRemove: [{ type: "command", command: ".rulesync/hooks/worktree-remove.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = claudecodeHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.WorktreeCreate).toBeDefined();
+      expect(parsed.hooks.WorktreeRemove).toBeDefined();
+      expect(parsed.hooks.WorktreeCreate[0].hooks[0].command).toContain("worktree-create.sh");
+      expect(parsed.hooks.WorktreeRemove[0].hooks[0].command).toContain("worktree-remove.sh");
+    });
+
+    it("should NOT emit matcher for worktreeCreate and worktreeRemove even if defined in config", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          worktreeCreate: [{ type: "command", command: "create.sh", matcher: "*.js" }],
+          worktreeRemove: [{ type: "command", command: "remove.sh", matcher: "*.ts" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = claudecodeHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.WorktreeCreate).toBeDefined();
+      expect(parsed.hooks.WorktreeCreate[0].matcher).toBeUndefined();
+      expect(parsed.hooks.WorktreeRemove).toBeDefined();
+      expect(parsed.hooks.WorktreeRemove[0].matcher).toBeUndefined();
+    });
+
+    it("should warn when matcher is defined on worktree events", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      const config = {
+        version: 1,
+        hooks: {
+          worktreeCreate: [{ type: "command", command: "create.sh", matcher: "*.js" }],
+          worktreeRemove: [{ type: "command", command: "remove.sh", matcher: "*.ts" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      await ClaudecodeHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('matcher "*.js" on "worktreeCreate" hook will be ignored'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('matcher "*.ts" on "worktreeRemove" hook will be ignored'),
+      );
+    });
+
+    it("should NOT emit matcher for worktree events in claudecode-specific config", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {},
+        claudecode: {
+          hooks: {
+            worktreeCreate: [
+              { type: "command", command: "create-claude.sh", matcher: "should-be-ignored" },
+            ],
+          },
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = claudecodeHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.WorktreeCreate).toBeDefined();
+      expect(parsed.hooks.WorktreeCreate[0].matcher).toBeUndefined();
+    });
+
+    it("should keep matcher for non-worktree events", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "session.sh", matcher: "*.js" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        baseDir: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = claudecodeHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.SessionStart).toBeDefined();
+      expect(parsed.hooks.SessionStart[0].matcher).toBe("*.js");
+    });
+  });
+
+  describe("toRulesyncHooks - worktree events", () => {
+    it("should import WorktreeCreate and WorktreeRemove back to canonical names", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        baseDir: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            WorktreeCreate: [
+              { hooks: [{ type: "command", command: "$CLAUDE_PROJECT_DIR/create.sh" }] },
+            ],
+            WorktreeRemove: [
+              { hooks: [{ type: "command", command: "$CLAUDE_PROJECT_DIR/remove.sh" }] },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.worktreeCreate).toHaveLength(1);
+      expect(json.hooks.worktreeCreate?.[0]?.command).toContain("create.sh");
+      expect(json.hooks.worktreeRemove).toHaveLength(1);
+      expect(json.hooks.worktreeRemove?.[0]?.command).toContain("remove.sh");
     });
   });
 

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -20,12 +20,15 @@ import {
   type ToolHooksSettablePaths,
 } from "./tool-hooks.js";
 
+const CLAUDE_NO_MATCHER_EVENTS: ReadonlySet<string> = new Set(["worktreeCreate", "worktreeRemove"]);
+
 const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   supportedEvents: CLAUDE_HOOK_EVENTS,
   canonicalToToolEventNames: CANONICAL_TO_CLAUDE_EVENT_NAMES,
   toolToCanonicalEventNames: CLAUDE_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "$CLAUDE_PROJECT_DIR",
   prefixDotRelativeCommandsOnly: true,
+  noMatcherEvents: CLAUDE_NO_MATCHER_EVENTS,
 };
 
 export class ClaudecodeHooks extends ToolHooks {

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -1,4 +1,5 @@
 import type { HookEvent, HooksConfig } from "../../types/hooks.js";
+import { logger } from "../../utils/logger.js";
 
 type ToolMatcherEntry = {
   matcher?: string;
@@ -28,6 +29,11 @@ export type ToolHooksConverterConfig = {
    * are prefixed with projectDirVar. Bare executable commands like `npx prettier ...` are left intact.
    */
   prefixDotRelativeCommandsOnly?: boolean;
+  /**
+   * Events that do not support the `matcher` field. Any matcher defined on these events
+   * will be silently dropped with a warning during export.
+   */
+  noMatcherEvents?: ReadonlySet<string>;
 };
 
 /**
@@ -67,7 +73,13 @@ export function canonicalToToolHooks({
       else byMatcher.set(key, [def]);
     }
     const entries: unknown[] = [];
+    const isNoMatcherEvent = converterConfig.noMatcherEvents?.has(eventName) ?? false;
     for (const [matcherKey, defs] of byMatcher) {
+      if (isNoMatcherEvent && matcherKey) {
+        logger.warn(
+          `matcher "${matcherKey}" on "${eventName}" hook will be ignored — this event does not support matchers`,
+        );
+      }
       const hooks = defs.map((def) => {
         const commandText = def.command;
         const trimmedCommand =
@@ -88,7 +100,8 @@ export function canonicalToToolHooks({
           ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
         };
       });
-      entries.push(matcherKey ? { matcher: matcherKey, hooks } : { hooks });
+      const includeMatcher = matcherKey && !isNoMatcherEvent;
+      entries.push(includeMatcher ? { matcher: matcherKey, hooks } : { hooks });
     }
     result[toolEventName] = entries;
   }
@@ -98,6 +111,11 @@ export function canonicalToToolHooks({
 /**
  * Convert tool-specific hooks back to canonical format (shared by Claude and Factory Droid).
  * Reverses event name mapping and strips project directory variable prefix from commands.
+ *
+ * Note: This function does not strip matchers for noMatcherEvents. Tools themselves never produce
+ * matchers on these events, so stripping is unnecessary on import. If a manually edited config
+ * includes a matcher on such an event, it will be preserved in canonical format but dropped
+ * on the next export (with a warning).
  */
 export function toolHooksToCanonical({
   hooks,

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -69,7 +69,9 @@ export type HookEvent =
   | "notification"
   | "setup"
   | "afterError"
-  | "beforeToolSelection";
+  | "beforeToolSelection"
+  | "worktreeCreate"
+  | "worktreeRemove";
 
 /** Hook events supported by Cursor. */
 export const CURSOR_HOOK_EVENTS: readonly HookEvent[] = [
@@ -108,6 +110,8 @@ export const CLAUDE_HOOK_EVENTS: readonly HookEvent[] = [
   "permissionRequest",
   "notification",
   "setup",
+  "worktreeCreate",
+  "worktreeRemove",
 ];
 
 /** Hook events supported by OpenCode. */
@@ -194,6 +198,8 @@ export const CANONICAL_TO_CLAUDE_EVENT_NAMES: Record<string, string> = {
   permissionRequest: "PermissionRequest",
   notification: "Notification",
   setup: "Setup",
+  worktreeCreate: "WorktreeCreate",
+  worktreeRemove: "WorktreeRemove",
 };
 
 /**


### PR DESCRIPTION
## Summary
- add Claude Code hook event support for `worktreeCreate` and `worktreeRemove`
- map the new canonical event names to/from Claude's `WorktreeCreate` / `WorktreeRemove`
- omit `matcher` when generating Claude settings for these worktree events and document the limitation
- add tests covering generation, matcher omission, and import behavior

## Testing
- `pnpm vitest run src/features/hooks/claudecode-hooks.test.ts`
- `pnpm run typecheck`
- `pnpm run eslint`

Closes #1298
