### PR TITLE
Add GitHub Actions workflow to auto-close stale maintainer-scrap issues

### DIFF
--- a/.github/workflows/auto-close-maintainer-scrap-issues.yml
+++ b/.github/workflows/auto-close-maintainer-scrap-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale maintainer-scrap issues
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const STALE_DAYS = 30;

--- a/.github/workflows/auto-close-maintainer-scrap-issues.yml
+++ b/.github/workflows/auto-close-maintainer-scrap-issues.yml
@@ -1,0 +1,56 @@
+name: Auto Close Stale Maintainer Scrap Issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close-stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale maintainer-scrap issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const STALE_DAYS = 30;
+            const staleThresholdMs = STALE_DAYS * 24 * 60 * 60 * 1000;
+            const now = Date.now();
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "maintainer-scrap",
+              per_page: 100,
+            });
+
+            const staleIssues = issues.filter((issue) => {
+              if (issue.pull_request) {
+                return false;
+              }
+
+              const updatedAt = new Date(issue.updated_at).getTime();
+              return now - updatedAt >= staleThresholdMs;
+            });
+
+            core.info(
+              `Found ${staleIssues.length} stale maintainer-scrap issue(s) older than ${STALE_DAYS} days.`
+            );
+
+            for (const issue of staleIssues) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+              });
+
+              core.info(
+                `Closed issue #${issue.number} (updated at ${issue.updated_at}).`
+              );
+            }


### PR DESCRIPTION
### Motivation
- Reduce manual triage by automatically closing issues labeled `maintainer-scrap` that have not been updated for a month.
- Provide a safe, auditable scheduled job that maintainers can also trigger manually.

### Description
- Add a new workflow file at `.github/workflows/auto-close-maintainer-scrap-issues.yml` that runs daily (UTC 00:00) and supports `workflow_dispatch` manual runs.
- Use `actions/github-script@v8` to list open issues with the `maintainer-scrap` label, skip pull requests, and close issues whose `updated_at` is >= 30 days old while logging actions.
- Grant minimal permissions required (`contents: read`, `issues: write`).

### Testing
- Ran `pnpm cicheck`, which includes formatting, linting, type checks, unit tests, and content checks, and it completed successfully.
- The test suite ran via `vitest` and reported all tests passing (`4901` tests passed).
- Content checks (`cspell` and `secretlint`) completed successfully as part of `pnpm cicheck`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fadc7ec88330b98699c5ea8cf883)