### PR TITLE
add skill-review CI for skill.md PRs

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,24 @@
+name: Skill Apply Optimize
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  skill-apply-optimize:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+
+      - uses: tessl-lab/skill-apply-optimize-action@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          tessl_api_token: ${{ secrets.TESSL_API_TOKEN }}

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,19 @@
+name: Skill Review
+
+on:
+  pull_request:
+    paths:
+      - "skills/**/skill.md"
+      - "**/skill.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  skill-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: tessl-lab/skill-review-action@d81583861aaf29d1da7f10e6539efef4e27b0dd5


### PR DESCRIPTION
hey @dyoshikawa, glad you found #1435 useful! adding two small workflow files that run the same evals I used for the improvements:

- `skill-review.yml` auto-posts a score on PRs touching skill.md files (read-only, `contents: read` + `pull-requests: write` for the comment - no signup, no tokens needed)
- `skill-apply-optimize.yml` lets you accept suggestions by commenting `/apply-optimize` (opt-in, needs a free token from tessl.io/account/api-keys as `TESSL_API_TOKEN` in repo secrets)

## how it fits with your existing CI

| workflow | trigger | what it does |
|----------|---------|-------------|
| Actionlint | push/PR to main (.github/workflows/**) | lints GitHub Actions workflow files |
| CI | push/PR to main | code quality checks, tests, and build |
| Deploy Docs | push to main (docs/**) | deploys documentation site |
| Draft Release | workflow_dispatch | creates draft releases |
| E2E Tests on Cross-Platform | push/PR to main | runs end-to-end tests on multiple platforms |
| PR Policy | pull_request_target (opened) | enforces external contributor policy |
| Publish Assets | PR closed to main / workflow_dispatch | builds and uploads release assets |
| Publish | after Publish Assets completes | publishes to NPM |
| Security Scan | weekly schedule / manual | security scanning with OpenRouter |
| Trivy Security Scan | push/PR (.devcontainer, workflows, .trivyignore) | container and config security scanning |
| **skill-review.yml** (new) | PR touching skill.md | posts eval score comment |
| **skill-apply-optimize.yml** (new) | `/apply-optimize` comment | applies optimization suggestions |

no overlap - the new workflows only trigger on skill.md changes or the `/apply-optimize` comment, while your existing CI covers code quality, testing, releases, and security. both action refs are SHA-pinned and you can inspect everything in `.github/workflows/` before approving runs.

this means you and your contributors get an instant quality signal + improvement suggestions before you review.