### PR TITLE
feat(permissions): add Kiro permissions generation/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | Roo Code            | roo          |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Qwen Code           | qwencode     |  ✅   |   ✅   |          |          |           |        |       |             |
-| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |             |
+| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
 | Google Antigravity  | antigravity  |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
 | JetBrains Junie     | junie        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode         | augmentcode  |  ✅   |   ✅   |          |          |           |        |       |             |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -458,4 +458,12 @@ For Gemini CLI, this generates `tools.allowed` and `tools.exclude` in `.gemini/s
 - `ask` rules are skipped with a warning (Gemini CLI settings do not support explicit ask entries)
 - Tool categories are mapped as: `bash` → `run_shell_command`, `read` → `read_file`, `edit` → `replace`, `write` → `write_file`, `webfetch` → `web_fetch`
 
+For Kiro, this generates tool permission settings in `.kiro/agents/default.json` (project mode):
+
+- `bash` maps to `toolsSettings.shell.allowedCommands` / `toolsSettings.shell.deniedCommands`
+- `read` maps to `toolsSettings.read.allowedPaths` / `toolsSettings.read.deniedPaths`
+- `edit` / `write` map to `toolsSettings.write.allowedPaths` / `toolsSettings.write.deniedPaths`
+- `webfetch` / `websearch` with pattern `*` map to `allowedTools` entries (`web_fetch` / `web_search`)
+- `ask` rules are skipped with a warning (Kiro config does not support explicit ask entries)
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -20,7 +20,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Roo Code            | roo          |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Qwen Code           | qwencode     |  ✅   |   ✅   |          |          |           |        |       |             |
-| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |             |
+| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
 | Google Antigravity  | antigravity  |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
 | JetBrains Junie     | junie        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode         | augmentcode  |  ✅   |   ✅   |          |          |           |        |       |             |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -458,4 +458,12 @@ For Gemini CLI, this generates `tools.allowed` and `tools.exclude` in `.gemini/s
 - `ask` rules are skipped with a warning (Gemini CLI settings do not support explicit ask entries)
 - Tool categories are mapped as: `bash` → `run_shell_command`, `read` → `read_file`, `edit` → `replace`, `write` → `write_file`, `webfetch` → `web_fetch`
 
+For Kiro, this generates tool permission settings in `.kiro/agents/default.json` (project mode):
+
+- `bash` maps to `toolsSettings.shell.allowedCommands` / `toolsSettings.shell.deniedCommands`
+- `read` maps to `toolsSettings.read.allowedPaths` / `toolsSettings.read.deniedPaths`
+- `edit` / `write` map to `toolsSettings.write.allowedPaths` / `toolsSettings.write.deniedPaths`
+- `webfetch` / `websearch` with pattern `*` map to `allowedTools` entries (`web_fetch` / `web_search`)
+- `ask` rules are skipped with a warning (Kiro config does not support explicit ask entries)
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -20,7 +20,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Roo Code            | roo          |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Qwen Code           | qwencode     |  ✅   |   ✅   |          |          |           |        |       |             |
-| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |             |
+| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
 | Google Antigravity  | antigravity  |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
 | JetBrains Junie     | junie        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode         | augmentcode  |  ✅   |   ✅   |          |          |           |        |       |             |

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -98,6 +98,37 @@ describe("E2E: permissions", () => {
     expect(content.tools.exclude).toContain("run_shell_command(rm *)");
     expect(content.tools.exclude).toContain("web_fetch(example.com)");
   });
