### PR TITLE
feat: add --mode gh to rulesync install for gh-skill-compatible layouts

### DIFF
--- a/docs/guide/declarative-sources.md
+++ b/docs/guide/declarative-sources.md
@@ -57,12 +57,84 @@ When `rulesync install` runs and `sources` is configured:
    - **First-declared source wins** — If two sources provide a skill with the same name, the one declared first in the `sources` array is used.
 5. **Output** — Fetched skills are written to `.rulesync/skills/.curated/<skill-name>/`. This directory is automatically added to `.gitignore` by `rulesync gitignore`.
 
+## Install Modes
+
+`rulesync install` supports three install modes via `--mode <mode>`:
+
+| Mode       | Manifest input               | Lockfile                 | Skill output layout                                                          |
+| ---------- | ---------------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `rulesync` | `rulesync.jsonc` `sources`   | `rulesync.lock`          | `.rulesync/skills/.curated/<name>/` (then re-emitted by `rulesync generate`) |
+| `apm`      | `apm.yml` `dependencies.apm` | `rulesync-apm.lock.yaml` | `.github/instructions/`, `.github/skills/` (APM v1 layout)                   |
+| `gh`       | `rulesync.jsonc` `sources`   | `rulesync-gh.lock.yaml`  | Per-agent / per-scope dirs (matching `gh skill install`)                     |
+
+When `--mode` is omitted, rulesync defaults to `rulesync` mode. If `apm.yml` is present and `sources` is also defined, you must pass `--mode apm` or `--mode rulesync` to disambiguate.
+
+### `--mode gh` — gh-skill-install–compatible layout
+
+`--mode gh` reads the same `sources` array from `rulesync.jsonc` but writes each discovered skill into the agent-specific directory expected by `gh skill install`. Each source supports two extra fields:
+
+| Property | Type     | Default          | Description                                                                               |
+| -------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `agent`  | `string` | `github-copilot` | One of `github-copilot`, `claude-code`, `cursor`, `codex`, `gemini`, `antigravity`.       |
+| `scope`  | `string` | `project`        | `project` writes inside the project root; `user` writes inside the user's home directory. |
+
+Agent → install directory mapping:
+
+| Agent            | Project scope (relative to project root) | User scope (relative to home) |
+| ---------------- | ---------------------------------------- | ----------------------------- |
+| `github-copilot` | `.agents/skills`                         | `.copilot/skills`             |
+| `claude-code`    | `.claude/skills`                         | `.claude/skills`              |
+| `cursor`         | `.agents/skills`                         | `.cursor/skills`              |
+| `codex`          | `.agents/skills`                         | `.codex/skills`               |
+| `gemini`         | `.agents/skills`                         | `.gemini/skills`              |
+| `antigravity`    | `.agents/skills`                         | `.gemini/antigravity/skills`  |
+
+For each skill discovered as `skills/<name>/SKILL.md` in the remote repository, rulesync deploys the entire skill directory to `<install-dir>/<name>/` and injects a provenance frontmatter block (`source`, `repository`, `ref`) into the deployed `SKILL.md`. The lockfile `rulesync-gh.lock.yaml` records one entry per `(source, agent, scope, skill)` tuple.
+
+Per-source field support in `--mode gh`:
+
+| Field       | Status                                                                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`    | Required. Must resolve to a GitHub repository (`owner/repo`, `owner/repo@ref`, or an `https://github.com/...` URL).                          |
+| `skills`    | Optional. When set, only the listed skill names are installed; remote skills not in the list are skipped, and missing names log a warning.   |
+| `ref`       | Optional. Pins a tag, branch, or commit SHA. When omitted, gh mode resolves to the latest release's tag, falling back to the default branch. |
+| `agent`     | Optional. Defaults to `github-copilot`. See the agent table above.                                                                           |
+| `scope`     | Optional. Defaults to `project`.                                                                                                             |
+| `transport` | **Rejected.** gh mode is GitHub-only and does not honor the `git` transport. Drop the field or switch to `--mode rulesync`.                  |
+| `path`      | **Rejected.** The remote layout is fixed to `skills/<name>/SKILL.md`. Repositories that store skills elsewhere are not supported in gh mode. |
+
+The remote repository must use the layout `skills/<name>/SKILL.md` (one directory per skill, each containing a `SKILL.md`). Other layouts are not auto-discovered.
+
+Example `rulesync.jsonc`:
+
+```jsonc
+{
+  "targets": ["claudecode"],
+  "features": ["rules"],
+  "sources": [
+    // Default: agent=github-copilot, scope=project -> .agents/skills/git-commit/
+    { "source": "acme/skills", "skills": ["git-commit"] },
+
+    // Same source, deployed for Claude Code at user scope -> ~/.claude/skills/git-commit/
+    {
+      "source": "acme/skills",
+      "skills": ["git-commit"],
+      "agent": "claude-code",
+      "scope": "user",
+    },
+  ],
+}
+```
+
+Run with `npx rulesync install --mode gh`.
+
 ## CLI Options
 
 The `install` command accepts these flags:
 
 | Flag              | Description                                                                                                                                                  |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--mode <mode>`   | Install mode: `rulesync` (default), `apm`, or `gh`. See **Install Modes** above.                                                                             |
 | `--update`        | Force re-resolve all source refs, ignoring the lockfile (useful to pull new updates).                                                                        |
 | `--frozen`        | Fail if lockfile is missing or out of sync. Fetches missing skills using locked refs without updating the lockfile. Useful for CI to ensure reproducibility. |
 | `--token <token>` | GitHub token for private repositories.                                                                                                                       |

--- a/skills/rulesync/declarative-sources.md
+++ b/skills/rulesync/declarative-sources.md
@@ -57,12 +57,84 @@ When `rulesync install` runs and `sources` is configured:
    - **First-declared source wins** — If two sources provide a skill with the same name, the one declared first in the `sources` array is used.
 5. **Output** — Fetched skills are written to `.rulesync/skills/.curated/<skill-name>/`. This directory is automatically added to `.gitignore` by `rulesync gitignore`.
 
+## Install Modes
+
+`rulesync install` supports three install modes via `--mode <mode>`:
+
+| Mode       | Manifest input               | Lockfile                 | Skill output layout                                                          |
+| ---------- | ---------------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| `rulesync` | `rulesync.jsonc` `sources`   | `rulesync.lock`          | `.rulesync/skills/.curated/<name>/` (then re-emitted by `rulesync generate`) |
+| `apm`      | `apm.yml` `dependencies.apm` | `rulesync-apm.lock.yaml` | `.github/instructions/`, `.github/skills/` (APM v1 layout)                   |
+| `gh`       | `rulesync.jsonc` `sources`   | `rulesync-gh.lock.yaml`  | Per-agent / per-scope dirs (matching `gh skill install`)                     |
+
+When `--mode` is omitted, rulesync defaults to `rulesync` mode. If `apm.yml` is present and `sources` is also defined, you must pass `--mode apm` or `--mode rulesync` to disambiguate.
+
+### `--mode gh` — gh-skill-install–compatible layout
+
+`--mode gh` reads the same `sources` array from `rulesync.jsonc` but writes each discovered skill into the agent-specific directory expected by `gh skill install`. Each source supports two extra fields:
+
+| Property | Type     | Default          | Description                                                                               |
+| -------- | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| `agent`  | `string` | `github-copilot` | One of `github-copilot`, `claude-code`, `cursor`, `codex`, `gemini`, `antigravity`.       |
+| `scope`  | `string` | `project`        | `project` writes inside the project root; `user` writes inside the user's home directory. |
+
+Agent → install directory mapping:
+
+| Agent            | Project scope (relative to project root) | User scope (relative to home) |
+| ---------------- | ---------------------------------------- | ----------------------------- |
+| `github-copilot` | `.agents/skills`                         | `.copilot/skills`             |
+| `claude-code`    | `.claude/skills`                         | `.claude/skills`              |
+| `cursor`         | `.agents/skills`                         | `.cursor/skills`              |
+| `codex`          | `.agents/skills`                         | `.codex/skills`               |
+| `gemini`         | `.agents/skills`                         | `.gemini/skills`              |
+| `antigravity`    | `.agents/skills`                         | `.gemini/antigravity/skills`  |
+
+For each skill discovered as `skills/<name>/SKILL.md` in the remote repository, rulesync deploys the entire skill directory to `<install-dir>/<name>/` and injects a provenance frontmatter block (`source`, `repository`, `ref`) into the deployed `SKILL.md`. The lockfile `rulesync-gh.lock.yaml` records one entry per `(source, agent, scope, skill)` tuple.
+
+Per-source field support in `--mode gh`:
+
+| Field       | Status                                                                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`    | Required. Must resolve to a GitHub repository (`owner/repo`, `owner/repo@ref`, or an `https://github.com/...` URL).                          |
+| `skills`    | Optional. When set, only the listed skill names are installed; remote skills not in the list are skipped, and missing names log a warning.   |
+| `ref`       | Optional. Pins a tag, branch, or commit SHA. When omitted, gh mode resolves to the latest release's tag, falling back to the default branch. |
+| `agent`     | Optional. Defaults to `github-copilot`. See the agent table above.                                                                           |
+| `scope`     | Optional. Defaults to `project`.                                                                                                             |
+| `transport` | **Rejected.** gh mode is GitHub-only and does not honor the `git` transport. Drop the field or switch to `--mode rulesync`.                  |
+| `path`      | **Rejected.** The remote layout is fixed to `skills/<name>/SKILL.md`. Repositories that store skills elsewhere are not supported in gh mode. |
+
+The remote repository must use the layout `skills/<name>/SKILL.md` (one directory per skill, each containing a `SKILL.md`). Other layouts are not auto-discovered.
+
+Example `rulesync.jsonc`:
+
+```jsonc
+{
+  "targets": ["claudecode"],
+  "features": ["rules"],
+  "sources": [
+    // Default: agent=github-copilot, scope=project -> .agents/skills/git-commit/
+    { "source": "acme/skills", "skills": ["git-commit"] },
+
+    // Same source, deployed for Claude Code at user scope -> ~/.claude/skills/git-commit/
+    {
+      "source": "acme/skills",
+      "skills": ["git-commit"],
+      "agent": "claude-code",
+      "scope": "user",
+    },
+  ],
+}
+```
+
+Run with `npx rulesync install --mode gh`.
+
 ## CLI Options
 
 The `install` command accepts these flags:
 
 | Flag              | Description                                                                                                                                                  |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--mode <mode>`   | Install mode: `rulesync` (default), `apm`, or `gh`. See **Install Modes** above.                                                                             |
 | `--update`        | Force re-resolve all source refs, ignoring the lockfile (useful to pull new updates).                                                                        |
 | `--frozen`        | Fail if lockfile is missing or out of sync. Fetches missing skills using locked refs without updating the lockfile. Useful for CI to ensure reproducibility. |
 | `--token <token>` | GitHub token for private repositories.                                                                                                                       |

--- a/src/cli/commands/install-gh.integration.test.ts
+++ b/src/cli/commands/install-gh.integration.test.ts
@@ -1,0 +1,146 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getGhLockPath } from "../../lib/gh/gh-lock.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { installCommand } from "./install.js";
+
+// Mock only the network boundary. Everything else (config loader, lockfile
+// read/write, filesystem deployment) runs for real against a temp directory —
+// this is the happy-path E2E for --mode gh.
+let mockClientInstance: any;
+
+vi.mock("../../lib/github-client.js", () => ({
+  GitHubClient: class MockGitHubClient {
+    static resolveToken = vi.fn().mockReturnValue(undefined);
+
+    getDefaultBranch(...args: any[]) {
+      return mockClientInstance.getDefaultBranch(...args);
+    }
+    getLatestRelease(...args: any[]) {
+      return mockClientInstance.getLatestRelease(...args);
+    }
+    resolveRefToSha(...args: any[]) {
+      return mockClientInstance.resolveRefToSha(...args);
+    }
+    listDirectory(...args: any[]) {
+      return mockClientInstance.listDirectory(...args);
+    }
+    getFileContent(...args: any[]) {
+      return mockClientInstance.getFileContent(...args);
+    }
+    getFileInfo(...args: any[]) {
+      return mockClientInstance.getFileInfo(...args);
+    }
+  },
+  GitHubClientError: class GitHubClientError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  logGitHubAuthHints: vi.fn(),
+}));
+
+const VALID_SHA = "a".repeat(40);
+
+describe("installCommand --mode gh (happy path)", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  const logger = createMockLogger();
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+
+    mockClientInstance = {
+      getDefaultBranch: vi.fn().mockResolvedValue("main"),
+      getLatestRelease: vi.fn().mockResolvedValue({
+        tag_name: "v1.2.3",
+        name: "v1.2.3",
+        prerelease: false,
+        draft: false,
+        assets: [],
+      }),
+      resolveRefToSha: vi.fn().mockResolvedValue(VALID_SHA),
+      listDirectory: vi.fn(),
+      getFileContent: vi.fn(),
+      getFileInfo: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("installs declared sources into agent dirs and writes rulesync-gh.lock.yaml", async () => {
+    // rulesync.jsonc with a gh-mode source pinned to claude-code / project scope.
+    await writeFileContent(
+      join(testDir, "rulesync.jsonc"),
+      `{
+  "targets": ["claudecode"],
+  "features": ["rules"],
+  "sources": [
+    { "source": "acme/skills", "agent": "claude-code", "scope": "project" }
+  ]
+}
+`,
+    );
+
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === "skills") {
+          return [{ name: "git-commit", path: "skills/git-commit", type: "dir", size: 0 }];
+        }
+        if (path === "skills/git-commit") {
+          return [
+            {
+              name: "SKILL.md",
+              path: "skills/git-commit/SKILL.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        const err = new Error(`Not found: ${path}`) as Error & { statusCode?: number };
+        err.statusCode = 404;
+        throw err;
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(
+      async (_owner: string, _repo: string, path: string) =>
+        path === "skills/git-commit/SKILL.md"
+          ? { name: "SKILL.md", path, type: "file", size: 100 }
+          : null,
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => `# Git Commit\n\nbody from ${path}\n`,
+    );
+
+    await installCommand(logger, { mode: "gh" });
+
+    const skillPath = join(testDir, ".claude/skills/git-commit/SKILL.md");
+    expect(await fileExists(skillPath)).toBe(true);
+    const content = await readFileContent(skillPath);
+    // Provenance frontmatter must be injected at the top.
+    expect(content.startsWith("---\n")).toBe(true);
+    expect(content).toContain("source: https://github.com/acme/skills");
+    expect(content).toContain("repository: acme/skills");
+    expect(content).toContain("ref: v1.2.3");
+    // Original body preserved.
+    expect(content).toContain("# Git Commit");
+
+    expect(await fileExists(getGhLockPath(testDir))).toBe(true);
+    const lockContent = await readFileContent(getGhLockPath(testDir));
+    expect(lockContent).toContain("lockfile_version:");
+    expect(lockContent).toContain("agent: claude-code");
+    expect(lockContent).toContain("scope: project");
+    expect(lockContent).toContain(VALID_SHA);
+    expect(lockContent).toContain(".claude/skills/git-commit/SKILL.md");
+  });
+});

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -5,6 +5,7 @@ import type { SourceEntry } from "../../config/config.js";
 import { Config } from "../../config/config.js";
 import { installApm } from "../../lib/apm/apm-install.js";
 import { apmManifestExists } from "../../lib/apm/apm-manifest.js";
