### PR TITLE
Include E2E spec glob in testing-guidelines rule

### DIFF
--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -2,7 +2,7 @@
 root: false
 targets: ["*"]
 description: "When you write tests, must follow these guidelines."
-globs: ["**/*.test.ts"]
+globs: ["**/*.test.ts", "src/e2e/**/*.spec.ts"]
 ---
 
 # Testing Guidelines


### PR DESCRIPTION
### Motivation
- Ensure the testing guidelines also apply to end-to-end spec files under `src/e2e/**/*.spec.ts` so E2E tests follow the same conventions as unit tests.

### Description
- Update frontmatter in `.rulesync/rules/testing-guidelines.md` to add `src/e2e/**/*.spec.ts` to the `globs` list alongside the existing `**/*.test.ts` pattern.

### Testing
- Ran `pnpm cicheck`, which runs format checks, linters, type checks, `vitest` tests, `cspell`, and `secretlint`, and all checks passed; `vitest` reported `180` test files and `4845` tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9b7cd2388330a7f1793946dc0fe6)