### PR TITLE
feat(rules): add `includeLocalRoot` per-target option

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+Please also reference the following rules as needed. The list below is provided in TOON format, and `@` stands for the project root directory.
+
+rules[4]:
+  - path: @.github/instructions/coding-guidelines.instructions.md
+    description: "When you write any code, must follow these guidelines."
+    applyTo[1]: **/*.ts
+  - path: @.github/instructions/feature-change-guidelines.instructions.md
+    description: "When you add or change features, must follow these guidelines."
+  - path: @.github/instructions/github-actions-security.instructions.md
+    description: Guidelines to avoid GitHub Actions script injection vulnerabilities.
+    applyTo[1]: .github/workflows/*.yml
+  - path: @.github/instructions/testing-guidelines.instructions.md
+    description: "When you write tests, must follow these guidelines."
+    applyTo[2]: **/*.test.ts,src/e2e/**/*.spec.ts
+
+# Rulesync Project Overview
+
+This is Rulesync, a Node.js CLI tool that automatically generates configuration files for various AI coding tools from unified AI rule files. The project enables teams to maintain consistent AI coding assistant rules across multiple tools.
+
+- Read `README.md` and `docs/**/*.md` if you want to know Rulesync specification.
+- Manage runtimes and package managers with @mise.toml .
+- When you want to check entire codebase:
+  - You can use:
+    - `pnpm cicheck:code` to check code style, type safety, and tests.
+    - `pnpm cicheck:content` to check content style, spelling, and secrets.
+    - `pnpm cicheck` to check both code and content.
+  - Basically, I recommend you to run `pnpm cicheck` to daily checks.
+- When doing `git commit`:
+  - You must run `pnpm cicheck` before committing to verify quality.
+  - You must not use here documents because it causes a sandbox error.
+  - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.
+  - When creating a PR, you should include a link in the PR description that associates the PR with its issue.
+- When you read or search the codebase:
+  - You should check Serena MCP server tools, and use those actively.
+- About the `skills/` directory at the repository root:
+  - This directory contains official skills that are distributed for users to install via the `rulesync fetch` command (e.g., `npx rulesync fetch dyoshikawa/rulesync --features skills`).
+  - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.
+  - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
+- The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.
+- Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.

--- a/.gitignore
+++ b/.gitignore
@@ -273,8 +273,6 @@ rulesync.local.jsonc
 **/.goosehints
 **/.goose/
 **/.gooseignore
-**/.github/copilot-instructions.md
-**/.github/instructions/
 **/.github/prompts/
 **/.github/agents/
 **/.github/skills/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -20,6 +20,8 @@
     ".claude/settings.json",
     ".serena/project.yml",
     ".github/copilot-instructions.md",
-    ".github/instructions/**"
+    ".github/instructions/**",
+    "rulesync.jsonc",
+    "rulesync.local.jsonc"
   ]
 }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -119,10 +119,11 @@ maps to either `true`/`false` (enable/disable) or an options object.
 
 The current per-feature options are:
 
-| Target       | Feature  | Option              | Values                                                       | Default      |
-| ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
-| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                      | tool default |
-| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
+| Target       | Feature  | Option              | Values                                                                         | Default      |
+| ------------ | -------- | ------------------- | ------------------------------------------------------------------------------ | ------------ |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                                        | tool default |
+| any          | `rules`  | `includeLocalRoot`  | `true` / `false` (when `false`, `localRoot` rules are skipped for this target) | `true`       |
+| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json)                   | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)
 for the rationale behind the Claude Code default and when to switch to

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -4,7 +4,32 @@
   // List of tools to generate configurations for
   "targets": ["copilot", "claudecode", "opencode"],
 