+import { installGh } from "../../lib/gh/gh-install.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { installCommand } from "./install.js";
@@ -14,6 +15,7 @@ vi.mock("../../config/config-resolver.js");
 vi.mock("../../lib/sources.js");
 vi.mock("../../lib/apm/apm-install.js");
 vi.mock("../../lib/apm/apm-manifest.js");
+vi.mock("../../lib/gh/gh-install.js");
 
 function createMockConfig(sources: SourceEntry[]): Config {
   return {
@@ -219,9 +221,49 @@ describe("installCommand", () => {
   });
 
   describe("gh mode", () => {
-    it("errors with a not-yet-implemented message", async () => {
+    it("invokes installGh with sources from rulesync.jsonc and reports success", async () => {
+      const sources: SourceEntry[] = [{ source: "owner/repo", agent: "claude-code" }];
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig(sources));
+      vi.mocked(installGh).mockResolvedValue({
+        sourcesProcessed: 1,
+        installedSkillCount: 2,
+        failedSourceCount: 0,
+      });
+
+      await installCommand(mockLogger, { mode: "gh" });
+
+      expect(installGh).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sources,
+          baseDir: process.cwd(),
+          options: { update: undefined, frozen: undefined, token: undefined },
+        }),
+      );
+      expect(mockLogger.success).toHaveBeenCalledWith("Installed 2 skill(s) from 1 gh source(s).");
+    });
+
+    it("warns when no sources are defined", async () => {
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig([]));
+
+      await installCommand(mockLogger, { mode: "gh" });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "No sources defined in configuration. Nothing to install.",
+      );
+      expect(installGh).not.toHaveBeenCalled();
+    });
+
+    it("throws when installGh reports failed sources", async () => {
+      const sources: SourceEntry[] = [{ source: "owner/repo" }];
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig(sources));
+      vi.mocked(installGh).mockResolvedValue({
+        sourcesProcessed: 1,
+        installedSkillCount: 0,
+        failedSourceCount: 1,
+      });
+
       await expect(installCommand(mockLogger, { mode: "gh" })).rejects.toThrow(
-        /not yet implemented/,
+        /Failed to install 1 of 1 gh source/,
       );
     });
   });

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,6 +1,7 @@
 import { ConfigResolver } from "../../config/config-resolver.js";
 import { installApm } from "../../lib/apm/apm-install.js";
 import { apmManifestExists } from "../../lib/apm/apm-manifest.js";
+import { installGh } from "../../lib/gh/gh-install.js";
 import { resolveAndFetchSources } from "../../lib/sources.js";
 import type { Logger } from "../../utils/logger.js";
 
@@ -24,9 +25,8 @@ export async function installCommand(
   const mode: InstallMode = options.mode ?? "rulesync";
 
   if (mode === "gh") {
-    throw new Error(
-      "--mode gh is not yet implemented. Use --mode rulesync (default) or --mode apm.",
-    );
+    await runGhInstall(logger, options);
+    return;
   }
 
   if (mode === "apm") {
@@ -132,5 +132,55 @@ async function runApmInstall(logger: Logger, options: InstallCommandOptions): Pr
     );
   } else {
     logger.success(`All apm dependencies up to date (${result.dependenciesProcessed} checked).`);
+  }
+}
+
+async function runGhInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
+  const baseDir = process.cwd();
+
+  // gh mode reads sources from `rulesync.jsonc`, never from `apm.yml`. The
+  // disambiguation between rulesync/apm modes lives in `runRulesyncInstall`;
+  // here the user has already opted into gh mode explicitly.
+  const config = await ConfigResolver.resolve({
+    configPath: options.configPath,
+    verbose: options.verbose,
+    silent: options.silent,
+  });
+  const sources = config.getSources();
+
+  if (sources.length === 0) {
+    logger.warn("No sources defined in configuration. Nothing to install.");
+    return;
+  }
+
+  const result = await installGh({
+    baseDir,
+    sources,
+    options: {
+      update: options.update,
+      frozen: options.frozen,
+      token: options.token,
+    },
+    logger,
+  });
+
+  if (logger.jsonMode) {
+    logger.captureData("sourcesProcessed", result.sourcesProcessed);
+    logger.captureData("installedSkillCount", result.installedSkillCount);
+    logger.captureData("failedSourceCount", result.failedSourceCount);
+  }
+
+  if (result.failedSourceCount > 0) {
+    throw new Error(
+      `Failed to install ${result.failedSourceCount} of ${result.sourcesProcessed} gh source(s). See the log above for details.`,
+    );
+  }
+
+  if (result.installedSkillCount > 0) {
+    logger.success(
+      `Installed ${result.installedSkillCount} skill(s) from ${result.sourcesProcessed} gh source(s).`,
+    );
+  } else {
+    logger.success(`All gh sources up to date (${result.sourcesProcessed} checked).`);
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -51,6 +51,12 @@ export const SourceEntrySchema = z.object({
       refine((v) => !hasControlCharacters(v), "path must not contain control characters"),
     ),
   ),
+  // gh-mode-only fields. Ignored by --mode rulesync. Defaults applied at the
+  // gh install site (`agent` defaults to "github-copilot", `scope` to "project").
+  agent: optional(
+    z.enum(["github-copilot", "claude-code", "cursor", "codex", "gemini", "antigravity"]),
+  ),
+  scope: optional(z.enum(["project", "user"])),
 });
 export type SourceEntry = z.infer<typeof SourceEntrySchema>;
 

--- a/src/lib/gh/gh-frontmatter.test.ts
+++ b/src/lib/gh/gh-frontmatter.test.ts
@@ -1,0 +1,119 @@
+import { load } from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+import { injectSourceMetadata } from "./gh-frontmatter.js";
+
+const PROVENANCE = {
+  source: "https://github.com/owner/repo",
+  repository: "owner/repo",
+  ref: "v1.0.0",
+};
+
+function readFrontmatter(content: string): Record<string, unknown> {
+  expect(content.startsWith("---\n")).toBe(true);
+  const end = content.indexOf("\n---", 4);
+  expect(end).toBeGreaterThan(0);
+  const yaml = content.substring(4, end);
+  const loaded = load(yaml);
+  expect(typeof loaded).toBe("object");
+  return loaded as Record<string, unknown>;
+}
+
+describe("injectSourceMetadata", () => {
+  it("prepends a fresh frontmatter when the file has none", () => {
+    const result = injectSourceMetadata({
+      content: "# heading\n\nbody\n",
+      ...PROVENANCE,
+    });
+    const fm = readFrontmatter(result);
+    expect(fm).toEqual(PROVENANCE);
+    expect(result).toContain("# heading\n\nbody\n");
+  });
+
+  it("preserves existing frontmatter keys and overwrites only provenance", () => {
+    const original = `---
+name: my-skill
+description: A skill
+custom_key: keep-me
+source: https://github.com/old/old
+---
+# body
+`;
+    const result = injectSourceMetadata({
+      content: original,
+      ...PROVENANCE,
+    });
+    const fm = readFrontmatter(result);
+    expect(fm.name).toBe("my-skill");
+    expect(fm.description).toBe("A skill");
+    expect(fm.custom_key).toBe("keep-me");
+    expect(fm.source).toBe(PROVENANCE.source);
+    expect(fm.repository).toBe(PROVENANCE.repository);
+    expect(fm.ref).toBe(PROVENANCE.ref);
+    expect(result).toContain("# body");
+  });
+
+  it("handles an empty frontmatter block by writing only provenance", () => {
+    const result = injectSourceMetadata({
+      content: "---\n---\n# body\n",
+      ...PROVENANCE,
+    });
+    const fm = readFrontmatter(result);
+    expect(fm).toEqual(PROVENANCE);
+    expect(result).toContain("# body\n");
+  });
+
+  it("throws on malformed YAML inside the frontmatter block", () => {
+    const original = `---
+name: my-skill
+unbalanced: [oops
+---
+# body
+`;
+    expect(() => injectSourceMetadata({ content: original, ...PROVENANCE })).toThrow(
+      /invalid frontmatter/,
+    );
+  });
+
+  it("throws on a frontmatter block whose body is a list (not an object)", () => {
+    const original = `---
+- one
+- two
+---
+# body
+`;
+    expect(() => injectSourceMetadata({ content: original, ...PROVENANCE })).toThrow(
+      /invalid frontmatter/,
+    );
+  });
+
+  it("throws on a missing closing fence", () => {
+    const original = `---
+name: my-skill
+# body without closing fence
+`;
+    expect(() => injectSourceMetadata({ content: original, ...PROVENANCE })).toThrow(
+      /invalid frontmatter/,
+    );
+  });
+
+  it("preserves existing keys when the file uses CRLF line endings", () => {
+    // Common on Windows / certain editors. Without explicit CRLF support the
+    // opening fence is treated as a normal line and a fresh provenance block
+    // is prepended above the entire (still-fenced) original frontmatter,
+    // producing two stacked frontmatter blocks and burying user metadata.
+    const original = "---\r\nname: my-skill\r\ncustom_key: keep-me\r\n---\r\n# body\r\n";
+    const result = injectSourceMetadata({ content: original, ...PROVENANCE });
+    const fm = readFrontmatter(result);
+    expect(fm.name).toBe("my-skill");
+    expect(fm.custom_key).toBe("keep-me");
+    expect(fm.source).toBe(PROVENANCE.source);
+    expect(fm.repository).toBe(PROVENANCE.repository);
+    expect(fm.ref).toBe(PROVENANCE.ref);
+    // The original body must survive (modulo the fact that the re-emitted
+    // frontmatter uses LF separators per js-yaml's dump output).
+    expect(result).toContain("# body\r\n");
+    // Crucially: there must be exactly one frontmatter block, not two.
+    expect(result.match(/^---$/gm)?.length ?? 0).toBe(2);
+  });
+});

