### PR TITLE
Add Codex CLI permissions support (generate/import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
-| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
+| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
 | Goose               | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |             |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -384,4 +384,10 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
+For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). Current Rulesync-to-Codex mapping supports `read`, `edit`/`write`, and `webfetch` categories:
+
+- `read`: `allow` → `read`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -7,7 +7,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
-| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
+| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI  | copilotcli   | ✅ 🌏 |        |  ✅ 🌏   |          |           |        |       |             |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -384,4 +384,10 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
+For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). Current Rulesync-to-Codex mapping supports `read`, `edit`/`write`, and `webfetch` categories:
+
+- `read`: `allow` → `read`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -7,7 +7,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
-| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
+| Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI  | copilotcli   | ✅ 🌏 |        |  ✅ 🌏   |          |           |        |       |             |

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import * as smolToml from "smol-toml";
 import { describe, expect, it } from "vitest";
 
 import { RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
@@ -37,6 +38,39 @@ describe("E2E: permissions", () => {
     expect(content.permission.bash["git *"]).toBe("allow");
     expect(content.permission.read[".env"]).toBe("deny");
   });
+
+  it("should generate codexcli permissions into .codex/config.toml", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            read: { "/workspace/project/**": "allow", "/workspace/project/.env": "deny" },
+            write: { "/workspace/project/src/**": "allow" },
+            webfetch: { "github.com": "allow", "example.com": "deny" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({ target: "codexcli", features: "permissions" });
+
+    const parsed = smolToml.parse(await readFileContent(join(testDir, ".codex", "config.toml")));
+    const table = toTable(parsed);
+    expect(table.default_permissions).toBe("rulesync");
+    const permissions = toTable(table.permissions);
+    const rulesyncProfile = toTable(permissions.rulesync);
+    const filesystem = toTable(rulesyncProfile.filesystem);
+    const network = toTable(rulesyncProfile.network);
+    const domains = toTable(network.domains);
+    expect(filesystem["/workspace/project/**"]).toBe("read");
+    expect(filesystem["/workspace/project/src/**"]).toBe("write");
+    expect(domains["github.com"]).toBe("allow");
+  });
 });
 
 describe("E2E: permissions (import)", () => {
@@ -66,6 +100,37 @@ describe("E2E: permissions (import)", () => {
     );
     expect(content.permission.bash["npm *"]).toBe("allow");
     expect(content.permission.read[".env"]).toBe("deny");
+  });
+
+  it("should import codexcli permissions into .rulesync/permissions.json", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, ".codex", "config.toml"),
+      `
+default_permissions = "rulesync"
+
+[permissions.rulesync.filesystem]
+"/workspace/project/**" = "read"
+"/workspace/project/src/**" = "write"
+"/workspace/project/.env" = "none"
+
+[permissions.rulesync.network.domains]
+"github.com" = "allow"
+"example.com" = "deny"
+`,
+    );
+
+    await runImport({ target: "codexcli", features: "permissions" });
+
+    const content = JSON.parse(
+      await readFileContent(join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH)),
+    );
+    expect(content.permission.read["/workspace/project/**"]).toBe("allow");
+    expect(content.permission.edit["/workspace/project/src/**"]).toBe("allow");
+    expect(content.permission.read["/workspace/project/.env"]).toBe("deny");
+    expect(content.permission.webfetch["github.com"]).toBe("allow");
+    expect(content.permission.webfetch["example.com"]).toBe("deny");
   });
 });
 
@@ -102,4 +167,48 @@ describe("E2E: permissions (global mode)", () => {
     );
     expect(generated.permission.bash["git status *"]).toBe("allow");
   });
