### PR TITLE
Enable Claude Code permissions in global mode and update docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | ------------------- | ------------ | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
-| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
+| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Goose               | goose        | ✅ 🌏 |   ✅   |          |          |           |        |       |             |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -391,7 +391,7 @@ Rulesync provides a JSON Schema for editor validation and autocompletion. Add th
 }
 ```
 
-For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in `.claude/settings.json` using PascalCase tool names (e.g., `Bash(git *)`, `Edit(src/**)`, `Read(.env)`).
+For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in `.claude/settings.json` (project mode) or `~/.claude/settings.json` (global mode) using PascalCase tool names (e.g., `Bash(git *)`, `Edit(src/**)`, `Read(.env)`).
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -6,7 +6,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | ------------------- | ------------ | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
-| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
+| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -391,7 +391,7 @@ Rulesync provides a JSON Schema for editor validation and autocompletion. Add th
 }
 ```
 
-For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in `.claude/settings.json` using PascalCase tool names (e.g., `Bash(git *)`, `Edit(src/**)`, `Read(.env)`).
+For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in `.claude/settings.json` (project mode) or `~/.claude/settings.json` (global mode) using PascalCase tool names (e.g., `Bash(git *)`, `Edit(src/**)`, `Read(.env)`).
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -6,7 +6,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | ------------------- | ------------ | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md           | agentsmd     |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills        | agentsskills |       |        |          |          |           |   ✅   |       |             |
-| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |     ✅      |
+| Claude Code         | claudecode   | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI           | codexcli     | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI          | geminicli    | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | GitHub Copilot      | copilot      | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -192,6 +192,52 @@ default_permissions = "rulesync"
 describe("E2E: permissions (global mode)", () => {
   const { getProjectDir, getHomeDir } = useGlobalTestDirectories();
 
+  it("should generate claudecode permissions in home directory with --global", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+
+    await writeFileContent(
+      join(projectDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            bash: { "git status *": "allow" },
+            read: { ".env": "deny" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await writeFileContent(
+      join(homeDir, ".claude", "settings.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo test" }] }],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({
+      target: "claudecode",
+      features: "permissions",
+      global: true,
+      env: { HOME_DIR: homeDir },
+    });
+
+    const generated = JSON.parse(await readFileContent(join(homeDir, ".claude", "settings.json")));
+    expect(generated.permissions.allow).toContain("Bash(git status *)");
+    expect(generated.permissions.deny).toContain("Read(.env)");
+    expect(generated.hooks).toEqual({
+      PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo test" }] }],
+    });
+  });
+
   it("should generate opencode permissions in home directory with --global", async () => {
     const projectDir = getProjectDir();
     const homeDir = getHomeDir();

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -76,9 +76,9 @@ describe("PermissionsProcessor", () => {
       expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
     });
 
-    it("should return codexcli, geminicli and opencode for global mode", () => {
+    it("should return claudecode, codexcli, geminicli and opencode for global mode", () => {
       const targets = PermissionsProcessor.getToolTargets({ global: true });
-      expect(targets).toEqual(["codexcli", "geminicli", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
     });
 
     it("should return importable targets", () => {

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -54,7 +54,7 @@ const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPer
       class: ClaudecodePermissions,
       meta: {
         supportsProject: true,
-        supportsGlobal: false,
+        supportsGlobal: true,
         supportsImport: true,
       },
     },

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -575,17 +575,23 @@ describe("generate", () => {
       expect(PermissionsProcessor).not.toHaveBeenCalled();
     });
 
-    it("should skip permissions generation in global mode", async () => {
+    it("should generate permissions in global mode when target supports it", async () => {
       mockConfig.getFeatures.mockReturnValue(["permissions"]);
       mockConfig.getGlobal.mockReturnValue(true);
       vi.mocked(PermissionsProcessor.getToolTargets).mockImplementation((params) =>
-        params?.global ? ["opencode"] : ["claudecode"],
+        params?.global ? ["claudecode"] : ["claudecode"],
       );
 
       const result = await generate({ logger, config: mockConfig as never });
 
-      expect(result.permissionsCount).toBe(0);
-      expect(PermissionsProcessor).not.toHaveBeenCalled();
+      expect(result.permissionsCount).toBe(1);
+      expect(PermissionsProcessor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseDir: ".",
+          toolTarget: "claudecode",
+          global: true,
+        }),
+      );
     });
 
     it("should handle errors gracefully and continue", async () => {

--- a/src/lib/import.test.ts
+++ b/src/lib/import.test.ts
@@ -681,11 +681,11 @@ describe("importFromTool", () => {
       expect(PermissionsProcessor).not.toHaveBeenCalled();
     });
 
-    it("should skip permissions import in global mode", async () => {
+    it("should import permissions in global mode when target supports it", async () => {
       mockConfig.getFeatures.mockReturnValue(["permissions"]);
       mockConfig.getGlobal.mockReturnValue(true);
       vi.mocked(PermissionsProcessor.getToolTargets).mockImplementation((params) =>
-        params?.global ? ["opencode"] : ["claudecode"],
+        params?.global ? ["claudecode"] : ["claudecode"],
       );
 
       const result = await importFromTool({
@@ -694,8 +694,14 @@ describe("importFromTool", () => {
         tool: "claudecode",
       });
 
-      expect(result.permissionsCount).toBe(0);
-      expect(PermissionsProcessor).not.toHaveBeenCalled();
+      expect(result.permissionsCount).toBe(1);
+      expect(PermissionsProcessor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseDir: ".",
+          toolTarget: "claudecode",
+          global: true,
+        }),
+      );
     });
 
     it("should return 0 when no tool files found", async () => {


### PR DESCRIPTION
### Motivation
- Allow Rulesync to generate/import permissions for Claude Code in global mode so users can manage `~/.claude/settings.json` as well as project-scoped settings.
- Clarify documentation about where generated Claude Code settings are written in project vs global mode.

### Description
- Mark `claudecode` as `supportsGlobal: true` in the `PermissionsProcessor` factory so the processor includes Claude Code in global targets. 
- Update unit tests and generation/import logic expectations to include `claudecode` for global mode (`generate`/`import` tests and `PermissionsProcessor` target tests). 
- Add an e2e test `should generate claudecode permissions in home directory with --global` to validate writing permissions to the home `.claude/settings.json` and preserving existing fields. 
- Update documentation and README entries (`README.md`, `docs/reference/*`, `skills/rulesync/*`, and supported-tools tables) to reflect that Claude Code supports global-mode permissions and to clarify the location of generated Claude settings. 

### Testing
- Ran unit tests including `permissions-processor.test.ts`, `generate.test.ts`, and `import.test.ts`, and updated expectations to reflect global support for `claudecode`, and they passed.
- Ran the end-to-end permissions spec `e2e-permissions.spec.ts` including the new global-mode claudecode case, and it passed. 
- Ran overall test suite to ensure no regressions and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df49d1454c8330969b7cf55ce58858)