--- a/src/lib/gh/gh-frontmatter.ts
+++ b/src/lib/gh/gh-frontmatter.ts
@@ -1,0 +1,97 @@
+import { dump, load } from "js-yaml";
+
+const FRONTMATTER_FENCE = "---";
+
+/**
+ * Parses YAML frontmatter at the head of a SKILL.md, sets/overwrites the
+ * three provenance keys (`source`, `repository`, `ref`), and re-serializes.
+ *
+ * If the file has no frontmatter block, a fresh one is prepended with only
+ * the provenance keys + the original body. All other existing frontmatter
+ * keys are preserved verbatim (the merge is a shallow object spread on the
+ * loaded YAML).
+ *
+ * Throws `Error("invalid frontmatter")` when an `---` fenced block exists
+ * but its body is not a YAML object (e.g. malformed YAML, or a list/scalar
+ * at the top level). Callers may choose to fall back to "prepend fresh" on
+ * this error, but the function itself does not silently rewrite — silently
+ * dropping a corrupted frontmatter could destroy user metadata.
+ */
+export function injectSourceMetadata(params: {
+  content: string;
+  source: string;
+  repository: string;
+  ref: string;
+}): string {
+  const { content, source, repository, ref } = params;
+  const provenance = { source, repository, ref };
+
+  // Detect the opening fence in both LF (`---\n`) and CRLF (`---\r\n`) forms.
+  // SKILL.md files authored on Windows or by editors that preserve CRLF must
+  // round-trip cleanly — without this branch the existing frontmatter would
+  // be buried inside a fresh provenance block on the first install.
+  let openFenceLen: number;
+  if (content.startsWith(`${FRONTMATTER_FENCE}\r\n`)) {
+    openFenceLen = 5;
+  } else if (content.startsWith(`${FRONTMATTER_FENCE}\n`)) {
+    openFenceLen = 4;
+  } else if (content === FRONTMATTER_FENCE) {
+    openFenceLen = 3;
+  } else {
+    // No frontmatter block. Prepend a fresh one with just the provenance keys.
+    const yaml = dump(provenance, { noRefs: true, lineWidth: -1, sortKeys: false });
+    return `${FRONTMATTER_FENCE}\n${yaml}${FRONTMATTER_FENCE}\n${content}`;
+  }
+
+  // Body starts immediately after the opening fence.
+  const afterOpen = content.substring(openFenceLen);
+
+  // Closing fence forms we accept:
+  //   - `---` immediately at the start of the body (i.e. `---\n---\n...`,
+  //     which yields an empty frontmatter block).
+  //   - `\n---` followed by a newline OR end-of-file (the trailing newline
+  //     after the closing `---` is optional so the fence may sit at EOF).
+  let fmBody: string;
+  let rest: string;
+  if (afterOpen.startsWith("---\n") || afterOpen.startsWith("---\r\n") || afterOpen === "---") {
+    fmBody = "";
+    const fenceLen = afterOpen.startsWith("---\r\n") ? 5 : afterOpen === "---" ? 3 : 4;
+    rest = afterOpen.substring(fenceLen);
+  } else {
+    const match = /\n---(\r?\n|$)/.exec(afterOpen);
+    if (!match) {
+      // The file starts with `---\n` but there is no closing `---` line. We
+      // refuse to guess where the frontmatter ends; treat as invalid so the
+      // caller can decide whether to fall back.
+      throw new Error("invalid frontmatter");
+    }
+    fmBody = afterOpen.substring(0, match.index);
+    rest = afterOpen.substring(match.index + match[0].length);
+  }
+
+  let loaded: unknown;
+  try {
+    loaded = load(fmBody);
+  } catch {
+    throw new Error("invalid frontmatter");
+  }
+
+  if (loaded === null || loaded === undefined) {
+    // Empty frontmatter block (`---\n---\n...`). Use only provenance.
+    const yaml = dump(provenance, { noRefs: true, lineWidth: -1, sortKeys: false });
+    return `${FRONTMATTER_FENCE}\n${yaml}${FRONTMATTER_FENCE}\n${rest}`;
+  }
+  if (typeof loaded !== "object" || Array.isArray(loaded)) {
+    throw new Error("invalid frontmatter");
+  }
+
+  // Shallow merge: existing keys preserved, provenance keys overwritten.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const existing = loaded as Record<string, unknown>;
+  const merged: Record<string, unknown> = {
+    ...existing,
+    ...provenance,
+  };
+  const yaml = dump(merged, { noRefs: true, lineWidth: -1, sortKeys: false });
+  return `${FRONTMATTER_FENCE}\n${yaml}${FRONTMATTER_FENCE}\n${rest}`;
+}

--- a/src/lib/gh/gh-install.test.ts
+++ b/src/lib/gh/gh-install.test.ts
@@ -1,0 +1,474 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SourceEntry } from "../../config/config.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent } from "../../utils/file.js";
+import { installGh } from "./gh-install.js";
+import { getGhLockPath, readGhLock } from "./gh-lock.js";
+
+let mockClientInstance: any;
+
+vi.mock("../github-client.js", () => ({
+  GitHubClient: class MockGitHubClient {
+    static resolveToken = vi.fn().mockReturnValue(undefined);
+
+    getDefaultBranch(...args: any[]) {
+      return mockClientInstance.getDefaultBranch(...args);
+    }
+    getLatestRelease(...args: any[]) {
+      return mockClientInstance.getLatestRelease(...args);
+    }
+    resolveRefToSha(...args: any[]) {
+      return mockClientInstance.resolveRefToSha(...args);
+    }
+    listDirectory(...args: any[]) {
+      return mockClientInstance.listDirectory(...args);
+    }
+    getFileContent(...args: any[]) {
+      return mockClientInstance.getFileContent(...args);
+    }
+    getFileInfo(...args: any[]) {
+      return mockClientInstance.getFileInfo(...args);
+    }
+  },
+  GitHubClientError: class GitHubClientError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  logGitHubAuthHints: vi.fn(),
+}));
+
+const VALID_SHA = "a".repeat(40);
+const SECOND_SHA = "b".repeat(40);
+
+function makeNotFound(): Error & { statusCode: number } {
+  const err = new Error("Not found") as Error & { statusCode: number };
+  err.statusCode = 404;
+  return err;
+}
+
+function source(overrides: Partial<SourceEntry> & { source: string }): SourceEntry {
+  return overrides;
+}
+
+describe("installGh", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  const logger = createMockLogger();
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+
+    mockClientInstance = {
+      getDefaultBranch: vi.fn().mockResolvedValue("main"),
+      getLatestRelease: vi.fn().mockResolvedValue({
+        tag_name: "v1.0.0",
+        name: "v1.0.0",
+        prerelease: false,
+        draft: false,
+        assets: [],
+      }),
+      resolveRefToSha: vi.fn().mockResolvedValue(VALID_SHA),
+      listDirectory: vi.fn(),
+      getFileContent: vi.fn(),
+      getFileInfo: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+  });
+
+  function setupSingleSkill(skillName: string, agent = "github-copilot"): void {
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === "skills") {
+          return [{ name: skillName, path: `skills/${skillName}`, type: "dir", size: 0 }];
+        }
+        if (path === `skills/${skillName}`) {
+          return [
+            {
+              name: "SKILL.md",
+              path: `skills/${skillName}/SKILL.md`,
+              type: "file",
+              size: 50,
+            },
+          ];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) => {
+      if (p === `skills/${skillName}/SKILL.md`) {
+        return { name: "SKILL.md", path: p, type: "file", size: 50 };
+      }
+      return null;
+    });
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_o: string, _r: string, p: string) => `# ${skillName}\n\nbody for ${p}\n`,
+    );
+    void agent;
+  }
+
+  it("returns early on empty sources", async () => {
+    const result = await installGh({ baseDir: testDir, sources: [], logger });
+    expect(result).toEqual({
+      sourcesProcessed: 0,
+      installedSkillCount: 0,
+      failedSourceCount: 0,
+    });
+  });
+
+  it("rejects non-github sources with a clear error", async () => {
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [source({ source: "https://gitlab.com/owner/repo" })],
+        logger,
+      }),
+    ).rejects.toThrow(/--mode gh only supports GitHub sources/);
+  });
+
+  it("rejects entry.transport='git' with a field-specific error", async () => {
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [source({ source: "owner/repo", transport: "git" })],
+        logger,
+      }),
+    ).rejects.toThrow(/"transport" is not supported/);
+  });
+
+  it("rejects entry.path with a field-specific error", async () => {
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [source({ source: "owner/repo", path: "exports/skills" })],
+        logger,
+      }),
+    ).rejects.toThrow(/"path" is not supported/);
+  });
+
+  it("--frozen fails up-front for a brand-new source not in the lockfile (no API calls)", async () => {
+    // Seed a lockfile that covers ONE source. The new install asks for two
+    // sources — the second has no installations at all in the lock.
+    setupSingleSkill("s");
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/first" })],
+      logger,
+    });
+
+    // Reset call counts so we can prove the second --frozen run never hits
+    // the GitHub API for the brand-new "owner/added" source.
+    mockClientInstance.getLatestRelease.mockClear();
+    mockClientInstance.listDirectory.mockClear();
+    mockClientInstance.resolveRefToSha.mockClear();
+
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [source({ source: "owner/first" }), source({ source: "owner/added" })],
+        options: { frozen: true },
+        logger,
+      }),
+    ).rejects.toThrow(/missing entries for/);
+
+    // Critical: the eager pre-flight must throw BEFORE any GitHub API call
+    // is issued, both to save quota and (the actual reason) to prevent a
+    // sibling source from writing to disk before this throw lands.
+    expect(mockClientInstance.getLatestRelease).not.toHaveBeenCalled();
+    expect(mockClientInstance.listDirectory).not.toHaveBeenCalled();
+    expect(mockClientInstance.resolveRefToSha).not.toHaveBeenCalled();
+  });
+
+  it("--frozen never writes any source's bytes when one sibling source fails", async () => {
+    // Seed two distinct sources (different agents so they land at different
+    // paths) so frozen pre-flight passes and we can observe per-source
+    // write behavior independently.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "s", path: "skills/s", type: "dir", size: 0 }];
+        }
+        if (p === "skills/s") {
+          return [{ name: "SKILL.md", path: "skills/s/SKILL.md", type: "file", size: 10 }];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p === "skills/s/SKILL.md" ? { name: "SKILL.md", path: p, type: "file", size: 10 } : null,
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("# original\n");
+
+    await installGh({
+      baseDir: testDir,
+      sources: [
+        source({ source: "owner/repo", agent: "github-copilot" }),
+        source({ source: "owner/repo", agent: "claude-code" }),
+      ],
+      logger,
+    });
+
+    const copilotPath = join(testDir, ".agents/skills/s/SKILL.md");
+    const claudePath = join(testDir, ".claude/skills/s/SKILL.md");
+    const originalCopilot = await readFileContent(copilotPath);
+    const originalClaude = await readFileContent(claudePath);
+
+    // Now under --frozen, return tampered bytes ONLY for the github-copilot
+    // installation (use the call sequence: copilot is the first source so
+    // its install runs first under Promise.all). The integrity check will
+    // throw for it. Under deferred-write semantics, the claude-code source
+    // (which would otherwise pass all checks AND write its bytes in
+    // installSource) must NOT touch the on-disk file before the throw.
+    let getContentCalls = 0;
+    mockClientInstance.getFileContent.mockImplementation(async () => {
+      getContentCalls += 1;
+      // First call: copilot -> tampered (will fail integrity).
+      // Second call: claude -> different bytes, would normally land on disk.
+      return getContentCalls === 1 ? "# tampered copilot\n" : "# would-write-claude\n";
+    });
+
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [
+          source({ source: "owner/repo", agent: "github-copilot" }),
+          source({ source: "owner/repo", agent: "claude-code" }),
+        ],
+        options: { frozen: true },
+        logger,
+      }),
+    ).rejects.toThrow(/content_hash mismatch/);
+
+    // Both files must remain at their pre-frozen bytes. If the claude-code
+    // source had been allowed to write inside its own installSource (the
+    // pre-fix behavior), claudePath would now contain "# would-write-claude\n".
+    expect(await readFileContent(copilotPath)).toBe(originalCopilot);
+    expect(await readFileContent(claudePath)).toBe(originalClaude);
+  });
+
+  it("discovers skills via skills/<name>/SKILL.md and writes them with default agent (github-copilot)", async () => {
+    setupSingleSkill("git-commit");
+    const result = await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      logger,
+    });
+    expect(result.sourcesProcessed).toBe(1);
+    expect(result.installedSkillCount).toBe(1);
+    expect(result.failedSourceCount).toBe(0);
+
+    // Default agent github-copilot, project scope -> .agents/skills.
+    const skillPath = join(testDir, ".agents/skills/git-commit/SKILL.md");
+    expect(await fileExists(skillPath)).toBe(true);
+    const content = await readFileContent(skillPath);
+    expect(content).toContain("source: https://github.com/owner/repo");
+    expect(content).toContain("repository: owner/repo");
+    expect(content).toContain("ref: v1.0.0");
+
+    const lock = await readGhLock(testDir);
+    expect(lock?.installations).toHaveLength(1);
+    expect(lock?.installations[0]).toMatchObject({
+      source: "owner/repo",
+      owner: "owner",
+      repo: "repo",
+      agent: "github-copilot",
+      scope: "project",
+      skill: "git-commit",
+      resolved_ref: "v1.0.0",
+      resolved_commit: VALID_SHA,
+      install_dir: ".agents/skills",
+      deployed_files: [".agents/skills/git-commit/SKILL.md"],
+    });
+  });
+
+  it("honors entry.agent (claude-code) and writes under .claude/skills", async () => {
+    setupSingleSkill("git-commit");
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code" })],
+      logger,
+    });
+    expect(await fileExists(join(testDir, ".claude/skills/git-commit/SKILL.md"))).toBe(true);
+  });
+
+  it("honors entry.skills filter and warns about missing names", async () => {
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [
+            { name: "wanted", path: "skills/wanted", type: "dir", size: 0 },
+            { name: "ignored", path: "skills/ignored", type: "dir", size: 0 },
+          ];
+        }
+        if (p === "skills/wanted") {
+          return [{ name: "SKILL.md", path: "skills/wanted/SKILL.md", type: "file", size: 10 }];
+        }
+        if (p === "skills/ignored") {
+          return [{ name: "SKILL.md", path: "skills/ignored/SKILL.md", type: "file", size: 10 }];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p.endsWith("/SKILL.md") ? { name: "SKILL.md", path: p, type: "file", size: 10 } : null,
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("# x\n");
+
+    const localLogger = createMockLogger();
+    const result = await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo", skills: ["wanted", "missing"] })],
+      logger: localLogger,
+    });
+    expect(result.installedSkillCount).toBe(1);
+    expect(await fileExists(join(testDir, ".agents/skills/wanted/SKILL.md"))).toBe(true);
+    expect(await fileExists(join(testDir, ".agents/skills/ignored/SKILL.md"))).toBe(false);
+
+    const warns = localLogger.warn.mock.calls.map((args) => String(args[0]));
+    expect(warns.some((m) => m.includes('"missing"'))).toBe(true);
+  });
+
+  it("uses entry.ref when present, skipping latest-release lookup", async () => {
+    setupSingleSkill("s");
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo", ref: "feature-branch" })],
+      logger,
+    });
+    expect(mockClientInstance.getLatestRelease).not.toHaveBeenCalled();
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith(
+      "owner",
+      "repo",
+      "feature-branch",
+    );
+  });
+
+  it("falls back to default branch when latest release returns 404", async () => {
+    setupSingleSkill("s");
+    mockClientInstance.getLatestRelease.mockRejectedValue(makeNotFound());
+    mockClientInstance.getDefaultBranch.mockResolvedValue("trunk");
+
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      logger,
+    });
+    expect(mockClientInstance.getDefaultBranch).toHaveBeenCalledWith("owner", "repo");
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith("owner", "repo", "trunk");
+
+    // When falling back to a branch (not a release tag), the SKILL.md ref
+    // recorded in the injected frontmatter should be the resolved commit SHA.
+    const content = await readFileContent(join(testDir, ".agents/skills/s/SKILL.md"));
+    expect(content).toContain(`ref: ${VALID_SHA}`);
+  });
+
+  it("--frozen fails when the lockfile is missing", async () => {
+    setupSingleSkill("s");
+    await expect(
+      installGh({
+        baseDir: testDir,
+        sources: [source({ source: "owner/repo" })],
+        options: { frozen: true },
+        logger,
+      }),
+    ).rejects.toThrow(/rulesync-gh\.lock\.yaml is missing/);
+  });
+
+  it("--update re-resolves refs even when the lockfile is present", async () => {
+    setupSingleSkill("s");
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      logger,
+    });
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
+
+    // Bump SHA to simulate upstream movement and re-run with --update.
+    mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      options: { update: true },
+      logger,
+    });
+    const lock = await readGhLock(testDir);
+    expect(lock?.installations[0]?.resolved_commit).toBe(SECOND_SHA);
+  });
+
+  it("removes stale files no longer present in the new lockfile", async () => {
+    // First install: skill with SKILL.md + extra.md.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "s", path: "skills/s", type: "dir", size: 0 }];
+        }
+        if (p === "skills/s") {
+          return [
+            { name: "SKILL.md", path: "skills/s/SKILL.md", type: "file", size: 10 },
+            { name: "extra.md", path: "skills/s/extra.md", type: "file", size: 10 },
+          ];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p === "skills/s/SKILL.md" ? { name: "SKILL.md", path: p, type: "file", size: 10 } : null,
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_o: string, _r: string, p: string) => `content of ${p}`,
+    );
+
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      logger,
+    });
+    expect(await fileExists(join(testDir, ".agents/skills/s/SKILL.md"))).toBe(true);
+    expect(await fileExists(join(testDir, ".agents/skills/s/extra.md"))).toBe(true);
+
+    // Second install: extra.md disappears upstream.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "s", path: "skills/s", type: "dir", size: 0 }];
+        }
+        if (p === "skills/s") {
+          return [{ name: "SKILL.md", path: "skills/s/SKILL.md", type: "file", size: 10 }];
+        }
+        throw makeNotFound();
+      },
+    );
+
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      options: { update: true },
+      logger,
+    });
+    expect(await fileExists(join(testDir, ".agents/skills/s/SKILL.md"))).toBe(true);
+    expect(await fileExists(join(testDir, ".agents/skills/s/extra.md"))).toBe(false);
+
+    const lock = await readGhLock(testDir);
+    expect(lock?.installations[0]?.deployed_files).toEqual([".agents/skills/s/SKILL.md"]);
+  });
+
+  it("writes the lockfile path correctly", async () => {
+    setupSingleSkill("s");
+    await installGh({
+      baseDir: testDir,
+      sources: [source({ source: "owner/repo" })],
+      logger,
+    });
+    expect(await fileExists(getGhLockPath(testDir))).toBe(true);
+  });
+});