-  "features": ["rules", "ignore", "mcp", "commands", "subagents", "skills"],
+  "features": {
+    "copilot": {
+      "rules": {
+        "ruleDiscoveryMode": "explicit",
+        "rule"
+      },
+      "commands": true,
+      "mcp": false,
+      "subagents": true,
+      "skills": true
+    },
+    "claudecode": {
+      "rules": true,
+      "commands": true,
+      "mcp": true,
+      "subagents": true,
+      "skills": true
+    },
+    "opencode": {
+      "rules": true,
+      "commands": true,
+      "mcp": true,
+      "subagents": true,
+      "skills": true
+    }
+  },
 
   // Base directory or directories for generation.
   "baseDirs": ["."],
@@ -16,5 +41,5 @@
 
   "simulateCommands": true,
   "simulateSubagents": true,
-  "simulateSkills": true,
+  "simulateSkills": true
 }

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -8,7 +8,7 @@
     "copilot": {
       "rules": {
         "ruleDiscoveryMode": "explicit",
-        "rule"
+        "includeLocalRoot": false // 追加
       },
       "commands": true,
       "mcp": false,

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -8,7 +8,7 @@
     "copilot": {
       "rules": {
         "ruleDiscoveryMode": "explicit",
-        "includeLocalRoot": false // 追加
+        "includeLocalRoot": false
       },
       "commands": true,
       "mcp": false,

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -119,10 +119,11 @@ maps to either `true`/`false` (enable/disable) or an options object.
 
 The current per-feature options are:
 
-| Target       | Feature  | Option              | Values                                                       | Default      |
-| ------------ | -------- | ------------------- | ------------------------------------------------------------ | ------------ |
-| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                      | tool default |
-| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json) | `"shared"`   |
+| Target       | Feature  | Option              | Values                                                                         | Default      |
+| ------------ | -------- | ------------------- | ------------------------------------------------------------------------------ | ------------ |
+| `claudecode` | `rules`  | `ruleDiscoveryMode` | `"none"` / `"explicit"`                                                        | tool default |
+| any          | `rules`  | `includeLocalRoot`  | `true` / `false` (when `false`, `localRoot` rules are skipped for this target) | `true`       |
+| `claudecode` | `ignore` | `fileMode`          | `"shared"` (settings.json) / `"local"` (settings.local.json)                   | `"shared"`   |
 
 See [`docs/reference/file-formats.md`](../reference/file-formats.md#where-ignore-patterns-are-written-per-tool)
 for the rationale behind the Claude Code default and when to switch to

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -1356,6 +1356,45 @@ targets: ["*"]
       expect(rootRule?.getFileContent()).toContain("\n\n# Local content");
     });
 
