### PR TITLE
ci: enforce docs and skills/rulesync synchronization in cicheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
   "scripts": {
     "build": "tsup src/cli/index.ts src/index.ts --format cjs,esm --dts --clean",
     "check": "pnpm run fmt:check && pnpm run oxlint && pnpm run eslint && pnpm run typecheck",
+    "check:sync-skill-docs": "tsx scripts/check-skill-docs-sync.ts",
     "cicheck": "pnpm run cicheck:code && pnpm run cicheck:content",
     "cicheck:code": "pnpm run check && pnpm run test",
-    "cicheck:content": "pnpm run cspell && pnpm run secretlint",
+    "cicheck:content": "pnpm run check:sync-skill-docs && pnpm run cspell && pnpm run secretlint",
     "cspell": "cspell --no-progress --gitignore .",
     "dev": "tsx src/cli/index.ts",
     "docs:build": "vitepress build docs",

--- a/scripts/check-skill-docs-sync.ts
+++ b/scripts/check-skill-docs-sync.ts
@@ -1,0 +1,20 @@
+import { execSync } from "node:child_process";
+
+import { formatError } from "../src/utils/error.js";
+import { syncSkillDocs } from "./sync-skill-docs.js";
+
+function main(): void {
+  syncSkillDocs();
+
+  try {
+    execSync("git diff --exit-code -- skills/rulesync", { stdio: "inherit" });
+  } catch (error) {
+    // oxlint-disable-next-line no-console
+    console.error(
+      `skills/rulesync/ is out of sync with docs/. Run "pnpm tsx scripts/sync-skill-docs.ts" and commit the result.\n${formatError(error)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/sync-skill-docs.ts
+++ b/scripts/sync-skill-docs.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import vitepressConfig from "../docs/.vitepress/config.js";
 
@@ -88,7 +89,7 @@ function assertNoFileNameCollision(
   seenFileNames.set(fileName, link);
 }
 
-function main(): void {
+export function syncSkillDocs(): void {
   const sidebar = vitepressConfig.themeConfig?.sidebar;
   if (!isSidebarItemArray(sidebar)) {
     throw new Error("No sidebar array found in VitePress config");
@@ -207,4 +208,7 @@ function main(): void {
   console.log(`Synced docs/ to ${SKILL_DIR}/ (${String(fileCount)} content files + SKILL.md)`);
 }
 
-main();
+const entryPointPath = process.argv[1];
+if (entryPointPath && fileURLToPath(import.meta.url) === entryPointPath) {
+  syncSkillDocs();
+}


### PR DESCRIPTION
### Motivation
- Prevent divergence between `docs/` and generated `skills/rulesync/` artifacts by making the sync check part of content CI so drift is detected even when pre-commit hooks are skipped.
- Avoid side effects when other scripts import the sync utility by removing global execution from `scripts/sync-skill-docs.ts`.

### Description
- Refactor `scripts/sync-skill-docs.ts` to export `syncSkillDocs()` and call it only when the file is executed directly to eliminate import-time side effects.
- Add `scripts/check-skill-docs-sync.ts` which runs `syncSkillDocs()` and then fails with `git diff --exit-code -- skills/rulesync` if the generated `skills/rulesync/` tree is out of sync.
- Add `check:sync-skill-docs` npm script and wire it into `cicheck:content` so the sync check runs as part of `pnpm cicheck`.
- Update documentation note in `CLAUDE.md` to explain that the sync is enforced by CI and how to fix it.

### Testing
- Ran `pnpm cicheck` which completed successfully with formatting, linting, typecheck, tests and content checks all passing.
- Unit/e2e test run results: `Test Files 186 passed` and `Tests 4950 passed` (Vitest run succeeded).
- The new sync check executed during `cicheck:content` and reported `Synced docs/ to /workspace/rulesync/skills/rulesync/ (16 content files + SKILL.md)` and exited cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74f3ed8a48330be686a5aaaabc165)