### PR TITLE
feat(permissions): add Gemini CLI support for permissions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
+| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Goose               | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |             |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI  | copilotcli   | ✅ 🌏 |        |  ✅ 🌏   |          |           |        |       |             |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -390,4 +390,11 @@ For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml`
 - `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
+For Gemini CLI, this generates `tools.allowed` and `tools.exclude` in `.gemini/settings.json` (project/global depending on mode):
+
+- `allow` rules are converted into `tools.allowed` entries
+- `deny` rules are converted into `tools.exclude` entries
+- `ask` rules are skipped with a warning (Gemini CLI settings do not support explicit ask entries)
+- Tool categories are mapped as: `bash` → `run_shell_command`, `read` → `read_file`, `edit` → `replace`, `write` → `write_file`, `webfetch` → `web_fetch`
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -8,7 +8,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
+| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI  | copilotcli   | ✅ 🌏 |        |  ✅ 🌏   |          |           |        |       |             |
 | Goose               | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |             |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -390,4 +390,11 @@ For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml`
 - `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
+For Gemini CLI, this generates `tools.allowed` and `tools.exclude` in `.gemini/settings.json` (project/global depending on mode):
+
+- `allow` rules are converted into `tools.allowed` entries
+- `deny` rules are converted into `tools.exclude` entries
+- `ask` rules are skipped with a warning (Gemini CLI settings do not support explicit ask entries)
+- Tool categories are mapped as: `bash` → `run_shell_command`, `read` → `read_file`, `edit` → `replace`, `write` → `write_file`, `webfetch` → `web_fetch`
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -8,7 +8,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
 | Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |             |
+| Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI  | copilotcli   | ✅ 🌏 |        |  ✅ 🌏   |          |           |        |       |             |
 | Goose               | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |             |

--- a/src/features/permissions/geminicli-permissions.test.ts
+++ b/src/features/permissions/geminicli-permissions.test.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { GeminicliPermissions } from "./geminicli-permissions.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+
+describe("GeminicliPermissions", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should convert rulesync permissions to Gemini CLI tools allowed/exclude", async () => {
+    const rulesyncPermissions = new RulesyncPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".rulesync",
+      relativeFilePath: "permissions.json",
+      fileContent: JSON.stringify({
+        permission: {
+          bash: { "git *": "allow", "rm *": "deny" },
+          read: { "src/**": "allow" },
+        },
+      }),
+    });
+
+    const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
+      baseDir: testDir,
+      rulesyncPermissions,
+    });
+
+    const content = JSON.parse(geminiPermissions.getFileContent());
+    expect(content.tools.allowed).toContain("run_shell_command(git *)");
+    expect(content.tools.allowed).toContain("read_file(src/**)");
+    expect(content.tools.exclude).toContain("run_shell_command(rm *)");
+  });
+
+  it("should convert Gemini CLI tools allowed/exclude to rulesync format", () => {
+    const geminiPermissions = new GeminicliPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".gemini",
+      relativeFilePath: "settings.json",
+      fileContent: JSON.stringify({
+        tools: {
+          allowed: ["run_shell_command(git *)", "read_file(src/**)"],
+          exclude: ["run_shell_command(rm *)"],
+        },
+      }),
+    });
+
+    const rulesyncPermissions = geminiPermissions.toRulesyncPermissions();
+    const json = rulesyncPermissions.getJson();
+
+    expect(json.permission.bash?.["git *"]).toBe("allow");
+    expect(json.permission.read?.["src/**"]).toBe("allow");
+    expect(json.permission.bash?.["rm *"]).toBe("deny");
+  });
+
+  it("should load existing .gemini/settings.json", async () => {
+    const geminiDir = join(testDir, ".gemini");
+    await ensureDir(geminiDir);
+    await writeFileContent(join(geminiDir, "settings.json"), JSON.stringify({ model: "x" }));
+
+    const loaded = await GeminicliPermissions.fromFile({ baseDir: testDir });
+    expect(loaded).toBeInstanceOf(GeminicliPermissions);
+    expect(JSON.parse(loaded.getFileContent()).model).toBe("x");
+  });
+});

