### PR TITLE
refactor: use spread syntax in fromFile and align sub-schemas with z.looseObject

### DIFF
--- a/src/features/rules/rulesync-rule.test.ts
+++ b/src/features/rules/rulesync-rule.test.ts
@@ -729,6 +729,56 @@ This has leading and trailing whitespace.
       expect(result.success).toBe(false);
     });
 
+    it("should preserve unknown keys in tool-specific sub-schemas via z.looseObject", () => {
+      const frontmatter = {
+        cursor: {
+          alwaysApply: true,
+          futureField: "preserved",
+        },
+        copilot: {
+          excludeAgent: "code-review" as const,
+          newOption: 42,
+        },
+        claudecode: {
+          paths: ["src/**/*.ts"],
+          experimentalFlag: true,
+        },
+        antigravity: {
+          trigger: "glob",
+          globs: ["*.md"],
+          extraSetting: "kept",
+        },
+        agentsmd: {
+          subprojectPath: "packages/app",
+          unknownProp: ["a", "b"],
+        },
+      };
+
+      const result = RulesyncRuleFrontmatterSchema.safeParse(frontmatter);
+      expect(result.success).toBe(true);
+      expect(result.data?.cursor).toEqual({
+        alwaysApply: true,
+        futureField: "preserved",
+      });
+      expect(result.data?.copilot).toEqual({
+        excludeAgent: "code-review",
+        newOption: 42,
+      });
+      expect(result.data?.claudecode).toEqual({
+        paths: ["src/**/*.ts"],
+        experimentalFlag: true,
+      });
+      expect(result.data?.antigravity).toEqual({
+        trigger: "glob",
+        globs: ["*.md"],
+        extraSetting: "kept",
+      });
+      expect(result.data?.agentsmd).toEqual({
+        subprojectPath: "packages/app",
+        unknownProp: ["a", "b"],
+      });
+    });
+
     it("should allow partial cursor configuration", () => {
       const frontmatter = {
         cursor: {

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -24,7 +24,7 @@ export const RulesyncRuleFrontmatterSchema = z.object({
   description: z.optional(z.string()),
   globs: z.optional(z.array(z.string())),
   agentsmd: z.optional(
-    z.object({
+    z.looseObject({
       // @example "path/to/subproject"
       subprojectPath: z.optional(z.string()),
     }),


### PR DESCRIPTION
## Summary
- Replace manual field listing in `RulesyncRule.fromFile` with spread syntax to prevent future bugs when new tool-specific fields are added to the schema
- Update `claudecode`, `cursor`, and `copilot` sub-schemas to use `z.looseObject()` for consistency with coding guidelines and the existing `antigravity` schema

Closes #1371

## Test plan
- [x] `pnpm cicheck` passes (all 4497 tests, lint, typecheck, spell check, secret lint)

Generated with [Claude Code](https://claude.com/claude-code)