### PR TITLE
fix(copilot): ensure .agent.md extension for Copilot subagent files

### DIFF
--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -129,12 +129,19 @@ export class CopilotSubagent extends ToolSubagent {
     const fileContent = stringifyFrontmatter(body, copilotFrontmatter);
     const paths = this.getSettablePaths({ global });
 
+    // Ensure .agent.md extension — required by VSCode Copilot Chat
+    // See: https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/customInstructions/common/promptTypes.ts
+    let relativeFilePath = rulesyncSubagent.getRelativeFilePath();
+    if (!relativeFilePath.endsWith(".agent.md")) {
+      relativeFilePath = relativeFilePath.replace(/\.md$/, ".agent.md");
+    }
+
     return new CopilotSubagent({
       baseDir: baseDir,
       frontmatter: copilotFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
-      relativeFilePath: rulesyncSubagent.getRelativeFilePath(),
+      relativeFilePath,
       fileContent,
       validate,
       global,


### PR DESCRIPTION
Fixes #1432

## Problem

When `rulesync generate` creates Copilot agent files, the generated file names lack the `.agent.md` extension required by VSCode Copilot Chat.

For example:
- Source: `.rulesync/subagents/planner.md`
- Generated (incorrect): `.github/agents/planner.md`
- Expected (correct): `.github/agents/planner.agent.md`

Because of this, the glob pattern in VSCode Copilot Chat doesn't match, and custom agents are never loaded.

## Evidence

From [microsoft/vscode-copilot-chat](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/customInstructions/common/promptTypes.ts#L39):

```typescript
export const AGENT_FILE_EXTENSION = '.agent.md';
```

## Fix

In `CopilotSubagent.fromRulesyncSubagent()`, ensure the output `relativeFilePath` ends with `.agent.md`:

```typescript
let relativeFilePath = rulesyncSubagent.getRelativeFilePath();
if (!relativeFilePath.endsWith('.agent.md')) {
  relativeFilePath = relativeFilePath.replace(/\.md$/, '.agent.md');
}
```

This is a minimal, targeted fix — only affects the Copilot subagent output path. No changes to other targets (Cursor, Claude Code, etc.).

## How to verify
1. Create a rulesync subagent at `.rulesync/subagents/planner.md` with `targets: ["copilot"]`
2. Run `npx rulesync generate`
3. Check that `.github/agents/planner.agent.md` was created (not `planner.md`)
4. Open VSCode with Copilot Chat — the custom agent should now appear in the agent list