### PR TITLE
feat: add post-issue-comment slash command

### DIFF
--- a/.rulesync/commands/post-issue-comment.md
+++ b/.rulesync/commands/post-issue-comment.md
@@ -1,0 +1,58 @@
+---
+targets:
+  - "*"
+description: >-
+  Post a reply comment on a GitHub issue in English with a natural, concise
+  writing style, based on the intent passed as arguments
+---
+
+arguments = $ARGUMENTS
+
+Parse `arguments` as:
+
+- `target_issue`: the issue number (or URL) to reply to
+- `intent`: the gist of the reply the user wants to post (what to say, the stance to take, the points to cover)
+
+If `target_issue` is not provided, ask the user which issue to comment on.
+If `intent` is not provided, ask the user what the reply should convey.
+
+## Step 1: Gather Issue Context
+
+Run the following in parallel:
+
+- Get the issue description and metadata: `gh issue view <issue_number>`
+- Get the issue comments: `gh issue view <issue_number> --comments`
+
+If the issue references related pull requests, commits, or files that are needed to craft an informed reply, gather that context as well.
+
+## Step 2: Draft the Reply
+
+Based on the issue content and the user's `intent`, draft a reply comment.
+
+- Ground the reply in the actual discussion — address the latest comment or the original issue as appropriate.
+- Reflect the user's `intent` faithfully; do not add positions the user did not ask for.
+- If relevant context is missing or a decision cannot be made without more information, say so in the reply rather than guessing.
+
+## Step 3: Post the Comment
+
+Post the drafted reply using:
+
+```bash
+gh issue comment <issue_number> --body "<reply body>"
+```
+
+## Writing Style
+
+Write in **English only**.
+
+Style guidelines — write like a human teammate, not a bot:
+
+- Use plain paragraphs. Avoid headings (`##`), horizontal rules (`---`), and excessive bullet lists.
+- Keep it conversational and direct. Say what matters, skip the filler.
+- Do not use phrases like "Great point!" or "Thanks for raising this!" unless you genuinely mean it and have nothing else to add.
+- Be honest. If you disagree or see an issue, say so clearly but respectfully.
+- Short is fine. A two-sentence comment is better than a five-paragraph essay with no substance.
+
+## Step 4: Report
+
+Output the issue number and a brief summary of the comment that was posted.

--- a/skills/rulesync/faq.md
+++ b/skills/rulesync/faq.md
@@ -35,3 +35,22 @@ echo "**/.agent/skills/" >> .git/info/exclude
 `.git/info/exclude` works like `.gitignore` but is local-only, so it won't affect Antigravity's ability to load the rules while still excluding these directories from Git.
 
 Note: `.git/info/exclude` can't be shared with your team since it's not committed to the repository.
+
+## Generated rule files create noise in pull request diffs
+
+Because many AI coding tools (Claude Code, Cursor, Copilot, Antigravity, etc.) need to read their rule files directly from the working tree, the files rulesync generates are intentionally not `.gitignore`d. On repositories with many targets, the generated files can dominate a pull request diff and make code review harder.
+
+**Workaround:** Add the generated paths to `.gitattributes` with the [`linguist-generated`](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github#marking-files-as-generated) attribute. GitHub's PR UI will then collapse those files by default while still keeping them visible and loadable by the tools themselves.
+
+Example `.gitattributes` for a repo that uses `.agent/`, Claude Code, Cursor, and Copilot targets:
+
+```
+.agent/rules/**           linguist-generated
+.agent/skills/**          linguist-generated
+.agent/workflows/**       linguist-generated
+CLAUDE.md                 linguist-generated
+.cursor/rules/**          linguist-generated
+.github/copilot-instructions.md linguist-generated
+```
+
+Adjust the list to match the targets you have configured. These entries only affect how GitHub displays the files in diffs — they don't change how Git tracks them, and they don't interfere with the tools reading the rules.


### PR DESCRIPTION
## Summary
- Add new `.rulesync/commands/post-issue-comment.md` slash command that drafts and posts a reply on a GitHub issue based on the intent passed via `$ARGUMENTS`, modeled after the existing `post-review-comments` command
- Sync `skills/rulesync/faq.md` with `docs/` (gitattributes FAQ entry) via `scripts/sync-skill-docs.ts`

## Test plan
- [ ] Run `/post-issue-comment <issue_number> <intent>` and verify the generated comment is posted to the target issue
- [ ] Verify `pnpm cicheck` passes