### PR TITLE
chore: update default opencode model to gpt-5.4

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "lsp": false,
-  "model": "github-copilot/claude-sonnet-4.6",
+  "model": "github-copilot/gpt-5.4",
   "agent": {
     "build": {
       "mode": "primary",


### PR DESCRIPTION
## Summary
- opencode.jsonのデフォルトモデルを `github-copilot/claude-sonnet-4.6` から `github-copilot/gpt-5.4` に更新

## Test plan
- [x] `pnpm cicheck` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)