### PR TITLE
feat: add clean-worktrees command

### DIFF
--- a/.rulesync/commands/clean-worktrees.md
+++ b/.rulesync/commands/clean-worktrees.md
@@ -1,0 +1,9 @@
+---
+description: "Clean git worktrees created by git-worktree-runner"
+targets:
+  - "*"
+---
+
+1. Run `git gtr list` to list all worktrees.
+2. For each worktree branch that is NOT the default branch (e.g. main), run `git gtr rm --force {branch}` to remove it.
+3. Run `git pull --prune` to fetch latest changes and prune deleted remote branches.


### PR DESCRIPTION
## Summary
- git-worktree-runner (gtr) で作成されたworktreeを一括削除する `clean-worktrees` コマンドを追加
- デフォルトブランチを除く全worktreeを `git gtr rm --force` で削除し、`git pull --prune` も実行

## Test plan
- [ ] `/clean-worktrees` コマンドが各ターゲット (Claude Code, Copilot, opencode) で正しく生成されることを確認
- [ ] コマンド実行時にデフォルトブランチが削除されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)