### PR TITLE
docs: remove experimental label from Single Binary installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install -g rulesync
 brew install rulesync
 ```
 
-### Single Binary (Experimental)
+### Single Binary
 
 ```bash
 curl -fsSL https://github.com/dyoshikawa/rulesync/releases/latest/download/install.sh | bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ rulesync --version
 rulesync --help
 ```
 
-## Single Binary (Experimental)
+## Single Binary
 
 Download pre-built binaries from the [latest release](https://github.com/dyoshikawa/rulesync/releases/latest). These binaries are built using [Bun's single-file executable bundler](https://bun.sh/docs/bundler/executables).
 

--- a/skills/rulesync/installation.md
+++ b/skills/rulesync/installation.md
@@ -12,7 +12,7 @@ rulesync --version
 rulesync --help
 ```
 
-## Single Binary (Experimental)
+## Single Binary
 
 Download pre-built binaries from the [latest release](https://github.com/dyoshikawa/rulesync/releases/latest). These binaries are built using [Bun's single-file executable bundler](https://bun.sh/docs/bundler/executables).
 


### PR DESCRIPTION
### Motivation
- Clarify documentation to reflect that the Single Binary distribution is no longer marked as experimental and keep installation docs consistent across sources.

### Description
- Removed the `(Experimental)` label from the Single Binary headings in `README.md` and `docs/getting-started/installation.md`, and the corresponding `skills/rulesync/installation.md` was updated via the repo's docs sync hook.

### Testing
- Ran `pnpm cicheck`, which initially reported a formatting issue in an unrelated `AGENTS.md` file that was cleaned up, and then `pnpm cicheck` completed successfully including `vitest` (`4874` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3469763c8330bc2e85e9574fdf5d)