### PR TITLE
chore: disable CLAUDE_CODE_NO_FLICKER setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
     "DISABLE_AUTOUPDATER": "0",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "0"
   },
   "sandbox": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Disable `CLAUDE_CODE_NO_FLICKER` env setting by changing its value from `"1"` to `"0"`

## Test plan
- [x] `pnpm cicheck` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)