### PR TITLE
Replace residual tsx/esm loader with node strip-types loader

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,10 @@
 export default {
   "*": ["npx secretlint"],
   "package.json": ["npx sort-package-json"],
-  "docs/**/*.md": ["node --import tsx/esm scripts/sync-skill-docs.ts", "git add skills/rulesync/"],
+  "docs/**/*.md": [
+    "node --experimental-transform-types --experimental-loader ./scripts/strip-types-loader.mjs scripts/sync-skill-docs.ts",
+    "git add skills/rulesync/",
+  ],
   // Regenerate tool configurations when rulesync source files change
   ".rulesync/**/*": [() => "pnpm dev generate"],
 };


### PR DESCRIPTION
## Summary
- Replace the last residual `node --import tsx/esm` invocation in `.lintstagedrc.js` with the project's `--experimental-transform-types --experimental-loader ./scripts/strip-types-loader.mjs` setup, matching how other scripts already run TypeScript under Node.

This finishes the migration started in 6d7150bf (replace tsx runtime with node) and ac0acf21 (custom strip-types loader for CI).

## Test plan
- [ ] Confirm lint-staged still regenerates synced skill docs when a `docs/**/*.md` file is staged.