### PR TITLE
fix: normalize Copilot subagent file path round-trip

### DIFF
--- a/src/features/subagents/copilot-subagent.test.ts
+++ b/src/features/subagents/copilot-subagent.test.ts
@@ -70,6 +70,7 @@ Plan tasks`;
       expect(subagent.getFrontmatter().tools).toEqual(["agent/runSubagent", "web/fetch"]);
       expect(subagent.getFrontmatter()).toMatchObject({ permissions: "workspace" });
       expect(subagent.getRelativeDirPath()).toBe(".github/agents");
+      expect(subagent.getRelativeFilePath()).toBe("planner.agent.md");
     });
 
     it("adds required tool when user tools are missing", () => {
@@ -95,6 +96,79 @@ Plan tasks`;
       }) as CopilotSubagent;
 
       expect(subagent.getFrontmatter().tools).toEqual(["agent/runSubagent"]);
+      expect(subagent.getRelativeFilePath()).toBe("planner.agent.md");
+    });
+
+    it("keeps .agent.md path as-is", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "planner.agent.md",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "planner",
+          description: "Plan things",
+        },
+        body: "Plan tasks",
+        validate: true,
+      });
+
+      const subagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(subagent.getRelativeFilePath()).toBe("planner.agent.md");
+    });
+
+    it("keeps non-.md extensions unchanged", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "planner.txt",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "planner",
+          description: "Plan things",
+        },
+        body: "Plan tasks",
+        validate: true,
+      });
+
+      const subagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(subagent.getRelativeFilePath()).toBe("planner.txt");
+    });
+
+    it("keeps extension-less paths unchanged", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "planner",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "planner",
+          description: "Plan things",
+        },
+        body: "Plan tasks",
+        validate: true,
+      });
+
+      const subagent = CopilotSubagent.fromRulesyncSubagent({
+        baseDir: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(subagent.getRelativeFilePath()).toBe("planner");
     });
   });
 
@@ -123,6 +197,27 @@ Plan tasks`;
         copilot: { tools: ["agent/runSubagent", "web/fetch"] },
       });
       expect(rulesyncSubagent.getBody()).toBe("Plan tasks");
+      expect(rulesyncSubagent.getRelativeFilePath()).toBe("planner.md");
+    });
+
+    it("keeps non-.agent.md paths unchanged", () => {
+      const subagent = new CopilotSubagent({
+        baseDir: testDir,
+        relativeDirPath: ".github/agents",
+        relativeFilePath: "planner",
+        frontmatter: {
+          name: "planner",
+          description: "Plan things",
+          tools: ["agent/runSubagent"],
+        },
+        body: "Plan tasks",
+        fileContent: validContent,
+        validate: true,
+      });
+
+      const rulesyncSubagent = subagent.toRulesyncSubagent();
+
+      expect(rulesyncSubagent.getRelativeFilePath()).toBe("planner");
     });
   });
 

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -44,6 +44,26 @@ const ensureRequiredTool = (tools: string[]): string[] => {
   return Array.from(mergedTools);
 };
 
+const toCopilotAgentFilePath = (relativeFilePath: string): string => {
+  if (relativeFilePath.endsWith(".agent.md")) {
+    return relativeFilePath;
+  }
+
+  if (relativeFilePath.endsWith(".md")) {
+    return relativeFilePath.replace(/\.md$/, ".agent.md");
+  }
+
+  return relativeFilePath;
+};
+
+const toRulesyncFilePath = (relativeFilePath: string): string => {
+  if (relativeFilePath.endsWith(".agent.md")) {
+    return relativeFilePath.replace(/\.agent\.md$/, ".md");
+  }
+
+  return relativeFilePath;
+};
+
 export class CopilotSubagent extends ToolSubagent {
   private readonly frontmatter: CopilotSubagentFrontmatter;
   private readonly body: string;
@@ -98,7 +118,7 @@ export class CopilotSubagent extends ToolSubagent {
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-      relativeFilePath: this.getRelativeFilePath(),
+      relativeFilePath: toRulesyncFilePath(this.getRelativeFilePath()),
       validate: true,
     });
   }
@@ -129,19 +149,12 @@ export class CopilotSubagent extends ToolSubagent {
     const fileContent = stringifyFrontmatter(body, copilotFrontmatter);
     const paths = this.getSettablePaths({ global });
 
-    // Ensure .agent.md extension — required by VSCode Copilot Chat
-    // See: https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/customInstructions/common/promptTypes.ts
-    let relativeFilePath = rulesyncSubagent.getRelativeFilePath();
-    if (!relativeFilePath.endsWith(".agent.md")) {
-      relativeFilePath = relativeFilePath.replace(/\.md$/, ".agent.md");
-    }
-
     return new CopilotSubagent({
       baseDir: baseDir,
       frontmatter: copilotFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
-      relativeFilePath,
+      relativeFilePath: toCopilotAgentFilePath(rulesyncSubagent.getRelativeFilePath()),
       fileContent,
       validate,
       global,


### PR DESCRIPTION
### Motivation
- Prevent Copilot-specific `.agent.md` suffix from leaking into the tool-agnostic Rulesync representation when converting between Rulesync and Copilot subagents. 
- Add explicit, testable behavior for edge cases (idempotency, non-`.md` extensions, extension-less paths) to avoid surprising renames during import/export. 
- Link this change to the follow-up issue: https://github.com/dyoshikawa/rulesync/issues/1486

### Description
- Add `toCopilotAgentFilePath` and `toRulesyncFilePath` helpers to `src/features/subagents/copilot-subagent.ts` to encapsulate the `.md` <-> `.agent.md` suffix rules. 
- Apply `toCopilotAgentFilePath` in `fromRulesyncSubagent()` to produce Copilot output that uses `.agent.md`, and apply `toRulesyncFilePath` in `toRulesyncSubagent()` to strip `.agent.md` back to `.md`. 
- Extend `src/features/subagents/copilot-subagent.test.ts` with tests that assert `.md` -> `.agent.md` conversion, `.agent.md` idempotency, non-`.md` and extension-less path preservation, and `toRulesyncSubagent()` inverse transform. 
- Files changed: `src/features/subagents/copilot-subagent.ts` and `src/features/subagents/copilot-subagent.test.ts`.

### Testing
- Ran the focused test file with `pnpm vitest run src/features/subagents/copilot-subagent.test.ts` and it passed. 
- Ran full repository checks with `pnpm cicheck` (format, lint, typecheck, and the test suite) and the command completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74f68a1a08330bd430f6444dd7e9f)