### PR TITLE
fix: update draft-release workflow to use skill reference

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -76,7 +76,7 @@ jobs:
 
             Then, check the environment variable $INPUT_NEW_VERSION. If it is not empty, use that value (without v prefix) as $new_version. For example, if $INPUT_NEW_VERSION is "1.0.0", the new version is "1.0.0".
 
-            If $INPUT_NEW_VERSION is empty, determine the new version automatically by performing the  /release-dry-run command.
+            If $INPUT_NEW_VERSION is empty, determine the new version automatically by performing the  release-dry-run skill.
 
             Let's resume the release process.
 


### PR DESCRIPTION
## Summary
- draft-release ワークフロー内の `/release-dry-run command` 参照を `release-dry-run skill` に更新
- #1391 での skills 形式への変換に合わせた修正

## Test plan
- [ ] draft-release ワークフローが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)