### PR TITLE
docs: remove GitHub Sponsors badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ A Node.js CLI tool that automatically generates configuration files for various 
 > If you are interested in Rulesync latest news, please follow the maintainer's X(Twitter) account:
 > [@dyoshikawa1993](https://x.com/dyoshikawa1993)
 
-<p align="center">
-  <a href="https://github.com/sponsors/dyoshikawa">
-    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=githubsponsors&style=for-the-badge" alt="Sponsor" />
-  </a>
-</p>
-
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- GitHub Sponsors の設定が未完了でリンクがリダイレクトされるため、スポンサーバッジを一旦除去

## Test plan
- [ ] READMEからバッジが除去されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)