### PR TITLE
fix: preserve multiline Codex CLI subagent instructions

### DIFF
--- a/src/features/subagents/codexcli-subagent.test.ts
+++ b/src/features/subagents/codexcli-subagent.test.ts
@@ -260,9 +260,8 @@ describe("CodexCliSubagent", () => {
       // Verify TOML body contains expected fields
       expect(codexcliSubagent.getBody()).toContain('name = "reviewer"');
       expect(codexcliSubagent.getBody()).toContain('description = "Code reviewer"');
-      expect(codexcliSubagent.getBody()).toContain(
-        'developer_instructions = "Review code changes"',
-      );
+      expect(codexcliSubagent.getBody()).toContain("developer_instructions =");
+      expect(codexcliSubagent.getBody()).toContain("Review code changes");
       expect(codexcliSubagent.getBody()).toContain('model = "gpt-5"');
       expect(codexcliSubagent.getBody()).toContain('sandbox_mode = "full"');
     });
@@ -646,6 +645,31 @@ describe("CodexCliSubagent", () => {
       const rulesyncSubagent = subagent.toRulesyncSubagent();
       expect(rulesyncSubagent.getBody()).toContain("Line 1");
       expect(rulesyncSubagent.getBody()).toContain("Line 2");
+    });
+
+    it("should preserve multiline body when generating developer_instructions", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "multiline.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          name: "multiline-agent",
+        },
+        body: ["## English", "", "Stay in exploration mode...", "", "1. Step one"].join("\n"),
+        validate: true,
+      });
+
+      const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        rulesyncSubagent,
+      }) as CodexCliSubagent;
+
+      expect(codexcliSubagent.getBody()).toContain("developer_instructions =");
+      expect(codexcliSubagent.getBody()).toContain("## English");
+      expect(codexcliSubagent.getBody()).toContain("1. Step one");
+      expect(codexcliSubagent.getBody()).not.toContain("\\n\\nStay in exploration mode");
     });
 
     it("should handle special characters in TOML values", () => {

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -26,6 +26,23 @@ export const CodexCliSubagentTomlSchema = z.looseObject({
 
 type CodexCliSubagentToml = z.infer<typeof CodexCliSubagentTomlSchema>;
 
+function stringifyCodexCliSubagentToml(tomlObj: CodexCliSubagentToml): string {
+  const { developer_instructions, ...restFields } = tomlObj;
+  const restToml = smolToml.stringify(restFields).trimEnd();
+
+  if (developer_instructions === undefined) {
+    return restToml;
+  }
+
+  const developerInstructionsToml = developer_instructions.includes("\n")
+    ? developer_instructions.includes("'''")
+      ? smolToml.stringify({ developer_instructions }).trimEnd()
+      : `developer_instructions = '''\n${developer_instructions}\n'''`
+    : smolToml.stringify({ developer_instructions }).trimEnd();
+
+  return [restToml, developerInstructionsToml].filter((value) => value.length > 0).join("\n");
+}
+
 export type CodexCliSubagentParams = {
   body: string;
 } & AiFileParams;
@@ -124,7 +141,7 @@ export class CodexCliSubagent extends ToolSubagent {
       ...codexcliSection,
     };
 
-    const body = smolToml.stringify(tomlObj);
+    const body = stringifyCodexCliSubagentToml(tomlObj);
     const paths = this.getSettablePaths({ global });
     const relativeFilePath = rulesyncSubagent.getRelativeFilePath().replace(/\.md$/, ".toml");
 


### PR DESCRIPTION
### Motivation

- Converting Rulesync subagent Markdown bodies to Codex CLI TOML collapsed multiline `developer_instructions` into a single escaped string, losing the original multiline structure. 
- The goal is to preserve the canonical Markdown multiline body when generating `developer_instructions` in Codex CLI subagent TOML while retaining safe fallback behavior for edge cases.

### Description

- Add `stringifyCodexCliSubagentToml` to serialize Codex CLI TOML while emitting `developer_instructions` as a TOML multiline literal when the body contains newlines and does not itself contain `'''`.
- Use `stringifyCodexCliSubagentToml` in `CodexCliSubagent.fromRulesyncSubagent` instead of `smolToml.stringify` to preserve multiline content. 
- Update existing tests to avoid brittle assertions about exact quoting and add a new test that verifies multiline Rulesync bodies are preserved in generated Codex CLI TOML. 
- Keep fallback behavior to call `smolToml.stringify` when multiline literal quoting could produce invalid TOML (e.g., body includes `'''`).

### Testing

- Ran the updated unit tests for the feature with `pnpm vitest run src/features/subagents/codexcli-subagent.test.ts`, and they passed (`38 tests`).
- Ran full CI checks with `pnpm cicheck`, which completed successfully including formatting, linting, typecheck, unit tests, and content checks.
- The change is covered by the added unit test that confirms multiline body preservation and by existing round-trip tests for subagent conversion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d851ba588330a173cb5f640fef18)