### PR TITLE
feat: add reporting rules to review-pr command

### DIFF
--- a/.github/instructions/coding-guidelines.instructions.md
+++ b/.github/instructions/coding-guidelines.instructions.md
@@ -1,8 +1,7 @@
 ---
-description: "When you write any code, must follow these guidelines."
-applyTo: "**/*.ts"
+description: 'When you write any code, must follow these guidelines.'
+applyTo: '**/*.ts'
 ---
-
 # Coding Guidelines
 
 - If the arguments are multiple, you should use object as the argument.

--- a/.github/instructions/feature-change-guidelines.instructions.md
+++ b/.github/instructions/feature-change-guidelines.instructions.md
@@ -1,7 +1,6 @@
 ---
-description: "When you add or change features, must follow these guidelines."
+description: 'When you add or change features, must follow these guidelines.'
 ---
-
 # Guidelines for Adding or Modifying Features
 
 - Check whether `rules-processor.ts` needs an updated Additional Convention, especially values within `additionalConvention`. For example, if you remove support for Cursor's Skill feature simulation, remove `skills: { skillClass: CursorSkill }` within convention entry for Cursor.

--- a/.github/instructions/github-actions-security.instructions.md
+++ b/.github/instructions/github-actions-security.instructions.md
@@ -2,7 +2,6 @@
 description: Guidelines to avoid GitHub Actions script injection vulnerabilities.
 applyTo: .github/workflows/*.yml
 ---
-
 # GitHub Actions Security: Script Injection
 
 When working with GitHub Actions workflows, ensure that untrusted inputs are never interpolated directly into `run` scripts or other execution contexts. Follow GitHub's guidance on avoiding script injection vulnerabilities.

--- a/.github/instructions/testing-guidelines.instructions.md
+++ b/.github/instructions/testing-guidelines.instructions.md
@@ -1,8 +1,7 @@
 ---
-description: "When you write tests, must follow these guidelines."
-applyTo: "**/*.test.ts"
+description: 'When you write tests, must follow these guidelines.'
+applyTo: '**/*.test.ts'
 ---
-
 # Testing Guidelines
 
 - Test code files should be placed next to the implementation. This is called the co-location pattern.

--- a/.rulesync/commands/review-pr.md
+++ b/.rulesync/commands/review-pr.md
@@ -19,4 +19,3 @@ Integrate and report the execution results from each subagent. Additionaly, plea
 
 - Assign a severity level to each finding: low, mid, high, or critical.
 - Assign a sequential number to each finding (e.g., #1, #2, #3, ...).
-- If all findings are low severity only, consider the PR mergeable and state so in the report.


### PR DESCRIPTION
## Summary
- review-prコマンドにレポーティングルールを追加
- 各指摘にseverity level (low/mid/high/critical) を付与
- 各指摘に連番を割り振り

## Test plan
- [ ] `/review-pr` を実行し、指摘にseverityと番号が付与されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)