### PR TITLE
fix(windsurf): include YAML frontmatter when generating rule files

### DIFF
--- a/src/features/rules/windsurf-rule.test.ts
+++ b/src/features/rules/windsurf-rule.test.ts
@@ -170,7 +170,9 @@ describe("WindsurfRule", () => {
       expect(windsurfRule).toBeInstanceOf(WindsurfRule);
       expect(windsurfRule.getRelativeDirPath()).toBe(".windsurf/rules");
       expect(windsurfRule.getRelativeFilePath()).toBe("test-rule.md");
-      expect(windsurfRule.getFileContent()).toBe("# Test Rule Content");
+      expect(windsurfRule.getFileContent()).toBe(
+        "---\ntitle: Test Rule\ntrigger: always_on\n---\n# Test Rule Content\n",
+      );
     });
 
     it("should create instance from RulesyncRule with custom baseDir", () => {
@@ -188,7 +190,9 @@ describe("WindsurfRule", () => {
       }) as WindsurfRule;
 
       expect(windsurfRule.getFilePath()).toBe("/custom/path/.windsurf/rules/custom-rule.md");
-      expect(windsurfRule.getFileContent()).toBe("# Custom Content");
+      expect(windsurfRule.getFileContent()).toBe(
+        "---\ntitle: Custom Rule\ntrigger: always_on\n---\n# Custom Content\n",
+      );
     });
 
     it("should create instance from RulesyncRule with validate false", () => {
@@ -205,7 +209,9 @@ describe("WindsurfRule", () => {
       }) as WindsurfRule;
 
       expect(windsurfRule).toBeInstanceOf(WindsurfRule);
-      expect(windsurfRule.getFileContent()).toBe("# Content");
+      expect(windsurfRule.getFileContent()).toBe(
+        "---\ntitle: Test Rule\ntrigger: always_on\n---\n# Content\n",
+      );
     });
 
     it("should handle RulesyncRule with complex frontmatter", () => {
@@ -224,7 +230,7 @@ describe("WindsurfRule", () => {
       }) as WindsurfRule;
 
       expect(windsurfRule.getFileContent()).toBe(
-        "# Complex Rule\n\nThis is a complex rule with multiple targets.",
+        "---\ntitle: A complex rule with metadata\ntrigger: always_on\n---\n# Complex Rule\n\nThis is a complex rule with multiple targets.\n",
       );
     });
 
@@ -240,7 +246,29 @@ describe("WindsurfRule", () => {
         rulesyncRule,
       }) as WindsurfRule;
 
-      expect(windsurfRule.getFileContent()).toBe("");
+      expect(windsurfRule.getFileContent()).toBe(
+        "---\ntitle: Empty Content\ntrigger: always_on\n---\n\n",
+      );
+    });
+
+    it("should include glob trigger and globs when specific globs are set", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "globbed.md",
+        frontmatter: {
+          description: "Globbed Rule",
+          globs: ["src/**/*.ts", "test/**/*.ts"],
+        },
+        body: "# Globbed",
+      });
+
+      const windsurfRule = WindsurfRule.fromRulesyncRule({
+        rulesyncRule,
+      }) as WindsurfRule;
+
+      expect(windsurfRule.getFileContent()).toBe(
+        "---\ntitle: Globbed Rule\ntrigger: glob\nglobs:\n  - src/**/*.ts\n  - test/**/*.ts\n---\n# Globbed\n",
+      );
     });
   });
 
@@ -302,7 +330,7 @@ describe("WindsurfRule", () => {
       const rulesyncRule = windsurfRule.toRulesyncRule();
 
       expect(rulesyncRule.getFileContent()).toContain(
-        "---\nroot: false\ntargets:\n  - '*'\nglobs: []\n---\n",
+        "---\nroot: false\ntargets:\n  - '*'\nglobs: []\n---\n\n",
       );
     });
   });

--- a/src/features/rules/windsurf-rule.ts
+++ b/src/features/rules/windsurf-rule.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
+import { stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -14,6 +15,11 @@ import {
 } from "./tool-rule.js";
 
 export type WindsurfRuleParams = ToolRuleParams;
+type WindsurfRuleFrontmatter = {
+  title: string;
+  trigger: "always_on" | "glob";
+  globs?: string[];
+};
 
 export type WindsurfRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   nonRoot: {
@@ -56,14 +62,23 @@ export class WindsurfRule extends ToolRule {
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
-    return new WindsurfRule(
-      this.buildToolRuleParamsDefault({
-        baseDir,
-        rulesyncRule,
-        validate,
-        nonRootPath: this.getSettablePaths().nonRoot,
-      }),
-    );
+    const toolRuleParams = this.buildToolRuleParamsDefault({
+      baseDir,
+      rulesyncRule,
+      validate,
+      nonRootPath: this.getSettablePaths().nonRoot,
+    });
+
+    const windsurfFrontmatter = this.buildWindsurfFrontmatter({
+      relativeFilePath: rulesyncRule.getRelativeFilePath(),
+      description: rulesyncRule.getFrontmatter().description,
+      globs: rulesyncRule.getFrontmatter().globs,
+    });
+
+    return new WindsurfRule({
+      ...toolRuleParams,
+      fileContent: stringifyFrontmatter(rulesyncRule.getBody(), windsurfFrontmatter),
+    });
   }
 
   toRulesyncRule(): RulesyncRule {
@@ -93,5 +108,23 @@ export class WindsurfRule extends ToolRule {
       rulesyncRule,
       toolTarget: "windsurf",
     });
+  }
+
+  private static buildWindsurfFrontmatter({
+    relativeFilePath,
+    description,
+    globs,
+  }: {
+    relativeFilePath: string;
+    description: string | undefined;
+    globs: string[] | undefined;
+  }): WindsurfRuleFrontmatter {
+    const hasSpecificGlobs = Boolean(globs && globs.length > 0 && !globs.includes("**/*"));
+
+    return {
+      title: description ?? relativeFilePath.replace(/\.md$/, ""),
+      trigger: hasSpecificGlobs ? "glob" : "always_on",
+      ...(hasSpecificGlobs && { globs }),
+    };
   }
 }


### PR DESCRIPTION
### Motivation
- Windsurf requires YAML frontmatter (`title`, `trigger`, `globs`) in `.windsurf/rules/*.md` files, but generated files previously contained only the rule body.
- Ensure generated Windsurf rule files include the required frontmatter so they work correctly in the Windsurf toolchain. 

### Description
- Serialize Windsurf frontmatter by importing `stringifyFrontmatter` and adding a `WindsurfRuleFrontmatter` shape. 
- Implement `buildWindsurfFrontmatter()` to derive `title` from rulesync `description` (fallback to filename), set `trigger` to `glob` when specific globs exist otherwise `always_on`, and include `globs` only for `glob` triggers. 
- Update `WindsurfRule.fromRulesyncRule()` to build tool params, compose Windsurf frontmatter, and set `fileContent` to `stringifyFrontmatter(body, windsurfFrontmatter)`. 
- Update `src/features/rules/windsurf-rule.test.ts` to assert the new frontmatter output and add coverage for glob-triggered rules. 

### Testing
- Ran the Windsurf unit tests with `pnpm vitest run src/features/rules/windsurf-rule.test.ts` and they passed (`38 passed`).
- Ran full project checks with `pnpm cicheck`, which completed formatting, linting, typechecks and the full test suite successfully (all automated checks passed; full test run completed without failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc56867e48330be2f71d0a901e5d5)