### PR TITLE
refactor: extract parseCommaSeparatedList utility and deduplicate warnings

### DIFF
--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -281,6 +281,17 @@ describe("filterGitignoreEntries", () => {
       filterGitignoreEntries({ features: ["rules", "commands", "*"] });
       expect(warnSpy).not.toHaveBeenCalled();
     });
+
+    it("should deduplicate warnings for the same invalid feature across targets (object format)", () => {
+      filterGitignoreEntries({
+        features: {
+          claudecode: ["bogus" as any],
+          copilot: ["bogus" as any],
+        },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown feature 'bogus'"));
+    });
   });
 
   describe("deduplication", () => {

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -194,23 +194,24 @@ const warnInvalidTargets = (targets: ReadonlyArray<string>): void => {
 
 const warnInvalidFeatures = (features: RulesyncFeatures): void => {
   const validFeatures = new Set<string>(ALL_FEATURES_WITH_WILDCARD);
+  const warned = new Set<string>();
+  const warnOnce = (feature: string): void => {
+    if (!validFeatures.has(feature) && !warned.has(feature)) {
+      warned.add(feature);
+      logger.warn(
+        `Unknown feature '${feature}'. Valid features: ${ALL_FEATURES_WITH_WILDCARD.join(", ")}`,
+      );
+    }
+  };
   if (Array.isArray(features)) {
     for (const feature of features) {
-      if (!validFeatures.has(feature)) {
-        logger.warn(
-          `Unknown feature '${feature}'. Valid features: ${ALL_FEATURES_WITH_WILDCARD.join(", ")}`,
-        );
-      }
+      warnOnce(feature);
     }
   } else {
     for (const targetFeatures of Object.values(features)) {
       if (!targetFeatures) continue;
       for (const feature of targetFeatures) {
-        if (!validFeatures.has(feature)) {
-          logger.warn(
-            `Unknown feature '${feature}'. Valid features: ${ALL_FEATURES_WITH_WILDCARD.join(", ")}`,
-          );
-        }
+        warnOnce(feature);
       }
     }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { FetchOptions } from "../types/fetch.js";
 import { CLIError } from "../types/json-output.js";
 import { formatError } from "../utils/error.js";
 import { ConsoleLogger, JsonLogger, Logger } from "../utils/logger.js";
+import { parseCommaSeparatedList } from "../utils/parse-comma-separated-list.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { generateCommand, GenerateOptions } from "./commands/generate.js";
 import { gitignoreCommand } from "./commands/gitignore.js";
@@ -88,22 +89,12 @@ const main = async () => {
     .option(
       "-t, --targets <tools>",
       "Comma-separated list of tools to include (e.g., 'claudecode,copilot' or '*' for all)",
-      (value) => {
-        return value
-          .split(",")
-          .map((t) => t.trim())
-          .filter(Boolean);
-      },
+      parseCommaSeparatedList,
     )
     .option(
       "-f, --features <features>",
       `Comma-separated list of features to include (${ALL_FEATURES.join(",")}) or '*' for all`,
-      (value) => {
-        return value
-          .split(",")
-          .map((f) => f.trim())
-          .filter(Boolean);
-      },
+      parseCommaSeparatedList,
     )
     .option("-V, --verbose", "Verbose output")
     .option("-s, --silent", "Suppress all output")
@@ -128,7 +119,7 @@ const main = async () => {
     .option(
       "-f, --features <features>",
       `Comma-separated list of features to fetch (${ALL_FEATURES.join(",")}) or '*' for all`,
-      (value) => value.split(",").map((f) => f.trim()),
+      parseCommaSeparatedList,
     )
     .option("-r, --ref <ref>", "Branch, tag, or commit SHA to fetch from")
     .option("-p, --path <path>", "Subdirectory path within the repository")
@@ -155,12 +146,12 @@ const main = async () => {
     .option(
       "-t, --targets <tool>",
       "Tool to import from (e.g., 'copilot', 'cursor', 'cline')",
-      (value) => value.split(",").map((t) => t.trim()),
+      parseCommaSeparatedList,
     )
     .option(
       "-f, --features <features>",
       `Comma-separated list of features to import (${ALL_FEATURES.join(",")}) or '*' for all`,
-      (value) => value.split(",").map((f) => f.trim()),
+      parseCommaSeparatedList,
     )
     .option("-V, --verbose", "Verbose output")
     .option("-s, --silent", "Suppress all output")
@@ -218,18 +209,18 @@ const main = async () => {
     .option(
       "-t, --targets <tools>",
       "Comma-separated list of tools to generate for (e.g., 'copilot,cursor,cline' or '*' for all)",
-      (value) => value.split(",").map((t) => t.trim()),
+      parseCommaSeparatedList,
     )
     .option(
       "-f, --features <features>",
       `Comma-separated list of features to generate (${ALL_FEATURES.join(",")}) or '*' for all`,
-      (value) => value.split(",").map((f) => f.trim()),
+      parseCommaSeparatedList,
     )
     .option("--delete", "Delete all existing files in output directories before generating")
     .option(
       "-b, --base-dir <paths>",
       "Base directories to generate files (comma-separated for multiple paths)",
-      (value) => value.split(",").map((p) => p.trim()),
+      parseCommaSeparatedList,
     )
     .option("-V, --verbose", "Verbose output")
     .option("-s, --silent", "Suppress all output")

--- a/src/utils/parse-comma-separated-list.test.ts
+++ b/src/utils/parse-comma-separated-list.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCommaSeparatedList } from "./parse-comma-separated-list.js";
+
+describe("parseCommaSeparatedList", () => {
+  it("splits a comma-separated string into trimmed values", () => {
+    expect(parseCommaSeparatedList("a, b, c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles values without spaces", () => {
+    expect(parseCommaSeparatedList("copilot,cursor,cline")).toEqual(["copilot", "cursor", "cline"]);
+  });
+
+  it("filters out empty strings from trailing commas", () => {
+    expect(parseCommaSeparatedList("rules,")).toEqual(["rules"]);
+  });
+
+  it("filters out empty strings from leading commas", () => {
+    expect(parseCommaSeparatedList(",rules")).toEqual(["rules"]);
+  });
+
+  it("filters out empty strings from consecutive commas", () => {
+    expect(parseCommaSeparatedList("a,,b")).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(parseCommaSeparatedList("")).toEqual([]);
+  });
+
+  it("returns an empty array for only commas", () => {
+    expect(parseCommaSeparatedList(",,,")).toEqual([]);
+  });
+
+  it("handles a single value", () => {
+    expect(parseCommaSeparatedList("*")).toEqual(["*"]);
+  });
+});

--- a/src/utils/parse-comma-separated-list.ts
+++ b/src/utils/parse-comma-separated-list.ts
@@ -1,0 +1,14 @@
+/**
+ * Parses a comma-separated string into a trimmed, non-empty array of strings.
+ *
+ * Handles trailing commas and extra whitespace gracefully.
+ *
+ * @example
+ * parseCommaSeparatedList("a, b, c") // => ["a", "b", "c"]
+ * parseCommaSeparatedList("a,,b,")   // => ["a", "b"]
+ */
+export const parseCommaSeparatedList = (value: string): string[] =>
+  value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);


### PR DESCRIPTION
## Summary
- Extracted a shared `parseCommaSeparatedList` utility (`src/utils/parse-comma-separated-list.ts`) to DRY up the repeated `value.split(",").map(s => s.trim())` pattern across all CLI commands (`generate`, `import`, `fetch`, `gitignore`)
- Applied `.filter(Boolean)` consistently via the shared utility, so all commands now gracefully handle trailing/leading/consecutive commas
- Added deduplication (`Set`) to `warnInvalidFeatures` so the same invalid feature is only warned once even when specified across multiple targets in object format

Closes #1312

## Test plan
- [x] Added unit tests for `parseCommaSeparatedList` (8 test cases covering normal, edge, and empty input)
- [x] Added test for deduplicated warnings in `warnInvalidFeatures` (object format with same invalid feature across multiple targets)
- [x] All 4367 existing tests pass (`pnpm cicheck:code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)