--- a/src/features/permissions/geminicli-permissions.ts
+++ b/src/features/permissions/geminicli-permissions.ts
@@ -1,0 +1,205 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import type { ValidationResult } from "../../types/ai-file.js";
+import type { PermissionsConfig } from "../../types/permissions.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+import {
+  ToolPermissions,
+  type ToolPermissionsForDeletionParams,
+  type ToolPermissionsFromFileParams,
+  type ToolPermissionsFromRulesyncPermissionsParams,
+  type ToolPermissionsSettablePaths,
+} from "./tool-permissions.js";
+
+const GeminiCliSettingsSchema = z.looseObject({
+  tools: z.optional(
+    z.looseObject({
+      allowed: z.optional(z.array(z.string())),
+      exclude: z.optional(z.array(z.string())),
+    }),
+  ),
+});
+
+type GeminiCliSettings = z.infer<typeof GeminiCliSettingsSchema>;
+
+const RULESYNC_TO_GEMINICLI_TOOL_NAME: Record<string, string> = {
+  bash: "run_shell_command",
+  read: "read_file",
+  edit: "replace",
+  write: "write_file",
+  webfetch: "web_fetch",
+};
+
+export class GeminicliPermissions extends ToolPermissions {
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolPermissionsSettablePaths {
+    return {
+      relativeDirPath: ".gemini",
+      relativeFilePath: "settings.json",
+    };
+  }
+
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolPermissionsFromFileParams): Promise<GeminicliPermissions> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
+    return new GeminicliPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncPermissions({
+    baseDir = process.cwd(),
+    rulesyncPermissions,
+    validate = true,
+    logger,
+    global = false,
+  }: ToolPermissionsFromRulesyncPermissionsParams): Promise<GeminicliPermissions> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
+
+    const settingsResult = GeminiCliSettingsSchema.safeParse(JSON.parse(existingContent));
+    if (!settingsResult.success) {
+      throw new Error(
+        `Failed to parse existing Gemini CLI settings at ${filePath}: ${formatError(settingsResult.error)}`,
+      );
+    }
+
+    const { allowed, exclude } = convertRulesyncToGeminicliTools({
+      config: rulesyncPermissions.getJson(),
+      logger,
+    });
+    const merged = {
+      ...settingsResult.data,
+      tools: {
+        ...settingsResult.data.tools,
+        ...(allowed.length > 0 ? { allowed } : {}),
+        ...(exclude.length > 0 ? { exclude } : {}),
+      },
+    };
+
+    return new GeminicliPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(merged, null, 2),
+      validate,
+    });
+  }
+
+  toRulesyncPermissions(): RulesyncPermissions {
+    let settings: GeminiCliSettings;
+    try {
+      const parsed = JSON.parse(this.getFileContent());
+      settings = GeminiCliSettingsSchema.parse(parsed);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Gemini CLI permissions content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+
+    const permission: PermissionsConfig["permission"] = {};
+
+    for (const toolEntry of settings.tools?.allowed ?? []) {
+      const mapped = parseGeminicliToolEntry({ entry: toolEntry });
+      const rules = (permission[mapped.category] ??= {});
+      rules[mapped.pattern] = "allow";
+    }
+
+    for (const toolEntry of settings.tools?.exclude ?? []) {
+      const mapped = parseGeminicliToolEntry({ entry: toolEntry });
+      const rules = (permission[mapped.category] ??= {});
+      rules[mapped.pattern] = "deny";
+    }
+
+    return this.toRulesyncPermissionsDefault({
+      fileContent: JSON.stringify({ permission }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolPermissionsForDeletionParams): GeminicliPermissions {
+    return new GeminicliPermissions({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({}, null, 2),
+      validate: false,
+    });
+  }
+}
+
+function convertRulesyncToGeminicliTools({
+  config,
+  logger,
+}: {
+  config: PermissionsConfig;
+  logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
+}): { allowed: string[]; exclude: string[] } {
+  const allowed: string[] = [];
+  const exclude: string[] = [];
+
+  for (const [toolName, rules] of Object.entries(config.permission)) {
+    const mappedToolName = RULESYNC_TO_GEMINICLI_TOOL_NAME[toolName] ?? toolName;
+    if (!RULESYNC_TO_GEMINICLI_TOOL_NAME[toolName]) {
+      logger?.warn(`Gemini CLI permissions use direct tool names. Mapping as-is: ${toolName}`);
+    }
+    for (const [pattern, action] of Object.entries(rules)) {
+      if (action === "ask") {
+        logger?.warn(
+          `Gemini CLI does not support explicit "ask" rules in settings. Skipping ${toolName}:${pattern}`,
+        );
+        continue;
+      }
+
+      const geminiEntry = pattern === "*" ? mappedToolName : `${mappedToolName}(${pattern})`;
+      if (action === "allow") {
+        allowed.push(geminiEntry);
+      } else {
+        exclude.push(geminiEntry);
+      }
+    }
+  }
+
+  return { allowed, exclude };
+}
+
+function parseGeminicliToolEntry({ entry }: { entry: string }): {
+  category: string;
+  pattern: string;
+} {
+  const match = /^([^()]+?)(?:\((.*)\))?$/.exec(entry);
+  if (!match) return { category: entry, pattern: "*" };
+  const rawToolName = match[1]?.trim() ?? entry;
+  const mappedCategory = Object.entries(RULESYNC_TO_GEMINICLI_TOOL_NAME).find(
+    ([, value]) => value === rawToolName,
+  )?.[0];
+  return {
+    category: mappedCategory ?? rawToolName,
+    pattern: (match[2] ?? "*").trim(),
+  };
+}

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -11,6 +11,7 @@ import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, readFileContent, writeFileContent } from "../../utils/file.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
 import { CodexcliPermissions } from "./codexcli-permissions.js";
+import { GeminicliPermissions } from "./geminicli-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { PermissionsProcessor } from "./permissions-processor.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -70,19 +71,19 @@ describe("PermissionsProcessor", () => {
   });
 
   describe("getToolTargets", () => {
-    it("should return claudecode, codexcli and opencode for project mode", () => {
+    it("should return claudecode, codexcli, geminicli and opencode for project mode", () => {
       const targets = PermissionsProcessor.getToolTargets();
-      expect(targets).toEqual(["claudecode", "codexcli", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
     });
 
-    it("should return codexcli and opencode for global mode", () => {
+    it("should return codexcli, geminicli and opencode for global mode", () => {
       const targets = PermissionsProcessor.getToolTargets({ global: true });
-      expect(targets).toEqual(["codexcli", "opencode"]);
+      expect(targets).toEqual(["codexcli", "geminicli", "opencode"]);
     });
 
     it("should return importable targets", () => {
       const targets = PermissionsProcessor.getToolTargets({ importOnly: true });
-      expect(targets).toEqual(["claudecode", "codexcli", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
     });
   });
 
@@ -207,6 +208,30 @@ default_permissions = "rulesync"
 
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(CodexcliPermissions);
+    });
+
+    it("should load Gemini CLI .gemini/settings.json", async () => {
+      const geminiDir = join(testDir, ".gemini");
+      await ensureDir(geminiDir);
+      await writeFileContent(
+        join(geminiDir, "settings.json"),
+        JSON.stringify({
+          tools: {
+            allowed: ["run_shell_command(git status)"],
+          },
+        }),
+      );
+
+      const processor = new PermissionsProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "geminicli",
+      });
+
+      const files = await processor.loadToolFiles();
+
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(GeminicliPermissions);
     });
   });
 

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -9,6 +9,7 @@ import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
 import { CodexcliPermissions } from "./codexcli-permissions.js";
+import { GeminicliPermissions } from "./geminicli-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 import type {
@@ -19,7 +20,12 @@ import type {
 } from "./tool-permissions.js";
 import { ToolPermissions } from "./tool-permissions.js";
 
-const permissionsProcessorToolTargetTuple = ["claudecode", "codexcli", "opencode"] as const;
+const permissionsProcessorToolTargetTuple = [
+  "claudecode",
+  "codexcli",
+  "geminicli",
+  "opencode",
+] as const;
 
 export type PermissionsProcessorToolTarget = (typeof permissionsProcessorToolTargetTuple)[number];
 
@@ -57,6 +63,17 @@ const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPer
     "codexcli",
     {
       class: CodexcliPermissions,
+      meta: {
+        supportsProject: true,
+        supportsGlobal: true,
+        supportsImport: true,
+      },
+    },
+  ],
+  [
+    "geminicli",
+    {
+      class: GeminicliPermissions,
       meta: {
         supportsProject: true,
         supportsGlobal: true,


### PR DESCRIPTION
### Motivation
- Add support for Gemini CLI permissions so `.rulesync/permissions.json` can be converted to and from Gemini CLI settings, closing issue #1419. 

### Description
- Add `GeminicliPermissions` in `src/features/permissions/geminicli-permissions.ts` to map Rulesync `permission` categories to Gemini `tools.allowed` / `tools.exclude` and to import the reverse mapping. 
- Register `geminicli` in the `PermissionsProcessor` tool target list and factory map so it is available for project/global generation and import. 
- Add tests in `src/features/permissions/geminicli-permissions.test.ts` and update `src/features/permissions/permissions-processor.test.ts` to cover conversion and loading. 
- Update documentation and supported-tools files (`README.md`, `docs/reference/*`, `skills/rulesync/*`) to declare Gemini CLI permission support and explain the mapping/limitations. 

### Testing
- Ran targeted unit tests with `pnpm vitest run src/features/permissions/geminicli-permissions.test.ts src/features/permissions/permissions-processor.test.ts`, and they passed. 
- Ran the full CI checks with `pnpm cicheck`; an initial run failed due to cached artifact files triggering `cspell`, the caches were removed and `pnpm cicheck` was re-run and completed successfully, including the full test suite and content checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc5ab22888330b71ba9343195e58e)