### PR TITLE
feat(config): warn when using deprecated root.features object format

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -67,6 +67,10 @@ Example:
 
 ## Per-Target Features
 
+> [!WARNING]
+> The root `features` object format is deprecated. If you still use it, Rulesync emits a warning log.
+> For fine-grained per-target settings, use `root.targets` configuration instead.
+
 The `features` option accepts both an array and an object format. Use the object format when you want to generate different features for different targets:
 
 ```jsonc

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -67,6 +67,10 @@ Example:
 
 ## Per-Target Features
 
+> [!WARNING]
+> The root `features` object format is deprecated. If you still use it, Rulesync emits a warning log.
+> For fine-grained per-target settings, use `root.targets` configuration instead.
+
 The `features` option accepts both an array and an object format. Use the object format when you want to generate different features for different targets:
 
 ```jsonc

--- a/src/cli/commands/config-deprecation-warning.test.ts
+++ b/src/cli/commands/config-deprecation-warning.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { warnDeprecatedConfigPatterns } from "./config-deprecation-warning.js";
+
+describe("warnDeprecatedConfigPatterns", () => {
+  it("should warn when root.features object format is used", () => {
+    const logger = createMockLogger();
+    const config = {
+      hasPerTargetFeatures: vi.fn().mockReturnValue(true),
+    } as any;
+
+    warnDeprecatedConfigPatterns({ config, logger });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Deprecated: root.features object format is deprecated. For fine-grained per-target settings, use root.targets instead.",
+    );
+  });
+
+  it("should not warn when root.features array format is used", () => {
+    const logger = createMockLogger();
+    const config = {
+      hasPerTargetFeatures: vi.fn().mockReturnValue(false),
+    } as any;
+
+    warnDeprecatedConfigPatterns({ config, logger });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/config-deprecation-warning.ts
+++ b/src/cli/commands/config-deprecation-warning.ts
@@ -1,0 +1,21 @@
+import type { Config } from "../../config/config.js";
+import type { Logger } from "../../utils/logger.js";
+
+/**
+ * Warn when deprecated config patterns are detected.
+ */
+export const warnDeprecatedConfigPatterns = (params: { config: Config; logger: Logger }): void => {
+  const { config, logger } = params;
+  const hasPerTargetFeatures =
+    "hasPerTargetFeatures" in config &&
+    typeof config.hasPerTargetFeatures === "function" &&
+    config.hasPerTargetFeatures();
+
+  if (!hasPerTargetFeatures) {
+    return;
+  }
+
+  logger.warn(
+    "Deprecated: root.features object format is deprecated. For fine-grained per-target settings, use root.targets instead.",
+  );
+};

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -3,6 +3,7 @@ import { checkRulesyncDirExists, generate } from "../../lib/generate.js";
 import { CLIError, ErrorCodes } from "../../types/json-output.js";
 import type { Logger } from "../../utils/logger.js";
 import { calculateTotalCount } from "../../utils/result.js";
+import { warnDeprecatedConfigPatterns } from "./config-deprecation-warning.js";
 
 export type GenerateOptions = ConfigResolverResolveParams;
 
@@ -34,6 +35,7 @@ function logFeatureResult(
 
 export async function generateCommand(logger: Logger, options: GenerateOptions): Promise<void> {
   const config = await ConfigResolver.resolve(options);
+  warnDeprecatedConfigPatterns({ config, logger });
 
   const check = config.getCheck();
 

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -3,6 +3,7 @@ import { importFromTool } from "../../lib/import.js";
 import { CLIError, ErrorCodes } from "../../types/json-output.js";
 import type { Logger } from "../../utils/logger.js";
 import { calculateTotalCount } from "../../utils/result.js";
+import { warnDeprecatedConfigPatterns } from "./config-deprecation-warning.js";
 
 export type ImportOptions = Omit<ConfigResolverResolveParams, "delete" | "baseDirs">;
 
@@ -16,6 +17,7 @@ export async function importCommand(logger: Logger, options: ImportOptions): Pro
   }
 
   const config = await ConfigResolver.resolve(options);
+  warnDeprecatedConfigPatterns({ config, logger });
 
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const tool = config.getTargets()[0]!;

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,6 +1,7 @@
 import { ConfigResolver } from "../../config/config-resolver.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import type { Logger } from "../../utils/logger.js";
+import { warnDeprecatedConfigPatterns } from "./config-deprecation-warning.js";
 
 export type InstallCommandOptions = {
   update?: boolean;
@@ -20,6 +21,7 @@ export async function installCommand(
     verbose: options.verbose,
     silent: options.silent,
   });
+  warnDeprecatedConfigPatterns({ config, logger });
 
   const sources = config.getSources();
 


### PR DESCRIPTION
### Motivation
- Deprecate the use of `root.features` as an object (per-target feature object form) and encourage using `root.targets` for fine-grained per-target settings. 
- Emit a warning so users are informed when their config uses the deprecated object form.

### Description
- Add `warnDeprecatedConfigPatterns` helper in `src/cli/commands/config-deprecation-warning.ts` that logs a warning when a resolved `Config` exposes `hasPerTargetFeatures()` as true. 
- Invoke the warning helper immediately after config resolution in the CLI commands `generate`, `import`, and `install` (`src/cli/commands/generate.ts`, `src/cli/commands/import.ts`, `src/cli/commands/install.ts`).
- Add unit tests for the warning helper in `src/cli/commands/config-deprecation-warning.test.ts` verifying warn behavior for object vs array formats. 
- Update the configuration guide docs (`docs/guide/configuration.md` and synced `skills/rulesync/configuration.md`) to note the deprecation and recommend `root.targets`.

### Testing
- Ran the new unit tests and related CLI tests with `pnpm vitest run src/cli/commands/config-deprecation-warning.test.ts src/cli/commands/generate.test.ts src/cli/commands/import.test.ts src/cli/commands/install.test.ts`, and they passed. 
- Ran the full project checks with `pnpm cicheck`, which completed successfully (formatting, linting, typecheck, tests, and content checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de26b8cd0883308a6e48b2b55c7fd1)