### PR TITLE
fix(ci): handle lightweight tags and verify remote SHA in publish-assets

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -99,23 +99,33 @@ jobs:
         run: |
           CURRENT_SHA="$(git rev-parse HEAD)"
 
+          LOCAL_TAG_EXISTS=0
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            LOCAL_TAG_EXISTS=1
             TAG_SHA="$(git rev-list -n 1 "$TAG")"
             if [ "$TAG_SHA" != "$CURRENT_SHA" ]; then
               echo "::error::Tag $TAG already exists locally but points to $TAG_SHA instead of $CURRENT_SHA"
               exit 1
             fi
-            echo "Tag $TAG already exists locally and points to the current commit, skipping creation"
-            exit 0
           fi
 
-          REMOTE_SHA="$(git ls-remote --tags origin "refs/tags/$TAG^{}" | awk '{print $1}' | head -n 1)"
+          # Query both peeled (annotated) and plain (lightweight) refs, preferring
+          # the peeled form when present so annotated tags resolve to their commit.
+          REMOTE_SHA="$(git ls-remote --tags origin "refs/tags/$TAG^{}" "refs/tags/$TAG" \
+            | awk '$2 ~ /\^\{\}$/ {peeled=$1} $2 !~ /\^\{\}$/ {plain=$1} END {print (peeled ? peeled : plain)}')"
           if [ -n "$REMOTE_SHA" ]; then
             if [ "$REMOTE_SHA" != "$CURRENT_SHA" ]; then
               echo "::error::Tag $TAG already exists on origin but points to $REMOTE_SHA instead of $CURRENT_SHA"
               exit 1
             fi
             echo "Tag $TAG already exists on origin and points to the current commit, skipping creation"
+            exit 0
+          fi
+
+          if [ "$LOCAL_TAG_EXISTS" -eq 1 ]; then
+            echo "Tag $TAG already exists locally and points to the current commit, pushing to origin"
+            git push origin "$TAG"
+            echo "Tag $TAG pushed"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Query both peeled (`^{}`) and plain refs in `git ls-remote` so lightweight tags on origin are detected. The previous `^{}`-only form returned empty for lightweight tags, causing `git push` to fail with a duplicate-tag error.
- Always verify the remote tag SHA even when the local tag matches, so a divergent remote tag is surfaced instead of being silently skipped.

Closes #1485

## Test plan
- [ ] Dispatch `Publish Assets` on a tag that already exists on origin as a lightweight tag and verify the workflow reports the existing tag instead of failing on push.
- [ ] Dispatch on a tag that exists locally (from checkout) but not on origin and verify it pushes successfully.
- [ ] Dispatch on a tag that exists on origin pointing to a different commit and verify the workflow fails with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)