### PR TITLE
Add rule to preserve Tool × Feature E2E happy-path tests

### DIFF
--- a/.rulesync/rules/feature-change-guidelines.md
+++ b/.rulesync/rules/feature-change-guidelines.md
@@ -11,3 +11,4 @@ description: "When you add or change features, must follow these guidelines."
 - Evaluate whether `gitignore.ts` needs additions or changes in its generated output. And `pnpm dev gitignore` should be run to update `.gitignore` in the project.
 - Consider project scope and global scope support. Simulated support should cover project scope only. For native support, implement both project and global scope when the target tool supports them. Consult the tool’s official documentation to decide scope support.
 - Keep `Supported Tools and Features` section and `Each File Format` section in `README.md` and `docs/**/*.md` synchronized with the implemented functionality.
+- Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.

--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -32,3 +32,4 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.
   - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
 - The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.
+- Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.


### PR DESCRIPTION
### Motivation
- Ensure that end-to-end happy-path test cases covering the Tool × Feature matrix are never removed so that tool/feature coverage remains validated by e2e tests.

### Description
- Added the requirement line to `.rulesync/rules/feature-change-guidelines.md` and to `.rulesync/rules/overview.md` to document that Tool × Feature e2e happy-path test cases must always be preserved; no application code was changed.

### Testing
- Ran `pnpm cicheck` after making the updates (temporary cache artifacts were removed during iteration) and all checks (format, lint, typecheck, unit tests, `cspell`, and `secretlint`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db91b55d5c833091e1bd342cb1102e)