### PR TITLE
refactor(hooks): clean up Codex CLI hooks implementation (#1445)

### DIFF
--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -9,7 +9,6 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
@@ -75,7 +74,6 @@ export class ClaudecodeHooks extends ToolHooks {
     logger,
   }: ToolHooksFromRulesyncHooksParams & {
     global?: boolean;
-    logger?: Logger;
   }): Promise<ClaudecodeHooks> {
     const paths = ClaudecodeHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);

--- a/src/features/hooks/codexcli-hooks.test.ts
+++ b/src/features/hooks/codexcli-hooks.test.ts
@@ -363,6 +363,31 @@ describe("CodexcliConfigToml", () => {
     expect(content).toContain("myserver");
   });
 
+  it("should merge with existing [features] section without overwriting other flags", async () => {
+    await ensureDir(join(testDir, ".codex"));
+    await writeFileContent(
+      join(testDir, ".codex", "config.toml"),
+      "[features]\nsome_other_flag = true\n",
+    );
+
+    const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
+    const content = configToml.getFileContent();
+    expect(content).toContain("codex_hooks = true");
+    expect(content).toContain("some_other_flag = true");
+  });
+
+  it("should throw a clear error when existing config.toml is malformed", async () => {
+    await ensureDir(join(testDir, ".codex"));
+    await writeFileContent(
+      join(testDir, ".codex", "config.toml"),
+      "this is not = valid = toml [[\n",
+    );
+
+    await expect(CodexcliConfigToml.fromBaseDir({ baseDir: testDir })).rejects.toThrow(
+      /Failed to parse existing Codex CLI config\.toml/,
+    );
+  });
+
   it("should set correct file paths", async () => {
     const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
     expect(configToml.getRelativeDirPath()).toBe(".codex");

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -1,20 +1,20 @@
 import { join } from "node:path";
 
 import * as smolToml from "smol-toml";
-import { z } from "zod/mini";
 
-import type { AiFileParams } from "../../types/ai-file.js";
-import type { ValidationResult } from "../../types/ai-file.js";
-import type { HooksConfig } from "../../types/hooks.js";
+import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import {
+  CANONICAL_TO_CODEXCLI_EVENT_NAMES,
   CODEXCLI_HOOK_EVENTS,
   CODEXCLI_TO_CANONICAL_EVENT_NAMES,
-  CANONICAL_TO_CODEXCLI_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { ToolFile } from "../../types/tool-file.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
+import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -24,107 +24,26 @@ import {
 } from "./tool-hooks.js";
 
 /**
- * Convert canonical hooks config to Codex CLI format.
- * Filters shared hooks to CODEXCLI_HOOK_EVENTS, merges config.codexcli?.hooks,
- * then converts to PascalCase and Codex CLI matcher/hooks structure.
- * Unlike Claude Code or Gemini CLI, Codex CLI has no project directory variable,
- * so commands are passed through as-is.
+ * Converter config for Codex CLI hooks.
+ *
+ * Differences from Claude/Factory Droid:
+ * - `projectDirVar: ""` — Codex CLI has no project directory variable, so commands are
+ *   passed through verbatim with no prefixing.
+ * - `supportedHookTypes: ["command"]` — Codex CLI only understands command-type hooks;
+ *   prompt-type hooks are filtered out on export. (See `ToolHooksConverterConfig` for the
+ *   intentional asymmetry with `toolHooksToCanonical`, which preserves prompt-type hooks
+ *   on import to avoid silent round-trip data loss.)
+ * - `omitEmptyEvents: true` — events whose entries become empty after filtering are
+ *   dropped entirely from the output, since Codex CLI's schema rejects empty event arrays.
  */
-function canonicalToCodexcliHooks(config: HooksConfig): Record<string, unknown[]> {
-  const codexSupported: Set<string> = new Set(CODEXCLI_HOOK_EVENTS);
-  const sharedHooks: HooksConfig["hooks"] = {};
-  for (const [event, defs] of Object.entries(config.hooks)) {
-    if (codexSupported.has(event)) {
-      sharedHooks[event] = defs;
-    }
-  }
-  const effectiveHooks: HooksConfig["hooks"] = {
-    ...sharedHooks,
-    ...config.codexcli?.hooks,
-  };
-  const codex: Record<string, unknown[]> = {};
-  for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const codexEventName = CANONICAL_TO_CODEXCLI_EVENT_NAMES[eventName] ?? eventName;
-    const byMatcher = new Map<string, HooksConfig["hooks"][string]>();
-    for (const def of definitions) {
-      const key = def.matcher ?? "";
-      const list = byMatcher.get(key);
-      if (list) list.push(def);
-      else byMatcher.set(key, [def]);
-    }
-    const entries: unknown[] = [];
-    for (const [matcherKey, defs] of byMatcher) {
-      const commandDefs = defs.filter((def) => !def.type || def.type === "command");
-      if (commandDefs.length === 0) continue;
-      const hooks = commandDefs.map((def) => ({
-        type: "command" as const,
-        ...(def.command !== undefined && def.command !== null && { command: def.command }),
-        ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
-      }));
-      entries.push(matcherKey ? { matcher: matcherKey, hooks } : { hooks });
-    }
-    if (entries.length > 0) {
-      codex[codexEventName] = entries;
-    }
-  }
-  return codex;
-}
-
-/**
- * Codex CLI hook entry as stored in each matcher group's `hooks` array.
- * Uses `z.looseObject` so that unknown fields added by future Codex CLI
- * versions are accepted and silently ignored during import.
- */
-const CodexHookEntrySchema = z.looseObject({
-  type: z.optional(z.string()),
-  command: z.optional(z.string()),
-  timeout: z.optional(z.number()),
-});
-
-/**
- * A matcher group entry in a Codex CLI event array.
- * Each event maps to an array of these groups.
- */
-const CodexMatcherEntrySchema = z.looseObject({
-  matcher: z.optional(z.string()),
-  hooks: z.optional(z.array(CodexHookEntrySchema)),
-});
-
-/**
- * Extract hooks from Codex CLI hooks.json into canonical format.
- */
-function codexcliHooksToCanonical(codexHooks: unknown): HooksConfig["hooks"] {
-  if (codexHooks === null || codexHooks === undefined || typeof codexHooks !== "object") {
-    return {};
-  }
-  const canonical: HooksConfig["hooks"] = {};
-  for (const [codexEventName, matcherEntries] of Object.entries(codexHooks)) {
-    const eventName = CODEXCLI_TO_CANONICAL_EVENT_NAMES[codexEventName] ?? codexEventName;
-    if (!Array.isArray(matcherEntries)) continue;
-    const defs: HooksConfig["hooks"][string] = [];
-    for (const rawEntry of matcherEntries) {
-      const parseResult = CodexMatcherEntrySchema.safeParse(rawEntry);
-      if (!parseResult.success) continue;
-      const entry = parseResult.data;
-      const hooks = entry.hooks ?? [];
-      for (const h of hooks) {
-        const hookType = h.type === "command" || h.type === "prompt" ? h.type : "command";
-        defs.push({
-          type: hookType,
-          ...(h.command !== undefined && h.command !== null && { command: h.command }),
-          ...(h.timeout !== undefined && h.timeout !== null && { timeout: h.timeout }),
-          ...(entry.matcher !== undefined &&
-            entry.matcher !== null &&
-            entry.matcher !== "" && { matcher: entry.matcher }),
-        });
-      }
-    }
-    if (defs.length > 0) {
-      canonical[eventName] = defs;
-    }
-  }
-  return canonical;
-}
+const CODEXCLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
+  supportedEvents: CODEXCLI_HOOK_EVENTS,
+  canonicalToToolEventNames: CANONICAL_TO_CODEXCLI_EVENT_NAMES,
+  toolToCanonicalEventNames: CODEXCLI_TO_CANONICAL_EVENT_NAMES,
+  projectDirVar: "",
+  supportedHookTypes: new Set(["command"]),
+  omitEmptyEvents: true,
+};
 
 /**
  * Build the content for `.codex/config.toml` with `[features] codex_hooks = true`.
@@ -134,7 +53,15 @@ function codexcliHooksToCanonical(codexHooks: unknown): HooksConfig["hooks"] {
 async function buildCodexConfigTomlContent({ baseDir }: { baseDir: string }): Promise<string> {
   const configPath = join(baseDir, ".codex", "config.toml");
   const existingContent = (await readFileContentOrNull(configPath)) ?? smolToml.stringify({});
-  const configToml = smolToml.parse(existingContent);
+  let configToml: smolToml.TomlTable;
+  try {
+    configToml = smolToml.parse(existingContent);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse existing Codex CLI config.toml at ${configPath}: ${formatError(error)}`,
+      { cause: error },
+    );
+  }
 
   if (typeof configToml.features !== "object" || configToml.features === null) {
     // eslint-disable-next-line no-type-assertion/no-type-assertion
@@ -178,6 +105,14 @@ export class CodexcliHooks extends ToolHooks {
     return { relativeDirPath: ".codex", relativeFilePath: "hooks.json" };
   }
 
+  /**
+   * Auxiliary files generated alongside `.codex/hooks.json`.
+   * The processor calls this generically so it does not need codexcli-specific branching.
+   */
+  static async getAuxiliaryFiles({ baseDir }: { baseDir: string }): Promise<ToolFile[]> {
+    return [await CodexcliConfigToml.fromBaseDir({ baseDir })];
+  }
+
   static async fromFile({
     baseDir = process.cwd(),
     validate = true,
@@ -200,10 +135,19 @@ export class CodexcliHooks extends ToolHooks {
     rulesyncHooks,
     validate = true,
     global = false,
-  }: ToolHooksFromRulesyncHooksParams & { global?: boolean }): Promise<CodexcliHooks> {
+    logger,
+  }: ToolHooksFromRulesyncHooksParams & {
+    global?: boolean;
+    logger?: Logger;
+  }): Promise<CodexcliHooks> {
     const paths = CodexcliHooks.getSettablePaths({ global });
     const config = rulesyncHooks.getJson();
-    const codexHooks = canonicalToCodexcliHooks(config);
+    const codexHooks = canonicalToToolHooks({
+      config,
+      toolOverrideHooks: config.codexcli?.hooks,
+      converterConfig: CODEXCLI_CONVERTER_CONFIG,
+      logger,
+    });
     const fileContent = JSON.stringify({ hooks: codexHooks }, null, 2);
 
     return new CodexcliHooks({
@@ -227,7 +171,10 @@ export class CodexcliHooks extends ToolHooks {
         },
       );
     }
-    const hooks = codexcliHooksToCanonical(parsed.hooks);
+    const hooks = toolHooksToCanonical({
+      hooks: parsed.hooks,
+      converterConfig: CODEXCLI_CONVERTER_CONFIG,
+    });
     return this.toRulesyncHooksDefault({
       fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
     });

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -11,7 +11,6 @@ import {
 import { ToolFile } from "../../types/tool-file.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
-import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
@@ -28,13 +27,18 @@ import {
  *
  * Differences from Claude/Factory Droid:
  * - `projectDirVar: ""` — Codex CLI has no project directory variable, so commands are
- *   passed through verbatim with no prefixing.
+ *   passed through verbatim with no prefixing. Note that this means a hand-edited
+ *   `.codex/hooks.json` containing other tools' variables (e.g. `$CLAUDE_PROJECT_DIR/foo.sh`)
+ *   will be imported into canonical form verbatim and re-exported as-is. Such cross-tool
+ *   variables are not interpreted by Codex CLI itself; rulesync simply does not rewrite them.
  * - `supportedHookTypes: ["command"]` — Codex CLI only understands command-type hooks;
  *   prompt-type hooks are filtered out on export. (See `ToolHooksConverterConfig` for the
  *   intentional asymmetry with `toolHooksToCanonical`, which preserves prompt-type hooks
  *   on import to avoid silent round-trip data loss.)
  * - `omitEmptyEvents: true` — events whose entries become empty after filtering are
  *   dropped entirely from the output, since Codex CLI's schema rejects empty event arrays.
+ * - `passthroughNameDescription: true` — Codex CLI's hook schema accepts `name` and
+ *   `description` metadata fields, so they are preserved across the conversion.
  */
 const CODEXCLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   supportedEvents: CODEXCLI_HOOK_EVENTS,
@@ -43,6 +47,7 @@ const CODEXCLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   projectDirVar: "",
   supportedHookTypes: new Set(["command"]),
   omitEmptyEvents: true,
+  passthroughNameDescription: true,
 };
 
 /**
@@ -138,7 +143,6 @@ export class CodexcliHooks extends ToolHooks {
     logger,
   }: ToolHooksFromRulesyncHooksParams & {
     global?: boolean;
-    logger?: Logger;
   }): Promise<CodexcliHooks> {
     const paths = CodexcliHooks.getSettablePaths({ global });
     const config = rulesyncHooks.getJson();

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -9,7 +9,6 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
@@ -69,7 +68,6 @@ export class FactorydroidHooks extends ToolHooks {
     logger,
   }: ToolHooksFromRulesyncHooksParams & {
     global?: boolean;
-    logger?: Logger;
   }): Promise<FactorydroidHooks> {
     const paths = FactorydroidHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);

--- a/src/features/hooks/geminicli-hooks.ts
+++ b/src/features/hooks/geminicli-hooks.ts
@@ -1,18 +1,17 @@
 import { join } from "node:path";
 
-import { z } from "zod/mini";
-
-import type { AiFileParams } from "../../types/ai-file.js";
-import type { ValidationResult } from "../../types/ai-file.js";
-import type { HooksConfig } from "../../types/hooks.js";
+import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import {
+  CANONICAL_TO_GEMINICLI_EVENT_NAMES,
   GEMINICLI_HOOK_EVENTS,
   GEMINICLI_TO_CANONICAL_EVENT_NAMES,
-  CANONICAL_TO_GEMINICLI_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
+import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -21,129 +20,13 @@ import {
   type ToolHooksSettablePaths,
 } from "./tool-hooks.js";
 
-/**
- * Convert canonical hooks config to Gemini CLI format.
- * Filters shared hooks to GEMINICLI_HOOK_EVENTS, merges config.geminicli?.hooks,
- * then converts to PascalCase and Gemini CLI matcher/hooks structure.
- */
-function canonicalToGeminicliHooks(config: HooksConfig): Record<string, unknown[]> {
-  const geminiSupported: Set<string> = new Set(GEMINICLI_HOOK_EVENTS);
-  const sharedHooks: HooksConfig["hooks"] = {};
-  for (const [event, defs] of Object.entries(config.hooks)) {
-    if (geminiSupported.has(event)) {
-      sharedHooks[event] = defs;
-    }
-  }
-  const effectiveHooks: HooksConfig["hooks"] = {
-    ...sharedHooks,
-    ...config.geminicli?.hooks,
-  };
-  const gemini: Record<string, unknown[]> = {};
-  for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const geminiEventName = CANONICAL_TO_GEMINICLI_EVENT_NAMES[eventName] ?? eventName;
-    const byMatcher = new Map<string, HooksConfig["hooks"][string]>();
-    for (const def of definitions) {
-      const key = def.matcher ?? "";
-      const list = byMatcher.get(key);
-      if (list) list.push(def);
-      else byMatcher.set(key, [def]);
-    }
-    const entries: unknown[] = [];
-    for (const [matcherKey, defs] of byMatcher) {
-      const hooks = defs.map((def) => {
-        const commandText = def.command;
-        const trimmedCommand =
-          typeof commandText === "string" ? commandText.trimStart() : undefined;
-        const shouldPrefix =
-          typeof trimmedCommand === "string" &&
-          !trimmedCommand.startsWith("$") &&
-          trimmedCommand.startsWith(".");
-
-        const command =
-          shouldPrefix && typeof trimmedCommand === "string"
-            ? `$GEMINI_PROJECT_DIR/${trimmedCommand.replace(/^\.\//, "")}`
-            : def.command;
-        return {
-          type: def.type ?? "command",
-          ...(command !== undefined && command !== null && { command }),
-          ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
-          ...(def.name !== undefined && def.name !== null && { name: def.name }),
-          ...(def.description !== undefined &&
-            def.description !== null && { description: def.description }),
-        };
-      });
-      entries.push(matcherKey ? { matcher: matcherKey, hooks } : { hooks });
-    }
-    gemini[geminiEventName] = entries;
-  }
-  return gemini;
-}
-
-/**
- * Gemini CLI hook entry as stored in each matcher group's `hooks` array.
- * Uses `z.looseObject` so that unknown fields added by future Gemini CLI
- * versions are accepted and silently ignored during import.
- */
-const GeminiHookEntrySchema = z.looseObject({
-  type: z.optional(z.string()),
-  command: z.optional(z.string()),
-  timeout: z.optional(z.number()),
-  name: z.optional(z.string()),
-  description: z.optional(z.string()),
-});
-
-/**
- * A matcher group entry in a Gemini CLI event array.
- * Each event maps to an array of these groups.
- */
-const GeminiMatcherEntrySchema = z.looseObject({
-  matcher: z.optional(z.string()),
-  hooks: z.optional(z.array(GeminiHookEntrySchema)),
-});
-
-/**
- * Extract hooks from Gemini CLI settings.json into canonical format.
- */
-function geminiHooksToCanonical(geminiHooks: unknown): HooksConfig["hooks"] {
-  if (geminiHooks === null || geminiHooks === undefined || typeof geminiHooks !== "object") {
-    return {};
-  }
-  const canonical: HooksConfig["hooks"] = {};
-  for (const [geminiEventName, matcherEntries] of Object.entries(geminiHooks)) {
-    const eventName = GEMINICLI_TO_CANONICAL_EVENT_NAMES[geminiEventName] ?? geminiEventName;
-    if (!Array.isArray(matcherEntries)) continue;
-    const defs: HooksConfig["hooks"][string] = [];
-    for (const rawEntry of matcherEntries) {
-      const parseResult = GeminiMatcherEntrySchema.safeParse(rawEntry);
-      if (!parseResult.success) continue;
-      const entry = parseResult.data;
-      const hooks = entry.hooks ?? [];
-      for (const h of hooks) {
-        const cmd = h.command;
-        const command =
-          typeof cmd === "string" && cmd.startsWith("$GEMINI_PROJECT_DIR/")
-            ? cmd.replace(/^\$GEMINI_PROJECT_DIR\/?/, "./")
-            : cmd;
-        const hookType = h.type === "command" || h.type === "prompt" ? h.type : "command";
-        defs.push({
-          type: hookType,
-          ...(command !== undefined && command !== null && { command }),
-          ...(h.timeout !== undefined && h.timeout !== null && { timeout: h.timeout }),
-          ...(h.name !== undefined && h.name !== null && { name: h.name }),
-          ...(h.description !== undefined &&
-            h.description !== null && { description: h.description }),
-          ...(entry.matcher !== undefined &&
-            entry.matcher !== null &&
-            entry.matcher !== "" && { matcher: entry.matcher }),
-        });
-      }
-    }
-    if (defs.length > 0) {
-      canonical[eventName] = defs;
-    }
-  }
-  return canonical;
-}
+const GEMINICLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
+  supportedEvents: GEMINICLI_HOOK_EVENTS,
+  canonicalToToolEventNames: CANONICAL_TO_GEMINICLI_EVENT_NAMES,
+  toolToCanonicalEventNames: GEMINICLI_TO_CANONICAL_EVENT_NAMES,
+  projectDirVar: "$GEMINI_PROJECT_DIR",
+  prefixDotRelativeCommandsOnly: true,
+};
 
 export class GeminicliHooks extends ToolHooks {
   constructor(params: AiFileParams) {
@@ -183,7 +66,11 @@ export class GeminicliHooks extends ToolHooks {
     rulesyncHooks,
     validate = true,
     global = false,
-  }: ToolHooksFromRulesyncHooksParams & { global?: boolean }): Promise<GeminicliHooks> {
+    logger,
+  }: ToolHooksFromRulesyncHooksParams & {
+    global?: boolean;
+    logger?: Logger;
+  }): Promise<GeminicliHooks> {
     const paths = GeminicliHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = await readOrInitializeFileContent(
@@ -200,7 +87,12 @@ export class GeminicliHooks extends ToolHooks {
       );
     }
     const config = rulesyncHooks.getJson();
-    const geminiHooks = canonicalToGeminicliHooks(config);
+    const geminiHooks = canonicalToToolHooks({
+      config,
+      toolOverrideHooks: config.geminicli?.hooks,
+      converterConfig: GEMINICLI_CONVERTER_CONFIG,
+      logger,
+    });
     const merged = { ...settings, hooks: geminiHooks };
     const fileContent = JSON.stringify(merged, null, 2);
     return new GeminicliHooks({
@@ -224,7 +116,10 @@ export class GeminicliHooks extends ToolHooks {
         },
       );
     }
-    const hooks = geminiHooksToCanonical(settings.hooks);
+    const hooks = toolHooksToCanonical({
+      hooks: settings.hooks,
+      converterConfig: GEMINICLI_CONVERTER_CONFIG,
+    });
     return this.toRulesyncHooksDefault({
       fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
     });

--- a/src/features/hooks/geminicli-hooks.ts
+++ b/src/features/hooks/geminicli-hooks.ts
@@ -8,7 +8,6 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
@@ -26,6 +25,7 @@ const GEMINICLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   toolToCanonicalEventNames: GEMINICLI_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "$GEMINI_PROJECT_DIR",
   prefixDotRelativeCommandsOnly: true,
+  passthroughNameDescription: true,
 };
 
 export class GeminicliHooks extends ToolHooks {
@@ -69,7 +69,6 @@ export class GeminicliHooks extends ToolHooks {
     logger,
   }: ToolHooksFromRulesyncHooksParams & {
     global?: boolean;
-    logger?: Logger;
   }): Promise<GeminicliHooks> {
     const paths = GeminicliHooks.getSettablePaths({ global });
     const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -21,7 +21,7 @@ import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
 import { ClaudecodeHooks } from "./claudecode-hooks.js";
-import { CodexcliConfigToml, CodexcliHooks } from "./codexcli-hooks.js";
+import { CodexcliHooks } from "./codexcli-hooks.js";
 import { CopilotHooks } from "./copilot-hooks.js";
 import { CursorHooks } from "./cursor-hooks.js";
 import { DeepagentsHooks } from "./deepagents-hooks.js";
@@ -65,6 +65,14 @@ type ToolHooksFactory = {
       relativeFilePath: string;
     };
     isDeletable?: (instance: ToolHooks) => boolean;
+    /**
+     * Optional hook for tools that need to emit auxiliary files alongside the
+     * main hooks file (e.g. Codex CLI's `.codex/config.toml` feature flag).
+     * Called once per `convertRulesyncFilesToToolFiles` invocation; the returned
+     * files are appended to the result so they are written through the normal
+     * write phase and respect dry-run mode.
+     */
+    getAuxiliaryFiles?: (params: { baseDir: string }) => Promise<ToolFile[]>;
   };
   meta: {
     supportsProject: boolean;
@@ -374,9 +382,9 @@ export class HooksProcessor extends FeatureProcessor {
 
     const result: ToolFile[] = [toolHooks];
 
-    // For codexcli, also generate .codex/config.toml with the feature flag
-    if (this.toolTarget === "codexcli") {
-      result.push(await CodexcliConfigToml.fromBaseDir({ baseDir: this.baseDir }));
+    if (factory.class.getAuxiliaryFiles) {
+      const auxiliaryFiles = await factory.class.getAuxiliaryFiles({ baseDir: this.baseDir });
+      result.push(...auxiliaryFiles);
     }
 
     return result;

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -378,6 +378,7 @@ export class HooksProcessor extends FeatureProcessor {
       rulesyncHooks,
       validate: true,
       global: this.global,
+      logger: this.logger,
     });
 
     const result: ToolFile[] = [toolHooks];

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -56,6 +56,14 @@ export type ToolHooksConverterConfig = {
    * config schema rejects empty event arrays.
    */
   omitEmptyEvents?: boolean;
+  /**
+   * If true, the canonical `name` and `description` fields are passed through in both
+   * directions. Disabled by default so tools whose schemas do not recognize these fields
+   * (e.g. Claude Code, Factory Droid) do not emit unknown keys into their config files.
+   * Currently enabled for tools whose schemas natively support these fields (e.g. Gemini
+   * CLI, Codex CLI).
+   */
+  passthroughNameDescription?: boolean;
 };
 
 /**
@@ -110,6 +118,7 @@ export function canonicalToToolHooks({
         ? defs.filter((def) => hookTypeFilter.has(def.type ?? "command"))
         : defs;
       if (filteredDefs.length === 0) continue;
+      const passthroughNameDescription = converterConfig.passthroughNameDescription ?? false;
       const hooks = filteredDefs.map((def) => {
         const commandText = def.command;
         const trimmedCommand =
@@ -129,8 +138,11 @@ export function canonicalToToolHooks({
           ...(command !== undefined && command !== null && { command }),
           ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
           ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
-          ...(def.name !== undefined && def.name !== null && { name: def.name }),
-          ...(def.description !== undefined &&
+          ...(passthroughNameDescription &&
+            def.name !== undefined &&
+            def.name !== null && { name: def.name }),
+          ...(passthroughNameDescription &&
+            def.description !== undefined &&
             def.description !== null && { description: def.description }),
         };
       });
@@ -166,6 +178,7 @@ export function toolHooksToCanonical({
   for (const [toolEventName, matcherEntries] of Object.entries(hooks)) {
     const eventName = converterConfig.toolToCanonicalEventNames[toolEventName] ?? toolEventName;
     if (!Array.isArray(matcherEntries)) continue;
+    const passthroughNameDescription = converterConfig.passthroughNameDescription ?? false;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of matcherEntries) {
       if (!isToolMatcherEntry(rawEntry)) continue;
@@ -187,8 +200,11 @@ export function toolHooksToCanonical({
         const hookType = h.type === "command" || h.type === "prompt" ? h.type : "command";
         const timeout = typeof h.timeout === "number" ? h.timeout : undefined;
         const prompt = typeof h.prompt === "string" ? h.prompt : undefined;
-        const name = typeof h.name === "string" ? h.name : undefined;
-        const description = typeof h.description === "string" ? h.description : undefined;
+        const name = passthroughNameDescription && typeof h.name === "string" ? h.name : undefined;
+        const description =
+          passthroughNameDescription && typeof h.description === "string"
+            ? h.description
+            : undefined;
         defs.push({
           type: hookType,
           ...(command !== undefined && command !== null && { command }),

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -23,6 +23,11 @@ export type ToolHooksConverterConfig = {
   supportedEvents: readonly HookEvent[];
   canonicalToToolEventNames: Record<string, string>;
   toolToCanonicalEventNames: Record<string, string>;
+  /**
+   * Variable name (e.g. `$CLAUDE_PROJECT_DIR`) used to prefix dot-relative commands so the
+   * tool can resolve them relative to the project root. Set to an empty string to disable
+   * prefixing entirely (e.g. for tools like Codex CLI that have no such variable).
+   */
   projectDirVar: string;
   /**
    * When true, only dot-relative commands (e.g. ./script.sh, ../script.sh, .rulesync/hooks/x.sh)
@@ -34,6 +39,23 @@ export type ToolHooksConverterConfig = {
    * will be silently dropped with a warning during export.
    */
   noMatcherEvents?: ReadonlySet<string>;
+  /**
+   * If specified, hooks whose `type` is not in this set are silently filtered out on
+   * export. Used by tools that only accept a subset of canonical hook types (e.g. Codex CLI
+   * only supports `command`).
+   *
+   * Note: the inverse direction (`toolHooksToCanonical`) intentionally does NOT enforce
+   * this filter — silently dropping data on import causes round-trip data loss. Such hooks
+   * are preserved in canonical form and only filtered on the next export, where the
+   * `hooks-processor.ts` warning makes the loss visible to the user.
+   */
+  supportedHookTypes?: ReadonlySet<string>;
+  /**
+   * If true, events whose entries become empty after type filtering are omitted from the
+   * output entirely (rather than emitted as an empty array). Required by tools whose
+   * config schema rejects empty event arrays.
+   */
+  omitEmptyEvents?: boolean;
 };
 
 /**
@@ -76,17 +98,24 @@ export function canonicalToToolHooks({
     }
     const entries: unknown[] = [];
     const isNoMatcherEvent = converterConfig.noMatcherEvents?.has(eventName) ?? false;
+    const hookTypeFilter = converterConfig.supportedHookTypes;
+    const prefixingEnabled = converterConfig.projectDirVar !== "";
     for (const [matcherKey, defs] of byMatcher) {
       if (isNoMatcherEvent && matcherKey) {
         logger?.warn(
           `matcher "${matcherKey}" on "${eventName}" hook will be ignored — this event does not support matchers`,
         );
       }
-      const hooks = defs.map((def) => {
+      const filteredDefs = hookTypeFilter
+        ? defs.filter((def) => hookTypeFilter.has(def.type ?? "command"))
+        : defs;
+      if (filteredDefs.length === 0) continue;
+      const hooks = filteredDefs.map((def) => {
         const commandText = def.command;
         const trimmedCommand =
           typeof commandText === "string" ? commandText.trimStart() : undefined;
         const shouldPrefix =
+          prefixingEnabled &&
           typeof trimmedCommand === "string" &&
           !trimmedCommand.startsWith("$") &&
           (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
@@ -100,11 +129,15 @@ export function canonicalToToolHooks({
           ...(command !== undefined && command !== null && { command }),
           ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
           ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
+          ...(def.name !== undefined && def.name !== null && { name: def.name }),
+          ...(def.description !== undefined &&
+            def.description !== null && { description: def.description }),
         };
       });
       const includeMatcher = matcherKey && !isNoMatcherEvent;
       entries.push(includeMatcher ? { matcher: matcherKey, hooks } : { hooks });
     }
+    if (entries.length === 0 && converterConfig.omitEmptyEvents) continue;
     result[toolEventName] = entries;
   }
   return result;
@@ -139,8 +172,11 @@ export function toolHooksToCanonical({
       const hookDefs = rawEntry.hooks ?? [];
       for (const h of hookDefs) {
         const cmd = typeof h.command === "string" ? h.command : undefined;
+        const prefixingEnabled = converterConfig.projectDirVar !== "";
         const command =
-          typeof cmd === "string" && cmd.includes(`${converterConfig.projectDirVar}/`)
+          prefixingEnabled &&
+          typeof cmd === "string" &&
+          cmd.includes(`${converterConfig.projectDirVar}/`)
             ? cmd.replace(
                 new RegExp(
                   `^${converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/?`,
@@ -151,11 +187,15 @@ export function toolHooksToCanonical({
         const hookType = h.type === "command" || h.type === "prompt" ? h.type : "command";
         const timeout = typeof h.timeout === "number" ? h.timeout : undefined;
         const prompt = typeof h.prompt === "string" ? h.prompt : undefined;
+        const name = typeof h.name === "string" ? h.name : undefined;
+        const description = typeof h.description === "string" ? h.description : undefined;
         defs.push({
           type: hookType,
           ...(command !== undefined && command !== null && { command }),
           ...(timeout !== undefined && timeout !== null && { timeout }),
           ...(prompt !== undefined && prompt !== null && { prompt }),
+          ...(name !== undefined && name !== null && { name }),
+          ...(description !== undefined && description !== null && { description }),
           ...(rawEntry.matcher !== undefined &&
             rawEntry.matcher !== null &&
             rawEntry.matcher !== "" && { matcher: rawEntry.matcher }),

--- a/src/features/hooks/tool-hooks.ts
+++ b/src/features/hooks/tool-hooks.ts
@@ -11,6 +11,7 @@ export type ToolHooksFromRulesyncHooksParams = Omit<
   "fileContent" | "relativeFilePath" | "relativeDirPath"
 > & {
   rulesyncHooks: RulesyncHooks;
+  logger?: Logger;
 };
 
 export type ToolHooksFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate" | "global">;


### PR DESCRIPTION
## Summary

Addresses the code-quality follow-ups from #1445 (review of #1439).

- **DRY**: `codexcli-hooks.ts` and `geminicli-hooks.ts` now delegate to the shared `canonicalToToolHooks` / `toolHooksToCanonical` helpers in `tool-hooks-converter.ts` instead of reimplementing the conversion logic. `ToolHooksConverterConfig` gained `supportedHookTypes`, `omitEmptyEvents`, and empty-`projectDirVar` support to express the Codex CLI quirks (command-only hooks, no project dir variable, drop empty events). The shared converter also now passes `name`/`description` through in both directions, fixing the silent drop on Codex CLI export.
- **OCP**: removed the `if (toolTarget === 'codexcli')` branch in `hooks-processor.ts`. Tools that need extra files now expose an optional static `getAuxiliaryFiles({ baseDir })`, and `CodexcliHooks` implements it to emit `.codex/config.toml`.
- **Error handling**: wrapped `smolToml.parse()` in `buildCodexConfigTomlContent` with `try`/`catch` and `formatError`, so a malformed `config.toml` produces a clear error mentioning the path.
- **Round-trip safety**: `toolHooksToCanonical` intentionally still preserves `prompt`-type hooks on import even for Codex CLI; the asymmetry is now documented in the converter config so the next export silently filters them (with the existing `hooks-processor` warning making the loss visible).
- **Cleanup**: consolidated the duplicate `AiFileParams` / `ValidationResult` import lines.
- **Tests**: added coverage for the `[features]` section merge in `CodexcliConfigToml` and for the malformed-TOML error path.

## Test plan

- [x] `pnpm cicheck` (lint, typecheck, 4774 tests, content checks) — all green