### PR TITLE
refactor: convert commands to skills format

### DIFF
--- a/.rulesync/skills/clean-worktrees/SKILL.md
+++ b/.rulesync/skills/clean-worktrees/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: clean-worktrees
 description: "Clean git worktrees created by git-worktree-runner"
 targets:
   - "*"

--- a/.rulesync/skills/create-issue/SKILL.md
+++ b/.rulesync/skills/create-issue/SKILL.md
@@ -1,9 +1,10 @@
 ---
-targets:
-  - "*"
+name: create-issue
 description: >-
   Create a GitHub issue with detailed description, purpose, and appropriate
   labels
+targets:
+  - "*"
 ---
 
 # Create GitHub Issue

--- a/.rulesync/skills/explain-pr/SKILL.md
+++ b/.rulesync/skills/explain-pr/SKILL.md
@@ -1,7 +1,8 @@
 ---
+name: explain-pr
+description: "Explain a PR: the background problem and the proposed solution"
 targets:
   - "*"
-description: "Explain a PR: the background problem and the proposed solution"
 ---
 
 target_pr = $ARGUMENTS

--- a/.rulesync/skills/merge-pr/SKILL.md
+++ b/.rulesync/skills/merge-pr/SKILL.md
@@ -1,7 +1,8 @@
 ---
+name: merge-pr
+description: Merge a pull request using gh pr merge --admin
 targets:
   - "*"
-description: Merge a pull request using gh pr merge --admin
 ---
 
 # Merge Pull Request

--- a/.rulesync/skills/post-review-comment/SKILL.md
+++ b/.rulesync/skills/post-review-comment/SKILL.md
@@ -1,9 +1,10 @@
 ---
-targets:
-  - "*"
+name: post-review-comment
 description: >-
   Post line-level review comments and an overall review comment on a PR in
   English with a natural, concise writing style
+targets:
+  - "*"
 ---
 
 target_pr = $ARGUMENTS

--- a/.rulesync/skills/release-dry-run/SKILL.md
+++ b/.rulesync/skills/release-dry-run/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: release-dry-run
 description: "Dry run for release: summarize changes since last release and suggest version bump."
 targets:
   - "*"

--- a/.rulesync/skills/release/SKILL.md
+++ b/.rulesync/skills/release/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: release
 description: "Release a new version of the project."
 targets:
   - "*"

--- a/.rulesync/skills/security-scan-diff/SKILL.md
+++ b/.rulesync/skills/security-scan-diff/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: security-scan-diff
 description: "Scan for malicious code in git diff between a tag/commit and HEAD"
 targets:
   - "*"


### PR DESCRIPTION
## Summary
- Convert 7 command files from `.rulesync/commands/` to skill format (`.rulesync/skills/<name>/SKILL.md`)
- Converted: clean-worktrees, create-issue, explain-pr, merge-pr, post-review-comment, release-dry-run, release, security-scan-diff
- Only `draft-release-post.md` remains as a command

## Test plan
- [x] `pnpm cicheck` passes
- [x] Pre-commit hooks pass
- [ ] Verify skills are correctly recognized by rulesync generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)