+
+  it("should generate codexcli permissions in home directory with --global", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+
+    await writeFileContent(
+      join(projectDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            read: { "/workspace/project/**": "allow" },
+            webfetch: { "github.com": "allow" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({
+      target: "codexcli",
+      features: "permissions",
+      global: true,
+      env: { HOME_DIR: homeDir },
+    });
+
+    const parsed = smolToml.parse(await readFileContent(join(homeDir, ".codex", "config.toml")));
+    const table = toTable(parsed);
+    expect(table.default_permissions).toBe("rulesync");
+    const permissions = toTable(table.permissions);
+    const rulesyncProfile = toTable(permissions.rulesync);
+    const filesystem = toTable(rulesyncProfile.filesystem);
+    const network = toTable(rulesyncProfile.network);
+    const domains = toTable(network.domains);
+    expect(filesystem["/workspace/project/**"]).toBe("read");
+    expect(domains["github.com"]).toBe("allow");
+  });
 });
+
+function toTable(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return { ...value };
+  }
+  return {};
+}

--- a/src/features/permissions/codexcli-permissions.test.ts
+++ b/src/features/permissions/codexcli-permissions.test.ts
@@ -1,0 +1,95 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { CodexcliPermissions } from "./codexcli-permissions.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+
+describe("CodexcliPermissions", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should convert rulesync permissions to Codex CLI config.toml profile", async () => {
+    const logger = createMockLogger();
+    const rulesyncPermissions = new RulesyncPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".rulesync",
+      relativeFilePath: "permissions.json",
+      fileContent: JSON.stringify({
+        permission: {
+          read: { "/workspace/project/**": "allow", "/workspace/project/.env": "deny" },
+          write: { "/workspace/project/src/**": "allow" },
+          webfetch: { "github.com": "allow", "example.com": "deny" },
+        },
+      }),
+    });
+
+    const codexPermissions = await CodexcliPermissions.fromRulesyncPermissions({
+      baseDir: testDir,
+      rulesyncPermissions,
+      logger,
+    });
+
+    const fileContent = codexPermissions.getFileContent();
+    expect(fileContent).toContain('default_permissions = "rulesync"');
+    expect(fileContent).toContain("[permissions.rulesync.filesystem]");
+    expect(fileContent).toContain('"/workspace/project/**" = "read"');
+    expect(fileContent).toContain('"/workspace/project/.env" = "none"');
+    expect(fileContent).toContain('"/workspace/project/src/**" = "write"');
+    expect(fileContent).toContain("[permissions.rulesync.network.domains]");
+    expect(fileContent).toContain('"github.com" = "allow"');
+    expect(fileContent).toContain('"example.com" = "deny"');
+  });
+
+  it("should convert Codex CLI permissions profile to rulesync format", () => {
+    const codexPermissions = new CodexcliPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".codex",
+      relativeFilePath: "config.toml",
+      fileContent: `
+default_permissions = "rulesync"
+
+[permissions.rulesync.filesystem]
+"/workspace/project/**" = "read"
+"/workspace/project/src/**" = "write"
+"/workspace/project/.env" = "none"
+
+[permissions.rulesync.network.domains]
+"github.com" = "allow"
+"example.com" = "deny"
+`,
+    });
+
+    const rulesyncPermissions = codexPermissions.toRulesyncPermissions();
+    const json = rulesyncPermissions.getJson();
+
+    expect(json.permission.read?.["/workspace/project/**"]).toBe("allow");
+    expect(json.permission.edit?.["/workspace/project/src/**"]).toBe("allow");
+    expect(json.permission.read?.["/workspace/project/.env"]).toBe("deny");
+    expect(json.permission.webfetch?.["github.com"]).toBe("allow");
+    expect(json.permission.webfetch?.["example.com"]).toBe("deny");
+  });
+
+  it("should load existing .codex/config.toml", async () => {
+    const codexDir = join(testDir, ".codex");
+    await ensureDir(codexDir);
+    await writeFileContent(join(codexDir, "config.toml"), 'default_permissions = "rulesync"');
+
+    const loaded = await CodexcliPermissions.fromFile({ baseDir: testDir });
+    expect(loaded).toBeInstanceOf(CodexcliPermissions);
+    expect(loaded.getFileContent()).toContain('default_permissions = "rulesync"');
+  });
+});