+
+  it("should generate kiro permissions into .kiro/agents/default.json", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            bash: { "git *": "allow", "rm *": "deny" },
+            read: { "src/**": "allow" },
+            write: { "docs/**": "allow" },
+            webfetch: { "*": "allow" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({ target: "kiro", features: "permissions" });
+
+    const content = JSON.parse(
+      await readFileContent(join(testDir, ".kiro", "agents", "default.json")),
+    );
+    expect(content.toolsSettings.shell.allowedCommands).toContain("git *");
+    expect(content.toolsSettings.shell.deniedCommands).toContain("rm *");
+    expect(content.toolsSettings.read.allowedPaths).toContain("src/**");
+    expect(content.toolsSettings.write.allowedPaths).toContain("docs/**");
+    expect(content.allowedTools).toContain("web_fetch");
+  });
 });
 
 describe("E2E: permissions (import)", () => {
@@ -186,6 +217,42 @@ default_permissions = "rulesync"
     expect(content.permission.read["src/**"]).toBe("allow");
     expect(content.permission.bash["rm *"]).toBe("deny");
     expect(content.permission.webfetch["example.com"]).toBe("deny");
+  });
+
+  it("should import kiro permissions into .rulesync/permissions.json", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, ".kiro", "agents", "default.json"),
+      JSON.stringify(
+        {
+          allowedTools: ["web_fetch"],
+          toolsSettings: {
+            shell: {
+              allowedCommands: ["git *"],
+              deniedCommands: ["rm *"],
+            },
+            read: {
+              allowedPaths: ["src/**"],
+              deniedPaths: [".env"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runImport({ target: "kiro", features: "permissions" });
+
+    const content = JSON.parse(
+      await readFileContent(join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH)),
+    );
+    expect(content.permission.bash["git *"]).toBe("allow");
+    expect(content.permission.bash["rm *"]).toBe("deny");
+    expect(content.permission.read["src/**"]).toBe("allow");
+    expect(content.permission.read[".env"]).toBe("deny");
+    expect(content.permission.webfetch["*"]).toBe("allow");
   });
 });
 

--- a/src/features/permissions/kiro-permissions.test.ts
+++ b/src/features/permissions/kiro-permissions.test.ts
@@ -1,0 +1,98 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { KiroPermissions } from "./kiro-permissions.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+
+describe("KiroPermissions", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("should convert rulesync permissions to Kiro default agent permissions", async () => {
+    const rulesyncPermissions = new RulesyncPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".rulesync",
+      relativeFilePath: "permissions.json",
+      fileContent: JSON.stringify({
+        permission: {
+          bash: { "git *": "allow", "rm *": "deny" },
+          read: { "src/**": "allow", ".env": "deny" },
+          write: { "docs/**": "allow" },
+          webfetch: { "*": "allow" },
+        },
+      }),
+    });
+
+    const kiroPermissions = await KiroPermissions.fromRulesyncPermissions({
+      baseDir: testDir,
+      rulesyncPermissions,
+    });
+
+    const content = JSON.parse(kiroPermissions.getFileContent());
+    expect(content.toolsSettings.shell.allowedCommands).toContain("git *");
+    expect(content.toolsSettings.shell.deniedCommands).toContain("rm *");
+    expect(content.toolsSettings.read.allowedPaths).toContain("src/**");
+    expect(content.toolsSettings.read.deniedPaths).toContain(".env");
+    expect(content.toolsSettings.write.allowedPaths).toContain("docs/**");
+    expect(content.allowedTools).toContain("web_fetch");
+  });
+
+  it("should convert Kiro default agent permissions to rulesync format", () => {
+    const kiroPermissions = new KiroPermissions({
+      baseDir: testDir,
+      relativeDirPath: join(".kiro", "agents"),
+      relativeFilePath: "default.json",
+      fileContent: JSON.stringify({
+        allowedTools: ["web_fetch"],
+        toolsSettings: {
+          shell: {
+            allowedCommands: ["git *"],
+            deniedCommands: ["rm *"],
+          },
+          read: {
+            allowedPaths: ["src/**"],
+            deniedPaths: [".env"],
+          },
+          write: {
+            allowedPaths: ["docs/**"],
+            deniedPaths: ["secrets/**"],
+          },
+        },
+      }),
+    });
+
+    const rulesyncPermissions = kiroPermissions.toRulesyncPermissions();
+    const json = rulesyncPermissions.getJson();
+
+    expect(json.permission.bash?.["git *"]).toBe("allow");
+    expect(json.permission.bash?.["rm *"]).toBe("deny");
+    expect(json.permission.read?.["src/**"]).toBe("allow");
+    expect(json.permission.read?.[".env"]).toBe("deny");
+    expect(json.permission.write?.["docs/**"]).toBe("allow");
+    expect(json.permission.write?.["secrets/**"]).toBe("deny");
+    expect(json.permission.webfetch?.["*"]).toBe("allow");
+  });
+
+  it("should load existing .kiro/agents/default.json", async () => {
+    const kiroDir = join(testDir, ".kiro", "agents");
+    await ensureDir(kiroDir);
+    await writeFileContent(join(kiroDir, "default.json"), JSON.stringify({ model: "x" }));
+
+    const loaded = await KiroPermissions.fromFile({ baseDir: testDir });
+    expect(loaded).toBeInstanceOf(KiroPermissions);
+    expect(JSON.parse(loaded.getFileContent()).model).toBe("x");
+  });
+});

