### PR TITLE
fix: Structured equivalence for known file types

### DIFF
--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { fileContentsEquivalent } from "../utils/content-equivalence.js";
 import {
   addTrailingNewline,
   ensureDir,
@@ -80,7 +81,7 @@ export abstract class DirFeatureProcessor {
         });
         mainFileContent = addTrailingNewline(content);
         const existingContent = await readFileContentOrNull(mainFilePath);
-        if (existingContent !== mainFileContent) {
+        if (!fileContentsEquivalent(mainFilePath, mainFileContent, existingContent)) {
           dirHasChanges = true;
         }
       }
@@ -94,7 +95,7 @@ export abstract class DirFeatureProcessor {
         if (!dirHasChanges) {
           const filePath = join(dirPath, file.relativeFilePathToDirPath);
           const existingContent = await readFileContentOrNull(filePath);
-          if (existingContent !== contentWithNewline) {
+          if (!fileContentsEquivalent(filePath, contentWithNewline, existingContent)) {
             dirHasChanges = true;
           }
         }

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -1,3 +1,4 @@
+import { fileContentsEquivalent } from "../utils/content-equivalence.js";
 import {
   addTrailingNewline,
   readFileContentOrNull,
@@ -59,7 +60,7 @@ export abstract class FeatureProcessor {
       const contentWithNewline = addTrailingNewline(aiFile.getFileContent());
       const existingContent = await readFileContentOrNull(filePath);
 
-      if (existingContent === contentWithNewline) {
+      if (fileContentsEquivalent(filePath, contentWithNewline, existingContent)) {
         continue;
       }
 

--- a/src/utils/content-equivalence.test.ts
+++ b/src/utils/content-equivalence.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { fileContentsEquivalent } from "./content-equivalence.js";
+import { addTrailingNewline } from "./file.js";
+import { stringifyFrontmatter } from "./frontmatter.js";
+
+describe("fileContentsEquivalent", () => {
+  it("returns false when existing is null", () => {
+    expect(fileContentsEquivalent("/x/a.json", "{}", null)).toBe(false);
+  });
+
+  it("treats JSON with different formatting as equivalent", () => {
+    const a = '{"x":1,"y":[2,3]}';
+    const b = `{
+  "x": 1,
+  "y": [2, 3]
+}`;
+    expect(fileContentsEquivalent("/project/settings.json", `${a}\n`, `${b}\n`)).toBe(true);
+  });
+
+  it("detects real JSON value changes", () => {
+    expect(fileContentsEquivalent("/x/c.json", '{"a":1}\n', '{"a":2}\n')).toBe(false);
+  });
+
+  it("falls back to text compare for invalid JSON", () => {
+    expect(fileContentsEquivalent("/x/broken.json", "not json\n", "not json\n")).toBe(true);
+    expect(fileContentsEquivalent("/x/broken.json", "not json\n", "not json 2\n")).toBe(false);
+  });
+
+  it("treats JSONC with comments and formatting differences as equivalent", () => {
+    const a = `{
+  // server
+  "mcp": { "x": 1 }
+}`;
+    const b = '{"mcp":{"x":1}}';
+    expect(fileContentsEquivalent("/x/opencode.jsonc", `${a}\n`, `${b}\n`)).toBe(true);
+  });
+
+  it("treats YAML with different layout as equivalent", () => {
+    const a = "a: 1\nb:\n  c: 2\n";
+    const b = "a: 1\nb: {c: 2}\n";
+    expect(fileContentsEquivalent("/x/copilot-mcp.yml", a, b)).toBe(true);
+  });
+
+  it("treats TOML with different layout as equivalent when semantic match", () => {
+    const a = `[sec]\na = 1\n`;
+    const b = `[sec]\na=1\n\n`;
+    expect(fileContentsEquivalent("/x/config.toml", a, b)).toBe(true);
+  });
+
+  it("treats markdown as equivalent when frontmatter differs only in YAML layout or key order", () => {
+    const body = "Hello\n";
+    const fm = { name: "test", version: "1.0.0" };
+    const generated = addTrailingNewline(stringifyFrontmatter(body, fm));
+    const onDisk = `---
+version: "1.0.0"
+name: test
+---
+
+Hello
+`;
+    expect(fileContentsEquivalent("/skill/SKILL.md", generated, onDisk)).toBe(true);
+  });
+
+  it("uses the same markdown rules for .mdc (e.g. Cursor rules)", () => {
+    const body = "Hello\n";
+    const fm = { name: "test" };
+    const generated = addTrailingNewline(stringifyFrontmatter(body, fm));
+    const onDisk = `---
+name: test
+---
+
+Hello
+`;
+    expect(fileContentsEquivalent(".cursor/rules/rule.mdc", generated, onDisk)).toBe(true);
+  });
+
+  it("treats avoidBlockScalars-flattened frontmatter as equivalent to prettier-styled YAML", () => {
+    const body = "Body\n";
+    const fm = { description: "line1\nline2" };
+    const generated = addTrailingNewline(
+      stringifyFrontmatter(body, fm, { avoidBlockScalars: true }),
+    );
+    const onDisk = `---
+description: "line1 line2"
+---
+
+Body
+`;
+    expect(fileContentsEquivalent("/skill/SKILL.md", generated, onDisk)).toBe(true);
+  });
+
+  it("uses strict text compare for unknown extensions", () => {
+    expect(fileContentsEquivalent("/x/foo.txt", "a\n", "a\n")).toBe(true);
+    expect(fileContentsEquivalent("/x/foo.txt", "a\n", "b\n")).toBe(false);
+  });
+});

--- a/src/utils/content-equivalence.ts
+++ b/src/utils/content-equivalence.ts
@@ -1,0 +1,119 @@
+import { extname } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import { load } from "js-yaml";
+import { parse as parseJsonc, type ParseError } from "jsonc-parser";
+import * as smolToml from "smol-toml";
+
+import { addTrailingNewline } from "./file.js";
+import { parseFrontmatter } from "./frontmatter.js";
+
+/**
+ * Structural equality for JSON and JSONC using jsonc-parser (valid JSON parses the same as JSONC).
+ */
+function tryJsonEquivalent(a: string, b: string): boolean | undefined {
+  const errorsA: ParseError[] = [];
+  const errorsB: ParseError[] = [];
+  const parsedA = parseJsonc(a, errorsA);
+  const parsedB = parseJsonc(b, errorsB);
+
+  if (errorsA.length > 0 || errorsB.length > 0) {
+    return undefined;
+  }
+
+  return isDeepStrictEqual(parsedA, parsedB);
+}
+
+function tryYamlEquivalent(a: string, b: string): boolean | undefined {
+  try {
+    return isDeepStrictEqual(load(a), load(b));
+  } catch {
+    return undefined;
+  }
+}
+
+function tryTomlEquivalent(a: string, b: string): boolean | undefined {
+  try {
+    return isDeepStrictEqual(smolToml.parse(a), smolToml.parse(b));
+  } catch {
+    return undefined;
+  }
+}
+
+function tryMarkdownEquivalent(expected: string, existing: string): boolean | undefined {
+  /**
+   * gray-matter often includes extra newlines right after the closing ---; strip those so the
+   * body matches across generators vs on-disk formatters. Trailing whitespace is normalized via
+   * addTrailingNewline (trimEnd + single newline), same as writes.
+   */
+  function normalizeMarkdownBody(body: string): string {
+    return addTrailingNewline(body.replace(/^\n+/, ""));
+  }
+
+  try {
+    const parsedExpected = parseFrontmatter(expected);
+    const parsedExisting = parseFrontmatter(existing);
+
+    if (!isDeepStrictEqual(parsedExpected.frontmatter, parsedExisting.frontmatter)) {
+      return false;
+    }
+
+    return (
+      normalizeMarkdownBody(parsedExpected.body) === normalizeMarkdownBody(parsedExisting.body)
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Structured compare for known extensions. Returns `undefined` when this path should use
+ * strict text comparison instead (unknown extension, or parse not applicable / failed).
+ */
+function tryFileContentsEquivalent(
+  filePath: string,
+  expected: string,
+  existing: string,
+): boolean | undefined {
+  const ext = extname(filePath).toLowerCase();
+
+  switch (ext) {
+    case ".json":
+    case ".jsonc":
+      return tryJsonEquivalent(expected, existing);
+    case ".yaml":
+    case ".yml":
+      return tryYamlEquivalent(expected, existing);
+    case ".toml":
+      return tryTomlEquivalent(expected, existing);
+    case ".md":
+    case ".mdc":
+      return tryMarkdownEquivalent(expected, existing);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Whether on-disk content is equivalent to generated content for --check / dry-run.
+ *
+ * Uses structured comparison for JSON/JSONC (via jsonc-parser), YAML, TOML, and Markdown-like
+ * frontmatter files (.md, .mdc — same gray-matter path as elsewhere).
+ */
+export function fileContentsEquivalent(
+  filePath: string,
+  expected: string,
+  existing: string | null,
+): boolean {
+  if (existing === null) {
+    return false;
+  }
+
+  const structured = tryFileContentsEquivalent(filePath, expected, existing);
+
+  if (structured !== undefined) {
+    return structured;
+  }
+
+  return addTrailingNewline(expected) === addTrailingNewline(existing);
+}


### PR DESCRIPTION
Closes #1358

It was trivial to add support for toml, yaml and md as well - so I did :)