### PR TITLE
Use claude sonnet for opencode

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "lsp": false,
-  "model": "github-copilot/claude-opus-4.6",
+  "model": "github-copilot/claude-sonnet-4.6",
   "agent": {
     "build": {
       "mode": "primary",


### PR DESCRIPTION
Update rulesync opencode config to use github-copilot/claude-sonnet-4.6 as the default model.