### PR TITLE
fix(ci): validate existing release tag commit in publish-assets workflow

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -97,13 +97,31 @@ jobs:
 
       - name: Create and push tag
         run: |
-          if [ -n "$(git tag -l "$TAG")" ] || [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
-            echo "Tag $TAG already exists (locally or on remote), skipping creation"
-          else
-            git tag "$TAG"
-            git push origin "$TAG"
-            echo "Tag $TAG created and pushed"
+          CURRENT_SHA="$(git rev-parse HEAD)"
+
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            TAG_SHA="$(git rev-list -n 1 "$TAG")"
+            if [ "$TAG_SHA" != "$CURRENT_SHA" ]; then
+              echo "::error::Tag $TAG already exists locally but points to $TAG_SHA instead of $CURRENT_SHA"
+              exit 1
+            fi
+            echo "Tag $TAG already exists locally and points to the current commit, skipping creation"
+            exit 0
           fi
+
+          REMOTE_SHA="$(git ls-remote --tags origin "refs/tags/$TAG^{}" | awk '{print $1}' | head -n 1)"
+          if [ -n "$REMOTE_SHA" ]; then
+            if [ "$REMOTE_SHA" != "$CURRENT_SHA" ]; then
+              echo "::error::Tag $TAG already exists on origin but points to $REMOTE_SHA instead of $CURRENT_SHA"
+              exit 1
+            fi
+            echo "Tag $TAG already exists on origin and points to the current commit, skipping creation"
+            exit 0
+          fi
+
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Tag $TAG created and pushed"
         env:
           TAG: ${{ steps.tag.outputs.tag }}
 


### PR DESCRIPTION
### Motivation
- Prevent uploading release assets to the wrong commit by ensuring a computed release tag (e.g. `vX.Y.Z`) actually points to the currently checked-out merge commit before creating or skipping tag creation.
- Avoid a downstream failure when making a draft release public via `gh release edit --draft=false` which requires a valid git tag to exist.

### Description
- Update `.github/workflows/publish-assets.yml` to strengthen the "Create and push tag" step by computing `CURRENT_SHA` with `git rev-parse HEAD` and using it for validation. 
- If a local tag exists, validate its SHA with `git rev-list -n 1 "$TAG"` and fail with `::error::` if it points to a different commit; otherwise skip creation. 
- If a remote tag exists, resolve the annotated tag target via `git ls-remote --tags origin "refs/tags/$TAG^{}"` and validate the SHA similarly, failing on mismatch and skipping if it matches. 
- Only create and push the tag when no conflicting local or remote tag exists, preserving idempotent behaviour when the tag already correctly points at the merge commit.

### Testing
- Ran `pnpm cicheck` (which runs `pnpm run check` and `pnpm run test`) and fixed transient content-cache files, then re-ran `pnpm cicheck` to validate the change.
- All automated code checks passed: `oxfmt`, `oxlint`, `eslint`, and typecheck (`tsgo`) completed successfully.
- Unit tests passed under `vitest` with `Test Files: 183 passed` and `Tests: 4866 passed`, and `cspell`/`secretlint` content checks also passed on the final run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2520c3cc8330a66b70381693927e)