### PR TITLE
chore: switch Claude Code default mode to auto

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,7 @@
     "allow": [
       "mcp__serena"
     ],
-    "defaultMode": "acceptEdits"
+    "defaultMode": "auto"
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
## Summary
- Change `.claude/settings.json` `defaultMode` from `acceptEdits` to `auto` so Claude Code starts in auto mode by default.

## Test plan
- [ ] Confirm Claude Code launches in auto mode with the updated settings.