--- a/src/lib/gh/gh-install.ts
+++ b/src/lib/gh/gh-install.ts
@@ -1,0 +1,639 @@
+import { createHash } from "node:crypto";
+import { basename, join, posix } from "node:path";
+
+import { Semaphore } from "es-toolkit/promise";
+
+import type { SourceEntry } from "../../config/config.js";
+import { FETCH_CONCURRENCY_LIMIT, MAX_FILE_SIZE } from "../../constants/rulesync-paths.js";
+import { formatError } from "../../utils/error.js";
+import {
+  checkPathTraversal,
+  getHomeDirectory,
+  removeFile,
+  toPosixPath,
+  writeFileContent,
+} from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
+import { GitHubClient, GitHubClientError, logGitHubAuthHints } from "../github-client.js";
+import { listDirectoryRecursive, withSemaphore } from "../github-utils.js";
+import { parseSource } from "../source-parser.js";
+import { injectSourceMetadata } from "./gh-frontmatter.js";
+import {
+  createEmptyGhLock,
+  findGhLockInstallation,
+  type GhLock,
+  type GhLockInstallation,
+  readGhLock,
+  RULESYNC_CONTENT_HASH_REGEX,
+  writeGhLock,
+} from "./gh-lock.js";
+import { type GhAgent, GH_AGENTS, type GhScope, relativeInstallDirFor } from "./gh-paths.js";
+
+const SKILLS_REMOTE_DIR = "skills";
+const SKILL_FILE_NAME = "SKILL.md";
+
+export type GhInstallOptions = {
+  /** Force re-resolve all refs, ignoring the lockfile. */
+  update?: boolean;
+  /** Fail if the lockfile is missing or out of sync (for CI). */
+  frozen?: boolean;
+  /** GitHub token for private repositories. */
+  token?: string;
+};
+
+export type GhInstallResult = {
+  sourcesProcessed: number;
+  installedSkillCount: number;
+  failedSourceCount: number;
+};
+
+type ResolvedSource = {
+  entry: SourceEntry;
+  owner: string;
+  repo: string;
+  ref?: string;
+  agent: GhAgent;
+  scope: GhScope;
+};
+
+type DeployedFile = {
+  /** Relative POSIX path under the install dir's scope root. Recorded in the lockfile. */
+  relativeToScopeRoot: string;
+  /** Absolute on-disk path where the bytes are written. */
+  absolutePath: string;
+  content: string;
+};
+
+type SkillInstallation = {
+  installation: GhLockInstallation;
+  deployed: DeployedFile[];
+};
+
+/**
+ * Entry point for `rulesync install --mode gh`. Reads `sources` from
+ * `rulesync.jsonc`, resolves each one against the GitHub API, and deploys
+ * each discovered `skills/<name>/` tree under the agent-specific install
+ * directory recorded by `resolveGhInstallDir`. Updates `rulesync-gh.lock.yaml`
+ * to pin commits and per-skill content hashes.
+ */
+export async function installGh(params: {
+  baseDir: string;
+  sources: SourceEntry[];
+  options?: GhInstallOptions;
+  logger: Logger;
+}): Promise<GhInstallResult> {
+  const { baseDir, sources, options = {}, logger } = params;
+
+  if (sources.length === 0) {
+    return { sourcesProcessed: 0, installedSkillCount: 0, failedSourceCount: 0 };
+  }
+
+  // Pre-resolve every source's owner/repo + agent/scope defaults so the
+  // frozen-mode coverage check below has a stable view of what installations
+  // are required. We do not contact the API yet — that happens per-source.
+  const resolvedSources: ResolvedSource[] = sources.map((entry) => {
+    const parsed = parseSource(entry.source);
+    if (parsed.provider !== "github") {
+      throw new Error(
+        `--mode gh only supports GitHub sources. "${entry.source}" resolves to provider "${parsed.provider}".`,
+      );
+    }
+    // gh mode does not honor `transport` or `path` from the SourceEntry —
+    // both are rulesync-mode-only concepts. Silently dropping them would
+    // surprise users migrating from --mode rulesync, so reject up-front
+    // with a message that names the offending field.
+    if (entry.transport !== undefined && entry.transport !== "github") {
+      throw new Error(
+        `--mode gh: field "transport" is not supported (got "${entry.transport}" for source "${entry.source}"). Drop the field or switch to --mode rulesync.`,
+      );
+    }
+    if (entry.path !== undefined) {
+      throw new Error(
+        `--mode gh: field "path" is not supported for source "${entry.source}". The remote layout is fixed to "skills/<name>/SKILL.md".`,
+      );
+    }
+    const agent = entry.agent ?? "github-copilot";
+    if (!GH_AGENTS.includes(agent)) {
+      throw new Error(
+        `--mode gh: unknown agent "${agent}" for source "${entry.source}". Valid agents: ${GH_AGENTS.join(", ")}.`,
+      );
+    }
+    const scope: GhScope = entry.scope ?? "project";
+    return {
+      entry,
+      owner: parsed.owner,
+      repo: parsed.repo,
+      ref: entry.ref ?? parsed.ref,
+      agent,
+      scope,
+    };
+  });
+
+  const existingLock = await readGhLock(baseDir);
+  const frozen = options.frozen ?? false;
+  const update = options.update ?? false;
+
+  if (frozen && !existingLock) {
+    throw new Error(
+      "Frozen install failed: rulesync-gh.lock.yaml is missing. Run 'rulesync install --mode gh' to create it.",
+    );
+  }
+
+  // Frozen mode: per-source coverage check. A brand-new source (no
+  // installations at all in the lock) must fail before we contact the
+  // GitHub API — both to save quota and to prevent in-flight Promise.all
+  // siblings from writing files when another source is going to throw.
+  // Per-skill coverage (when entry.skills lists names that ARE absent from
+  // the lock) is still enforced lazily inside installSource, since that
+  // requires API discovery to know which skills exist remotely.
+  if (frozen && existingLock) {
+    const uncovered: string[] = [];
+    for (const rs of resolvedSources) {
+      const hasAny = existingLock.installations.some(
+        (i) =>
+          i.source.toLowerCase() === rs.entry.source.toLowerCase() &&
+          i.agent === rs.agent &&
+          i.scope === rs.scope,
+      );
+      if (!hasAny) {
+        uncovered.push(`${rs.entry.source} (agent=${rs.agent}, scope=${rs.scope})`);
+      }
+    }
+    if (uncovered.length > 0) {
+      throw new Error(
+        `Frozen install failed: rulesync-gh.lock.yaml is missing entries for: ${uncovered.join(", ")}. Run 'rulesync install --mode gh' to update the lockfile.`,
+      );
+    }
+
+    // Detect manifest drift on `ref`: when the user edited `ref` in
+    // rulesync.jsonc without re-running install, refuse rather than
+    // silently install the locked SHA against a different declared ref.
+    const drifted: string[] = [];
+    for (const rs of resolvedSources) {
+      if (!rs.ref) continue;
+      const matches = existingLock.installations.filter(
+        (i) => i.source.toLowerCase() === rs.entry.source.toLowerCase(),
+      );
+      for (const m of matches) {
+        if (m.requested_ref !== undefined && m.requested_ref !== rs.ref) {
+          drifted.push(`${rs.entry.source} (manifest=${rs.ref}, lock=${m.requested_ref})`);
+          break;
+        }
+      }
+    }
+    if (drifted.length > 0) {
+      throw new Error(
+        `Frozen install failed: manifest ref does not match rulesync-gh.lock.yaml for: ${drifted.join(", ")}. Run 'rulesync install --mode gh' to update the lockfile.`,
+      );
+    }
+  }
+
+  const token = GitHubClient.resolveToken(options.token);
+  const client = new GitHubClient({ token });
+  const semaphore = new Semaphore(FETCH_CONCURRENCY_LIMIT);
+
+  const newLock: GhLock = createEmptyGhLock({ existingLock });
+
+  type SourceResult =
+    | { status: "ok"; installations: SkillInstallation[] }
+    | { status: "failed"; preserved: GhLockInstallation[] };
+
+  const runOne = async (rs: ResolvedSource): Promise<SourceResult> => {
+    const installations = await installSource({
+      rs,
+      client,
+      semaphore,
+      baseDir,
+      existingLock,
+      frozen,
+      update,
+      logger,
+    });
+    return { status: "ok", installations };
+  };
+
+  const results: SourceResult[] = frozen
+    ? await Promise.all(resolvedSources.map(runOne))
+    : await Promise.all(
+        resolvedSources.map(async (rs): Promise<SourceResult> => {
+          try {
+            return await runOne(rs);
+          } catch (error) {
+            logger.error(`Failed to install gh source "${rs.entry.source}": ${formatError(error)}`);
+            if (error instanceof GitHubClientError) {
+              logGitHubAuthHints({ error, logger });
+            }
+            // Preserve all prior installations for this source so that a
+            // transient error does not erase previously pinned commit SHAs.
+            const preserved = existingLock
+              ? existingLock.installations.filter(
+                  (i) => i.source.toLowerCase() === rs.entry.source.toLowerCase(),
+                )
+              : [];
+            return { status: "failed", preserved };
+          }
+        }),
+      );
+
+  // Frozen-mode deferred writes. `installSource` never touches the disk
+  // under --frozen — every write lands here, only after Promise.all has
+  // resolved successfully for every source. Without this gate, source A
+  // could finish writing its bytes before source B's coverage / integrity
+  // check throws, leaving the working tree in a partially-frozen state
+  // despite the install reporting failure.
+  if (frozen) {
+    for (const result of results) {
+      if (result.status !== "ok") continue;
+      for (const inst of result.installations) {
+        for (const d of inst.deployed) {
+          await writeFileContent(d.absolutePath, d.content);
+        }
+      }
+    }
+  }
+
+  let totalInstalled = 0;
+  let failedCount = 0;
+  for (const result of results) {
+    if (result.status === "ok") {
+      for (const inst of result.installations) {
+        newLock.installations.push(inst.installation);
+      }
+      totalInstalled += result.installations.length;
+    } else {
+      failedCount += 1;
+      for (const preserved of result.preserved) {
+        newLock.installations.push(preserved);
+      }
+    }
+  }
+
+  // Stale-file cleanup. Same hardening shape as apm-install.
+  if (existingLock) {
+    const newDeployed = new Set<string>();
+    for (const inst of newLock.installations) {
+      for (const file of inst.deployed_files) {
+        // Key by (scope, path) so a file in `<home>/.claude/skills/foo` and a
+        // file at `<base>/.claude/skills/foo` are not conflated.
+        newDeployed.add(`${inst.scope}::${file}`);
+      }
+    }
+    for (const prev of existingLock.installations) {
+      for (const deployed of prev.deployed_files) {
+        const key = `${prev.scope}::${deployed}`;
+        if (newDeployed.has(key)) continue;
+        await removeStaleFile({
+          relativePath: deployed,
+          scope: prev.scope === "user" ? "user" : "project",
+          baseDir,
+          logger,
+        });
+      }
+    }
+  }
+
+  if (!frozen) {
+    newLock.generated_at = new Date().toISOString();
+    await writeGhLock({ baseDir, lock: newLock });
+    if (failedCount === 0) {
+      logger.debug("rulesync-gh.lock.yaml updated.");
+    } else {
+      logger.warn(
+        `rulesync-gh.lock.yaml written with partially successful installs (${failedCount} source(s) failed).`,
+      );
+    }
+  }
+
+  return {
+    sourcesProcessed: sources.length,
+    installedSkillCount: totalInstalled,
+    failedSourceCount: failedCount,
+  };
+}
+
+async function installSource(params: {
+  rs: ResolvedSource;
+  client: GitHubClient;
+  semaphore: Semaphore;
+  baseDir: string;
+  existingLock: GhLock | null;
+  frozen: boolean;
+  update: boolean;
+  logger: Logger;
+}): Promise<SkillInstallation[]> {
+  const { rs, client, semaphore, baseDir, existingLock, frozen, update, logger } = params;
+  const { entry, owner, repo, agent, scope } = rs;
+  const sourceKey = entry.source;
+
+  // Resolve the ref. Order:
+  //   1. entry.ref (explicit pin)
+  //   2. latest release's tag_name
+  //   3. default branch (when the repo has no releases)
+  let resolvedRef: string;
+  let usedTag = false;
+  if (rs.ref) {
+    resolvedRef = rs.ref;
+  } else {
+    try {
+      const release = await client.getLatestRelease(owner, repo);
+      resolvedRef = release.tag_name;
+      usedTag = true;
+    } catch (error) {
+      // gh's behavior: when a repo has no releases, getLatestRelease returns
+      // 404. We treat any 404 (real GitHubClientError or any thrown value
+      // carrying statusCode 404) as "no releases" and fall back to the
+      // default branch. Other errors propagate.
+      if (is404(error)) {
+        resolvedRef = await client.getDefaultBranch(owner, repo);
+      } else {
+        throw error;
+      }
+    }
+  }
+  const resolvedSha = await client.resolveRefToSha(owner, repo, resolvedRef);
+  logger.debug(`Resolved ${sourceKey} -> ref=${resolvedRef} sha=${resolvedSha}`);
+
+  // Discover skills under `skills/`.
+  let topLevel: Awaited<ReturnType<GitHubClient["listDirectory"]>>;
+  try {
+    topLevel = await client.listDirectory(owner, repo, SKILLS_REMOTE_DIR, resolvedSha);
+  } catch (error) {
+    if (is404(error)) {
+      logger.warn(`No skills/ directory found in ${sourceKey}. Skipping.`);
+      return [];
+    }
+    throw error;
+  }
+
+  const skillDirs = topLevel
+    .filter((e) => e.type === "dir")
+    .map((e) => ({ name: e.name, path: e.path }));
+
+  // Discover which subdirectories are actual skills (contain a SKILL.md).
+  // Resolved sequentially to avoid hammering the API for large monorepos
+  // beyond the FETCH_CONCURRENCY_LIMIT.
+  const validatedSkills: Array<{ name: string; path: string }> = [];
+  for (const sk of skillDirs) {
+    const info = await withSemaphore(semaphore, () =>
+      client.getFileInfo(owner, repo, posix.join(sk.path, SKILL_FILE_NAME), resolvedSha),
+    );
+    if (info) {
+      validatedSkills.push(sk);
+    }
+  }
+
+  // Apply the explicit skill filter when provided.
+  let selected = validatedSkills;
+  if (entry.skills && entry.skills.length > 0) {
+    const requested = new Set(entry.skills);
+    selected = validatedSkills.filter((s) => requested.has(s.name));
+    const presentNames = new Set(validatedSkills.map((s) => s.name));
+    for (const want of entry.skills) {
+      if (!presentNames.has(want)) {
+        logger.warn(`Requested skill "${want}" not found in ${sourceKey} under skills/. Skipping.`);
+      }
+    }
+  }
+
+  // Frozen-mode coverage check (per-skill). Only enforceable now that we know
+  // the requested skill set.
+  if (frozen && existingLock) {
+    const missing: string[] = [];
+    for (const sk of selected) {
+      const locked = findGhLockInstallation(existingLock, {
+        source: sourceKey,
+        agent,
+        scope,
+        skill: sk.name,
+      });
+      if (!locked) {
+        missing.push(sk.name);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `Frozen install failed: rulesync-gh.lock.yaml is missing entries for ${sourceKey} (agent=${agent}, scope=${scope}) skills: ${missing.join(", ")}. Run 'rulesync install --mode gh' to update the lockfile.`,
+      );
+    }
+  }
+
+  const results: SkillInstallation[] = [];
+  const installRelDir = relativeInstallDirFor({ agent, scope });
+  const scopeRoot = scope === "user" ? getHomeDirectory() : baseDir;
+
+  // Source URL recorded in injected frontmatter. Mirrors the canonical form
+  // used by `gh skill install`.
+  const sourceUrl = `https://github.com/${owner}/${repo}`;
+  const repository = `${owner}/${repo}`;
+  // gh records the *resolved* ref (the tag name when one was used, else the
+  // commit SHA) into the SKILL.md frontmatter so the deployed file has a
+  // human-readable provenance hint.
+  const provenanceRef = usedTag ? resolvedRef : resolvedSha;
+
+  for (const sk of selected) {
+    const locked =
+      existingLock && !update
+        ? findGhLockInstallation(existingLock, {
+            source: sourceKey,
+            agent,
+            scope,
+            skill: sk.name,
+          })
+        : undefined;
+
+    // Recursively list this skill's tree.
+    const allFiles = await listDirectoryRecursive({
+      client,
+      owner,
+      repo,
+      path: sk.path,
+      ref: resolvedSha,
+      semaphore,
+    });
+
+    const deployed: DeployedFile[] = [];
+    for (const file of allFiles) {
+      if (file.size > MAX_FILE_SIZE) {
+        logger.warn(
+          `Skipping "${file.path}" from ${sourceKey}: ${(file.size / 1024 / 1024).toFixed(2)}MB exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit.`,
+        );
+        continue;
+      }
+      // Path of the file relative to the skill directory root upstream.
+      const relativeToSkill = posix.relative(sk.path, toPosixPath(file.path));
+      if (
+        !relativeToSkill ||
+        relativeToSkill.startsWith("..") ||
+        posix.isAbsolute(relativeToSkill)
+      ) {
+        logger.warn(`Skipping "${file.path}" from ${sourceKey}: resolved outside of "${sk.path}".`);
+        continue;
+      }
+
+      // Path under the scope root (relative). This is the value persisted to
+      // the lockfile.
+      const deployRelative = toPosixPath(join(installRelDir, sk.name, relativeToSkill));
+      // Path-traversal hardening rooted at the scope root, then a tighter
+      // check rooted at the per-(agent,scope) install dir to refuse anything
+      // that escapes the agent-specific deployment directory.
+      checkPathTraversal({ relativePath: deployRelative, intendedRootDir: scopeRoot });
+      const installAbs = join(scopeRoot, installRelDir);
+      const withinInstallDir = toPosixPath(join(sk.name, relativeToSkill));
+      checkPathTraversal({ relativePath: withinInstallDir, intendedRootDir: installAbs });
+
+      let content = await withSemaphore(semaphore, () =>
+        client.getFileContent(owner, repo, file.path, resolvedSha),
+      );
+      const byteLength = Buffer.byteLength(content, "utf8");
+      if (byteLength > MAX_FILE_SIZE) {
+        logger.warn(
+          `Skipping "${file.path}" from ${sourceKey}: fetched ${(byteLength / 1024 / 1024).toFixed(2)}MB exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit.`,
+        );
+        continue;
+      }
+
+      // Inject provenance frontmatter into SKILL.md files. Other files
+      // (e.g. supporting markdown, scripts) pass through unchanged.
+      if (basename(file.path) === SKILL_FILE_NAME) {
+        try {
+          content = injectSourceMetadata({
+            content,
+            source: sourceUrl,
+            repository,
+            ref: provenanceRef,
+          });
+        } catch {
+          // Frontmatter exists but is not parseable. Fall back to a fresh
+          // prepend so we still record provenance — but warn the user.
+          logger.warn(
+            `Frontmatter in ${file.path} (${sourceKey}) is invalid. Prepending a fresh provenance block.`,
+          );
+          content = `---\nsource: ${sourceUrl}\nrepository: ${repository}\nref: ${provenanceRef}\n---\n${content}`;
+        }
+      }
+
+      const absolutePath = join(scopeRoot, deployRelative);
+      deployed.push({ relativeToScopeRoot: deployRelative, absolutePath, content });
+
+      if (!frozen) {
+        await writeFileContent(absolutePath, content);
+      }
+    }
+
+    deployed.sort((a, b) =>
+      a.relativeToScopeRoot < b.relativeToScopeRoot
+        ? -1
+        : a.relativeToScopeRoot > b.relativeToScopeRoot
+          ? 1
+          : 0,
+    );
+    const deployedFiles = deployed.map((d) => d.relativeToScopeRoot);
+    const contentHash = computeContentHash(deployed);
+
+    // Frozen integrity check: refuse to overwrite known-good bytes with
+    // tampered ones when the prior content_hash matches the rulesync format.
+    if (frozen && locked?.content_hash) {
+      if (RULESYNC_CONTENT_HASH_REGEX.test(locked.content_hash)) {
+        if (locked.content_hash !== contentHash) {
+          throw new Error(
+            `content_hash mismatch for ${sourceKey} skill "${sk.name}" (agent=${agent}, scope=${scope}): lock=${locked.content_hash} computed=${contentHash}. Refuse to trust the deployment under --frozen.`,
+          );
+        }
+      } else {
+        logger.debug(
+          `Skipping content_hash integrity check for ${sourceKey} skill "${sk.name}": recorded hash "${locked.content_hash}" was not written by rulesync.`,
+        );
+      }
+    }
+
+    // Under --frozen we deliberately do NOT write here even after the
+    // integrity check passes. Writes are deferred to the top-level installGh
+    // so that a sibling source failing its check cannot leave partial bytes
+    // on disk from a peer that already passed.
+    const installation: GhLockInstallation = {
+      source: sourceKey,
+      owner,
+      repo,
+      agent,
+      scope,
+      skill: sk.name,
+      resolved_ref: resolvedRef,
+      resolved_commit: resolvedSha,
+      install_dir: toPosixPath(installRelDir),
+      deployed_files: deployedFiles,
+      content_hash: contentHash,
+    };
+    if (rs.ref !== undefined) {
+      installation.requested_ref = rs.ref;
+    }
+    results.push({ installation, deployed });
+
+    logger.info(
+      `Installed gh skill "${sk.name}" from ${sourceKey} (agent=${agent}, scope=${scope}, ref=${resolvedRef})`,
+    );
+  }
+
+  return results;
+}
+
+async function removeStaleFile(params: {
+  relativePath: string;
+  scope: GhScope;
+  baseDir: string;
+  logger: Logger;
+}): Promise<void> {
+  const { relativePath, scope, baseDir, logger } = params;
+  if (posix.isAbsolute(relativePath) || relativePath.split(/[/\\]/).includes("..")) {
+    logger.warn(`Refusing to remove stale gh file with suspicious path: "${relativePath}".`);
+    return;
+  }
+  const scopeRoot = scope === "user" ? getHomeDirectory() : baseDir;
+  try {
+    checkPathTraversal({ relativePath, intendedRootDir: scopeRoot });
+  } catch {
+    logger.warn(`Refusing to remove stale gh file outside ${scope} root: "${relativePath}".`);
+    return;
+  }
+  const absolute = join(scopeRoot, relativePath);
+  await removeFile(absolute);
+  logger.debug(`Removed stale gh file: ${relativePath}`);
+}
+
+/**
+ * Detect a 404-like error in a way that tolerates both real `GitHubClientError`
+ * instances and any other thrown value that exposes a numeric `statusCode`
+ * (e.g. plain Errors raised from a test mock that does not import the real
+ * client class).
+ */
+function is404(error: unknown): boolean {
+  if (error instanceof GitHubClientError && error.statusCode === 404) {
+    return true;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    error.statusCode === 404
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * SHA-256 over a canonical, order-independent representation of the deployed
+ * files. Identical algorithm to the apm-install hash so users familiar with
+ * one mode can read the other.
+ */
+function computeContentHash(
+  files: Array<{ relativeToScopeRoot: string; content: string }>,
+): string {
+  const hash = createHash("sha256");
+  for (const { relativeToScopeRoot, content } of files) {
+    hash.update(relativeToScopeRoot);
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}

--- a/src/lib/gh/gh-install.user-scope.test.ts
+++ b/src/lib/gh/gh-install.user-scope.test.ts
@@ -1,0 +1,280 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SourceEntry } from "../../config/config.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { installGh } from "./gh-install.js";
+import { getGhLockPath } from "./gh-lock.js";
+
+// Mock the GitHub network boundary like the sibling gh-install.test.ts does.
+let mockClientInstance: any;
+
+vi.mock("../github-client.js", () => ({
+  GitHubClient: class MockGitHubClient {
+    static resolveToken = vi.fn().mockReturnValue(undefined);
+    getDefaultBranch(...args: any[]) {
+      return mockClientInstance.getDefaultBranch(...args);
+    }
+    getLatestRelease(...args: any[]) {
+      return mockClientInstance.getLatestRelease(...args);
+    }
+    resolveRefToSha(...args: any[]) {
+      return mockClientInstance.resolveRefToSha(...args);
+    }
+    listDirectory(...args: any[]) {
+      return mockClientInstance.listDirectory(...args);
+    }
+    getFileContent(...args: any[]) {
+      return mockClientInstance.getFileContent(...args);
+    }
+    getFileInfo(...args: any[]) {
+      return mockClientInstance.getFileInfo(...args);
+    }
+  },
+  GitHubClientError: class GitHubClientError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  logGitHubAuthHints: vi.fn(),
+}));
+
+// Pseudo-home pattern from .claude/rules/testing-guidelines.md. We mock
+// `getHomeDirectory` so user-scope writes land under a controlled testDir
+// rather than the real $HOME.
+const { getHomeDirectoryMock } = vi.hoisted(() => ({
+  getHomeDirectoryMock: vi.fn(),
+}));
+vi.mock("../../utils/file.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/file.js")>("../../utils/file.js");
+  return {
+    ...actual,
+    getHomeDirectory: getHomeDirectoryMock,
+  };
+});
+
+const VALID_SHA = "a".repeat(40);
+
+function source(overrides: Partial<SourceEntry> & { source: string }): SourceEntry {
+  return overrides;
+}
+
+function makeNotFound(): Error & { statusCode: number } {
+  const err = new Error("Not found") as Error & { statusCode: number };
+  err.statusCode = 404;
+  return err;
+}
+
+describe("installGh — user scope", () => {
+  let projectDir: string;
+  let projectCleanup: () => Promise<void>;
+  let homeDir: string;
+  let homeCleanup: () => Promise<void>;
+  const logger = createMockLogger();
+
+  beforeEach(async () => {
+    ({ testDir: projectDir, cleanup: projectCleanup } = await setupTestDirectory());
+    ({ testDir: homeDir, cleanup: homeCleanup } = await setupTestDirectory({ home: true }));
+    getHomeDirectoryMock.mockReturnValue(homeDir);
+
+    mockClientInstance = {
+      getDefaultBranch: vi.fn().mockResolvedValue("main"),
+      getLatestRelease: vi.fn().mockResolvedValue({
+        tag_name: "v1.0.0",
+        name: "v1.0.0",
+        prerelease: false,
+        draft: false,
+        assets: [],
+      }),
+      resolveRefToSha: vi.fn().mockResolvedValue(VALID_SHA),
+      listDirectory: vi.fn(),
+      getFileContent: vi.fn(),
+      getFileInfo: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await projectCleanup();
+    await homeCleanup();
+    getHomeDirectoryMock.mockClear();
+    vi.clearAllMocks();
+  });
+
+  function setupSingleSkill(skillName: string, files: Array<{ name: string; size?: number }>) {
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: skillName, path: `skills/${skillName}`, type: "dir", size: 0 }];
+        }
+        if (p === `skills/${skillName}`) {
+          return files.map((f) => ({
+            name: f.name,
+            // The malicious-tree cases below override `path` with `..`-laden
+            // values; honor any name shaped like a relative path here.
+            path: f.name.includes("..") ? f.name : `skills/${skillName}/${f.name}`,
+            type: "file",
+            size: f.size ?? 10,
+          }));
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p === `skills/${skillName}/SKILL.md`
+        ? { name: "SKILL.md", path: p, type: "file", size: 10 }
+        : null,
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_o: string, _r: string, p: string) => `# ${skillName}\nfrom ${p}\n`,
+    );
+  }
+
+  it("writes claude-code user-scope files under <home>/.claude/skills/<skill>/", async () => {
+    setupSingleSkill("git-commit", [{ name: "SKILL.md" }]);
+
+    const result = await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
+      logger,
+    });
+
+    expect(result.installedSkillCount).toBe(1);
+    // Files must NOT land in the project tree.
+    expect(await fileExists(join(projectDir, ".claude/skills/git-commit/SKILL.md"))).toBe(false);
+    // Files MUST land under the pseudo-home dir.
+    const userPath = join(homeDir, ".claude/skills/git-commit/SKILL.md");
+    expect(await fileExists(userPath)).toBe(true);
+    expect(await readFileContent(userPath)).toContain("source: https://github.com/owner/repo");
+
+    // The lockfile itself still lives at the project root (next to rulesync.jsonc).
+    expect(await fileExists(getGhLockPath(projectDir))).toBe(true);
+  });
+
+  it("writes antigravity user-scope files under <home>/.gemini/antigravity/skills/<skill>/", async () => {
+    setupSingleSkill("av-skill", [{ name: "SKILL.md" }]);
+
+    await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "antigravity", scope: "user" })],
+      logger,
+    });
+
+    const userPath = join(homeDir, ".gemini/antigravity/skills/av-skill/SKILL.md");
+    expect(await fileExists(userPath)).toBe(true);
+  });
+
+  it("rejects a malicious upstream tree entry whose path escapes the skill directory", async () => {
+    // Upstream lists a file whose `path` resolves outside the skills/ tree
+    // via a `..` segment. The path-traversal hardening in installSource
+    // (rooted at the install dir for user scope = pseudo-home dir) must
+    // skip / refuse such entries rather than write them under <home>.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "evil", path: "skills/evil", type: "dir", size: 0 }];
+        }
+        if (p === "skills/evil") {
+          return [
+            { name: "SKILL.md", path: "skills/evil/SKILL.md", type: "file", size: 10 },
+            // Attacker-controlled path: would resolve to <home>/escape.md.
+            { name: "escape.md", path: "../../../../escape.md", type: "file", size: 10 },
+          ];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p === "skills/evil/SKILL.md" ? { name: "SKILL.md", path: p, type: "file", size: 10 } : null,
+    );
+    mockClientInstance.getFileContent.mockResolvedValue("payload\n");
+
+    const localLogger = createMockLogger();
+    await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
+      logger: localLogger,
+    });
+
+    // The legitimate SKILL.md was deployed.
+    expect(await fileExists(join(homeDir, ".claude/skills/evil/SKILL.md"))).toBe(true);
+    // The escape attempt did NOT land at <home>/escape.md or anywhere else.
+    expect(await fileExists(join(homeDir, "escape.md"))).toBe(false);
+    expect(await fileExists(join(projectDir, "escape.md"))).toBe(false);
+    // A skip warning was emitted for the escape entry.
+    const warnMessages = localLogger.warn.mock.calls.map((args) => String(args[0]));
+    expect(warnMessages.some((m) => m.includes("escape.md") || m.includes(".."))).toBe(true);
+  });
+
+  it("respects the user-scope root when removing stale files from a previous install", async () => {
+    // First install: deploy SKILL.md + extra.md under user scope.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "s", path: "skills/s", type: "dir", size: 0 }];
+        }
+        if (p === "skills/s") {
+          return [
+            { name: "SKILL.md", path: "skills/s/SKILL.md", type: "file", size: 10 },
+            { name: "extra.md", path: "skills/s/extra.md", type: "file", size: 10 },
+          ];
+        }
+        throw makeNotFound();
+      },
+    );
+    mockClientInstance.getFileInfo.mockImplementation(async (_o: string, _r: string, p: string) =>
+      p === "skills/s/SKILL.md" ? { name: "SKILL.md", path: p, type: "file", size: 10 } : null,
+    );
+    mockClientInstance.getFileContent.mockImplementation(
+      async (_o: string, _r: string, p: string) => `content of ${p}\n`,
+    );
+
+    await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
+      logger,
+    });
+    expect(await fileExists(join(homeDir, ".claude/skills/s/extra.md"))).toBe(true);
+
+    // Second install: extra.md is gone from the upstream tree. Stale-file
+    // cleanup must (a) remove it from <home>/.claude/skills/s/, NOT from
+    // the project dir, and (b) leave the legitimate SKILL.md in place.
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_o: string, _r: string, p: string) => {
+        if (p === "skills") {
+          return [{ name: "s", path: "skills/s", type: "dir", size: 0 }];
+        }
+        if (p === "skills/s") {
+          return [{ name: "SKILL.md", path: "skills/s/SKILL.md", type: "file", size: 10 }];
+        }
+        throw makeNotFound();
+      },
+    );
+
+    await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
+      options: { update: true },
+      logger,
+    });
+
+    expect(await fileExists(join(homeDir, ".claude/skills/s/SKILL.md"))).toBe(true);
+    expect(await fileExists(join(homeDir, ".claude/skills/s/extra.md"))).toBe(false);
+    // Defense-in-depth: a same-named file inside the project dir must not
+    // have been deleted by a wrong-scope cleanup.
+    await writeFileContent(join(projectDir, ".claude/skills/s/extra.md"), "project-scope sentinel");
+    // Re-run install to trigger another stale-cleanup pass; the sentinel
+    // (which is not in any lockfile entry) must survive.
+    await installGh({
+      baseDir: projectDir,
+      sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
+      options: { update: true },
+      logger,
+    });
+    expect(await fileExists(join(projectDir, ".claude/skills/s/extra.md"))).toBe(true);
+  });
+});

