### PR TITLE
feat: add agentsmd.subprojectPath to github-actions-security rule

### DIFF
--- a/.rulesync/rules/github-actions-security.md
+++ b/.rulesync/rules/github-actions-security.md
@@ -6,6 +6,8 @@ targets:
 description: Guidelines to avoid GitHub Actions script injection vulnerabilities.
 globs:
   - ".github/workflows/*.yml"
+agentsmd:
+  subprojectPath: ".github/workflows"
 ---
 
 # GitHub Actions Security: Script Injection


### PR DESCRIPTION
## Summary

Add `agentsmd.subprojectPath: .github/workflows` to the GitHub Actions security rule so that it generates a nested `AGENTS.md` under `.github/workflows/` instead of the default `.agents/memories/` location.

This ensures the security guideline is scoped to the workflows directory where it matters most.