### PR TITLE
feat: add --mode apm to rulesync install

### DIFF
--- a/src/cli/commands/install-apm.integration.test.ts
+++ b/src/cli/commands/install-apm.integration.test.ts
@@ -1,0 +1,137 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getApmLockPath } from "../../lib/apm/apm-lock.js";
+import { getApmManifestPath } from "../../lib/apm/apm-manifest.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { installCommand } from "./install.js";
+
+// Mock only the network boundary. Everything else (manifest parsing,
+// lockfile read/write, filesystem deployment) runs for real against a
+// temporary test directory — this is the happy-path E2E for --mode apm.
+let mockClientInstance: any;
+
+vi.mock("../../lib/github-client.js", () => ({
+  GitHubClient: class MockGitHubClient {
+    static resolveToken = vi.fn().mockReturnValue(undefined);
+
+    getDefaultBranch(...args: any[]) {
+      return mockClientInstance.getDefaultBranch(...args);
+    }
+    resolveRefToSha(...args: any[]) {
+      return mockClientInstance.resolveRefToSha(...args);
+    }
+    listDirectory(...args: any[]) {
+      return mockClientInstance.listDirectory(...args);
+    }
+    getFileContent(...args: any[]) {
+      return mockClientInstance.getFileContent(...args);
+    }
+  },
+  GitHubClientError: class GitHubClientError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  logGitHubAuthHints: vi.fn(),
+}));
+
+const VALID_SHA = "a".repeat(40);
+
+describe("installCommand --mode apm (happy path)", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  const logger = createMockLogger();
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+
+    mockClientInstance = {
+      getDefaultBranch: vi.fn().mockResolvedValue("main"),
+      resolveRefToSha: vi.fn().mockResolvedValue(VALID_SHA),
+      listDirectory: vi.fn(),
+      getFileContent: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("installs declared dependencies into .github/ and writes apm.lock.yaml", async () => {
+    await writeFileContent(
+      getApmManifestPath(testDir),
+      `name: demo
+version: 1.0.0
+dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "sql-injection.instructions.md",
+              path: ".apm/instructions/sql-injection.instructions.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        if (path === ".apm/skills") {
+          return [
+            {
+              name: "security-audit",
+              path: ".apm/skills/security-audit",
+              type: "dir",
+              size: 0,
+            },
+          ];
+        }
+        if (path === ".apm/skills/security-audit") {
+          return [
+            {
+              name: "SKILL.md",
+              path: ".apm/skills/security-audit/SKILL.md",
+              type: "file",
+              size: 50,
+            },
+          ];
+        }
+        const err = new Error(`Not found: ${path}`) as Error & { statusCode?: number };
+        err.statusCode = 404;
+        throw err;
+      },
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `# contents of ${path}\n`,
+    );
+
+    await installCommand(logger, { mode: "apm" });
+
+    expect(
+      await readFileContent(join(testDir, ".github/instructions/sql-injection.instructions.md")),
+    ).toBe("# contents of .apm/instructions/sql-injection.instructions.md\n");
+    expect(await readFileContent(join(testDir, ".github/skills/security-audit/SKILL.md"))).toBe(
+      "# contents of .apm/skills/security-audit/SKILL.md\n",
+    );
+
+    expect(await fileExists(getApmLockPath(testDir))).toBe(true);
+    const lockContent = await readFileContent(getApmLockPath(testDir));
+    expect(lockContent).toContain("lockfile_version:");
+    expect(lockContent).toContain("resolved_commit:");
+    expect(lockContent).toContain(VALID_SHA);
+    expect(lockContent).toContain(".github/instructions/sql-injection.instructions.md");
+    expect(lockContent).toContain(".github/skills/security-audit/SKILL.md");
+  });
+});

--- a/src/cli/commands/install-apm.integration.test.ts
+++ b/src/cli/commands/install-apm.integration.test.ts
@@ -65,7 +65,7 @@ describe("installCommand --mode apm (happy path)", () => {
     vi.clearAllMocks();
   });
 