--- a/src/lib/gh/gh-lock.test.ts
+++ b/src/lib/gh/gh-lock.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { readFileContent } from "../../utils/file.js";
+import {
+  createEmptyGhLock,
+  findGhLockInstallation,
+  GH_LOCKFILE_VERSION,
+  getGhLockPath,
+  parseGhLock,
+  readGhLock,
+  serializeGhLock,
+  writeGhLock,
+} from "./gh-lock.js";
+
+const VALID_SHA = "a".repeat(40);
+
+describe("gh-lock", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createEmptyGhLock", () => {
+    it("uses lockfile_version 1 and an empty installations array", () => {
+      const lock = createEmptyGhLock();
+      expect(lock.lockfile_version).toBe(GH_LOCKFILE_VERSION);
+      expect(lock.installations).toEqual([]);
+      expect(typeof lock.generated_at).toBe("string");
+    });
+
+    it("preserves top-level looseObject extras from existingLock", () => {
+      const existing = parseGhLock(
+        `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+custom_top_level:
+  any: thing
+installations: []
+`,
+      );
+      expect(existing).not.toBeNull();
+      const lock = createEmptyGhLock({ existingLock: existing });
+      expect((lock as unknown as { custom_top_level: unknown }).custom_top_level).toEqual({
+        any: "thing",
+      });
+      expect(lock.installations).toEqual([]);
+    });
+  });
+
+  describe("parseGhLock", () => {
+    it("returns null for empty content", () => {
+      expect(parseGhLock("")).toBeNull();
+    });
+
+    it("returns null for malformed YAML", () => {
+      expect(parseGhLock("::: not yaml :::")).toBeNull();
+    });
+
+    it("parses a minimal v1 lockfile", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+installations:
+  - source: owner/repo
+    owner: owner
+    repo: repo
+    agent: claude-code
+    scope: project
+    skill: my-skill
+    resolved_ref: v1.0.0
+    resolved_commit: ${VALID_SHA}
+    install_dir: .claude/skills
+    deployed_files:
+      - .claude/skills/my-skill/SKILL.md
+`;
+      const parsed = parseGhLock(content);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.installations).toHaveLength(1);
+      expect(parsed?.installations[0]).toMatchObject({
+        source: "owner/repo",
+        agent: "claude-code",
+        scope: "project",
+        skill: "my-skill",
+        resolved_commit: VALID_SHA,
+      });
+    });
+
+    it("preserves unknown installation fields via looseObject", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+installations:
+  - source: owner/repo
+    owner: owner
+    repo: repo
+    agent: claude-code
+    scope: project
+    skill: my-skill
+    resolved_ref: v1.0.0
+    resolved_commit: ${VALID_SHA}
+    install_dir: .claude/skills
+    deployed_files: []
+    future_field: preserved
+`;
+      const parsed = parseGhLock(content);
+      expect(parsed?.installations[0]).toMatchObject({
+        future_field: "preserved",
+      });
+    });
+
+    it("throws when resolved_commit is not a 40-char SHA", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+installations:
+  - source: owner/repo
+    owner: owner
+    repo: repo
+    agent: claude-code
+    scope: project
+    skill: my-skill
+    resolved_ref: v1.0.0
+    resolved_commit: not-a-sha
+    install_dir: .claude/skills
+    deployed_files: []
+`;
+      expect(() => parseGhLock(content)).toThrow(/resolved_commit/);
+    });
+
+    it('throws when lockfile_version is not "1"', () => {
+      const content = `lockfile_version: "2"
+generated_at: "2026-04-20T00:00:00Z"
+installations: []
+`;
+      expect(() => parseGhLock(content)).toThrow(/Invalid rulesync-gh\.lock\.yaml/);
+    });
+
+    it("throws when scope is not project|user", () => {
+      const content = `lockfile_version: "1"
+generated_at: "2026-04-20T00:00:00Z"
+installations:
+  - source: owner/repo
+    owner: owner
+    repo: repo
+    agent: claude-code
+    scope: global
+    skill: my-skill
+    resolved_ref: v1.0.0
+    resolved_commit: ${VALID_SHA}
+    install_dir: .claude/skills
+    deployed_files: []
+`;
+      expect(() => parseGhLock(content)).toThrow(/Invalid rulesync-gh\.lock\.yaml/);
+    });
+  });
+
+  describe("serializeGhLock round-trip", () => {
+    it("survives a serialize/parse round-trip", () => {
+      const lock = createEmptyGhLock();
+      lock.installations.push({
+        source: "owner/repo",
+        owner: "owner",
+        repo: "repo",
+        agent: "claude-code",
+        scope: "project",
+        skill: "my-skill",
+        resolved_ref: "v1.0.0",
+        resolved_commit: VALID_SHA,
+        install_dir: ".claude/skills",
+        deployed_files: [".claude/skills/my-skill/SKILL.md"],
+      });
+      const serialized = serializeGhLock(lock);
+      const parsed = parseGhLock(serialized);
+      expect(parsed).toEqual(lock);
+    });
+  });
+
+  describe("read/write", () => {
+    let testDir: string;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      ({ testDir, cleanup } = await setupTestDirectory());
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    it("returns null when the lockfile does not exist", async () => {
+      expect(await readGhLock(testDir)).toBeNull();
+    });
+
+    it("writes and reads back a lockfile", async () => {
+      const lock = createEmptyGhLock();
+      lock.installations.push({
+        source: "owner/repo",
+        owner: "owner",
+        repo: "repo",
+        agent: "claude-code",
+        scope: "project",
+        skill: "my-skill",
+        resolved_ref: "v1.0.0",
+        resolved_commit: VALID_SHA,
+        install_dir: ".claude/skills",
+        deployed_files: [],
+      });
+      await writeGhLock({ baseDir: testDir, lock });
+      const written = await readFileContent(getGhLockPath(testDir));
+      expect(written).toContain("lockfile_version:");
+      const readBack = await readGhLock(testDir);
+      expect(readBack).toEqual(lock);
+    });
+  });
+
+  describe("findGhLockInstallation", () => {
+    it("matches the (source, agent, scope, skill) tuple case-insensitively on source", () => {
+      const lock = createEmptyGhLock();
+      lock.installations.push({
+        source: "Owner/Repo",
+        owner: "owner",
+        repo: "repo",
+        agent: "claude-code",
+        scope: "project",
+        skill: "my-skill",
+        resolved_ref: "v1",
+        resolved_commit: VALID_SHA,
+        install_dir: ".claude/skills",
+        deployed_files: [],
+      });
+      expect(
+        findGhLockInstallation(lock, {
+          source: "owner/repo",
+          agent: "claude-code",
+          scope: "project",
+          skill: "my-skill",
+        }),
+      ).toBeDefined();
+      expect(
+        findGhLockInstallation(lock, {
+          source: "owner/repo",
+          agent: "claude-code",
+          scope: "user",
+          skill: "my-skill",
+        }),
+      ).toBeUndefined();
+      expect(
+        findGhLockInstallation(lock, {
+          source: "owner/other",
+          agent: "claude-code",
+          scope: "project",
+          skill: "my-skill",
+        }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/gh/gh-lock.ts
+++ b/src/lib/gh/gh-lock.ts
@@ -1,0 +1,147 @@
+import { join } from "node:path";
+
+import { dump, load } from "js-yaml";
+import { optional, refine, z } from "zod/mini";
+
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+
+/**
+ * Filename of the rulesync-managed gh-skill-compatible lockfile. Distinct
+ * from the rulesync sources lockfile (`rulesync.lock`) and from the
+ * apm-mode lockfile (`rulesync-apm.lock.yaml`) so the three install modes
+ * never fight over the same file.
+ */
+export const GH_LOCKFILE_FILE_NAME = "rulesync-gh.lock.yaml";
+export const GH_LOCKFILE_VERSION = "1" as const;
+
+/**
+ * Shape of content_hash values that rulesync writes for gh installs. Same
+ * format as the apm-mode hash so callers can reuse the integrity check
+ * conventions; under `--frozen` only values matching this regex are
+ * considered comparable.
+ */
+export const RULESYNC_CONTENT_HASH_REGEX = /^sha256:[0-9a-f]{64}$/;
+
+const ScopeSchema = z.enum(["project", "user"]);
+
+/**
+ * Single installation entry in `rulesync-gh.lock.yaml`. Each entry pins one
+ * skill from one source under one (agent, scope) pair — matching the gh CLI
+ * model where `gh skill install` deploys exactly one skill at a time.
+ */
+export const GhLockInstallationSchema = z.looseObject({
+  source: z.string(),
+  owner: z.string(),
+  repo: z.string(),
+  agent: z.string(),
+  scope: ScopeSchema,
+  skill: z.string(),
+  requested_ref: optional(z.string()),
+  resolved_ref: z.string(),
+  resolved_commit: z
+    .string()
+    .check(refine((v) => /^[0-9a-f]{40}$/.test(v), "resolved_commit must be a 40-char hex SHA")),
+  install_dir: z.string(),
+  deployed_files: z.array(z.string()),
+  content_hash: optional(z.string()),
+});
+export type GhLockInstallation = z.infer<typeof GhLockInstallationSchema>;
+
+export const GhLockSchema = z.looseObject({
+  lockfile_version: z.literal("1"),
+  generated_at: z.string(),
+  installations: z.array(GhLockInstallationSchema),
+});
+export type GhLock = z.infer<typeof GhLockSchema>;
+
+export function getGhLockPath(baseDir: string): string {
+  return join(baseDir, GH_LOCKFILE_FILE_NAME);
+}
+
+export async function ghLockExists(baseDir: string): Promise<boolean> {
+  return fileExists(getGhLockPath(baseDir));
+}
+
+/**
+ * Create an empty gh lockfile structure. When `existingLock` is provided,
+ * top-level looseObject extras are carried forward so unknown fields (added
+ * by future tools or other lockfile producers) round-trip cleanly.
+ */
+export function createEmptyGhLock(params?: { existingLock?: GhLock | null }): GhLock {
+  const base = params?.existingLock ? { ...params.existingLock } : {};
+  return {
+    ...base,
+    lockfile_version: GH_LOCKFILE_VERSION,
+    generated_at: new Date().toISOString(),
+    installations: [],
+  };
+}
+
+/**
+ * Parse `rulesync-gh.lock.yaml` content into a `GhLock`. Returns `null` for
+ * empty / non-YAML-object content so callers can treat the lockfile as
+ * missing. A *structurally* present lockfile that fails schema validation
+ * throws, rather than silently dropping previously pinned entries.
+ */
+export function parseGhLock(content: string): GhLock | null {
+  if (!content.trim()) {
+    return null;
+  }
+  let loaded: unknown;
+  try {
+    loaded = load(content);
+  } catch {
+    return null;
+  }
+  if (!loaded || typeof loaded !== "object") {
+    return null;
+  }
+  const parsed = GhLockSchema.safeParse(loaded);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `  - ${issue.path.join(".") || "<root>"}: ${issue.message}`)
+      .join("\n");
+    throw new Error(`Invalid ${GH_LOCKFILE_FILE_NAME}:\n${issues}`);
+  }
+  return parsed.data;
+}
+
+export async function readGhLock(baseDir: string): Promise<GhLock | null> {
+  const path = getGhLockPath(baseDir);
+  if (!(await fileExists(path))) {
+    return null;
+  }
+  const content = await readFileContent(path);
+  return parseGhLock(content);
+}
+
+export async function writeGhLock(params: { baseDir: string; lock: GhLock }): Promise<void> {
+  const path = getGhLockPath(params.baseDir);
+  const content = serializeGhLock(params.lock);
+  await writeFileContent(path, content);
+}
+
+export function serializeGhLock(lock: GhLock): string {
+  // `noRefs: true` avoids YAML anchors/aliases; `lineWidth: -1` keeps long
+  // URLs and sha values on a single line so the file stays diff-friendly.
+  return dump(lock, { noRefs: true, lineWidth: -1, sortKeys: false });
+}
+
+/**
+ * Find the locked installation for a given (source, agent, scope, skill)
+ * tuple. Source is matched case-insensitively because GitHub routes
+ * `owner/repo` paths case-insensitively.
+ */
+export function findGhLockInstallation(
+  lock: GhLock,
+  params: { source: string; agent: string; scope: "project" | "user"; skill: string },
+): GhLockInstallation | undefined {
+  const target = params.source.toLowerCase();
+  return lock.installations.find(
+    (i) =>
+      i.source.toLowerCase() === target &&
+      i.agent === params.agent &&
+      i.scope === params.scope &&
+      i.skill === params.skill,
+  );
+}

--- a/src/lib/gh/gh-paths.test.ts
+++ b/src/lib/gh/gh-paths.test.ts
@@ -1,0 +1,83 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import {
+  type GhAgent,
+  type GhScope,
+  relativeInstallDirFor,
+  resolveGhInstallDir,
+} from "./gh-paths.js";
+
+describe("relativeInstallDirFor", () => {
+  // Project scope: github-copilot + the four "shared layout" agents all
+  // collapse to .agents/skills; claude-code is the lone exception.
+  const PROJECT_CASES: Array<[GhAgent, string]> = [
+    ["github-copilot", join(".agents", "skills")],
+    ["claude-code", join(".claude", "skills")],
+    ["cursor", join(".agents", "skills")],
+    ["codex", join(".agents", "skills")],
+    ["gemini", join(".agents", "skills")],
+    ["antigravity", join(".agents", "skills")],
+  ];
+
+  it.each(PROJECT_CASES)("project scope: %s -> %s", (agent, expected) => {
+    expect(relativeInstallDirFor({ agent, scope: "project" })).toBe(expected);
+  });
+
+  // User scope: each agent fans out to its own per-tool dot-prefixed directory.
+  const USER_CASES: Array<[GhAgent, string]> = [
+    ["github-copilot", join(".copilot", "skills")],
+    ["claude-code", join(".claude", "skills")],
+    ["cursor", join(".cursor", "skills")],
+    ["codex", join(".codex", "skills")],
+    ["gemini", join(".gemini", "skills")],
+    ["antigravity", join(".gemini", "antigravity", "skills")],
+  ];
+
+  it.each(USER_CASES)("user scope: %s -> %s", (agent, expected) => {
+    expect(relativeInstallDirFor({ agent, scope: "user" })).toBe(expected);
+  });
+});
+
+describe("resolveGhInstallDir", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory({ home: true }));
+    originalHome = process.env.HOME_DIR;
+    process.env.HOME_DIR = testDir;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME_DIR;
+    } else {
+      process.env.HOME_DIR = originalHome;
+    }
+    await cleanup();
+  });
+
+  it("returns absolute path under baseDir for project scope", () => {
+    const baseDir = "/tmp/some-project";
+    expect(resolveGhInstallDir({ agent: "github-copilot", scope: "project", baseDir })).toBe(
+      join(baseDir, ".agents", "skills"),
+    );
+    expect(resolveGhInstallDir({ agent: "claude-code", scope: "project", baseDir })).toBe(
+      join(baseDir, ".claude", "skills"),
+    );
+  });
+
+  it("returns absolute path under HOME_DIR for user scope", () => {
+    const cases: Array<[GhAgent, GhScope, string]> = [
+      ["github-copilot", "user", join(testDir, ".copilot", "skills")],
+      ["antigravity", "user", join(testDir, ".gemini", "antigravity", "skills")],
+    ];
+    for (const [agent, scope, expected] of cases) {
+      expect(resolveGhInstallDir({ agent, scope, baseDir: "/ignored" })).toBe(expected);
+    }
+  });
+});

--- a/src/lib/gh/gh-paths.ts
+++ b/src/lib/gh/gh-paths.ts
@@ -1,0 +1,75 @@
+import { join } from "node:path";
+
+import { getHomeDirectory } from "../../utils/file.js";
+
+/**
+ * Agents recognized by `--mode gh`. Mirrors the agent list documented for
+ * `gh skill install`. The same skill content can be deployed under multiple
+ * agent-specific directories simultaneously, one entry per `(agent, scope)`
+ * pair in `rulesync.jsonc`.
+ */
+export const GH_AGENTS = [
+  "github-copilot",
+  "claude-code",
+  "cursor",
+  "codex",
+  "gemini",
+  "antigravity",
+] as const;
+export type GhAgent = (typeof GH_AGENTS)[number];
+
+export type GhScope = "project" | "user";
+
+/**
+ * Resolve the absolute install directory for a given agent + scope, matching
+ * the layout expected by `gh skill install`.
+ *
+ * Project scope writes inside `baseDir`. The `github-copilot` agent uses the
+ * shared `.agents/skills` directory (the host-agnostic project layout); other
+ * agents that share that location (cursor, codex, gemini, antigravity) write
+ * to `.agents/skills` for project scope and to their own `.<tool>/skills`
+ * directory for user scope. Claude Code is the exception: project and user
+ * scope both use `.claude/skills`, just rooted at `baseDir` vs the home
+ * directory respectively.
+ */
+export function resolveGhInstallDir(params: {
+  agent: GhAgent;
+  scope: GhScope;
+  baseDir: string;
+}): string {
+  const { agent, scope, baseDir } = params;
+  const home = scope === "user" ? getHomeDirectory() : baseDir;
+  const relative = relativeInstallDirFor({ agent, scope });
+  return join(home, relative);
+}
+
+/**
+ * Returns the install directory relative to its scope root (baseDir for
+ * project scope, home for user scope). Exposed separately so the lockfile can
+ * record the same canonical relative path it deploys to.
+ */
+export function relativeInstallDirFor(params: { agent: GhAgent; scope: GhScope }): string {
+  const { agent, scope } = params;
+  if (scope === "project") {
+    if (agent === "claude-code") {
+      return join(".claude", "skills");
+    }
+    // github-copilot and the rest share the shared project layout.
+    return join(".agents", "skills");
+  }
+  // user scope
+  switch (agent) {
+    case "github-copilot":
+      return join(".copilot", "skills");
+    case "claude-code":
+      return join(".claude", "skills");
+    case "cursor":
+      return join(".cursor", "skills");
+    case "codex":
+      return join(".codex", "skills");
+    case "gemini":
+      return join(".gemini", "skills");
+    case "antigravity":
+      return join(".gemini", "antigravity", "skills");
+  }
+}


### PR DESCRIPTION
## Summary

Implements `--mode gh` for `rulesync install`, completing the matrix started by `--mode apm` (#1526). In gh mode, sources from `rulesync.jsonc` are deployed to the agent-specific directories used by `gh skill install`, with provenance frontmatter (`source`/`repository`/`ref`) injected into each `SKILL.md` and a dedicated `rulesync-gh.lock.yaml` for reproducibility.

Refs https://github.com/dyoshikawa/rulesync/issues/1524

### Per-source extension

`SourceEntrySchema` gains two optional fields, both honored only in `--mode gh`:

| Field   | Default          | Values                                                                                |
| ------- | ---------------- | ------------------------------------------------------------------------------------- |
| `agent` | `github-copilot` | `github-copilot`, `claude-code`, `cursor`, `codex`, `gemini`, `antigravity`           |
| `scope` | `project`        | `project` (writes inside the project root) / `user` (writes inside `getHomeDirectory()`) |

`transport: "git"` and `path` are explicitly rejected in gh mode with field-named errors pointing at `--mode rulesync`.

### Install directories

Mirrors the `gh skill install` table from the GitHub CLI:

| Agent           | Project scope    | User scope                   |
| --------------- | ---------------- | ---------------------------- |
| github-copilot  | `.agents/skills` | `~/.copilot/skills`          |
| claude-code     | `.claude/skills` | `~/.claude/skills`           |
| cursor          | `.agents/skills` | `~/.cursor/skills`           |
| codex           | `.agents/skills` | `~/.codex/skills`            |
| gemini          | `.agents/skills` | `~/.gemini/skills`           |
| antigravity     | `.agents/skills` | `~/.gemini/antigravity/skills` |

### Resolution and lockfile semantics

- Discovers skills via `skills/<name>/SKILL.md`. Filters by `entry.skills[]` when set.
- Ref order: explicit `entry.ref` > latest release tag > default branch HEAD (matches `gh`).
- `rulesync-gh.lock.yaml` records one installation per `(source, agent, scope, skill)` tuple with `resolved_commit`, `resolved_ref`, `deployed_files`, and a `content_hash` for `--frozen` integrity checks.
- `--frozen` fails up-front when the lockfile is missing coverage for any declared source — no GitHub API call is made — and defers all writes until every source passes its checks (no partial writes on a single-source failure).
- `--update` re-resolves every ref and rewrites the lockfile.

### Frontmatter injection

`SKILL.md` files have `source` (`https://github.com/<owner>/<repo>`), `repository` (`<owner>/<repo>`), and `ref` (resolved tag or 40-char SHA) merged into existing frontmatter. Existing keys are preserved. Both LF and CRLF opening fences are handled.

## Out of scope (not regressions)

- Marketplace, multi-source-per-skill rewrites, or changes to the rulesync-mode lockfile.
- `--mode gh` does not shell out to `gh skill install` — it reimplements the install pathway on top of the existing GitHub client (per #1524 proposal).

## Test plan

- [x] `pnpm cicheck` — 5068/5068 vitest tests pass; lint, typecheck, sync-skill-docs check, cspell, and secretlint all clean.
- [x] Unit coverage for `gh-paths`, `gh-lock`, `gh-frontmatter`, `gh-install` (happy paths, ref order, `--frozen` pre-flight, `--update` re-resolution, `transport`/`path` rejection, frontmatter CRLF, stale-file cleanup).
- [x] Dedicated user-scope test file (`gh-install.user-scope.test.ts`) covering happy path, antigravity nested dir, malicious `..`-laden tree rejection, and stale-cleanup root scoping.
- [x] Integration test (`install-gh.integration.test.ts`) modeled on `install-apm.integration.test.ts`, exercising the full `installCommand({ mode: "gh" })` pipeline against a temp dir with a mocked GitHub client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
