### PR TITLE
fix: pass global flag in ClaudecodeMcp factory methods

### DIFF
--- a/src/features/mcp/claudecode-mcp.test.ts
+++ b/src/features/mcp/claudecode-mcp.test.ts
@@ -319,6 +319,7 @@ describe("ClaudecodeMcp", () => {
       expect(claudecodeMcp).toBeInstanceOf(ClaudecodeMcp);
       expect(claudecodeMcp.getJson()).toEqual(jsonData);
       expect(claudecodeMcp.getFilePath()).toBe(join(testDir, ".claude/.claude.json"));
+      expect(claudecodeMcp.isDeletable()).toBe(false);
     });
 
     it("should create instance from file in local mode (default)", async () => {
@@ -535,6 +536,7 @@ describe("ClaudecodeMcp", () => {
       expect(claudecodeMcp.getJson()).toEqual(jsonData);
       expect(claudecodeMcp.getRelativeDirPath()).toBe(".claude");
       expect(claudecodeMcp.getRelativeFilePath()).toBe(".claude.json");
+      expect(claudecodeMcp.isDeletable()).toBe(false);
     });
 
     it("should create instance from RulesyncMcp in local mode (default)", async () => {

--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -64,6 +64,7 @@ export class ClaudecodeMcp extends ToolMcp {
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
       validate,
+      global,
     });
   }
 
@@ -89,6 +90,7 @@ export class ClaudecodeMcp extends ToolMcp {
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(mcpJson, null, 2),
       validate,
+      global,
     });
   }
 


### PR DESCRIPTION
### Motivation
- Fix bug from #1275 where `ClaudecodeMcp.fromFile` and `ClaudecodeMcp.fromRulesyncMcp` did not forward the `global` flag to the `ClaudecodeMcp` constructor, causing global-mode instances to incorrectly report `isDeletable() === true` (issue: https://github.com/dyoshikawa/rulesync/issues/1275). 

### Description
- Pass `global` into the `ClaudecodeMcp` constructor in both `fromFile` and `fromRulesyncMcp` in `src/features/mcp/claudecode-mcp.ts`. 
- Add regression asserts checking `isDeletable()` is `false` for global-mode instances in `src/features/mcp/claudecode-mcp.test.ts`.

### Testing
- Ran `pnpm vitest run src/features/mcp/claudecode-mcp.test.ts` and all tests in that file passed. 
- Ran full `pnpm cicheck` (format, lint, typecheck, tests, content checks) after cleaning transient cache dirs and it completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8d47c5cc8330aeb167dc711f2c1b)