--- a/src/features/permissions/codexcli-permissions.ts
+++ b/src/features/permissions/codexcli-permissions.ts
@@ -1,0 +1,260 @@
+import { join } from "node:path";
+
+import * as smolToml from "smol-toml";
+
+import type { ValidationResult } from "../../types/ai-file.js";
+import type { PermissionAction, PermissionsConfig } from "../../types/permissions.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+import {
+  ToolPermissions,
+  type ToolPermissionsForDeletionParams,
+  type ToolPermissionsFromFileParams,
+  type ToolPermissionsFromRulesyncPermissionsParams,
+  type ToolPermissionsSettablePaths,
+} from "./tool-permissions.js";
+
+const RULESYNC_PROFILE_NAME = "rulesync";
+
+type CodexPermissionProfile = {
+  filesystem?: Record<string, "read" | "write" | "none">;
+  network?: {
+    domains?: Record<string, "allow" | "deny">;
+  };
+};
+type UnknownTable = Record<string, unknown>;
+
+export class CodexcliPermissions extends ToolPermissions {
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolPermissionsSettablePaths {
+    return {
+      relativeDirPath: ".codex",
+      relativeFilePath: "config.toml",
+    };
+  }
+
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolPermissionsFromFileParams): Promise<CodexcliPermissions> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? smolToml.stringify({});
+
+    return new CodexcliPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncPermissions({
+    baseDir = process.cwd(),
+    rulesyncPermissions,
+    validate = true,
+    logger,
+    global = false,
+  }: ToolPermissionsFromRulesyncPermissionsParams): Promise<CodexcliPermissions> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = (await readFileContentOrNull(filePath)) ?? smolToml.stringify({});
+    const parsed = toMutableTable(smolToml.parse(existingContent));
+
+    const profile = convertRulesyncToCodexProfile({
+      config: rulesyncPermissions.getJson(),
+      logger,
+    });
+
+    const permissionsTable = toMutableTable(parsed.permissions);
+    permissionsTable[RULESYNC_PROFILE_NAME] = profile;
+    parsed.permissions = permissionsTable;
+    parsed.default_permissions = RULESYNC_PROFILE_NAME;
+
+    return new CodexcliPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: smolToml.stringify(parsed),
+      validate,
+    });
+  }
+
+  toRulesyncPermissions(): RulesyncPermissions {
+    let parsed: unknown;
+    try {
+      parsed = smolToml.parse(this.getFileContent());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Codex CLI permissions content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+
+    const table = toMutableTable(parsed);
+    const defaultProfile =
+      typeof table.default_permissions === "string" ? table.default_permissions : undefined;
+    const permissionsTable = toMutableTable(table.permissions);
+
+    const profile =
+      toCodexProfile(permissionsTable[defaultProfile ?? RULESYNC_PROFILE_NAME]) ??
+      toCodexProfile(permissionsTable[RULESYNC_PROFILE_NAME]);
+
+    const config = convertCodexProfileToRulesync(profile);
+
+    return this.toRulesyncPermissionsDefault({
+      fileContent: JSON.stringify(config, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolPermissionsForDeletionParams): CodexcliPermissions {
+    return new CodexcliPermissions({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: smolToml.stringify({}),
+      validate: false,
+    });
+  }
+}
+
+function convertRulesyncToCodexProfile({
+  config,
+  logger,
+}: {
+  config: PermissionsConfig;
+  logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
+}): CodexPermissionProfile {
+  const filesystem: Record<string, "read" | "write" | "none"> = {};
+  const domains: Record<string, "allow" | "deny"> = {};
+
+  for (const [toolName, rules] of Object.entries(config.permission)) {
+    if (toolName === "read") {
+      for (const [pattern, action] of Object.entries(rules)) {
+        filesystem[pattern] = mapReadAction(action);
+      }
+      continue;
+    }
+
+    if (toolName === "edit" || toolName === "write") {
+      for (const [pattern, action] of Object.entries(rules)) {
+        filesystem[pattern] = mapWriteAction(action);
+      }
+      continue;
+    }
+
+    if (toolName === "webfetch") {
+      for (const [pattern, action] of Object.entries(rules)) {
+        if (action === "ask") {
+          logger?.warn(
+            `Codex CLI does not support "ask" for network domain permissions. Skipping webfetch rule: ${pattern}`,
+          );
+          continue;
+        }
+        domains[pattern] = action;
+      }
+      continue;
+    }
+
+    logger?.warn(
+      `Codex CLI permissions support only read/edit/write/webfetch categories. Skipping: ${toolName}`,
+    );
+  }
+
+  return {
+    ...(Object.keys(filesystem).length > 0 ? { filesystem } : {}),
+    ...(Object.keys(domains).length > 0 ? { network: { domains } } : {}),
+  };
+}
+
+function convertCodexProfileToRulesync(profile?: CodexPermissionProfile): PermissionsConfig {
+  const permission: PermissionsConfig["permission"] = {};
+
+  if (profile?.filesystem) {
+    permission.read = {};
+    permission.edit = {};
+    for (const [pattern, access] of Object.entries(profile.filesystem)) {
+      if (access === "none") {
+        permission.read[pattern] = "deny";
+        permission.edit[pattern] = "deny";
+      } else if (access === "read") {
+        permission.read[pattern] = "allow";
+      } else {
+        permission.edit[pattern] = "allow";
+      }
+    }
+  }
+
+  if (profile?.network?.domains) {
+    permission.webfetch = {};
+    for (const [domain, value] of Object.entries(profile.network.domains)) {
+      permission.webfetch[domain] = value;
+    }
+  }
+
+  return { permission };
+}
+
+function toCodexProfile(value: unknown): CodexPermissionProfile | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const table = toMutableTable(value);
+  const filesystem = toFilesystemRecord(table.filesystem);
+  const networkRaw = toMutableTable(table.network);
+  const domains = toDomainRecord(networkRaw.domains);
+  return {
+    ...(filesystem ? { filesystem } : {}),
+    ...(domains ? { network: { domains } } : {}),
+  };
+}
+
+function toMutableTable(value: unknown): UnknownTable {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return { ...value };
+}
+
+function toFilesystemRecord(value: unknown): Record<string, "read" | "write" | "none"> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: Record<string, "read" | "write" | "none"> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw !== "string") continue;
+    if (raw === "read" || raw === "write" || raw === "none") {
+      result[key] = raw;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function toDomainRecord(value: unknown): Record<string, "allow" | "deny"> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: Record<string, "allow" | "deny"> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (raw === "allow" || raw === "deny") {
+      result[key] = raw;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function mapReadAction(action: PermissionAction): "read" | "none" {
+  return action === "allow" ? "read" : "none";
+}
+
+function mapWriteAction(action: PermissionAction): "write" | "none" {
+  return action === "allow" ? "write" : "none";
+}

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -10,6 +10,7 @@ import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, readFileContent, writeFileContent } from "../../utils/file.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
+import { CodexcliPermissions } from "./codexcli-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { PermissionsProcessor } from "./permissions-processor.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -69,19 +70,19 @@ describe("PermissionsProcessor", () => {
   });
 
   describe("getToolTargets", () => {
-    it("should return claudecode and opencode for project mode", () => {
+    it("should return claudecode, codexcli and opencode for project mode", () => {
       const targets = PermissionsProcessor.getToolTargets();
-      expect(targets).toEqual(["claudecode", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "opencode"]);
     });
 
-    it("should return opencode for global mode", () => {
+    it("should return codexcli and opencode for global mode", () => {
       const targets = PermissionsProcessor.getToolTargets({ global: true });
-      expect(targets).toEqual(["opencode"]);
+      expect(targets).toEqual(["codexcli", "opencode"]);
     });
 
     it("should return importable targets", () => {
       const targets = PermissionsProcessor.getToolTargets({ importOnly: true });
-      expect(targets).toEqual(["claudecode", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "opencode"]);
     });
   });
 
@@ -181,6 +182,31 @@ describe("PermissionsProcessor", () => {
 
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(OpencodePermissions);
+    });
+
+    it("should load Codex CLI .codex/config.toml", async () => {
+      const codexDir = join(testDir, ".codex");
+      await ensureDir(codexDir);
+      await writeFileContent(
+        join(codexDir, "config.toml"),
+        `
+default_permissions = "rulesync"
+
+[permissions.rulesync.filesystem]
+"/workspace/project" = "read"
+`,
+      );
+
+      const processor = new PermissionsProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "codexcli",
+      });
+
+      const files = await processor.loadToolFiles();
+
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(CodexcliPermissions);
     });
   });
 

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -8,6 +8,7 @@ import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
+import { CodexcliPermissions } from "./codexcli-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 import type {
@@ -18,7 +19,7 @@ import type {
 } from "./tool-permissions.js";
 import { ToolPermissions } from "./tool-permissions.js";
 
-const permissionsProcessorToolTargetTuple = ["claudecode", "opencode"] as const;
+const permissionsProcessorToolTargetTuple = ["claudecode", "codexcli", "opencode"] as const;
 
 export type PermissionsProcessorToolTarget = (typeof permissionsProcessorToolTargetTuple)[number];
 
@@ -48,6 +49,17 @@ const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPer
       meta: {
         supportsProject: true,
         supportsGlobal: false,
+        supportsImport: true,
+      },
+    },
+  ],
+  [
+    "codexcli",
+    {
+      class: CodexcliPermissions,
+      meta: {
+        supportsProject: true,
+        supportsGlobal: true,
         supportsImport: true,
       },
     },


### PR DESCRIPTION
### Motivation

- Add support for exporting and importing permissions to/from Codex CLI so Rulesync can manage Codex profiles alongside Claude/OpenCode.
- Document and surface the mapping between Rulesync permission categories and Codex CLI `config.toml` so users get predictable behavior for `read`, `edit`/`write`, and `webfetch` rules.

### Description

- Implement a new `CodexcliPermissions` tool adapter that converts Rulesync `permissions.json` into a `rulesync` profile in `.codex/config.toml` (and vice versa) and sets `default_permissions = "rulesync"` in the config. The mapping maps `read` -> `filesystem.read`, `edit`/`write` -> `filesystem.write`, and `webfetch` -> `network.domains` and skips unsupported `ask` for domains with a warning.
- Register `codexcli` in the `PermissionsProcessor` tool targets and factories so it is included in generation/import flows and global mode support is enabled.
- Add unit tests (`src/features/permissions/codexcli-permissions.test.ts`) and e2e tests (`src/e2e/e2e-permissions.spec.ts`) covering generation, import, and global mode behavior, plus helper `toTable` parsing in e2e tests.
- Update docs and README (`README.md`, `docs/reference/*`, `skills/rulesync/*`) to list `codexcli` as supporting `permissions` and to document the Rulesync-to-Codex mapping rules.

### Testing

- Ran the unit test suite with `vitest`, including `codexcli-permissions.test.ts` and updated `permissions-processor.test.ts`, and all tests passed.
- Ran the end-to-end permissions spec `src/e2e/e2e-permissions.spec.ts` which covers generation/import and global mode for Codex CLI and OpenCode, and the e2e tests passed.
- Executed the overall test command (`pnpm test`) to validate integration of the new feature and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb2d1522c833092a37f6672e2afde)