### PR TITLE
docs: PR説明に関連Issueリンクを含める旨を追加

### DIFF
--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -25,6 +25,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - You must run `pnpm cicheck` before committing to verify quality.
   - You must not use here documents because it causes a sandbox error.
   - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.
+  - When creating a PR, you should include a link in the PR description that associates the PR with its issue.
 - When you read or search the codebase:
   - You should check Serena MCP server tools, and use those actively.
 - About the `skills/` directory at the repository root:


### PR DESCRIPTION
### Motivation
- PR作成時にIssueとの紐付けを明確化して変更の追跡性を高めるため、開発ガイドに案内を追加しました。

### Description
- `.rulesync/rules/overview.md` の `When doing `git commit`` セクションに、PR作成時はPR descriptionに関連Issueへのリンクを含める旨の一行を追加しました。

### Testing
- 実行した自動チェックは `pnpm cicheck`（内部で `pnpm run test` を含む）で、最初に `cspell` が一時生成物の影響で失敗したものの一時生成物を削除して再実行した結果、全てのチェックを通過し、テストは `4845` 件すべて成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9c0808188330bc8d8a9106923ee4)