-  it("installs declared dependencies into .github/ and writes apm.lock.yaml", async () => {
+  it("installs declared dependencies into .github/ and writes rulesync-apm.lock.yaml", async () => {
     await writeFileContent(
       getApmManifestPath(testDir),
       `name: demo

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -173,6 +173,7 @@ describe("installCommand", () => {
       vi.mocked(installApm).mockResolvedValue({
         dependenciesProcessed: 2,
         deployedFileCount: 5,
+        failedDependencyCount: 0,
       });
 
       await installCommand(mockLogger, { mode: "apm", update: true, token: "tok" });
@@ -193,12 +194,26 @@ describe("installCommand", () => {
       vi.mocked(installApm).mockResolvedValue({
         dependenciesProcessed: 2,
         deployedFileCount: 0,
+        failedDependencyCount: 0,
       });
 
       await installCommand(mockLogger, { mode: "apm" });
 
       expect(mockLogger.success).toHaveBeenCalledWith(
         "All apm dependencies up to date (2 checked).",
+      );
+    });
+
+    it("throws when installApm reports failed dependencies", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(true);
+      vi.mocked(installApm).mockResolvedValue({
+        dependenciesProcessed: 2,
+        deployedFileCount: 1,
+        failedDependencyCount: 1,
+      });
+
+      await expect(installCommand(mockLogger, { mode: "apm" })).rejects.toThrow(
+        /Failed to install 1 of 2 apm dependency/,
       );
     });
   });

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigResolver } from "../../config/config-resolver.js";
 import type { SourceEntry } from "../../config/config.js";
 import { Config } from "../../config/config.js";
+import { installApm } from "../../lib/apm/apm-install.js";
+import { apmManifestExists } from "../../lib/apm/apm-manifest.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { installCommand } from "./install.js";
@@ -10,6 +12,8 @@ import { installCommand } from "./install.js";
 // Mock dependencies
 vi.mock("../../config/config-resolver.js");
 vi.mock("../../lib/sources.js");
+vi.mock("../../lib/apm/apm-install.js");
+vi.mock("../../lib/apm/apm-manifest.js");
 
 function createMockConfig(sources: SourceEntry[]): Config {
   return {
@@ -22,13 +26,14 @@ describe("installCommand", () => {
 
   beforeEach(() => {
     mockLogger = createMockLogger();
+    vi.mocked(apmManifestExists).mockResolvedValue(false);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe("successful install", () => {
+  describe("rulesync mode (default)", () => {
     it("should install skills and log success", async () => {
       const sources: SourceEntry[] = [{ source: "owner/repo" }];
       vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig(sources));
@@ -78,9 +83,30 @@ describe("installCommand", () => {
       );
       expect(resolveAndFetchSources).not.toHaveBeenCalled();
     });
+
+    it("should warn and suggest --mode apm when apm.yml is present but no sources", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(true);
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig([]));
+
+      await installCommand(mockLogger, {});
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("apm.yml is present"));
+      expect(resolveAndFetchSources).not.toHaveBeenCalled();
+    });
+
+    it("should error when both apm.yml and sources are defined", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(true);
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(
+        createMockConfig([{ source: "owner/repo" }]),
+      );
+
+      await expect(installCommand(mockLogger, {})).rejects.toThrow(
+        /Both apm.yml and rulesync.jsonc/,
+      );
+    });
   });
 
-  describe("option forwarding", () => {
+  describe("option forwarding (rulesync mode)", () => {
     it("should pass --update option", async () => {
       const sources: SourceEntry[] = [{ source: "owner/repo" }];
       vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig(sources));
@@ -129,6 +155,58 @@ describe("installCommand", () => {
         expect.objectContaining({
           options: expect.objectContaining({ token: "my-token" }),
         }),
+      );
+    });
+  });
+
+  describe("apm mode", () => {
+    it("errors when apm.yml is missing", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(false);
+
+      await expect(installCommand(mockLogger, { mode: "apm" })).rejects.toThrow(
+        /requires an apm.yml/,
+      );
+    });
+
+    it("routes to installApm and reports success when files are deployed", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(true);
+      vi.mocked(installApm).mockResolvedValue({
+        dependenciesProcessed: 2,
+        deployedFileCount: 5,
+      });
+
+      await installCommand(mockLogger, { mode: "apm", update: true, token: "tok" });
+
+      expect(installApm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseDir: process.cwd(),
+          options: expect.objectContaining({ update: true, token: "tok" }),
+        }),
+      );
+      expect(mockLogger.success).toHaveBeenCalledWith(
+        "Installed 5 file(s) from 2 apm dependency(ies).",
+      );
+    });
+
+    it("reports up-to-date when no files are deployed", async () => {
+      vi.mocked(apmManifestExists).mockResolvedValue(true);
+      vi.mocked(installApm).mockResolvedValue({
+        dependenciesProcessed: 2,
+        deployedFileCount: 0,
+      });
+
+      await installCommand(mockLogger, { mode: "apm" });
+
+      expect(mockLogger.success).toHaveBeenCalledWith(
+        "All apm dependencies up to date (2 checked).",
+      );
+    });
+  });
+
+  describe("gh mode", () => {
+    it("errors with a not-yet-implemented message", async () => {
+      await expect(installCommand(mockLogger, { mode: "gh" })).rejects.toThrow(
+        /not yet implemented/,
       );
     });
   });

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,8 +1,14 @@
 import { ConfigResolver } from "../../config/config-resolver.js";
+import { installApm } from "../../lib/apm/apm-install.js";
+import { apmManifestExists } from "../../lib/apm/apm-manifest.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import type { Logger } from "../../utils/logger.js";
 
+export const INSTALL_MODES = ["rulesync", "apm", "gh"] as const;
+export type InstallMode = (typeof INSTALL_MODES)[number];
+
 export type InstallCommandOptions = {
+  mode?: InstallMode;
   update?: boolean;
   frozen?: boolean;
   token?: string;
@@ -15,15 +21,49 @@ export async function installCommand(
   logger: Logger,
   options: InstallCommandOptions,
 ): Promise<void> {
+  const mode: InstallMode = options.mode ?? "rulesync";
+
+  if (mode === "gh") {
+    throw new Error(
+      "--mode gh is not yet implemented. Use --mode rulesync (default) or --mode apm.",
+    );
+  }
+
+  if (mode === "apm") {
+    await runApmInstall(logger, options);
+    return;
+  }
+
+  await runRulesyncInstall(logger, options);
+}
+
+async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
+  const baseDir = process.cwd();
+
+  // If both apm.yml and rulesync.jsonc sources are defined, refuse to guess.
+  // `--mode apm` is required to opt into the APM layout.
+  const apmExists = await apmManifestExists(baseDir);
+
   const config = await ConfigResolver.resolve({
     configPath: options.configPath,
     verbose: options.verbose,
     silent: options.silent,
   });
-
   const sources = config.getSources();
 
+  if (apmExists && sources.length > 0) {
+    throw new Error(
+      "Both apm.yml and rulesync.jsonc `sources` are defined. Pass --mode apm or --mode rulesync to disambiguate.",
+    );
+  }
+
   if (sources.length === 0) {
+    if (apmExists) {
+      logger.warn(
+        "No sources defined in rulesync.jsonc, but apm.yml is present. Did you mean --mode apm?",
+      );
+      return;
+    }
     logger.warn("No sources defined in configuration. Nothing to install.");
     return;
   }
@@ -32,7 +72,7 @@ export async function installCommand(
 
   const result = await resolveAndFetchSources({
     sources,
-    baseDir: process.cwd(),
+    baseDir,
     options: {
       updateSources: options.update,
       frozen: options.frozen,
@@ -41,7 +81,6 @@ export async function installCommand(
     logger,
   });
 
-  // Capture JSON data if in JSON mode
   if (logger.jsonMode) {
     logger.captureData("sourcesProcessed", result.sourcesProcessed);
     logger.captureData("skillsFetched", result.fetchedSkillCount);
@@ -53,5 +92,38 @@ export async function installCommand(
     );
   } else {
     logger.success(`All skills up to date (${result.sourcesProcessed} source(s) checked).`);
+  }
+}
+
+async function runApmInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
+  const baseDir = process.cwd();
+
+  if (!(await apmManifestExists(baseDir))) {
+    throw new Error(
+      "--mode apm requires an apm.yml at the project root. Create one or drop --mode apm to fall back to rulesync mode.",
+    );
+  }
+
+  const result = await installApm({
+    baseDir,
+    options: {
+      update: options.update,
+      frozen: options.frozen,
+      token: options.token,
+    },
+    logger,
+  });
+
+  if (logger.jsonMode) {
+    logger.captureData("dependenciesProcessed", result.dependenciesProcessed);
+    logger.captureData("deployedFileCount", result.deployedFileCount);
+  }
+
+  if (result.deployedFileCount > 0) {
+    logger.success(
+      `Installed ${result.deployedFileCount} file(s) from ${result.dependenciesProcessed} apm dependency(ies).`,
+    );
+  } else {
+    logger.success(`All apm dependencies up to date (${result.dependenciesProcessed} checked).`);
   }
 }

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -117,6 +117,13 @@ async function runApmInstall(logger: Logger, options: InstallCommandOptions): Pr
   if (logger.jsonMode) {
     logger.captureData("dependenciesProcessed", result.dependenciesProcessed);
     logger.captureData("deployedFileCount", result.deployedFileCount);
+    logger.captureData("failedDependencyCount", result.failedDependencyCount);
+  }
+
+  if (result.failedDependencyCount > 0) {
+    throw new Error(
+      `Failed to install ${result.failedDependencyCount} of ${result.dependenciesProcessed} apm dependency(ies). See the log above for details.`,
+    );
   }
 
   if (result.deployedFileCount > 0) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@ import { generateCommand, GenerateOptions } from "./commands/generate.js";
 import { gitignoreCommand } from "./commands/gitignore.js";
 import { importCommand, ImportOptions } from "./commands/import.js";
 import { initCommand } from "./commands/init.js";
-import { installCommand } from "./commands/install.js";
+import { INSTALL_MODES, InstallMode, installCommand } from "./commands/install.js";
 import { mcpCommand } from "./commands/mcp.js";
 import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js";
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
@@ -151,7 +151,11 @@ const main = async () => {
 
   program
     .command("install")
-    .description("Install skills from declarative sources in rulesync.jsonc")
+    .description("Install skills/primitives from declarative sources (rulesync.jsonc) or apm.yml")
+    .option(
+      "--mode <mode>",
+      `Install layout to produce (${INSTALL_MODES.join("|")}). Default: rulesync`,
+    )
     .option("--update", "Force re-resolve all source refs, ignoring lockfile")
     .option(
       "--frozen",
@@ -163,7 +167,11 @@ const main = async () => {
     .option("-s, --silent", "Suppress all output")
     .action(
       wrapCommand("install", "INSTALL_FAILED", async (logger, options) => {
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        const rawMode = (options as { mode?: string }).mode;
+        const mode = parseInstallMode(rawMode);
         await installCommand(logger, {
+          mode,
           // eslint-disable-next-line no-type-assertion/no-type-assertion
           update: (options as { update?: boolean }).update,
           // eslint-disable-next-line no-type-assertion/no-type-assertion
@@ -241,6 +249,15 @@ const main = async () => {
 
   program.parse();
 };
+
+function parseInstallMode(raw: string | undefined): InstallMode | undefined {
+  if (raw === undefined) return undefined;
+  const match = INSTALL_MODES.find((m) => m === raw);
+  if (!match) {
+    throw new Error(`Invalid --mode value "${raw}". Expected one of: ${INSTALL_MODES.join(", ")}.`);
+  }
+  return match;
+}
 
 main().catch((error) => {
   console.error(formatError(error));

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -1,0 +1,271 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { installApm } from "./apm-install.js";
+import { getApmLockPath, readApmLock } from "./apm-lock.js";
+import { getApmManifestPath } from "./apm-manifest.js";
+
+let mockClientInstance: any;
+
+vi.mock("../github-client.js", () => ({
+  GitHubClient: class MockGitHubClient {
+    static resolveToken = vi.fn().mockReturnValue(undefined);
+
+    getDefaultBranch(...args: any[]) {
+      return mockClientInstance.getDefaultBranch(...args);
+    }
+    resolveRefToSha(...args: any[]) {
+      return mockClientInstance.resolveRefToSha(...args);
+    }
+    listDirectory(...args: any[]) {
+      return mockClientInstance.listDirectory(...args);
+    }
+    getFileContent(...args: any[]) {
+      return mockClientInstance.getFileContent(...args);
+    }
+  },
+  GitHubClientError: class GitHubClientError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  logGitHubAuthHints: vi.fn(),
+}));
+
+const VALID_SHA = "a".repeat(40);
+const SECOND_SHA = "b".repeat(40);
+
+describe("installApm", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  const logger = createMockLogger();
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+
+    mockClientInstance = {
+      getDefaultBranch: vi.fn().mockResolvedValue("main"),
+      resolveRefToSha: vi.fn().mockResolvedValue(VALID_SHA),
+      listDirectory: vi.fn(),
+      getFileContent: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  async function writeManifest(content: string): Promise<void> {
+    await writeFileContent(getApmManifestPath(testDir), content);
+  }
+
+  it("warns and returns early when there are no dependencies", async () => {
+    await writeManifest("name: my-project\nversion: 1.0.0\n");
+
+    const result = await installApm({ baseDir: testDir, logger });
+
+    expect(result).toEqual({ dependenciesProcessed: 0, deployedFileCount: 0 });
+    expect(await fileExists(getApmLockPath(testDir))).toBe(false);
+  });
+
+  it("fetches .apm/instructions and .apm/skills and deploys to .github/", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+
+    // Stub github tree walk: one instructions file + one skill file.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "security.instructions.md",
+              path: ".apm/instructions/security.instructions.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        if (path === ".apm/skills") {
+          return [
+            {
+              name: "git-commit",
+              path: ".apm/skills/git-commit",
+              type: "dir",
+              size: 0,
+            },
+          ];
+        }
+        if (path === ".apm/skills/git-commit") {
+          return [
+            {
+              name: "SKILL.md",
+              path: ".apm/skills/git-commit/SKILL.md",
+              type: "file",
+              size: 50,
+            },
+          ];
+        }
+        const err = new Error(`Not found: ${path}`) as Error & { statusCode?: number };
+        err.statusCode = 404;
+        throw err;
+      },
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `content of ${path}`,
+    );
+
+    const result = await installApm({ baseDir: testDir, logger });
+
+    expect(result.dependenciesProcessed).toBe(1);
+    expect(result.deployedFileCount).toBe(2);
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith("acme", "security", "v1.0.0");
+
+    const instructions = await readFileContent(
+      join(testDir, ".github/instructions/security.instructions.md"),
+    );
+    expect(instructions).toBe("content of .apm/instructions/security.instructions.md");
+
+    const skill = await readFileContent(join(testDir, ".github/skills/git-commit/SKILL.md"));
+    expect(skill).toBe("content of .apm/skills/git-commit/SKILL.md");
+
+    const lock = await readApmLock(testDir);
+    expect(lock).not.toBeNull();
+    expect(lock?.dependencies).toHaveLength(1);
+    expect(lock?.dependencies[0]).toMatchObject({
+      repo_url: "https://github.com/acme/security",
+      resolved_commit: VALID_SHA,
+      resolved_ref: "v1.0.0",
+      depth: 1,
+      package_type: "apm_package",
+      deployed_files: [
+        ".github/instructions/security.instructions.md",
+        ".github/skills/git-commit/SKILL.md",
+      ],
+    });
+  });
+
+  it("uses the default branch when no ref is given", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security
+`,
+    );
+    mockClientInstance.getDefaultBranch.mockResolvedValue("trunk");
+    mockClientInstance.listDirectory.mockImplementation(async () => {
+      const err = new Error("Not found") as Error & { statusCode?: number };
+      err.statusCode = 404;
+      throw err;
+    });
+
+    await installApm({ baseDir: testDir, logger });
+
+    expect(mockClientInstance.getDefaultBranch).toHaveBeenCalledWith("acme", "security");
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith("acme", "security", "trunk");
+  });
+
+  it("reuses the locked commit SHA on subsequent runs and skips re-resolution", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+
+    // First pass: populate the lockfile.
+    await installApm({ baseDir: testDir, logger });
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
+
+    // Second pass: lockfile should short-circuit ref resolution.
+    mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
+    await installApm({ baseDir: testDir, logger });
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
+
+    const lock = await readApmLock(testDir);
+    expect(lock?.dependencies[0]?.resolved_commit).toBe(VALID_SHA);
+  });
+
+  it("--update forces ref re-resolution and lockfile rewrite", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+
+    await installApm({ baseDir: testDir, logger });
+    mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
+
+    await installApm({ baseDir: testDir, logger, options: { update: true } });
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(2);
+
+    const lock = await readApmLock(testDir);
+    expect(lock?.dependencies[0]?.resolved_commit).toBe(SECOND_SHA);
+  });
+
+  it("--frozen fails when the lockfile is missing", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).rejects.toThrow(/apm.lock.yaml is missing/);
+  });
+
+  it("--frozen fails when the lockfile is missing a declared dependency", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+    - acme/new#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+    await installApm({ baseDir: testDir, logger });
+
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+    - acme/added#v1.0.0
+`,
+    );
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).rejects.toThrow(/missing entries for/);
+  });
+
+  it("--frozen succeeds and does not rewrite the lockfile when all deps are locked", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+    await installApm({ baseDir: testDir, logger });
+
+    const before = await readFileContent(getApmLockPath(testDir));
+    await installApm({ baseDir: testDir, logger, options: { frozen: true } });
+    const after = await readFileContent(getApmLockPath(testDir));
+    expect(after).toBe(before);
+  });
+});

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -339,7 +339,7 @@ describe("installApm", () => {
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
     await installApm({ baseDir: testDir, logger });
-    const lockBefore = await readFileContent(getApmLockPath(testDir));
+    const lockBefore = await readApmLock(testDir);
 
     mockClientInstance.resolveRefToSha.mockRejectedValue(new Error("network error"));
 
@@ -350,8 +350,189 @@ describe("installApm", () => {
     });
     expect(result.failedDependencyCount).toBe(1);
 
-    // The lockfile on disk must be untouched so the previous SHA survives.
-    const lockAfter = await readFileContent(getApmLockPath(testDir));
-    expect(lockAfter).toBe(lockBefore);
+    // The previously pinned SHA must survive the failed re-install: the
+    // lockfile is rewritten (only `generated_at` drifts) but the dependency
+    // entry itself is preserved verbatim.
+    const lockAfter = await readApmLock(testDir);
+    expect(lockAfter?.dependencies).toEqual(lockBefore?.dependencies);
+  });
+
+  it("removes files that were deployed previously but are no longer in the upstream tree", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+
+    // First install: two instruction files A and B.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "a.instructions.md",
+              path: ".apm/instructions/a.instructions.md",
+              type: "file",
+              size: 10,
+            },
+            {
+              name: "b.instructions.md",
+              path: ".apm/instructions/b.instructions.md",
+              type: "file",
+              size: 10,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `content of ${path}`,
+    );
+
+    await installApm({ baseDir: testDir, logger });
+    expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
+    expect(await fileExists(join(testDir, ".github/instructions/b.instructions.md"))).toBe(true);
+
+    // Second install: only A remains upstream.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "a.instructions.md",
+              path: ".apm/instructions/a.instructions.md",
+              type: "file",
+              size: 10,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+
+    await installApm({ baseDir: testDir, logger, options: { update: true } });
+
+    expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
+    // B must be removed both from disk and from the lockfile.
+    expect(await fileExists(join(testDir, ".github/instructions/b.instructions.md"))).toBe(false);
+    const lock = await readApmLock(testDir);
+    expect(lock?.dependencies[0]?.deployed_files).toEqual([
+      ".github/instructions/a.instructions.md",
+    ]);
+  });
+
+  it("--frozen refuses tampered content WITHOUT overwriting the on-disk file", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "a.instructions.md",
+              path: ".apm/instructions/a.instructions.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("original content");
+    await installApm({ baseDir: testDir, logger });
+
+    const deployedPath = join(testDir, ".github/instructions/a.instructions.md");
+    const before = await readFileContent(deployedPath);
+    expect(before).toBe("original content");
+
+    // Upstream starts returning tampered bytes under the same SHA.
+    mockClientInstance.getFileContent.mockResolvedValue("tampered content");
+
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).rejects.toThrow(/content_hash mismatch/);
+
+    // The on-disk file must still contain the original bytes, not the
+    // tampered payload.
+    const after = await readFileContent(deployedPath);
+    expect(after).toBe("original content");
+  });
+
+  it("deploys files from under dep.path (object-form path field)", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - git: https://github.com/acme/mono.git
+      path: packages/security
+      ref: v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === "packages/security/.apm/instructions") {
+          return [
+            {
+              name: "s.instructions.md",
+              path: "packages/security/.apm/instructions/s.instructions.md",
+              type: "file",
+              size: 20,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `content of ${path}`,
+    );
+
+    const result = await installApm({ baseDir: testDir, logger });
+    expect(result.deployedFileCount).toBe(1);
+    const deployed = await readFileContent(join(testDir, ".github/instructions/s.instructions.md"));
+    expect(deployed).toBe("content of packages/security/.apm/instructions/s.instructions.md");
+    const lock = await readApmLock(testDir);
+    expect(lock?.dependencies[0]?.virtual_path).toBe("packages/security");
+  });
+
+  it("skips tree entries whose path escapes remoteBase with a warning", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+
+    // A malicious tree entry pretends to live under .apm/instructions but
+    // its `path` actually resolves outside of it. Such entries must be
+    // skipped rather than written to disk.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "escape.md",
+              path: "../escape.md",
+              type: "file",
+              size: 10,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("evil");
+
+    const result = await installApm({ baseDir: testDir, logger });
+    expect(result.deployedFileCount).toBe(0);
+    // The escape payload must not appear anywhere under baseDir.
+    expect(await fileExists(join(testDir, "escape.md"))).toBe(false);
+    expect(await fileExists(join(testDir, ".github/instructions/escape.md"))).toBe(false);
   });
 });

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -330,6 +330,52 @@ describe("installApm", () => {
     ).rejects.toThrow(/content_hash mismatch/);
   });
 
+  it("writes preserved-for-failure lock entries in manifest order, not completion order", async () => {
+    // Seed lockfile with two deps in a known manifest order.
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/first#v1.0.0
+    - acme/second#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+    mockClientInstance.resolveRefToSha.mockImplementation(async (_owner: string, repo: string) =>
+      repo === "first" ? VALID_SHA : SECOND_SHA,
+    );
+    await installApm({ baseDir: testDir, logger });
+    const lockBefore = await readApmLock(testDir);
+    expect(lockBefore?.dependencies.map((d) => d.repo_url)).toEqual([
+      "https://github.com/acme/first",
+      "https://github.com/acme/second",
+    ]);
+
+    // Now make the FIRST dep fail slowly while the SECOND dep succeeds fast.
+    // Without ordering logic, the failed-first dep's preserved entry would
+    // land after the succeeded-second dep in the rewritten lockfile.
+    mockClientInstance.resolveRefToSha.mockImplementation(async (_owner: string, repo: string) => {
+      if (repo === "first") {
+        await new Promise((r) => setTimeout(r, 20));
+        throw new Error("network error on first");
+      }
+      return SECOND_SHA;
+    });
+
+    const result = await installApm({
+      baseDir: testDir,
+      logger,
+      options: { update: true },
+    });
+    expect(result.failedDependencyCount).toBe(1);
+
+    const lockAfter = await readApmLock(testDir);
+    // Manifest-order preservation: "first" (preserved) must stay at index 0.
+    expect(lockAfter?.dependencies.map((d) => d.repo_url)).toEqual([
+      "https://github.com/acme/first",
+      "https://github.com/acme/second",
+    ]);
+  });
+
   it("preserves the existing lock entry when a dependency fails to install", async () => {
     await writeManifest(
       `dependencies:
@@ -499,6 +545,160 @@ describe("installApm", () => {
     expect(deployed).toBe("content of packages/security/.apm/instructions/s.instructions.md");
     const lock = await readApmLock(testDir);
     expect(lock?.dependencies[0]?.virtual_path).toBe("packages/security");
+  });
+
+  it("refuses to remove stale files whose recorded path escapes baseDir", async () => {
+    // Hand-craft a lockfile whose deployed_files contains attacker-controlled
+    // paths. `deployed_files` is only schema-validated as a string array, so
+    // a hostile repo could plant this and trigger arbitrary `removeFile` on
+    // the next `rulesync install` run. The guard must skip such entries
+    // with a warn log so that the remove never actually happens.
+    //
+    // We cannot safely write a file *outside* testDir from a test (the
+    // testing guidelines forbid polluting anything outside the project
+    // test directory), so we prove the defense by asserting (a) the guard
+    // warns for each offending entry and (b) legitimate in-baseDir cleanup
+    // still proceeds as a control.
+    const absoluteOutside = "/tmp/rulesync-apm-test-absolute-target.md";
+    const lockYaml = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/acme/security
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: v1.0.0
+    depth: 1
+    package_type: apm_package
+    deployed_files:
+      - ../escape-one.md
+      - ${absoluteOutside}
+      - .github/instructions/old.instructions.md
+`;
+    await writeFileContent(getApmLockPath(testDir), lockYaml);
+
+    // Plant the "clean" stale file that lives inside baseDir so we can
+    // verify the normal cleanup path still works even when the guard skips
+    // its neighbors.
+    await writeFileContent(
+      join(testDir, ".github/instructions/old.instructions.md"),
+      "stale legit",
+    );
+
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    // New install returns no files, so prior entries become stale.
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+
+    const localLogger = createMockLogger();
+    await installApm({ baseDir: testDir, logger: localLogger, options: { update: true } });
+
+    // Legit in-baseDir stale file is still removed (control: cleanup works).
+    expect(await fileExists(join(testDir, ".github/instructions/old.instructions.md"))).toBe(false);
+    // Warn logs were emitted for the two refused entries.
+    const warnMessages = localLogger.warn.mock.calls.map((args) => String(args[0]));
+    expect(warnMessages.some((m) => m.includes("../escape-one.md"))).toBe(true);
+    expect(warnMessages.some((m) => m.includes(absoluteOutside))).toBe(true);
+  });
+
+  it("preserves top-level mcp_servers and other loose fields across install rewrites", async () => {
+    // A lockfile produced by the upstream `apm` CLI may carry extra top-level
+    // fields (mcp_servers, custom extensions, etc.). Rulesync must not wipe
+    // these when it rewrites the lockfile — only dependencies/generated_at
+    // should be owned by us.
+    const validHash = `sha256:${"0".repeat(64)}`;
+    const lockYaml = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+mcp_servers:
+  - security-scanner
+  - code-reviewer
+custom_extension:
+  foo: bar
+dependencies:
+  - repo_url: https://github.com/acme/security
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: v1.0.0
+    depth: 1
+    package_type: apm_package
+    content_hash: ${validHash}
+    deployed_files: []
+`;
+    await writeFileContent(getApmLockPath(testDir), lockYaml);
+
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+
+    await installApm({ baseDir: testDir, logger, options: { update: true } });
+
+    const after = await readApmLock(testDir);
+    expect(after?.mcp_servers).toEqual(["security-scanner", "code-reviewer"]);
+    expect((after as unknown as { custom_extension: unknown }).custom_extension).toEqual({
+      foo: "bar",
+    });
+  });
+
+  it("tolerates a non-rulesync content_hash under --frozen without tripping integrity", async () => {
+    // The upstream `apm` CLI may write content_hash values that do not match
+    // the rulesync regex. readApmLock must accept them (regression for the
+    // hard regex) AND frozen installs must not throw `content_hash mismatch`
+    // for such entries — the commit SHA is still the integrity anchor.
+    const lockYaml = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/acme/security
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: v1.0.0
+    depth: 1
+    package_type: apm_package
+    content_hash: "sha256:legacy"
+    deployed_files:
+      - .github/instructions/a.instructions.md
+`;
+    await writeFileContent(getApmLockPath(testDir), lockYaml);
+
+    // readApmLock must not throw on the legacy-shape hash.
+    const parsed = await readApmLock(testDir);
+    expect(parsed?.dependencies[0]?.content_hash).toBe("sha256:legacy");
+
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "a.instructions.md",
+              path: ".apm/instructions/a.instructions.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    // Content is totally different from what the legacy hash supposedly
+    // covered. Rulesync must NOT raise `content_hash mismatch` here because
+    // the recorded hash is not a rulesync-written value.
+    mockClientInstance.getFileContent.mockResolvedValue("arbitrary content");
+
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).resolves.toBeDefined();
   });
 
   it("skips tree entries whose path escapes remoteBase with a warning", async () => {

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -71,7 +71,11 @@ describe("installApm", () => {
 
     const result = await installApm({ baseDir: testDir, logger });
 
-    expect(result).toEqual({ dependenciesProcessed: 0, deployedFileCount: 0 });
+    expect(result).toEqual({
+      dependenciesProcessed: 0,
+      deployedFileCount: 0,
+      failedDependencyCount: 0,
+    });
     expect(await fileExists(getApmLockPath(testDir))).toBe(false);
   });
 
@@ -153,6 +157,7 @@ describe("installApm", () => {
         ".github/skills/git-commit/SKILL.md",
       ],
     });
+    expect(lock?.dependencies[0]?.content_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
   });
 
   it("uses the default branch when no ref is given", async () => {
@@ -267,5 +272,86 @@ describe("installApm", () => {
     await installApm({ baseDir: testDir, logger, options: { frozen: true } });
     const after = await readFileContent(getApmLockPath(testDir));
     expect(after).toBe(before);
+  });
+
+  it("--frozen fails when the manifest ref drifts from the locked ref", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+    await installApm({ baseDir: testDir, logger });
+
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v2.0.0
+`,
+    );
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).rejects.toThrow(/manifest ref does not match/);
+  });
+
+  it("--frozen fails when deployed content no longer matches content_hash", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === ".apm/instructions") {
+          return [
+            {
+              name: "a.instructions.md",
+              path: ".apm/instructions/a.instructions.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        // Other primitive dirs (e.g., .apm/skills) are absent.
+        return [];
+      },
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("original content");
+
+    await installApm({ baseDir: testDir, logger });
+
+    // Simulate tampered upstream: same SHA, different bytes on next install.
+    mockClientInstance.getFileContent.mockResolvedValue("tampered content");
+
+    await expect(
+      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+    ).rejects.toThrow(/content_hash mismatch/);
+  });
+
+  it("preserves the existing lock entry when a dependency fails to install", async () => {
+    await writeManifest(
+      `dependencies:
+  apm:
+    - acme/security#v1.0.0
+`,
+    );
+    mockClientInstance.listDirectory.mockResolvedValue([]);
+    await installApm({ baseDir: testDir, logger });
+    const lockBefore = await readFileContent(getApmLockPath(testDir));
+
+    mockClientInstance.resolveRefToSha.mockRejectedValue(new Error("network error"));
+
+    const result = await installApm({
+      baseDir: testDir,
+      logger,
+      options: { update: true },
+    });
+    expect(result.failedDependencyCount).toBe(1);
+
+    // The lockfile on disk must be untouched so the previous SHA survives.
+    const lockAfter = await readFileContent(getApmLockPath(testDir));
+    expect(lockAfter).toBe(lockBefore);
   });
 });

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -232,7 +232,7 @@ describe("installApm", () => {
 
     await expect(
       installApm({ baseDir: testDir, logger, options: { frozen: true } }),
-    ).rejects.toThrow(/apm.lock.yaml is missing/);
+    ).rejects.toThrow(/rulesync-apm.lock.yaml is missing/);
   });
 
   it("--frozen fails when the lockfile is missing a declared dependency", async () => {

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { join, posix } from "node:path";
 
 import { Semaphore } from "es-toolkit/promise";
 
@@ -54,6 +55,7 @@ export type ApmInstallOptions = {
 export type ApmInstallResult = {
   dependenciesProcessed: number;
   deployedFileCount: number;
+  failedDependencyCount: number;
 };
 
 /**
@@ -71,7 +73,7 @@ export async function installApm(params: {
   const manifest = await readApmManifest(baseDir);
   if (manifest.dependencies.length === 0) {
     logger.warn("apm.yml has no dependencies.apm entries. Nothing to install.");
-    return { dependenciesProcessed: 0, deployedFileCount: 0 };
+    return { dependenciesProcessed: 0, deployedFileCount: 0, failedDependencyCount: 0 };
   }
 
   const existingLock = await readApmLock(baseDir);
@@ -90,6 +92,25 @@ export async function installApm(params: {
         `Frozen install failed: apm.lock.yaml is missing entries for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
       );
     }
+    // Detect manifest drift: when the user edited `ref` in apm.yml without
+    // re-running install, the locked ref no longer matches the declared one.
+    // In frozen mode we refuse rather than silently install the locked SHA.
+    const drifted = manifest.dependencies.filter((dep) => {
+      if (dep.ref === undefined) return false;
+      const locked = findApmLockDependency(existingLock, canonicalRepoUrl(dep));
+      return locked?.resolved_ref !== undefined && locked.resolved_ref !== dep.ref;
+    });
+    if (drifted.length > 0) {
+      const names = drifted
+        .map((d) => {
+          const locked = findApmLockDependency(existingLock, canonicalRepoUrl(d));
+          return `${d.gitUrl} (manifest=${d.ref}, lock=${locked?.resolved_ref})`;
+        })
+        .join(", ");
+      throw new Error(
+        `Frozen install failed: manifest ref does not match apm.lock.yaml for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
+      );
+    }
   }
 
   const token = GitHubClient.resolveToken(options.token);
@@ -101,6 +122,7 @@ export async function installApm(params: {
   });
 
   let totalDeployed = 0;
+  let failedCount = 0;
   for (const dep of manifest.dependencies) {
     try {
       const deployed = await installDependency({
@@ -109,28 +131,50 @@ export async function installApm(params: {
         semaphore,
         baseDir,
         existingLock,
+        frozen: options.frozen ?? false,
         update: options.update ?? false,
         logger,
       });
       newLock.dependencies.push(deployed.lockEntry);
       totalDeployed += deployed.deployedFiles.length;
     } catch (error) {
+      // Under --frozen, any failure is a hard error — we must not silently
+      // degrade an integrity check into a warning.
+      if (options.frozen) {
+        throw error;
+      }
+      failedCount += 1;
       logger.error(`Failed to install apm dependency "${dep.gitUrl}": ${formatError(error)}`);
       if (error instanceof GitHubClientError) {
         logGitHubAuthHints({ error, logger });
       }
+      // Preserve the prior lock entry for failed deps so that a transient
+      // network error does not destroy a previously pinned commit SHA.
+      const previous = existingLock
+        ? findApmLockDependency(existingLock, canonicalRepoUrl(dep))
+        : undefined;
+      if (previous) {
+        newLock.dependencies.push(previous);
+      }
     }
   }
 
-  if (!options.frozen) {
+  // Only rewrite the lockfile on a clean run. If any dep failed, keep the
+  // existing file untouched so users retain a known-good state.
+  if (!options.frozen && failedCount === 0) {
     newLock.generated_at = new Date().toISOString();
     await writeApmLock({ baseDir, lock: newLock });
     logger.debug("apm.lock.yaml updated.");
+  } else if (failedCount > 0) {
+    logger.warn(
+      `Skipping apm.lock.yaml rewrite: ${failedCount} dependency(ies) failed to install.`,
+    );
   }
 
   return {
     dependenciesProcessed: manifest.dependencies.length,
     deployedFileCount: totalDeployed,
+    failedDependencyCount: failedCount,
   };
 }
 
@@ -140,10 +184,11 @@ async function installDependency(params: {
   semaphore: Semaphore;
   baseDir: string;
   existingLock: ApmLock | null;
+  frozen: boolean;
   update: boolean;
   logger: Logger;
 }): Promise<{ lockEntry: ApmLockDependency; deployedFiles: string[] }> {
-  const { dep, client, semaphore, baseDir, existingLock, update, logger } = params;
+  const { dep, client, semaphore, baseDir, existingLock, frozen, update, logger } = params;
   const repoUrl = canonicalRepoUrl(dep);
   const locked = existingLock ? findApmLockDependency(existingLock, repoUrl) : undefined;
 
@@ -159,10 +204,10 @@ async function installDependency(params: {
     logger.debug(`Resolved ${repoUrl} ref "${resolvedRef}" -> ${resolvedSha}`);
   }
 
-  const deployedFiles: string[] = [];
+  const deployed: Array<{ path: string; content: string }> = [];
   for (const primitive of APM_PRIMITIVES) {
     const remoteBase = dep.path
-      ? toPosixPath(join(dep.path, primitive.sourceDir))
+      ? toPosixPath(posix.join(dep.path, primitive.sourceDir))
       : primitive.sourceDir;
     const files = await listPrimitiveFiles({
       client,
@@ -182,7 +227,13 @@ async function installDependency(params: {
         );
         continue;
       }
-      const relativeToBase = file.path.substring(remoteBase.length + 1);
+      const relativeToBase = posix.relative(remoteBase, toPosixPath(file.path));
+      if (!relativeToBase || relativeToBase.startsWith("..") || posix.isAbsolute(relativeToBase)) {
+        logger.warn(
+          `Skipping "${file.path}" from ${repoUrl}: resolved outside of "${remoteBase}".`,
+        );
+        continue;
+      }
       const deployRelative = toPosixPath(join(primitive.deployDir, relativeToBase));
       checkPathTraversal({
         relativePath: deployRelative,
@@ -192,11 +243,23 @@ async function installDependency(params: {
         client.getFileContent(dep.owner, dep.repo, file.path, resolvedSha),
       );
       await writeFileContent(join(baseDir, deployRelative), content);
-      deployedFiles.push(deployRelative);
+      deployed.push({ path: deployRelative, content });
     }
   }
 
-  deployedFiles.sort();
+  deployed.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const deployedFiles = deployed.map((d) => d.path);
+  const contentHash = computeContentHash(deployed);
+
+  // Verify integrity against the lockfile when running frozen and the prior
+  // lock recorded a hash. A mismatch means either the upstream content moved
+  // under the same SHA (unlikely with git) or someone tampered with the
+  // lockfile / deployed files.
+  if (frozen && locked?.content_hash && locked.content_hash !== contentHash) {
+    throw new Error(
+      `content_hash mismatch for ${repoUrl}: lock=${locked.content_hash} computed=${contentHash}. Refuse to trust the deployment under --frozen.`,
+    );
+  }
 
   const lockEntry: ApmLockDependency = {
     repo_url: repoUrl,
@@ -204,6 +267,7 @@ async function installDependency(params: {
     resolved_ref: resolvedRef,
     depth: 1,
     package_type: "apm_package",
+    content_hash: contentHash,
     deployed_files: deployedFiles,
   };
   if (dep.path) {
@@ -213,6 +277,22 @@ async function installDependency(params: {
   logger.info(`Installed ${deployedFiles.length} file(s) from ${repoUrl}@${shortSha(resolvedSha)}`);
 
   return { lockEntry, deployedFiles };
+}
+
+/**
+ * SHA-256 over a canonical, order-independent representation of the deployed
+ * files. Written into `content_hash` so that `--frozen` installs can refuse
+ * to trust tampered output.
+ */
+function computeContentHash(files: Array<{ path: string; content: string }>): string {
+  const hash = createHash("sha256");
+  for (const { path, content } of files) {
+    hash.update(path);
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
 }
 
 async function listPrimitiveFiles(params: {

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -6,7 +6,7 @@ import { Semaphore } from "es-toolkit/promise";
 import { FETCH_CONCURRENCY_LIMIT, MAX_FILE_SIZE } from "../../constants/rulesync-paths.js";
 import type { GitHubFileEntry } from "../../types/fetch.js";
 import { formatError } from "../../utils/error.js";
-import { checkPathTraversal, toPosixPath, writeFileContent } from "../../utils/file.js";
+import { checkPathTraversal, removeFile, toPosixPath, writeFileContent } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { GitHubClient, GitHubClientError, logGitHubAuthHints } from "../github-client.js";
 import { listDirectoryRecursive, withSemaphore } from "../github-utils.js";
@@ -121,54 +121,112 @@ export async function installApm(params: {
     apmVersion: existingLock?.apm_version ?? RULESYNC_APM_COMPAT_VERSION,
   });
 
+  // Dependencies are independent, so install them in parallel. The within-dep
+  // tree walk is already rate-limited by the shared FETCH_CONCURRENCY_LIMIT
+  // semaphore, so top-level parallelism is bounded naturally.
+  //
+  // Semantics:
+  //   frozen=true  — any failure aborts the whole install (Promise.all
+  //                   rejects on the first rejection).
+  //   frozen=false — each dep's promise resolves to a result object so that
+  //                   one failing dep does not abort the others.
+  type DepResult =
+    | { status: "ok"; lockEntry: ApmLockDependency; deployedCount: number }
+    | { status: "failed" };
+
+  const frozen = options.frozen ?? false;
+
+  const runOne = async (dep: ApmDependency): Promise<DepResult> => {
+    const installed = await installDependency({
+      dep,
+      client,
+      semaphore,
+      baseDir,
+      existingLock,
+      frozen,
+      update: options.update ?? false,
+      logger,
+    });
+    return {
+      status: "ok",
+      lockEntry: installed.lockEntry,
+      deployedCount: installed.deployedFiles.length,
+    };
+  };
+
+  const results: DepResult[] = frozen
+    ? await Promise.all(manifest.dependencies.map(runOne))
+    : await Promise.all(
+        manifest.dependencies.map(async (dep): Promise<DepResult> => {
+          try {
+            return await runOne(dep);
+          } catch (error) {
+            logger.error(`Failed to install apm dependency "${dep.gitUrl}": ${formatError(error)}`);
+            if (error instanceof GitHubClientError) {
+              logGitHubAuthHints({ error, logger });
+            }
+            // Preserve the prior lock entry for failed deps so that a
+            // transient network error does not destroy a previously pinned
+            // commit SHA.
+            const previous = existingLock
+              ? findApmLockDependency(existingLock, canonicalRepoUrl(dep))
+              : undefined;
+            if (previous) {
+              newLock.dependencies.push(previous);
+            }
+            return { status: "failed" };
+          }
+        }),
+      );
+
   let totalDeployed = 0;
   let failedCount = 0;
-  for (const dep of manifest.dependencies) {
-    try {
-      const deployed = await installDependency({
-        dep,
-        client,
-        semaphore,
-        baseDir,
-        existingLock,
-        frozen: options.frozen ?? false,
-        update: options.update ?? false,
-        logger,
-      });
-      newLock.dependencies.push(deployed.lockEntry);
-      totalDeployed += deployed.deployedFiles.length;
-    } catch (error) {
-      // Under --frozen, any failure is a hard error — we must not silently
-      // degrade an integrity check into a warning.
-      if (options.frozen) {
-        throw error;
-      }
+  // Iterate in manifest order to keep the lockfile deterministic.
+  for (const result of results) {
+    if (result.status === "ok") {
+      newLock.dependencies.push(result.lockEntry);
+      totalDeployed += result.deployedCount;
+    } else {
       failedCount += 1;
-      logger.error(`Failed to install apm dependency "${dep.gitUrl}": ${formatError(error)}`);
-      if (error instanceof GitHubClientError) {
-        logGitHubAuthHints({ error, logger });
-      }
-      // Preserve the prior lock entry for failed deps so that a transient
-      // network error does not destroy a previously pinned commit SHA.
-      const previous = existingLock
-        ? findApmLockDependency(existingLock, canonicalRepoUrl(dep))
-        : undefined;
-      if (previous) {
-        newLock.dependencies.push(previous);
-      }
     }
   }
 
-  // Only rewrite the lockfile on a clean run. If any dep failed, keep the
-  // existing file untouched so users retain a known-good state.
-  if (!options.frozen && failedCount === 0) {
+  // Remove files that were deployed by a previous install but are no longer
+  // part of any current dependency's deployed_files. Without this, stale
+  // artifacts would accumulate on disk forever as upstream content changes.
+  if (existingLock) {
+    const newDeployedFiles = new Set(newLock.dependencies.flatMap((d) => d.deployed_files));
+    const toDelete: string[] = [];
+    for (const prev of existingLock.dependencies) {
+      for (const deployed of prev.deployed_files) {
+        if (!newDeployedFiles.has(deployed)) {
+          toDelete.push(deployed);
+        }
+      }
+    }
+    for (const relativePath of toDelete) {
+      const absolute = join(baseDir, relativePath);
+      // `removeFile` is best-effort and swallows ENOENT, so missing files are
+      // a no-op. This keeps a corrupted partial-install from blowing up here.
+      await removeFile(absolute);
+      logger.debug(`Removed stale apm file: ${relativePath}`);
+    }
+  }
+
+  // Always rewrite the lockfile (except under --frozen, which is a verify-only
+  // mode). Even on a partially successful install we persist the union of
+  // newly pinned entries and preserved previous entries so that first-ever
+  // runs with mixed results still record the successful pins.
+  if (!frozen) {
     newLock.generated_at = new Date().toISOString();
     await writeApmLock({ baseDir, lock: newLock });
-    logger.debug("apm.lock.yaml updated.");
-  } else if (failedCount > 0) {
-    logger.warn(
-      `Skipping apm.lock.yaml rewrite: ${failedCount} dependency(ies) failed to install.`,
-    );
+    if (failedCount === 0) {
+      logger.debug("apm.lock.yaml updated.");
+    } else {
+      logger.warn(
+        `apm.lock.yaml written with partially successful installs (${failedCount} dep(s) failed).`,
+      );
+    }
   }
 
   return {
@@ -204,6 +262,10 @@ async function installDependency(params: {
     logger.debug(`Resolved ${repoUrl} ref "${resolvedRef}" -> ${resolvedSha}`);
   }
 
+  // Collect (path, content) pairs before writing to disk. This lets us hash
+  // them up-front and, under --frozen, refuse to overwrite good files with
+  // tampered bytes. Under non-frozen we still write as we go for incremental
+  // progress feedback on large dep trees.
   const deployed: Array<{ path: string; content: string }> = [];
   for (const primitive of APM_PRIMITIVES) {
     const remoteBase = dep.path
@@ -242,8 +304,19 @@ async function installDependency(params: {
       const content = await withSemaphore(semaphore, () =>
         client.getFileContent(dep.owner, dep.repo, file.path, resolvedSha),
       );
-      await writeFileContent(join(baseDir, deployRelative), content);
+      // The tree-listing size can lie (LFS pointers, filter-driver output),
+      // so enforce the cap on the fetched bytes as well.
+      const byteLength = Buffer.byteLength(content, "utf8");
+      if (byteLength > MAX_FILE_SIZE) {
+        logger.warn(
+          `Skipping "${file.path}" from ${repoUrl}: fetched ${(byteLength / 1024 / 1024).toFixed(2)}MB exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit.`,
+        );
+        continue;
+      }
       deployed.push({ path: deployRelative, content });
+      if (!frozen) {
+        await writeFileContent(join(baseDir, deployRelative), content);
+      }
     }
   }
 
@@ -254,11 +327,19 @@ async function installDependency(params: {
   // Verify integrity against the lockfile when running frozen and the prior
   // lock recorded a hash. A mismatch means either the upstream content moved
   // under the same SHA (unlikely with git) or someone tampered with the
-  // lockfile / deployed files.
+  // lockfile / deployed files. We do this *before* writing anything to disk
+  // under --frozen so that tampered bytes never hit the filesystem.
   if (frozen && locked?.content_hash && locked.content_hash !== contentHash) {
     throw new Error(
       `content_hash mismatch for ${repoUrl}: lock=${locked.content_hash} computed=${contentHash}. Refuse to trust the deployment under --frozen.`,
     );
+  }
+
+  // Under --frozen we deferred all writes until after the hash check passed.
+  if (frozen) {
+    for (const { path: deployRelative, content } of deployed) {
+      await writeFileContent(join(baseDir, deployRelative), content);
+    }
   }
 
   const lockEntry: ApmLockDependency = {

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -1,0 +1,258 @@
+import { join } from "node:path";
+
+import { Semaphore } from "es-toolkit/promise";
+
+import { FETCH_CONCURRENCY_LIMIT, MAX_FILE_SIZE } from "../../constants/rulesync-paths.js";
+import type { GitHubFileEntry } from "../../types/fetch.js";
+import { formatError } from "../../utils/error.js";
+import { checkPathTraversal, toPosixPath, writeFileContent } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
+import { GitHubClient, GitHubClientError, logGitHubAuthHints } from "../github-client.js";
+import { listDirectoryRecursive, withSemaphore } from "../github-utils.js";
+import {
+  type ApmLock,
+  type ApmLockDependency,
+  createEmptyApmLock,
+  findApmLockDependency,
+  readApmLock,
+  writeApmLock,
+} from "./apm-lock.js";
+import { type ApmDependency, readApmManifest } from "./apm-manifest.js";
+
+/** APM compatibility marker written into `apm_version` when rulesync writes a lockfile. */
+const RULESYNC_APM_COMPAT_VERSION = "rulesync-compat/0.1";
+
+/**
+ * Primitives the first iteration deploys. Ordered by scan priority.
+ * Each entry maps a package-relative source directory (rooted at the
+ * dependency's `path` if given, else the repo root) to the on-disk
+ * deployment directory. This matches the default APM layout when the
+ * github-copilot host is present.
+ */
+const APM_PRIMITIVES: Array<{ sourceDir: string; deployDir: string; packageType: string }> = [
+  {
+    sourceDir: ".apm/instructions",
+    deployDir: ".github/instructions",
+    packageType: "apm_package",
+  },
+  {
+    sourceDir: ".apm/skills",
+    deployDir: ".github/skills",
+    packageType: "apm_package",
+  },
+];
+
+export type ApmInstallOptions = {
+  /** Force re-resolve all refs, ignoring the lockfile. */
+  update?: boolean;
+  /** Fail if the lockfile is missing or out of sync (for CI). */
+  frozen?: boolean;
+  /** GitHub token for private repositories. */
+  token?: string;
+};
+
+export type ApmInstallResult = {
+  dependenciesProcessed: number;
+  deployedFileCount: number;
+};
+
+/**
+ * Entry point for `rulesync install --mode apm`. Reads `apm.yml`, resolves
+ * every declared APM dependency, fetches the subset of primitives rulesync
+ * currently understands (Instructions and Skills), and updates `apm.lock.yaml`.
+ */
+export async function installApm(params: {
+  baseDir: string;
+  options?: ApmInstallOptions;
+  logger: Logger;
+}): Promise<ApmInstallResult> {
+  const { baseDir, options = {}, logger } = params;
+
+  const manifest = await readApmManifest(baseDir);
+  if (manifest.dependencies.length === 0) {
+    logger.warn("apm.yml has no dependencies.apm entries. Nothing to install.");
+    return { dependenciesProcessed: 0, deployedFileCount: 0 };
+  }
+
+  const existingLock = await readApmLock(baseDir);
+  if (options.frozen) {
+    if (!existingLock) {
+      throw new Error(
+        "Frozen install failed: apm.lock.yaml is missing. Run 'rulesync install --mode apm' to create it.",
+      );
+    }
+    const missing = manifest.dependencies.filter(
+      (dep) => !findApmLockDependency(existingLock, canonicalRepoUrl(dep)),
+    );
+    if (missing.length > 0) {
+      const names = missing.map((d) => d.gitUrl).join(", ");
+      throw new Error(
+        `Frozen install failed: apm.lock.yaml is missing entries for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
+      );
+    }
+  }
+
+  const token = GitHubClient.resolveToken(options.token);
+  const client = new GitHubClient({ token });
+  const semaphore = new Semaphore(FETCH_CONCURRENCY_LIMIT);
+
+  const newLock: ApmLock = createEmptyApmLock({
+    apmVersion: existingLock?.apm_version ?? RULESYNC_APM_COMPAT_VERSION,
+  });
+
+  let totalDeployed = 0;
+  for (const dep of manifest.dependencies) {
+    try {
+      const deployed = await installDependency({
+        dep,
+        client,
+        semaphore,
+        baseDir,
+        existingLock,
+        update: options.update ?? false,
+        logger,
+      });
+      newLock.dependencies.push(deployed.lockEntry);
+      totalDeployed += deployed.deployedFiles.length;
+    } catch (error) {
+      logger.error(`Failed to install apm dependency "${dep.gitUrl}": ${formatError(error)}`);
+      if (error instanceof GitHubClientError) {
+        logGitHubAuthHints({ error, logger });
+      }
+    }
+  }
+
+  if (!options.frozen) {
+    newLock.generated_at = new Date().toISOString();
+    await writeApmLock({ baseDir, lock: newLock });
+    logger.debug("apm.lock.yaml updated.");
+  }
+
+  return {
+    dependenciesProcessed: manifest.dependencies.length,
+    deployedFileCount: totalDeployed,
+  };
+}
+
+async function installDependency(params: {
+  dep: ApmDependency;
+  client: GitHubClient;
+  semaphore: Semaphore;
+  baseDir: string;
+  existingLock: ApmLock | null;
+  update: boolean;
+  logger: Logger;
+}): Promise<{ lockEntry: ApmLockDependency; deployedFiles: string[] }> {
+  const { dep, client, semaphore, baseDir, existingLock, update, logger } = params;
+  const repoUrl = canonicalRepoUrl(dep);
+  const locked = existingLock ? findApmLockDependency(existingLock, repoUrl) : undefined;
+
+  let resolvedRef: string;
+  let resolvedSha: string;
+  if (locked && !update && locked.resolved_commit && locked.resolved_ref) {
+    resolvedRef = locked.resolved_ref;
+    resolvedSha = locked.resolved_commit;
+    logger.debug(`Using locked commit for ${repoUrl}: ${resolvedSha}`);
+  } else {
+    resolvedRef = dep.ref ?? (await client.getDefaultBranch(dep.owner, dep.repo));
+    resolvedSha = await client.resolveRefToSha(dep.owner, dep.repo, resolvedRef);
+    logger.debug(`Resolved ${repoUrl} ref "${resolvedRef}" -> ${resolvedSha}`);
+  }
+
+  const deployedFiles: string[] = [];
+  for (const primitive of APM_PRIMITIVES) {
+    const remoteBase = dep.path
+      ? toPosixPath(join(dep.path, primitive.sourceDir))
+      : primitive.sourceDir;
+    const files = await listPrimitiveFiles({
+      client,
+      semaphore,
+      owner: dep.owner,
+      repo: dep.repo,
+      ref: resolvedSha,
+      remoteBase,
+      logger,
+    });
+    if (files.length === 0) continue;
+
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        logger.warn(
+          `Skipping "${file.path}" from ${repoUrl}: ${(file.size / 1024 / 1024).toFixed(2)}MB exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit.`,
+        );
+        continue;
+      }
+      const relativeToBase = file.path.substring(remoteBase.length + 1);
+      const deployRelative = toPosixPath(join(primitive.deployDir, relativeToBase));
+      checkPathTraversal({
+        relativePath: deployRelative,
+        intendedRootDir: baseDir,
+      });
+      const content = await withSemaphore(semaphore, () =>
+        client.getFileContent(dep.owner, dep.repo, file.path, resolvedSha),
+      );
+      await writeFileContent(join(baseDir, deployRelative), content);
+      deployedFiles.push(deployRelative);
+    }
+  }
+
+  deployedFiles.sort();
+
+  const lockEntry: ApmLockDependency = {
+    repo_url: repoUrl,
+    resolved_commit: resolvedSha,
+    resolved_ref: resolvedRef,
+    depth: 1,
+    package_type: "apm_package",
+    deployed_files: deployedFiles,
+  };
+  if (dep.path) {
+    lockEntry.virtual_path = dep.path;
+  }
+
+  logger.info(`Installed ${deployedFiles.length} file(s) from ${repoUrl}@${shortSha(resolvedSha)}`);
+
+  return { lockEntry, deployedFiles };
+}
+
+async function listPrimitiveFiles(params: {
+  client: GitHubClient;
+  semaphore: Semaphore;
+  owner: string;
+  repo: string;
+  ref: string;
+  remoteBase: string;
+  logger: Logger;
+}): Promise<GitHubFileEntry[]> {
+  const { client, semaphore, owner, repo, ref, remoteBase, logger } = params;
+  try {
+    return await listDirectoryRecursive({
+      client,
+      owner,
+      repo,
+      path: remoteBase,
+      ref,
+      semaphore,
+    });
+  } catch (error) {
+    if (error instanceof GitHubClientError && error.statusCode === 404) {
+      logger.debug(`No ${remoteBase}/ in ${owner}/${repo}, skipping.`);
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Canonical repo_url written into the lockfile. We always use the HTTPS form
+ * without a trailing `.git` so that lock files round-trip deterministically
+ * regardless of whether the manifest referenced the repo with or without
+ * the suffix.
+ */
+function canonicalRepoUrl(dep: ApmDependency): string {
+  return `https://github.com/${dep.owner}/${dep.repo}`;
+}
+
+function shortSha(sha: string): string {
+  return sha.substring(0, 7);
+}

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -16,6 +16,7 @@ import {
   createEmptyApmLock,
   findApmLockDependency,
   readApmLock,
+  RULESYNC_CONTENT_HASH_REGEX,
   writeApmLock,
 } from "./apm-lock.js";
 import { type ApmDependency, readApmManifest } from "./apm-manifest.js";
@@ -119,6 +120,7 @@ export async function installApm(params: {
 
   const newLock: ApmLock = createEmptyApmLock({
     apmVersion: existingLock?.apm_version ?? RULESYNC_APM_COMPAT_VERSION,
+    existingLock,
   });
 
   // Dependencies are independent, so install them in parallel. The within-dep
@@ -132,7 +134,7 @@ export async function installApm(params: {
   //                   one failing dep does not abort the others.
   type DepResult =
     | { status: "ok"; lockEntry: ApmLockDependency; deployedCount: number }
-    | { status: "failed" };
+    | { status: "failed"; previous: ApmLockDependency | undefined };
 
   const frozen = options.frozen ?? false;
 
@@ -167,33 +169,44 @@ export async function installApm(params: {
             }
             // Preserve the prior lock entry for failed deps so that a
             // transient network error does not destroy a previously pinned
-            // commit SHA.
+            // commit SHA. We return it rather than pushing here so that the
+            // post-loop pushes preserved entries in manifest order, not in
+            // promise-completion order.
             const previous = existingLock
               ? findApmLockDependency(existingLock, canonicalRepoUrl(dep))
               : undefined;
-            if (previous) {
-              newLock.dependencies.push(previous);
-            }
-            return { status: "failed" };
+            return { status: "failed", previous };
           }
         }),
       );
 
   let totalDeployed = 0;
   let failedCount = 0;
-  // Iterate in manifest order to keep the lockfile deterministic.
+  // Iterate in manifest order to keep the lockfile deterministic regardless
+  // of promise-completion timing.
   for (const result of results) {
     if (result.status === "ok") {
       newLock.dependencies.push(result.lockEntry);
       totalDeployed += result.deployedCount;
     } else {
       failedCount += 1;
+      if (result.previous) {
+        newLock.dependencies.push(result.previous);
+      }
     }
   }
 
   // Remove files that were deployed by a previous install but are no longer
   // part of any current dependency's deployed_files. Without this, stale
   // artifacts would accumulate on disk forever as upstream content changes.
+  //
+  // SECURITY: `deployed_files` is only schema-validated as `z.array(z.string())`,
+  // so a hostile lockfile (planted in a repo and processed by CI) could try
+  // to make us `removeFile("../../etc/passwd")`. We defense-in-depth guard
+  // each entry: (a) reject absolute paths and `..` segments by shape, then
+  // (b) run `checkPathTraversal` for the canonical check used on the write
+  // path. Offending entries are skipped with a warn log rather than fatal so
+  // that a single bad row cannot brick the install.
   if (existingLock) {
     const newDeployedFiles = new Set(newLock.dependencies.flatMap((d) => d.deployed_files));
     const toDelete: string[] = [];
@@ -205,6 +218,16 @@ export async function installApm(params: {
       }
     }
     for (const relativePath of toDelete) {
+      if (posix.isAbsolute(relativePath) || relativePath.split(/[/\\]/).includes("..")) {
+        logger.warn(`Refusing to remove stale apm file with suspicious path: "${relativePath}".`);
+        continue;
+      }
+      try {
+        checkPathTraversal({ relativePath, intendedRootDir: baseDir });
+      } catch {
+        logger.warn(`Refusing to remove stale apm file outside baseDir: "${relativePath}".`);
+        continue;
+      }
       const absolute = join(baseDir, relativePath);
       // `removeFile` is best-effort and swallows ENOENT, so missing files are
       // a no-op. This keeps a corrupted partial-install from blowing up here.
@@ -325,14 +348,29 @@ async function installDependency(params: {
   const contentHash = computeContentHash(deployed);
 
   // Verify integrity against the lockfile when running frozen and the prior
-  // lock recorded a hash. A mismatch means either the upstream content moved
-  // under the same SHA (unlikely with git) or someone tampered with the
-  // lockfile / deployed files. We do this *before* writing anything to disk
-  // under --frozen so that tampered bytes never hit the filesystem.
-  if (frozen && locked?.content_hash && locked.content_hash !== contentHash) {
-    throw new Error(
-      `content_hash mismatch for ${repoUrl}: lock=${locked.content_hash} computed=${contentHash}. Refuse to trust the deployment under --frozen.`,
-    );
+  // lock recorded a hash rulesync itself wrote. A mismatch means either the
+  // upstream content moved under the same SHA (unlikely with git) or someone
+  // tampered with the lockfile / deployed files. We do this *before* writing
+  // anything to disk under --frozen so that tampered bytes never hit the
+  // filesystem.
+  //
+  // If the recorded hash does not match the rulesync format (e.g. the
+  // lockfile was produced by the upstream `apm` CLI which writes a different
+  // shape), we skip the integrity check rather than fail — the commit SHA
+  // pin is still enforced, and this preserves interop for users migrating
+  // from `apm` to `rulesync install --mode apm`.
+  if (frozen && locked?.content_hash) {
+    if (RULESYNC_CONTENT_HASH_REGEX.test(locked.content_hash)) {
+      if (locked.content_hash !== contentHash) {
+        throw new Error(
+          `content_hash mismatch for ${repoUrl}: lock=${locked.content_hash} computed=${contentHash}. Refuse to trust the deployment under --frozen.`,
+        );
+      }
+    } else {
+      logger.debug(
+        `Skipping content_hash integrity check for ${repoUrl}: recorded hash "${locked.content_hash}" was not written by rulesync.`,
+      );
+    }
   }
 
   // Under --frozen we deferred all writes until after the hash check passed.

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -62,7 +62,7 @@ export type ApmInstallResult = {
 /**
  * Entry point for `rulesync install --mode apm`. Reads `apm.yml`, resolves
  * every declared APM dependency, fetches the subset of primitives rulesync
- * currently understands (Instructions and Skills), and updates `apm.lock.yaml`.
+ * currently understands (Instructions and Skills), and updates `rulesync-apm.lock.yaml`.
  */
 export async function installApm(params: {
   baseDir: string;
@@ -81,7 +81,7 @@ export async function installApm(params: {
   if (options.frozen) {
     if (!existingLock) {
       throw new Error(
-        "Frozen install failed: apm.lock.yaml is missing. Run 'rulesync install --mode apm' to create it.",
+        "Frozen install failed: rulesync-apm.lock.yaml is missing. Run 'rulesync install --mode apm' to create it.",
       );
     }
     const missing = manifest.dependencies.filter(
@@ -90,7 +90,7 @@ export async function installApm(params: {
     if (missing.length > 0) {
       const names = missing.map((d) => d.gitUrl).join(", ");
       throw new Error(
-        `Frozen install failed: apm.lock.yaml is missing entries for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
+        `Frozen install failed: rulesync-apm.lock.yaml is missing entries for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
       );
     }
     // Detect manifest drift: when the user edited `ref` in apm.yml without
@@ -109,7 +109,7 @@ export async function installApm(params: {
         })
         .join(", ");
       throw new Error(
-        `Frozen install failed: manifest ref does not match apm.lock.yaml for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
+        `Frozen install failed: manifest ref does not match rulesync-apm.lock.yaml for: ${names}. Run 'rulesync install --mode apm' to update the lockfile.`,
       );
     }
   }
@@ -244,10 +244,10 @@ export async function installApm(params: {
     newLock.generated_at = new Date().toISOString();
     await writeApmLock({ baseDir, lock: newLock });
     if (failedCount === 0) {
-      logger.debug("apm.lock.yaml updated.");
+      logger.debug("rulesync-apm.lock.yaml updated.");
     } else {
       logger.warn(
-        `apm.lock.yaml written with partially successful installs (${failedCount} dep(s) failed).`,
+        `rulesync-apm.lock.yaml written with partially successful installs (${failedCount} dep(s) failed).`,
       );
     }
   }

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -65,6 +65,7 @@ dependencies:
     });
 
     it("preserves unknown fields via looseObject", () => {
+      const validHash = `sha256:${"0".repeat(64)}`;
       const content = `lockfile_version: "1"
 generated_at: "2026-04-20T00:00:00Z"
 apm_version: "0.7.7"
@@ -76,7 +77,7 @@ dependencies:
     resolved_ref: main
     depth: 1
     package_type: apm_package
-    content_hash: sha256:abc
+    content_hash: ${validHash}
     deployed_files: []
     future_field: preserved
 `;
@@ -84,12 +85,12 @@ dependencies:
       expect(parsed).not.toBeNull();
       expect(parsed?.mcp_servers).toEqual(["security-scanner"]);
       expect(parsed?.dependencies[0]).toMatchObject({
-        content_hash: "sha256:abc",
+        content_hash: validHash,
         future_field: "preserved",
       });
     });
 
-    it("rejects dependencies with a non-SHA resolved_commit", () => {
+    it("throws when a dependency has a non-SHA resolved_commit", () => {
       const content = `lockfile_version: "1"
 generated_at: "2026-04-20T00:00:00Z"
 apm_version: "0.7.7"
@@ -101,7 +102,47 @@ dependencies:
     package_type: apm_package
     deployed_files: []
 `;
-      expect(parseApmLock(content)).toBeNull();
+      expect(() => parseApmLock(content)).toThrow(/resolved_commit/);
+    });
+
+    it("throws when depth is negative", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/owner/repo
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: main
+    depth: -1
+    package_type: apm_package
+    deployed_files: []
+`;
+      expect(() => parseApmLock(content)).toThrow(/Invalid apm\.lock\.yaml/);
+    });
+
+    it("throws when content_hash does not match sha256:<64-hex>", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/owner/repo
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: main
+    depth: 1
+    package_type: apm_package
+    content_hash: sha256:abc
+    deployed_files: []
+`;
+      expect(() => parseApmLock(content)).toThrow(/content_hash/);
+    });
+
+    it('throws when lockfile_version is not "1"', () => {
+      const content = `lockfile_version: "2"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies: []
+`;
+      expect(() => parseApmLock(content)).toThrow(/Invalid apm\.lock\.yaml/);
     });
   });
 

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -28,6 +28,31 @@ describe("apm-lock", () => {
       expect(lock.dependencies).toEqual([]);
       expect(typeof lock.generated_at).toBe("string");
     });
+
+    it("preserves top-level fields from existingLock", () => {
+      const existing = parseApmLock(
+        `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+mcp_servers:
+  - security-scanner
+custom_top_level:
+  any: thing
+dependencies: []
+`,
+      );
+      expect(existing).not.toBeNull();
+      const lock = createEmptyApmLock({
+        apmVersion: "rulesync-compat/0.1",
+        existingLock: existing,
+      });
+      expect(lock.mcp_servers).toEqual(["security-scanner"]);
+      expect((lock as unknown as { custom_top_level: unknown }).custom_top_level).toEqual({
+        any: "thing",
+      });
+      expect(lock.dependencies).toEqual([]);
+      expect(lock.apm_version).toBe("rulesync-compat/0.1");
+    });
   });
 
   describe("parseApmLock", () => {
@@ -120,7 +145,12 @@ dependencies:
       expect(() => parseApmLock(content)).toThrow(/Invalid apm\.lock\.yaml/);
     });
 
-    it("throws when content_hash does not match sha256:<64-hex>", () => {
+    it("accepts content_hash values that do not match the rulesync regex (upstream apm interop)", () => {
+      // The strict regex was relaxed at the parse site so that a lockfile
+      // produced by the upstream `apm` CLI with a different content_hash
+      // shape can still be read. Rulesync itself always writes the strict
+      // form; the `--frozen` integrity check is responsible for deciding
+      // whether a recorded hash is comparable.
       const content = `lockfile_version: "1"
 generated_at: "2026-04-20T00:00:00Z"
 apm_version: "0.7.7"
@@ -130,10 +160,11 @@ dependencies:
     resolved_ref: main
     depth: 1
     package_type: apm_package
-    content_hash: sha256:abc
+    content_hash: sha256:legacy
     deployed_files: []
 `;
-      expect(() => parseApmLock(content)).toThrow(/content_hash/);
+      const parsed = parseApmLock(content);
+      expect(parsed?.dependencies[0]?.content_hash).toBe("sha256:legacy");
     });
 
     it('throws when lockfile_version is not "1"', () => {

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -142,7 +142,7 @@ dependencies:
     package_type: apm_package
     deployed_files: []
 `;
-      expect(() => parseApmLock(content)).toThrow(/Invalid apm\.lock\.yaml/);
+      expect(() => parseApmLock(content)).toThrow(/Invalid rulesync-apm\.lock\.yaml/);
     });
 
     it("accepts content_hash values that do not match the rulesync regex (upstream apm interop)", () => {
@@ -173,7 +173,7 @@ generated_at: "2026-04-20T00:00:00Z"
 apm_version: "0.7.7"
 dependencies: []
 `;
-      expect(() => parseApmLock(content)).toThrow(/Invalid apm\.lock\.yaml/);
+      expect(() => parseApmLock(content)).toThrow(/Invalid rulesync-apm\.lock\.yaml/);
     });
   });
 

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { readFileContent } from "../../utils/file.js";
+import {
+  APM_LOCKFILE_VERSION,
+  createEmptyApmLock,
+  findApmLockDependency,
+  getApmLockPath,
+  parseApmLock,
+  readApmLock,
+  serializeApmLock,
+  writeApmLock,
+} from "./apm-lock.js";
+
+const VALID_SHA = "a".repeat(40);
+
+describe("apm-lock", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createEmptyApmLock", () => {
+    it("uses the APM v1 lockfile_version and a provided apm_version string", () => {
+      const lock = createEmptyApmLock({ apmVersion: "rulesync-compat/0.1" });
+      expect(lock.lockfile_version).toBe(APM_LOCKFILE_VERSION);
+      expect(lock.apm_version).toBe("rulesync-compat/0.1");
+      expect(lock.dependencies).toEqual([]);
+      expect(typeof lock.generated_at).toBe("string");
+    });
+  });
+
+  describe("parseApmLock", () => {
+    it("returns null for empty content", () => {
+      expect(parseApmLock("")).toBeNull();
+    });
+
+    it("returns null for malformed YAML", () => {
+      expect(parseApmLock("::: not yaml :::")).toBeNull();
+    });
+
+    it("parses a minimal v1 lockfile", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/owner/repo
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: v1.0.0
+    version: "1.0.0"
+    depth: 1
+    package_type: apm_package
+    deployed_files:
+      - .github/instructions/security.instructions.md
+`;
+      const parsed = parseApmLock(content);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.dependencies).toHaveLength(1);
+      expect(parsed?.dependencies[0]).toMatchObject({
+        repo_url: "https://github.com/owner/repo",
+        resolved_commit: VALID_SHA,
+        depth: 1,
+        package_type: "apm_package",
+      });
+    });
+
+    it("preserves unknown fields via looseObject", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+mcp_servers:
+  - security-scanner
+dependencies:
+  - repo_url: https://github.com/owner/repo
+    resolved_commit: ${VALID_SHA}
+    resolved_ref: main
+    depth: 1
+    package_type: apm_package
+    content_hash: sha256:abc
+    deployed_files: []
+    future_field: preserved
+`;
+      const parsed = parseApmLock(content);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.mcp_servers).toEqual(["security-scanner"]);
+      expect(parsed?.dependencies[0]).toMatchObject({
+        content_hash: "sha256:abc",
+        future_field: "preserved",
+      });
+    });
+
+    it("rejects dependencies with a non-SHA resolved_commit", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+apm_version: "0.7.7"
+dependencies:
+  - repo_url: https://github.com/owner/repo
+    resolved_commit: not-a-sha
+    resolved_ref: main
+    depth: 1
+    package_type: apm_package
+    deployed_files: []
+`;
+      expect(parseApmLock(content)).toBeNull();
+    });
+  });
+
+  describe("serializeApmLock", () => {
+    it("round-trips a simple lockfile", () => {
+      const original = createEmptyApmLock({ apmVersion: "0.7.7" });
+      original.dependencies.push({
+        repo_url: "https://github.com/owner/repo",
+        resolved_commit: VALID_SHA,
+        resolved_ref: "main",
+        depth: 1,
+        package_type: "apm_package",
+        deployed_files: [".github/instructions/a.instructions.md"],
+      });
+      const serialized = serializeApmLock(original);
+      const parsed = parseApmLock(serialized);
+      expect(parsed).toEqual(original);
+    });
+  });
+
+  describe("read/write", () => {
+    let testDir: string;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      ({ testDir, cleanup } = await setupTestDirectory());
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it("returns null when the lockfile does not exist", async () => {
+      expect(await readApmLock(testDir)).toBeNull();
+    });
+
+    it("writes and reads back a lockfile", async () => {
+      const lock = createEmptyApmLock({ apmVersion: "0.7.7" });
+      lock.dependencies.push({
+        repo_url: "https://github.com/owner/repo",
+        resolved_commit: VALID_SHA,
+        resolved_ref: "main",
+        depth: 1,
+        package_type: "apm_package",
+        deployed_files: [".github/instructions/a.instructions.md"],
+      });
+      await writeApmLock({ baseDir: testDir, lock });
+      const written = await readFileContent(getApmLockPath(testDir));
+      expect(written).toContain("lockfile_version:");
+      const readBack = await readApmLock(testDir);
+      expect(readBack).toEqual(lock);
+    });
+  });
+
+  describe("findApmLockDependency", () => {
+    it("matches on exact repo_url", () => {
+      const lock = createEmptyApmLock({ apmVersion: "0.7.7" });
+      lock.dependencies.push({
+        repo_url: "https://github.com/owner/repo",
+        resolved_commit: VALID_SHA,
+        resolved_ref: "main",
+        depth: 1,
+        package_type: "apm_package",
+        deployed_files: [],
+      });
+      expect(findApmLockDependency(lock, "https://github.com/owner/repo")).toBeDefined();
+      expect(findApmLockDependency(lock, "https://github.com/owner/other")).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -1,12 +1,20 @@
 import { join } from "node:path";
 
 import { dump, load } from "js-yaml";
-import { nonnegative, optional, refine, regex, z } from "zod/mini";
+import { nonnegative, optional, refine, z } from "zod/mini";
 
 import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
 
 export const APM_LOCKFILE_FILE_NAME = "apm.lock.yaml";
 export const APM_LOCKFILE_VERSION = "1" as const;
+
+/**
+ * Shape of content_hash values that rulesync writes. Used by `--frozen`
+ * integrity checks to decide whether a prior hash is comparable: any value
+ * not matching this regex (e.g. written by the upstream `apm` CLI) is
+ * skipped rather than throwing so that cross-tool interop works.
+ */
+export const RULESYNC_CONTENT_HASH_REGEX = /^sha256:[0-9a-f]{64}$/;
 
 /**
  * Single dependency entry in `apm.lock.yaml`. Mirrors the subset of the
@@ -27,9 +35,13 @@ export const ApmLockDependencySchema = z.looseObject({
   depth: z.int().check(nonnegative()),
   resolved_by: optional(z.string()),
   package_type: z.string(),
-  content_hash: optional(
-    z.string().check(regex(/^sha256:[0-9a-f]{64}$/, "content_hash must be sha256:<64-char-hex>")),
-  ),
+  // Intentionally loose: the upstream `apm` CLI may write content_hash values
+  // that do not match the strict rulesync format. We accept any string on read
+  // so that a lockfile produced by `apm` round-trips through rulesync without
+  // throwing. Rulesync itself always writes values matching
+  // `RULESYNC_CONTENT_HASH_REGEX`, and `--frozen` integrity checks only
+  // enforce the comparison when the recorded hash matches that shape.
+  content_hash: optional(z.string()),
   is_dev: optional(z.boolean()),
   deployed_files: z.array(z.string()),
   source: optional(z.string()),
@@ -60,9 +72,20 @@ export async function apmLockExists(baseDir: string): Promise<boolean> {
  * Create an empty lockfile structure. `apm_version` is set to the rulesync
  * compatibility-marker string so downstream tooling can tell this lockfile
  * was produced by rulesync rather than the upstream `apm` CLI.
+ *
+ * When `existingLock` is provided, all top-level fields from that lock (e.g.
+ * `mcp_servers` and any looseObject extras written by the upstream `apm`
+ * CLI) are carried forward. `dependencies` is always reset to an empty array
+ * and `generated_at` is refreshed; `apm_version` is overwritten by the value
+ * passed in `params.apmVersion`.
  */
-export function createEmptyApmLock(params: { apmVersion: string }): ApmLock {
+export function createEmptyApmLock(params: {
+  apmVersion: string;
+  existingLock?: ApmLock | null;
+}): ApmLock {
+  const base = params.existingLock ? { ...params.existingLock } : {};
   return {
+    ...base,
     lockfile_version: APM_LOCKFILE_VERSION,
     generated_at: new Date().toISOString(),
     apm_version: params.apmVersion,

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -1,12 +1,12 @@
 import { join } from "node:path";
 
 import { dump, load } from "js-yaml";
-import { optional, refine, z } from "zod/mini";
+import { nonnegative, optional, refine, regex, z } from "zod/mini";
 
 import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
 
 export const APM_LOCKFILE_FILE_NAME = "apm.lock.yaml";
-export const APM_LOCKFILE_VERSION = "1";
+export const APM_LOCKFILE_VERSION = "1" as const;
 
 /**
  * Single dependency entry in `apm.lock.yaml`. Mirrors the subset of the
@@ -24,10 +24,12 @@ export const ApmLockDependencySchema = z.looseObject({
   ),
   resolved_ref: optional(z.string()),
   version: optional(z.string()),
-  depth: z.number(),
+  depth: z.int().check(nonnegative()),
   resolved_by: optional(z.string()),
   package_type: z.string(),
-  content_hash: optional(z.string()),
+  content_hash: optional(
+    z.string().check(regex(/^sha256:[0-9a-f]{64}$/, "content_hash must be sha256:<64-char-hex>")),
+  ),
   is_dev: optional(z.boolean()),
   deployed_files: z.array(z.string()),
   source: optional(z.string()),
@@ -38,7 +40,7 @@ export const ApmLockDependencySchema = z.looseObject({
 export type ApmLockDependency = z.infer<typeof ApmLockDependencySchema>;
 
 export const ApmLockSchema = z.looseObject({
-  lockfile_version: z.string(),
+  lockfile_version: z.literal("1"),
   generated_at: z.string(),
   apm_version: z.string(),
   dependencies: z.array(ApmLockDependencySchema),
@@ -69,8 +71,11 @@ export function createEmptyApmLock(params: { apmVersion: string }): ApmLock {
 }
 
 /**
- * Parse `apm.lock.yaml` content into an `ApmLock`. Returns `null` if the
- * content is empty or invalid so callers can fall back to an empty lock.
+ * Parse `apm.lock.yaml` content into an `ApmLock`. Returns `null` when the
+ * content is absent / empty / non-YAML-object so callers can treat the lock
+ * as missing. A *structurally* present lockfile that fails schema validation
+ * throws a descriptive error rather than being silently dropped — silently
+ * discarding a corrupt lockfile would erase previously pinned commits.
  */
 export function parseApmLock(content: string): ApmLock | null {
   if (!content.trim()) {
@@ -87,7 +92,10 @@ export function parseApmLock(content: string): ApmLock | null {
   }
   const parsed = ApmLockSchema.safeParse(loaded);
   if (!parsed.success) {
-    return null;
+    const issues = parsed.error.issues
+      .map((issue) => `  - ${issue.path.join(".") || "<root>"}: ${issue.message}`)
+      .join("\n");
+    throw new Error(`Invalid ${APM_LOCKFILE_FILE_NAME}:\n${issues}`);
   }
   return parsed.data;
 }
@@ -114,11 +122,15 @@ export function serializeApmLock(lock: ApmLock): string {
 }
 
 /**
- * Find the locked entry for a repo_url (case-sensitive), if any.
+ * Find the locked entry for a repo_url. GitHub routes `owner/repo` path
+ * components case-insensitively, so the comparison here is case-insensitive
+ * to match `apm-manifest.ts` canonicalization and avoid frozen-mode false
+ * positives when users re-case their manifest.
  */
 export function findApmLockDependency(
   lock: ApmLock,
   repoUrl: string,
 ): ApmLockDependency | undefined {
-  return lock.dependencies.find((d) => d.repo_url === repoUrl);
+  const target = repoUrl.toLowerCase();
+  return lock.dependencies.find((d) => d.repo_url.toLowerCase() === target);
 }

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -5,7 +5,13 @@ import { nonnegative, optional, refine, z } from "zod/mini";
 
 import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
 
-export const APM_LOCKFILE_FILE_NAME = "apm.lock.yaml";
+/**
+ * Filename of the rulesync-managed apm-compatible lockfile. Rulesync uses a
+ * lockfile name distinct from the upstream `apm` CLI's `apm.lock.yaml` so the
+ * two tools do not fight over the same file: the schema is still the apm v1
+ * lockfile format, but rulesync only reads/writes its own file.
+ */
+export const APM_LOCKFILE_FILE_NAME = "rulesync-apm.lock.yaml";
 export const APM_LOCKFILE_VERSION = "1" as const;
 
 /**
@@ -17,7 +23,7 @@ export const APM_LOCKFILE_VERSION = "1" as const;
 export const RULESYNC_CONTENT_HASH_REGEX = /^sha256:[0-9a-f]{64}$/;
 
 /**
- * Single dependency entry in `apm.lock.yaml`. Mirrors the subset of the
+ * Single dependency entry in `rulesync-apm.lock.yaml`. Mirrors the subset of the
  * APM v1 lockfile schema that rulesync currently populates. Extra fields
  * from the spec (content_hash, is_dev, virtual_path, ...) are preserved
  * verbatim so that rulesync does not strip them out when re-writing a
@@ -94,7 +100,7 @@ export function createEmptyApmLock(params: {
 }
 
 /**
- * Parse `apm.lock.yaml` content into an `ApmLock`. Returns `null` when the
+ * Parse `rulesync-apm.lock.yaml` content into an `ApmLock`. Returns `null` when the
  * content is absent / empty / non-YAML-object so callers can treat the lock
  * as missing. A *structurally* present lockfile that fails schema validation
  * throws a descriptive error rather than being silently dropped — silently

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -1,0 +1,124 @@
+import { join } from "node:path";
+
+import { dump, load } from "js-yaml";
+import { optional, refine, z } from "zod/mini";
+
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+
+export const APM_LOCKFILE_FILE_NAME = "apm.lock.yaml";
+export const APM_LOCKFILE_VERSION = "1";
+
+/**
+ * Single dependency entry in `apm.lock.yaml`. Mirrors the subset of the
+ * APM v1 lockfile schema that rulesync currently populates. Extra fields
+ * from the spec (content_hash, is_dev, virtual_path, ...) are preserved
+ * verbatim so that rulesync does not strip them out when re-writing a
+ * lockfile produced by `apm` itself.
+ */
+export const ApmLockDependencySchema = z.looseObject({
+  repo_url: z.string(),
+  resolved_commit: optional(
+    z
+      .string()
+      .check(refine((v) => /^[0-9a-f]{40}$/.test(v), "resolved_commit must be a 40-char hex SHA")),
+  ),
+  resolved_ref: optional(z.string()),
+  version: optional(z.string()),
+  depth: z.number(),
+  resolved_by: optional(z.string()),
+  package_type: z.string(),
+  content_hash: optional(z.string()),
+  is_dev: optional(z.boolean()),
+  deployed_files: z.array(z.string()),
+  source: optional(z.string()),
+  local_path: optional(z.string()),
+  virtual_path: optional(z.string()),
+  is_virtual: optional(z.boolean()),
+});
+export type ApmLockDependency = z.infer<typeof ApmLockDependencySchema>;
+
+export const ApmLockSchema = z.looseObject({
+  lockfile_version: z.string(),
+  generated_at: z.string(),
+  apm_version: z.string(),
+  dependencies: z.array(ApmLockDependencySchema),
+  mcp_servers: optional(z.array(z.string())),
+});
+export type ApmLock = z.infer<typeof ApmLockSchema>;
+
+export function getApmLockPath(baseDir: string): string {
+  return join(baseDir, APM_LOCKFILE_FILE_NAME);
+}
+
+export async function apmLockExists(baseDir: string): Promise<boolean> {
+  return fileExists(getApmLockPath(baseDir));
+}
+
+/**
+ * Create an empty lockfile structure. `apm_version` is set to the rulesync
+ * compatibility-marker string so downstream tooling can tell this lockfile
+ * was produced by rulesync rather than the upstream `apm` CLI.
+ */
+export function createEmptyApmLock(params: { apmVersion: string }): ApmLock {
+  return {
+    lockfile_version: APM_LOCKFILE_VERSION,
+    generated_at: new Date().toISOString(),
+    apm_version: params.apmVersion,
+    dependencies: [],
+  };
+}
+
+/**
+ * Parse `apm.lock.yaml` content into an `ApmLock`. Returns `null` if the
+ * content is empty or invalid so callers can fall back to an empty lock.
+ */
+export function parseApmLock(content: string): ApmLock | null {
+  if (!content.trim()) {
+    return null;
+  }
+  let loaded: unknown;
+  try {
+    loaded = load(content);
+  } catch {
+    return null;
+  }
+  if (!loaded || typeof loaded !== "object") {
+    return null;
+  }
+  const parsed = ApmLockSchema.safeParse(loaded);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export async function readApmLock(baseDir: string): Promise<ApmLock | null> {
+  const path = getApmLockPath(baseDir);
+  if (!(await fileExists(path))) {
+    return null;
+  }
+  const content = await readFileContent(path);
+  return parseApmLock(content);
+}
+
+export async function writeApmLock(params: { baseDir: string; lock: ApmLock }): Promise<void> {
+  const path = getApmLockPath(params.baseDir);
+  const content = serializeApmLock(params.lock);
+  await writeFileContent(path, content);
+}
+
+export function serializeApmLock(lock: ApmLock): string {
+  // `noRefs: true` avoids YAML anchors/aliases; `lineWidth: -1` keeps long
+  // URLs on a single line so the file stays diff-friendly.
+  return dump(lock, { noRefs: true, lineWidth: -1, sortKeys: false });
+}
+
+/**
+ * Find the locked entry for a repo_url (case-sensitive), if any.
+ */
+export function findApmLockDependency(
+  lock: ApmLock,
+  repoUrl: string,
+): ApmLockDependency | undefined {
+  return lock.dependencies.find((d) => d.repo_url === repoUrl);
+}

--- a/src/lib/apm/apm-manifest.test.ts
+++ b/src/lib/apm/apm-manifest.test.ts
@@ -144,6 +144,30 @@ dependencies:
     ).toThrow(/Only HTTPS GitHub URLs/);
   });
 
+  it("rejects object-form entries with a '..' segment in path", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - git: https://github.com/acme/rules.git
+      path: ../escape
+`,
+      ),
+    ).toThrow(/"path" must not contain ".." segments/);
+  });
+
+  it("rejects object-form entries with an absolute path", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - git: https://github.com/acme/rules.git
+      path: /etc/passwd
+`,
+      ),
+    ).toThrow(/must be a non-empty relative path without a leading slash/);
+  });
+
   it("rejects object-form entries missing the git field", () => {
     expect(() =>
       parseApmManifest(

--- a/src/lib/apm/apm-manifest.test.ts
+++ b/src/lib/apm/apm-manifest.test.ts
@@ -168,6 +168,33 @@ dependencies:
     ).toThrow(/must be a non-empty relative path without a leading slash/);
   });
 
+  it("canonicalizes owner and repo to lower-case (shorthand)", () => {
+    const manifest = parseApmManifest(
+      `dependencies:
+  apm:
+    - Owner/Repo#v1.0.0
+`,
+    );
+    expect(manifest.dependencies[0]).toMatchObject({
+      owner: "owner",
+      repo: "repo",
+      gitUrl: "https://github.com/owner/repo.git",
+    });
+  });
+
+  it("canonicalizes owner and repo to lower-case (object form URL)", () => {
+    const manifest = parseApmManifest(
+      `dependencies:
+  apm:
+    - git: https://github.com/Acme/Coding-Standards.git
+`,
+    );
+    expect(manifest.dependencies[0]).toMatchObject({
+      owner: "acme",
+      repo: "coding-standards",
+    });
+  });
+
   it("rejects object-form entries missing the git field", () => {
     expect(() =>
       parseApmManifest(

--- a/src/lib/apm/apm-manifest.test.ts
+++ b/src/lib/apm/apm-manifest.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { parseApmManifest } from "./apm-manifest.js";
+
+describe("parseApmManifest", () => {
+  it("returns an empty dependency list when the file is empty", () => {
+    expect(parseApmManifest("")).toEqual({ dependencies: [] });
+  });
+
+  it("parses string shorthand without a ref", () => {
+    const manifest = parseApmManifest(
+      `name: my-project
+version: 1.0.0
+dependencies:
+  apm:
+    - microsoft/apm-sample-package
+`,
+    );
+
+    expect(manifest).toEqual({
+      name: "my-project",
+      version: "1.0.0",
+      dependencies: [
+        {
+          gitUrl: "https://github.com/microsoft/apm-sample-package.git",
+          owner: "microsoft",
+          repo: "apm-sample-package",
+        },
+      ],
+    });
+  });
+
+  it("parses string shorthand with a ref", () => {
+    const manifest = parseApmManifest(
+      `dependencies:
+  apm:
+    - owner/repo#v1.0.0
+`,
+    );
+
+    expect(manifest.dependencies).toEqual([
+      {
+        gitUrl: "https://github.com/owner/repo.git",
+        owner: "owner",
+        repo: "repo",
+        ref: "v1.0.0",
+      },
+    ]);
+  });
+
+  it("parses an HTTPS GitHub URL with a ref", () => {
+    const manifest = parseApmManifest(
+      `dependencies:
+  apm:
+    - https://github.com/owner/repo.git#main
+`,
+    );
+
+    expect(manifest.dependencies).toEqual([
+      {
+        gitUrl: "https://github.com/owner/repo.git",
+        owner: "owner",
+        repo: "repo",
+        ref: "main",
+      },
+    ]);
+  });
+
+  it("parses the object form with git/path/ref/alias", () => {
+    const manifest = parseApmManifest(
+      `dependencies:
+  apm:
+    - git: https://github.com/acme/coding-standards.git
+      path: instructions/security
+      ref: v2.0
+      alias: review
+`,
+    );
+
+    expect(manifest.dependencies).toEqual([
+      {
+        gitUrl: "https://github.com/acme/coding-standards.git",
+        owner: "acme",
+        repo: "coding-standards",
+        ref: "v2.0",
+        path: "instructions/security",
+        alias: "review",
+      },
+    ]);
+  });
+
+  it("rejects local path dependencies with a clear not-yet-supported error", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - ./packages/my-skills
+`,
+      ),
+    ).toThrow(/local path dependencies/);
+  });
+
+  it("rejects SSH dependencies with a clear not-yet-supported error", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - git@github.com:owner/repo.git
+`,
+      ),
+    ).toThrow(/SSH URL/);
+  });
+
+  it("rejects marketplace dependencies with a clear not-yet-supported error", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - awesome@marketplace
+`,
+      ),
+    ).toThrow(/marketplace/);
+  });
+
+  it("rejects FQDN/sub-path shorthand with a clear not-yet-supported error", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - gitlab.com/acme/rules
+`,
+      ),
+    ).toThrow(/FQDN shorthand|sub-path/);
+  });
+
+  it("rejects non-GitHub HTTPS URLs", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - https://gitlab.com/acme/rules.git
+`,
+      ),
+    ).toThrow(/Only HTTPS GitHub URLs/);
+  });
+
+  it("rejects object-form entries missing the git field", () => {
+    expect(() =>
+      parseApmManifest(
+        `dependencies:
+  apm:
+    - path: some/path
+`,
+      ),
+    ).toThrow(/"git" field/);
+  });
+});

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -207,8 +207,9 @@ function normalizeStringDependency(entry: string, index: number): ApmDependency 
       `apm.yml dependency #${index + 1}: FQDN shorthand or sub-path shorthand ("${entry}") is not yet supported. Use the object form with an explicit "git" URL.`,
     );
   }
-  const owner = ownerRepo.substring(0, slashIndex);
-  const repo = ownerRepo.substring(slashIndex + 1);
+  // Canonicalize owner/repo to lower-case for case-insensitive matching.
+  const owner = ownerRepo.substring(0, slashIndex).toLowerCase();
+  const repo = ownerRepo.substring(slashIndex + 1).toLowerCase();
   return {
     gitUrl: `https://github.com/${owner}/${repo}.git`,
     owner,
@@ -250,12 +251,16 @@ function parseHttpsGitHubUrl(url: string): { gitUrl: string; owner: string; repo
   if (segments.length < 2) {
     return null;
   }
-  const owner = segments[0];
+  const rawOwner = segments[0];
   const rawRepo = segments[1];
-  if (!owner || !rawRepo) {
+  if (!rawOwner || !rawRepo) {
     return null;
   }
-  const repo = rawRepo.replace(/\.git$/, "");
+  // GitHub treats owner/repo names case-insensitively for routing. Canonicalize
+  // to lower-case so that lockfile comparisons and frozen-mode checks are not
+  // tripped up by a user re-casing their manifest.
+  const owner = rawOwner.toLowerCase();
+  const repo = rawRepo.replace(/\.git$/, "").toLowerCase();
   return {
     gitUrl: `https://github.com/${owner}/${repo}.git`,
     owner,

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -141,6 +141,9 @@ function normalizeDependency(
       `apm.yml dependency #${index + 1}: unsupported git URL "${gitUrl}". Only HTTPS GitHub URLs (https://github.com/owner/repo[.git]) are supported in this version. SSH, GitLab, Bitbucket, and other hosts are not yet supported.`,
     );
   }
+  if (entry.path !== undefined) {
+    validateSubPath(entry.path, index);
+  }
   return {
     gitUrl: parsedUrl.gitUrl,
     owner: parsedUrl.owner,
@@ -149,6 +152,24 @@ function normalizeDependency(
     path: entry.path,
     alias: entry.alias,
   };
+}
+
+/**
+ * Reject `dep.path` values that could escape the repository root or be
+ * interpreted as an absolute path on the remote tree.
+ */
+function validateSubPath(subPath: string, index: number): void {
+  if (subPath === "" || subPath.startsWith("/") || subPath.startsWith("\\")) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: "path" must be a non-empty relative path without a leading slash. Received: ${JSON.stringify(subPath)}.`,
+    );
+  }
+  const segments = subPath.split(/[/\\]/);
+  if (segments.includes("..")) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: "path" must not contain ".." segments. Received: ${JSON.stringify(subPath)}.`,
+    );
+  }
 }
 
 function normalizeStringDependency(entry: string, index: number): ApmDependency {

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -1,0 +1,249 @@
+import { join } from "node:path";
+
+import { dump, load } from "js-yaml";
+import { optional, z } from "zod/mini";
+
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+
+export const APM_MANIFEST_FILE_NAME = "apm.yml";
+
+/**
+ * Parsed representation of a single APM `dependencies.apm` entry after
+ * normalization. Every accepted input form (string shorthand, object form,
+ * HTTPS URL) lands here.
+ */
+export type ApmDependency = {
+  /** Canonical git URL. Always an HTTPS URL for the first iteration. */
+  gitUrl: string;
+  /** GitHub owner (extracted for use with the REST client). */
+  owner: string;
+  /** GitHub repo. */
+  repo: string;
+  /**
+   * Optional ref (tag, branch, or commit SHA). Absent means "resolve against
+   * the repository's default branch".
+   */
+  ref?: string;
+  /**
+   * Optional virtual sub-directory within the repository. When present the
+   * install layout is rooted at this path.
+   */
+  path?: string;
+  /**
+   * Optional alias used to override the local install directory name.
+   */
+  alias?: string;
+};
+
+const ApmObjectDependencySchema = z.looseObject({
+  git: optional(z.string()),
+  source: optional(z.string()),
+  path: optional(z.string()),
+  ref: optional(z.string()),
+  alias: optional(z.string()),
+});
+
+const ApmDependencyInputSchema = z.union([z.string(), ApmObjectDependencySchema]);
+
+const ApmManifestSchema = z.looseObject({
+  name: optional(z.string()),
+  version: optional(z.string()),
+  dependencies: optional(
+    z.looseObject({
+      apm: optional(z.array(ApmDependencyInputSchema)),
+    }),
+  ),
+});
+
+export type ApmManifest = {
+  name?: string;
+  version?: string;
+  dependencies: ApmDependency[];
+};
+
+/**
+ * Return the absolute path to the project's `apm.yml`.
+ */
+export function getApmManifestPath(baseDir: string): string {
+  return join(baseDir, APM_MANIFEST_FILE_NAME);
+}
+
+/**
+ * True if `apm.yml` exists at the given base directory.
+ */
+export async function apmManifestExists(baseDir: string): Promise<boolean> {
+  return fileExists(getApmManifestPath(baseDir));
+}
+
+/**
+ * Parse `apm.yml` content. Throws with a descriptive error when parsing
+ * or any dependency entry fails normalization.
+ */
+export function parseApmManifest(content: string): ApmManifest {
+  const loaded = load(content);
+  if (loaded === undefined || loaded === null) {
+    return { dependencies: [] };
+  }
+  const parsed = ApmManifestSchema.safeParse(loaded);
+  if (!parsed.success) {
+    throw new Error(`Invalid apm.yml: ${parsed.error.message}`);
+  }
+  const raw = parsed.data;
+  const rawDeps = raw.dependencies?.apm ?? [];
+  const dependencies: ApmDependency[] = rawDeps.map((entry, index) =>
+    normalizeDependency(entry, index),
+  );
+  return {
+    name: raw.name,
+    version: raw.version,
+    dependencies,
+  };
+}
+
+/**
+ * Read and parse `apm.yml` from disk.
+ */
+export async function readApmManifest(baseDir: string): Promise<ApmManifest> {
+  const path = getApmManifestPath(baseDir);
+  const content = await readFileContent(path);
+  return parseApmManifest(content);
+}
+
+/**
+ * Write an `apm.yml` back to disk. Only used by tests today — the install
+ * command itself does not mutate the manifest.
+ */
+export async function writeApmManifest(params: {
+  baseDir: string;
+  manifest: { name?: string; version?: string; dependencies?: unknown[] };
+}): Promise<void> {
+  const path = getApmManifestPath(params.baseDir);
+  const content = dump(params.manifest, { lineWidth: -1 });
+  await writeFileContent(path, content);
+}
+
+function normalizeDependency(
+  entry: string | z.infer<typeof ApmObjectDependencySchema>,
+  index: number,
+): ApmDependency {
+  if (typeof entry === "string") {
+    return normalizeStringDependency(entry, index);
+  }
+  const gitUrl = entry.git ?? entry.source;
+  if (!gitUrl) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: object form requires a "git" field. Received: ${JSON.stringify(entry)}.`,
+    );
+  }
+  const parsedUrl = parseHttpsGitHubUrl(gitUrl);
+  if (!parsedUrl) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: unsupported git URL "${gitUrl}". Only HTTPS GitHub URLs (https://github.com/owner/repo[.git]) are supported in this version. SSH, GitLab, Bitbucket, and other hosts are not yet supported.`,
+    );
+  }
+  return {
+    gitUrl: parsedUrl.gitUrl,
+    owner: parsedUrl.owner,
+    repo: parsedUrl.repo,
+    ref: entry.ref,
+    path: entry.path,
+    alias: entry.alias,
+  };
+}
+
+function normalizeStringDependency(entry: string, index: number): ApmDependency {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    throw new Error(`apm.yml dependency #${index + 1}: entry must be a non-empty string.`);
+  }
+  rejectUnsupportedShorthand(trimmed, index);
+
+  if (trimmed.startsWith("https://")) {
+    const [urlPart, refPart] = splitOnFirst(trimmed, "#");
+    const parsed = parseHttpsGitHubUrl(urlPart);
+    if (!parsed) {
+      throw new Error(
+        `apm.yml dependency #${index + 1}: unsupported URL "${urlPart}". Only HTTPS GitHub URLs (https://github.com/owner/repo[.git]) are supported in this version.`,
+      );
+    }
+    return {
+      gitUrl: parsed.gitUrl,
+      owner: parsed.owner,
+      repo: parsed.repo,
+      ref: refPart || undefined,
+    };
+  }
+
+  const [ownerRepo, refPart] = splitOnFirst(trimmed, "#");
+  const slashIndex = ownerRepo.indexOf("/");
+  if (slashIndex === -1 || slashIndex === 0 || slashIndex === ownerRepo.length - 1) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: shorthand "${entry}" must be in the form "owner/repo[#ref]".`,
+    );
+  }
+  if (ownerRepo.includes("/", slashIndex + 1)) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: FQDN shorthand or sub-path shorthand ("${entry}") is not yet supported. Use the object form with an explicit "git" URL.`,
+    );
+  }
+  const owner = ownerRepo.substring(0, slashIndex);
+  const repo = ownerRepo.substring(slashIndex + 1);
+  return {
+    gitUrl: `https://github.com/${owner}/${repo}.git`,
+    owner,
+    repo,
+    ref: refPart || undefined,
+  };
+}
+
+function rejectUnsupportedShorthand(entry: string, index: number): void {
+  if (entry.startsWith("./") || entry.startsWith("../") || entry.startsWith("/")) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: local path dependencies ("${entry}") are not yet supported by rulesync.`,
+    );
+  }
+  if (entry.startsWith("git@") || entry.startsWith("ssh://")) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: SSH URL dependencies ("${entry}") are not yet supported. Use an HTTPS GitHub URL.`,
+    );
+  }
+  if (entry.includes("@marketplace")) {
+    throw new Error(
+      `apm.yml dependency #${index + 1}: APM marketplace dependencies ("${entry}") are not yet supported.`,
+    );
+  }
+}
+
+function parseHttpsGitHubUrl(url: string): { gitUrl: string; owner: string; repo: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "github.com" && host !== "www.github.com") {
+    return null;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length < 2) {
+    return null;
+  }
+  const owner = segments[0];
+  const rawRepo = segments[1];
+  if (!owner || !rawRepo) {
+    return null;
+  }
+  const repo = rawRepo.replace(/\.git$/, "");
+  return {
+    gitUrl: `https://github.com/${owner}/${repo}.git`,
+    owner,
+    repo,
+  };
+}
+
+function splitOnFirst(input: string, separator: string): [string, string | undefined] {
+  const idx = input.indexOf(separator);
+  if (idx === -1) return [input, undefined];
+  return [input.substring(0, idx), input.substring(idx + 1)];
+}


### PR DESCRIPTION
## Summary

Scoped first step toward #1524. Adds a `--mode <rulesync|apm|gh>` flag to `rulesync install`:

- **`rulesync`** (default): existing behavior, unchanged.
- **`apm`**: reads `apm.yml`, fetches dependencies from GitHub, deploys `.apm/instructions/**` and `.apm/skills/**` to the APM default target directories (`.github/instructions/`, `.github/skills/`), and writes an `apm.lock.yaml` compatible with APM's v1 lockfile schema (`lockfile_version: \"1\"`, `repo_url`, `resolved_commit`, `resolved_ref`, `depth`, `package_type`, `deployed_files`).
- **`gh`**: intentionally not yet implemented — returns a clear error. Deferred to a follow-up PR.

### APM dependency forms supported

- String shorthand: `owner/repo[#ref]`
- HTTPS GitHub URL: `https://github.com/owner/repo[.git][#ref]`
- Object form: `{ git, path, ref, alias }`

Marketplace (`name@marketplace`), local paths, SSH URLs, FQDN shorthand, and non-GitHub hosts are rejected with explicit \"not yet supported\" errors so users get a precise message about what to change.

### Manifest disambiguation

If both `apm.yml` and `rulesync.jsonc` `sources` are defined, the command now errors and asks the user to pass `--mode`. If only `apm.yml` is present but `--mode` is omitted, the command warns and suggests `--mode apm`.

### `--update` and `--frozen`

Both flags are honored in APM mode:

- `--update` re-resolves every dependency's ref and rewrites the lockfile.
- `--frozen` fails if `apm.lock.yaml` is missing or any declared dependency is absent from the lockfile.

## Explicitly out of scope (follow-ups)

- `--mode gh` implementation.
- Primitives other than Instructions and Skills (Commands, Agents, Prompts, Hooks, MCP Servers, Plugins).
- APM marketplace, local-path, SSH, FQDN-shorthand, and non-GitHub sources.
- Multi-host fanout (\`apm compile\`-style target switching).
- README / docs updates — will land once the scope stabilizes.

## Test plan

- [x] `pnpm cicheck` — 4971 tests pass, lint/typecheck/cspell/secretlint all clean.
- [x] Unit coverage for `apm-manifest`, `apm-lock`, and `apm-install` (happy paths, \`--update\`, \`--frozen\`, locked-commit reuse, unsupported forms).
- [x] Happy-path integration test at \`src/cli/commands/install-apm.integration.test.ts\` that runs the full \`installCommand({ mode: \"apm\" })\` pipeline against a real tmp directory with a mocked GitHub client and asserts on deployed files plus \`apm.lock.yaml\` contents.

Refs https://github.com/dyoshikawa/rulesync/issues/1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)