--- a/src/features/permissions/kiro-permissions.ts
+++ b/src/features/permissions/kiro-permissions.ts
@@ -1,0 +1,228 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import type { ValidationResult } from "../../types/ai-file.js";
+import type { PermissionsConfig } from "../../types/permissions.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+import {
+  ToolPermissions,
+  type ToolPermissionsForDeletionParams,
+  type ToolPermissionsFromFileParams,
+  type ToolPermissionsFromRulesyncPermissionsParams,
+  type ToolPermissionsSettablePaths,
+} from "./tool-permissions.js";
+
+const KiroAgentSchema = z.looseObject({
+  allowedTools: z.optional(z.array(z.string())),
+  toolsSettings: z.optional(z.record(z.string(), z.unknown())),
+});
+
+type KiroAgent = z.infer<typeof KiroAgentSchema>;
+const UnknownRecordSchema = z.record(z.string(), z.unknown());
+
+export class KiroPermissions extends ToolPermissions {
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolPermissionsSettablePaths {
+    return {
+      relativeDirPath: join(".kiro", "agents"),
+      relativeFilePath: "default.json",
+    };
+  }
+
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static async fromFile({
+    baseDir = process.cwd(),
+    validate = true,
+  }: ToolPermissionsFromFileParams): Promise<KiroPermissions> {
+    const paths = this.getSettablePaths();
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
+    return new KiroPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncPermissions({
+    baseDir = process.cwd(),
+    rulesyncPermissions,
+    validate = true,
+    logger,
+  }: ToolPermissionsFromRulesyncPermissionsParams): Promise<KiroPermissions> {
+    const paths = this.getSettablePaths();
+    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
+
+    const parsedResult = KiroAgentSchema.safeParse(JSON.parse(existingContent));
+    if (!parsedResult.success) {
+      throw new Error(
+        `Failed to parse existing Kiro agent config at ${filePath}: ${formatError(parsedResult.error)}`,
+      );
+    }
+
+    const config = rulesyncPermissions.getJson();
+    const next = buildKiroPermissionsFromRulesync({ config, logger, existing: parsedResult.data });
+
+    return new KiroPermissions({
+      baseDir,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(next, null, 2),
+      validate,
+    });
+  }
+
+  toRulesyncPermissions(): RulesyncPermissions {
+    let parsed: KiroAgent;
+    try {
+      parsed = KiroAgentSchema.parse(JSON.parse(this.getFileContent()));
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Kiro permissions content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+
+    const permission: PermissionsConfig["permission"] = {};
+    const toolsSettings = parsed.toolsSettings ?? {};
+
+    const shellSettings = asRecord(toolsSettings.shell);
+    const shellAllow = asStringArray(shellSettings.allowedCommands);
+    const shellDeny = asStringArray(shellSettings.deniedCommands);
+    if (shellAllow.length > 0 || shellDeny.length > 0) {
+      permission.bash = {};
+      for (const pattern of shellAllow) permission.bash[pattern] = "allow";
+      for (const pattern of shellDeny) permission.bash[pattern] = "deny";
+    }
+
+    const readSettings = asRecord(toolsSettings.read);
+    const readAllow = asStringArray(readSettings.allowedPaths);
+    const readDeny = asStringArray(readSettings.deniedPaths);
+    if (readAllow.length > 0 || readDeny.length > 0) {
+      permission.read = {};
+      for (const pattern of readAllow) permission.read[pattern] = "allow";
+      for (const pattern of readDeny) permission.read[pattern] = "deny";
+    }
+
+    const writeSettings = asRecord(toolsSettings.write);
+    const writeAllow = asStringArray(writeSettings.allowedPaths);
+    const writeDeny = asStringArray(writeSettings.deniedPaths);
+    if (writeAllow.length > 0 || writeDeny.length > 0) {
+      permission.write = {};
+      for (const pattern of writeAllow) permission.write[pattern] = "allow";
+      for (const pattern of writeDeny) permission.write[pattern] = "deny";
+    }
+
+    const allowedTools = new Set(parsed.allowedTools ?? []);
+    if (allowedTools.has("web_fetch")) {
+      permission.webfetch = { "*": "allow" };
+    }
+    if (allowedTools.has("web_search")) {
+      permission.websearch = { "*": "allow" };
+    }
+
+    return this.toRulesyncPermissionsDefault({
+      fileContent: JSON.stringify({ permission }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    baseDir = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolPermissionsForDeletionParams): KiroPermissions {
+    return new KiroPermissions({
+      baseDir,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({}, null, 2),
+      validate: false,
+    });
+  }
+}
+
+function buildKiroPermissionsFromRulesync({
+  config,
+  logger,
+  existing,
+}: {
+  config: PermissionsConfig;
+  logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
+  existing: KiroAgent;
+}): KiroAgent {
+  const nextAllowedTools = new Set(existing.allowedTools ?? []);
+  const nextToolsSettings = { ...asRecord(existing.toolsSettings) };
+
+  const shell: { allowedCommands: string[]; deniedCommands: string[] } = {
+    allowedCommands: [],
+    deniedCommands: [],
+  };
+  const read: { allowedPaths: string[]; deniedPaths: string[] } = {
+    allowedPaths: [],
+    deniedPaths: [],
+  };
+  const write: { allowedPaths: string[]; deniedPaths: string[] } = {
+    allowedPaths: [],
+    deniedPaths: [],
+  };
+
+  for (const [category, rules] of Object.entries(config.permission)) {
+    for (const [pattern, action] of Object.entries(rules)) {
+      if (action === "ask") {
+        logger?.warn(`Kiro permissions do not support "ask". Skipping ${category}:${pattern}`);
+        continue;
+      }
+      if (category === "bash") {
+        (action === "allow" ? shell.allowedCommands : shell.deniedCommands).push(pattern);
+      } else if (category === "read") {
+        (action === "allow" ? read.allowedPaths : read.deniedPaths).push(pattern);
+      } else if (category === "edit" || category === "write") {
+        (action === "allow" ? write.allowedPaths : write.deniedPaths).push(pattern);
+      } else if (category === "webfetch" || category === "websearch") {
+        if (pattern !== "*") {
+          logger?.warn(
+            `Kiro ${category} supports only wildcard (*) via allowedTools. Skipping rule: ${pattern}`,
+          );
+          continue;
+        }
+        if (action === "allow")
+          nextAllowedTools.add(category === "webfetch" ? "web_fetch" : "web_search");
+      } else {
+        logger?.warn(`Kiro permissions do not support category: ${category}. Skipping.`);
+      }
+    }
+  }
+
+  nextToolsSettings.shell = shell;
+  nextToolsSettings.read = read;
+  nextToolsSettings.write = write;
+
+  return {
+    ...existing,
+    allowedTools: [...nextAllowedTools].toSorted(),
+    toolsSettings: nextToolsSettings,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  const result = UnknownRecordSchema.safeParse(value);
+  return result.success ? result.data : {};
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -12,6 +12,7 @@ import { ensureDir, readFileContent, writeFileContent } from "../../utils/file.j
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
 import { CodexcliPermissions } from "./codexcli-permissions.js";
 import { GeminicliPermissions } from "./geminicli-permissions.js";
+import { KiroPermissions } from "./kiro-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { PermissionsProcessor } from "./permissions-processor.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -71,9 +72,9 @@ describe("PermissionsProcessor", () => {
   });
 
   describe("getToolTargets", () => {
-    it("should return claudecode, codexcli, geminicli and opencode for project mode", () => {
+    it("should return claudecode, codexcli, geminicli, kiro and opencode for project mode", () => {
       const targets = PermissionsProcessor.getToolTargets();
-      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "kiro", "opencode"]);
     });
 
     it("should return claudecode, codexcli, geminicli and opencode for global mode", () => {
@@ -83,7 +84,7 @@ describe("PermissionsProcessor", () => {
 
     it("should return importable targets", () => {
       const targets = PermissionsProcessor.getToolTargets({ importOnly: true });
-      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "opencode"]);
+      expect(targets).toEqual(["claudecode", "codexcli", "geminicli", "kiro", "opencode"]);
     });
   });
 
@@ -232,6 +233,32 @@ default_permissions = "rulesync"
 
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(GeminicliPermissions);
+    });
+
+    it("should load Kiro .kiro/agents/default.json", async () => {
+      const kiroDir = join(testDir, ".kiro", "agents");
+      await ensureDir(kiroDir);
+      await writeFileContent(
+        join(kiroDir, "default.json"),
+        JSON.stringify({
+          toolsSettings: {
+            shell: {
+              allowedCommands: ["git *"],
+            },
+          },
+        }),
+      );
+
+      const processor = new PermissionsProcessor({
+        logger,
+        baseDir: testDir,
+        toolTarget: "kiro",
+      });
+
+      const files = await processor.loadToolFiles();
+
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(KiroPermissions);
     });
   });
 

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -10,6 +10,7 @@ import type { Logger } from "../../utils/logger.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
 import { CodexcliPermissions } from "./codexcli-permissions.js";
 import { GeminicliPermissions } from "./geminicli-permissions.js";
+import { KiroPermissions } from "./kiro-permissions.js";
 import { OpencodePermissions } from "./opencode-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 import type {
@@ -24,6 +25,7 @@ const permissionsProcessorToolTargetTuple = [
   "claudecode",
   "codexcli",
   "geminicli",
+  "kiro",
   "opencode",
 ] as const;
 
@@ -77,6 +79,17 @@ const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPer
       meta: {
         supportsProject: true,
         supportsGlobal: true,
+        supportsImport: true,
+      },
+    },
+  ],
+  [
+    "kiro",
+    {
+      class: KiroPermissions,
+      meta: {
+        supportsProject: true,
+        supportsGlobal: false,
         supportsImport: true,
       },
     },


### PR DESCRIPTION
### Motivation
- Add support for Kiro tool permissions so Rulesync can generate `.kiro/agents/default.json` from `.rulesync/permissions.json` and import Kiro agent settings back into Rulesync format. 
- Map canonical Rulesync permission categories to Kiro fields (`toolsSettings.shell/read/write` and `allowedTools`) and surface warnings for unsupported mappings (e.g., `ask`).

### Description
- Introduce `KiroPermissions` implementation in `src/features/permissions/kiro-permissions.ts` to convert between Rulesync permissions and Kiro agent JSON shape. 
- Register `kiro` in the `PermissionsProcessor` factories and tool-target tuple so `permissions` generation/import works for Kiro (project mode + import support). 
- Add unit tests (`src/features/permissions/kiro-permissions.test.ts`, updates to `permissions-processor.test.ts`) and E2E coverage (`src/e2e/e2e-permissions.spec.ts`) to verify generate/import happy paths. 
- Update documentation and support matrix (`README.md`, `docs/reference/file-formats.md`, `docs/reference/supported-tools.md` and synced `skills/rulesync/*`) to reflect Kiro permissions support.

### Testing
- Ran focused unit tests with `pnpm -s vitest run src/features/permissions/kiro-permissions.test.ts src/features/permissions/permissions-processor.test.ts src/e2e/e2e-permissions.spec.ts`, which passed. 
- Ran full CI checks with `pnpm cicheck`; an initial run failed due to local compile cache artifacts, the cache was cleaned and the final `pnpm cicheck` run completed successfully with all tests and linters passing. 
- E2E scenarios exercise Kiro generate/import flows and were added to the existing permissions E2E matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fa8489e88330bf2235ca50003610)