+    it("should skip localRoot content when includeLocalRoot is false", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "copilot",
+        featureOptions: { includeLocalRoot: false },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: {
+            root: true,
+            targets: ["*"],
+          },
+          body: "# Root content",
+        }),
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "local.md",
+          frontmatter: {
+            localRoot: true,
+            targets: ["*"],
+          },
+          body: "# Local content",
+        }),
+      ];
+
+      const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+      expect(result).toHaveLength(1);
+      const rootRule = result.find((r) => r instanceof CopilotRule && r.isRoot());
+      expect(rootRule?.getFileContent()).toContain("# Root content");
+      expect(rootRule?.getFileContent()).not.toContain("# Local content");
+    });
+
     it("should not generate localRoot rule in global mode", async () => {
       const processor = new RulesProcessor({
         logger,

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -1395,6 +1395,97 @@ targets: ["*"]
       expect(rootRule?.getFileContent()).not.toContain("# Local content");
     });
 
+    it("should include localRoot content when includeLocalRoot is explicitly true", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "copilot",
+        featureOptions: { includeLocalRoot: true },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { root: true, targets: ["*"] },
+          body: "# Root content",
+        }),
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "local.md",
+          frontmatter: { localRoot: true, targets: ["*"] },
+          body: "# Local content",
+        }),
+      ];
+
+      const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+      const rootRule = result.find((r) => r instanceof CopilotRule && r.isRoot());
+      expect(rootRule?.getFileContent()).toContain("# Root content");
+      expect(rootRule?.getFileContent()).toContain("# Local content");
+    });
+
+    it("should throw when includeLocalRoot is not a boolean", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "copilot",
+        featureOptions: { includeLocalRoot: "false" as unknown as boolean },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { root: true, targets: ["*"] },
+          body: "# Root",
+        }),
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "local.md",
+          frontmatter: { localRoot: true, targets: ["*"] },
+          body: "# Local",
+        }),
+      ];
+
+      await expect(processor.convertRulesyncFilesToToolFiles(rulesyncRules)).rejects.toThrow(
+        /includeLocalRoot.*must be a boolean/,
+      );
+    });
+
+    it("should coexist with ruleDiscoveryMode option", async () => {
+      const processor = new RulesProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "claudecode",
+        featureOptions: { includeLocalRoot: false, ruleDiscoveryMode: "explicit" },
+      });
+
+      const rulesyncRules = [
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { root: true, targets: ["*"] },
+          body: "# Root content",
+        }),
+        new RulesyncRule({
+          baseDir: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "local.md",
+          frontmatter: { localRoot: true, targets: ["*"] },
+          body: "# Local content",
+        }),
+      ];
+
+      const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+      const localRule = result.find((r) => r.getRelativeFilePath() === "CLAUDE.local.md");
+      expect(localRule).toBeUndefined();
+    });
+
     it("should not generate localRoot rule in global mode", async () => {
       const processor = new RulesProcessor({
         logger,

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -108,6 +108,7 @@ const formatRulePaths = (rules: RulesyncRule[]): string =>
 type RuleDiscoveryMode = "auto" | "toon" | "claudecode-legacy";
 const RulesFeatureOptionsSchema = z.looseObject({
   ruleDiscoveryMode: z.optional(z.enum(["none", "explicit"])),
+  includeLocalRoot: z.optional(z.boolean()),
 });
 
 const resolveRuleDiscoveryMode = ({
@@ -132,6 +133,22 @@ const resolveRuleDiscoveryMode = ({
     return defaultMode;
   }
   return parsed.data.ruleDiscoveryMode === "none" ? "auto" : "toon";
+};
+
+const IncludeLocalRootSchema = z.looseObject({
+  includeLocalRoot: z.optional(z.boolean()),
+});
+
+const resolveIncludeLocalRoot = (options?: FeatureOptions): boolean => {
+  if (!options) return true;
+  const parsed = IncludeLocalRootSchema.safeParse(options);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid options for rules feature: ${parsed.error.message}. ` +
+        "`includeLocalRoot` must be a boolean.",
+    );
+  }
+  return parsed.data.includeLocalRoot ?? true;
 };
 
 /**
@@ -614,8 +631,10 @@ export class RulesProcessor extends FeatureProcessor {
       })
       .filter((rule): rule is ToolRule => rule !== null);
 
-    // Handle localRoot rules (only in non-global mode)
-    if (localRootRules.length > 0 && !this.global) {
+    const includeLocalRoot = resolveIncludeLocalRoot(this.featureOptions);
+
+    // Handle localRoot rules (only in non-global mode and when enabled)
+    if (localRootRules.length > 0 && !this.global && includeLocalRoot) {
       const localRootRule = localRootRules[0];
       if (localRootRule && factory.class.isTargetedByRulesyncRule(localRootRule)) {
         this.handleLocalRootRule(toolRules, localRootRule, factory);


### PR DESCRIPTION
## Summary

- Add `includeLocalRoot` boolean option to the rules per-feature options. When `false`, `localRoot: true` rulesync rules are skipped for that target (e.g. not appended to the root file for tools like Copilot, not generated as `CLAUDE.local.md`/`AGENTS.local.md` for Claude Code / Rovodev). Default is `true` (preserves existing behavior).
- Apply the new option in `rulesync.jsonc` for the `copilot` target.
- Update `docs/guide/configuration.md` (and the synced `skills/rulesync/configuration.md`) per-feature options table.

## Test plan

- [x] `pnpm cicheck` passes (183 test files, 4863 tests)
- [x] New unit test covers `includeLocalRoot: false` skipping localRoot append for copilot