### PR TITLE
feat(rules): allow per-target rules.ruleDiscoveryMode override (auto|toon)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -110,7 +110,7 @@ maps to either `true`/`false` (enable/disable) or an options object.
   "targets": ["claudecode"],
   "features": {
     "claudecode": {
-      "rules": true,
+      "rules": { "ruleDiscoveryMode": "toon" },
       "ignore": { "fileMode": "local" },
     },
   },
@@ -119,9 +119,10 @@ maps to either `true`/`false` (enable/disable) or an options object.
 
 The current per-feature options are:
 
-| Target       | Feature  | Option     | Values                                                       | Default    |
-| ------------ | -------- | ---------- | ------------------------------------------------------------ | ---------- |
-| `claudecode` | `ignore` | `fileMode` | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"` |
+| Target       | Feature  | Option              | Values                                                       | Default      |
+| ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"auto"` / `"toon"`                                          | tool default |
+| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)
 for the rationale behind the Claude Code default and when to switch to

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -110,7 +110,7 @@ maps to either `true`/`false` (enable/disable) or an options object.
   "targets": ["claudecode"],
   "features": {
     "claudecode": {
-      "rules": { "ruleDiscoveryMode": "toon" },
+      "rules": { "ruleDiscoveryMode": "explicit" },
       "ignore": { "fileMode": "local" },
     },
   },
@@ -121,7 +121,7 @@ The current per-feature options are:
 
 | Target       | Feature  | Option              | Values                                                       | Default      |
 | ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
-| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"auto"` / `"toon"`                                          | tool default |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                      | tool default |
 | `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -110,7 +110,7 @@ maps to either `true`/`false` (enable/disable) or an options object.
   "targets": ["claudecode"],
   "features": {
     "claudecode": {
-      "rules": true,
+      "rules": { "ruleDiscoveryMode": "toon" },
       "ignore": { "fileMode": "local" },
     },
   },
@@ -119,9 +119,10 @@ maps to either `true`/`false` (enable/disable) or an options object.
 
 The current per-feature options are:
 
-| Target       | Feature  | Option     | Values                                                       | Default    |
-| ------------ | -------- | ---------- | ------------------------------------------------------------ | ---------- |
-| `claudecode` | `ignore` | `fileMode` | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"` |
+| Target       | Feature  | Option              | Values                                                       | Default      |
+| ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"auto"` / `"toon"`                                          | tool default |
+| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)
 for the rationale behind the Claude Code default and when to switch to

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -110,7 +110,7 @@ maps to either `true`/`false` (enable/disable) or an options object.
   "targets": ["claudecode"],
   "features": {
     "claudecode": {
-      "rules": { "ruleDiscoveryMode": "toon" },
+      "rules": { "ruleDiscoveryMode": "explicit" },
       "ignore": { "fileMode": "local" },
     },
   },
@@ -121,7 +121,7 @@ The current per-feature options are:
 
 | Target       | Feature  | Option              | Values                                                       | Default      |
 | ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
-| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"auto"` / `"toon"`                                          | tool default |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                      | tool default |
 | `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -426,11 +426,11 @@ describe("RulesProcessor", () => {
       expect(content).not.toContain("@.claude/");
     });
 
-    it("should generate TOON references section for claudecode when ruleDiscoveryMode is overridden to toon", async () => {
+    it("should generate TOON references section for claudecode when ruleDiscoveryMode is overridden to explicit", async () => {
       const processor = new RulesProcessor({
         logger,
         toolTarget: "claudecode",
-        featureOptions: { ruleDiscoveryMode: "toon" },
+        featureOptions: { ruleDiscoveryMode: "explicit" },
       });
 
       const rulesyncRules = [
@@ -490,7 +490,7 @@ describe("RulesProcessor", () => {
       ];
 
       await expect(processor.convertRulesyncFilesToToolFiles(rulesyncRules)).rejects.toThrow(
-        '`ruleDiscoveryMode` must be either "auto" or "toon"',
+        '`ruleDiscoveryMode` must be either "none" or "explicit"',
       );
     });
 

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -426,6 +426,74 @@ describe("RulesProcessor", () => {
       expect(content).not.toContain("@.claude/");
     });
 
+    it("should generate TOON references section for claudecode when ruleDiscoveryMode is overridden to toon", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        toolTarget: "claudecode",
+        featureOptions: { ruleDiscoveryMode: "toon" },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: {
+            root: true,
+            targets: ["*"],
+          },
+          body: "# Root content",
+        }),
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "feature.md",
+          frontmatter: {
+            root: false,
+            targets: ["*"],
+            description: "Feature rule",
+            globs: ["src/**/*.ts"],
+          },
+          body: "# Feature content",
+        }),
+      ];
+
+      const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+      const rootRule = result.find((rule) => rule instanceof ClaudecodeRule && rule.isRoot());
+      const content = rootRule?.getFileContent();
+
+      expect(content).toContain("Please also reference the following rules as needed.");
+      expect(content).toContain("rules[1]:");
+      expect(content).toContain("- path: @.claude/rules/feature.md");
+      expect(content).toContain("applyTo[1]: src/**/*.ts");
+      expect(content).toContain("# Root content");
+    });
+
+    it("should throw for invalid rules feature options", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        toolTarget: "claudecode",
+        featureOptions: { ruleDiscoveryMode: "invalid" },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: {
+            root: true,
+            targets: ["*"],
+          },
+          body: "# Root content",
+        }),
+      ];
+
+      await expect(processor.convertRulesyncFilesToToolFiles(rulesyncRules)).rejects.toThrow(
+        '`ruleDiscoveryMode` must be either "auto" or "toon"',
+      );
+    });
+
     it("should handle multiple globs correctly for claudecode-legacy", async () => {
       const processor = new RulesProcessor({ logger, toolTarget: "claudecode-legacy" });
 

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -107,7 +107,7 @@ const formatRulePaths = (rules: RulesyncRule[]): string =>
  */
 type RuleDiscoveryMode = "auto" | "toon" | "claudecode-legacy";
 const RulesFeatureOptionsSchema = z.looseObject({
-  ruleDiscoveryMode: z.optional(z.enum(["auto", "toon"])),
+  ruleDiscoveryMode: z.optional(z.enum(["none", "explicit"])),
 });
 
 const resolveRuleDiscoveryMode = ({
@@ -125,10 +125,13 @@ const resolveRuleDiscoveryMode = ({
   if (!parsed.success) {
     throw new Error(
       `Invalid options for rules feature: ${parsed.error.message}. ` +
-        '`ruleDiscoveryMode` must be either "auto" or "toon".',
+        '`ruleDiscoveryMode` must be either "none" or "explicit".',
     );
   }
-  return parsed.data.ruleDiscoveryMode ?? defaultMode;
+  if (!parsed.data.ruleDiscoveryMode) {
+    return defaultMode;
+  }
+  return parsed.data.ruleDiscoveryMode === "none" ? "auto" : "toon";
 };
 
 /**

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -10,6 +10,7 @@ import {
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
 import { FeatureProcessor } from "../../types/feature-processor.js";
+import type { FeatureOptions } from "../../types/features.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
 import { ToolTarget } from "../../types/tool-targets.js";
@@ -105,6 +106,30 @@ const formatRulePaths = (rules: RulesyncRule[]): string =>
  * - `claudecode-legacy`: Uses Claude Code specific reference format (legacy mode only)
  */
 type RuleDiscoveryMode = "auto" | "toon" | "claudecode-legacy";
+const RulesFeatureOptionsSchema = z.looseObject({
+  ruleDiscoveryMode: z.optional(z.enum(["auto", "toon"])),
+});
+
+const resolveRuleDiscoveryMode = ({
+  defaultMode,
+  options,
+}: {
+  defaultMode: RuleDiscoveryMode;
+  options?: FeatureOptions;
+}): RuleDiscoveryMode => {
+  if (defaultMode === "claudecode-legacy") {
+    return defaultMode;
+  }
+  if (!options) return defaultMode;
+  const parsed = RulesFeatureOptionsSchema.safeParse(options);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid options for rules feature: ${parsed.error.message}. ` +
+        '`ruleDiscoveryMode` must be either "auto" or "toon".',
+    );
+  }
+  return parsed.data.ruleDiscoveryMode ?? defaultMode;
+};
 
 /**
  * Type for command class that provides settable paths.
@@ -516,6 +541,7 @@ export class RulesProcessor extends FeatureProcessor {
   private readonly global: boolean;
   private readonly getFactory: GetFactory;
   private readonly skills?: RulesyncSkill[];
+  private readonly featureOptions?: FeatureOptions;
 
   constructor({
     baseDir = process.cwd(),
@@ -526,6 +552,7 @@ export class RulesProcessor extends FeatureProcessor {
     global = false,
     getFactory = defaultGetFactory,
     skills,
+    featureOptions,
     dryRun = false,
     logger,
   }: {
@@ -537,6 +564,7 @@ export class RulesProcessor extends FeatureProcessor {
     simulateSkills?: boolean;
     getFactory?: GetFactory;
     skills?: RulesyncSkill[];
+    featureOptions?: FeatureOptions;
     dryRun?: boolean;
     logger: Logger;
   }) {
@@ -554,6 +582,7 @@ export class RulesProcessor extends FeatureProcessor {
     this.simulateSkills = simulateSkills;
     this.getFactory = getFactory;
     this.skills = skills;
+    this.featureOptions = featureOptions;
   }
 
   async convertRulesyncFilesToToolFiles(rulesyncFiles: RulesyncFile[]): Promise<ToolFile[]> {
@@ -766,7 +795,11 @@ export class RulesProcessor extends FeatureProcessor {
     meta: ToolRuleFactory["meta"],
     toolRules: ToolRule[],
   ): string {
-    switch (meta.ruleDiscoveryMode) {
+    const mode = resolveRuleDiscoveryMode({
+      defaultMode: meta.ruleDiscoveryMode,
+      options: this.featureOptions,
+    });
+    switch (mode) {
       case "toon":
         return this.generateToonReferencesSection(toolRules);
       case "claudecode-legacy":

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -255,6 +255,7 @@ async function generateRulesCore(params: {
         simulateSubagents: config.getSimulateSubagents(),
         simulateSkills: config.getSimulateSkills(),
         skills: skills,
+        featureOptions: config.getFeatureOptions(toolTarget, "rules"),
         dryRun: config.isPreviewMode(),
         logger,
       });


### PR DESCRIPTION
### Motivation
- Allow `rules` to accept per-target options when `features` is provided as an object so users can override how non-root rules are referenced without changing tool defaults.

### Description
- Add `features.<target>.rules.ruleDiscoveryMode` parsing (accepts `"auto"` or `"toon"`) and validation via a Zod schema in `src/features/rules/rules-processor.ts` while preserving `claudecode-legacy` behavior.
- Introduce `featureOptions` on `RulesProcessor` and use a `resolveRuleDiscoveryMode` helper to determine the effective discovery mode when generating reference sections.
- Wire `config.getFeatureOptions(toolTarget, "rules")` into `RulesProcessor` during generation in `src/lib/generate.ts` so config-specified options are applied.
- Add unit tests to `src/features/rules/rules-processor.test.ts` for TOON override behavior and invalid option validation, and update configuration docs in `docs/guide/configuration.md` (synced to `skills/rulesync/configuration.md`).

### Testing
- Ran `pnpm test -- src/features/rules/rules-processor.test.ts` and iterated on a failing assertion until the test passed, after which the file's tests succeeded.
- Ran the full test suite with `pnpm test` and observed all tests passing (`4862` tests in the run used here).
- Ran `pnpm cicheck` which initially failed due to formatting/cspell artifacts but passed after formatting (`pnpm fmt`) and cleanup, completing the content and code checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd026a79ec8330b33e6afca224ce4e)