### PR TITLE
fix: keep .rulesync/.aiignore exception effective in gitignore

### DIFF
--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -31,7 +31,6 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   },
   { target: "common", feature: "general", entry: ".rulesync/rules/*.local.md" },
   { target: "common", feature: "general", entry: "rulesync.local.jsonc" },
-  { target: "common", feature: "general", entry: "!.rulesync/.aiignore" },
   // AGENTS.local.md is placed in common scope (not rovodev-only) so that
   // local rule files are always gitignored regardless of which targets are enabled.
   // This prevents accidental commits when a user disables the rovodev target.
@@ -178,6 +177,8 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "kiro", feature: "subagents", entry: "**/.kiro/agents/" },
   { target: "kiro", feature: "mcp", entry: "**/.kiro/settings/mcp.json" },
   { target: "kiro", feature: "ignore", entry: "**/.aiignore" },
+  // Keep this after ignore entries like "**/.aiignore" so the exception remains effective.
+  { target: "common", feature: "general", entry: "!.rulesync/.aiignore" },
 
   // OpenCode
   { target: "opencode", feature: "commands", entry: "**/.opencode/command/" },

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -92,6 +92,18 @@ describe("gitignoreCommand", () => {
       expect(content).not.toContain("**/.agent/skills/");
     });
 
+    it("should place .rulesync/.aiignore exception after .aiignore ignore entries", async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+
+      await gitignoreCommand(mockLogger);
+
+      const writeCall = vi.mocked(writeFileContent).mock.calls[0];
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1];
+
+      expect(content.indexOf("**/.aiignore")).toBeLessThan(content.indexOf("!.rulesync/.aiignore"));
+    });
+
     it("should format content properly with newline at end", async () => {
       vi.mocked(fileExists).mockResolvedValue(false);
 


### PR DESCRIPTION
### Motivation
- Fix a bug where the negation entry `!.rulesync/.aiignore` was placed before broad `**/.aiignore` ignore rules, causing the exception to be ineffective in generated `.gitignore`.
- Add a regression check to ensure the exception ordering is preserved so `.rulesync/.aiignore` is not accidentally ignored.

### Description
- Moved the `!.rulesync/.aiignore` entry in `GITIGNORE_ENTRY_REGISTRY` so it appears after ignore entries such as `**/.aiignore` and added an explanatory comment.
- Added a unit test to `src/cli/commands/gitignore.test.ts` that asserts the generated `.gitignore` places `**/.aiignore` before `!.rulesync/.aiignore`.
- Updated `src/cli/commands/gitignore-entries.ts` and the corresponding test to reflect the new ordering.

### Testing
- Ran `pnpm vitest run src/cli/commands/gitignore.test.ts src/cli/commands/gitignore-entries.test.ts` and the two test files passed (all assertions succeeded).
- Ran full CI checks with `pnpm cicheck` which completed successfully including formatting, linting, typecheck, the full test suite (all tests passed), and content checks (`cspell` and `secretlint`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8b409f648330a2337e8962c10e93)