### PR TITLE
chore: update default opencode model to glm-5.1

### DIFF
--- a/.github/actions/select-opencode-model/action.yml
+++ b/.github/actions/select-opencode-model/action.yml
@@ -27,7 +27,7 @@ runs:
         elif [[ "$INPUT_TEXT" == *"kimi"* ]]; then
           echo "model=openrouter/moonshotai/kimi-k2.5" >> $GITHUB_OUTPUT
         else
-          echo "model=zai-coding-plan/glm-5" >> $GITHUB_OUTPUT
+          echo "model=zai-coding-plan/glm-5.1" >> $GITHUB_OUTPUT
         fi
         CLEANED="${INPUT_TEXT//\/oc/}"
         CLEANED="${CLEANED//\/opencode/}"


### PR DESCRIPTION
Update the default model in `select-opencode-model` action from `zai-coding-plan/glm-5` to `zai-coding-plan/glm-5.1`.