### PR TITLE
fix: correct Factory Droid supported features table and improve simulated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | GitHub Copilot CLI | copilotcli   |       |        |  ✅ 🌏   |          |           |        |       |
 | Cursor             | cursor       |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
-| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
+| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |
 | OpenCode           | opencode     | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
 | Cline              | cline        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |
 | Kilo Code          | kilo         | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -12,7 +12,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | Goose              | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |
 | Cursor             | cursor       |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
-| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
+| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |
 | OpenCode           | opencode     | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
 | Cline              | cline        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |
 | Kilo Code          | kilo         | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -12,7 +12,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot     | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |
 | Goose              | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |
 | Cursor             | cursor       |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  ✅   |
-| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
+| Factory Droid      | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |
 | OpenCode           | opencode     | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |
 | Cline              | cline        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |
 | Kilo Code          | kilo         | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -111,16 +111,30 @@ async function processEmptyFeatureGeneration(params: {
   return { count: totalCount, paths: [], hasDiff };
 }
 
+const SIMULATE_OPTION_MAP: Partial<Record<Feature, string>> = {
+  commands: "--simulate-commands",
+  subagents: "--simulate-subagents",
+  skills: "--simulate-skills",
+};
+
 function warnUnsupportedTargets(params: {
   config: Config;
   supportedTargets: ToolTarget[];
+  simulatedTargets?: ToolTarget[];
   featureName: Feature;
   logger: Logger;
 }): void {
-  const { config, supportedTargets, featureName, logger } = params;
+  const { config, supportedTargets, simulatedTargets = [], featureName, logger } = params;
   for (const target of config.getTargets()) {
     if (!supportedTargets.includes(target) && config.getFeatures(target).includes(featureName)) {
-      logger.warn(`Target '${target}' does not support the feature '${featureName}'. Skipping.`);
+      const simulateOption = SIMULATE_OPTION_MAP[featureName];
+      if (simulateOption && simulatedTargets.includes(target)) {
+        logger.warn(
+          `Target '${target}' only supports simulated '${featureName}'. Use '${simulateOption}' to enable it. Skipping.`,
+        );
+      } else {
+        logger.warn(`Target '${target}' does not support the feature '${featureName}'. Skipping.`);
+      }
     }
   }
 }
@@ -370,6 +384,7 @@ async function generateCommandsCore(params: {
   warnUnsupportedTargets({
     config,
     supportedTargets: supportedCommandsTargets,
+    simulatedTargets: CommandsProcessor.getToolTargetsSimulated(),
     featureName: "commands",
     logger,
   });
@@ -425,6 +440,7 @@ async function generateSubagentsCore(params: {
   warnUnsupportedTargets({
     config,
     supportedTargets: supportedSubagentsTargets,
+    simulatedTargets: SubagentsProcessor.getToolTargetsSimulated(),
     featureName: "subagents",
     logger,
   });
@@ -481,6 +497,7 @@ async function generateSkillsCore(params: {
   warnUnsupportedTargets({
     config,
     supportedTargets: supportedSkillsTargets,
+    simulatedTargets: SkillsProcessor.getToolTargetsSimulated(),
     featureName: "skills",
     logger,
   });


### PR DESCRIPTION
## Summary
- Factory Droid の commands/subagents/skills はsimulated-onlyだが、サポート表ではnative support（✅ 🌏）として表示されていた。正しいsimulatedマーク（🎮）に修正
- simulatedのみサポートするtargetに対して、`--simulate-*` フラグの使用を案内する警告メッセージを追加

Closes #1356

## Test plan
- [x] `pnpm cicheck:code` passed (lint, typecheck, 4441 tests)
- [ ] Verify warning message: `rulesync generate --targets factorydroid --features commands` で `Use '--simulate-commands' to enable it` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)