### PR TITLE
fix: handle denied web tools in kiro permissions

### DIFF
--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -140,6 +140,41 @@ describe("E2E: permissions", () => {
     expect(content.toolsSettings.write.allowedPaths).toContain("docs/**");
     expect(content.allowedTools).toContain("web_fetch");
   });
+
+  it("should remove denied Kiro web tools from existing allowedTools", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            webfetch: { "*": "deny" },
+            websearch: { "*": "deny" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFileContent(
+      join(testDir, ".kiro", "agents", "default.json"),
+      JSON.stringify(
+        {
+          allowedTools: ["web_fetch", "web_search", "read"],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({ target: "kiro", features: "permissions" });
+
+    const content = JSON.parse(
+      await readFileContent(join(testDir, ".kiro", "agents", "default.json")),
+    );
+    expect(content.allowedTools).toEqual(["read"]);
+  });
 });
 
 describe("E2E: permissions (import)", () => {

--- a/src/features/permissions/kiro-permissions.test.ts
+++ b/src/features/permissions/kiro-permissions.test.ts
@@ -95,4 +95,35 @@ describe("KiroPermissions", () => {
     expect(loaded).toBeInstanceOf(KiroPermissions);
     expect(JSON.parse(loaded.getFileContent()).model).toBe("x");
   });
+
+  it("should remove web tools from allowedTools when denied", async () => {
+    const kiroDir = join(testDir, ".kiro", "agents");
+    await ensureDir(kiroDir);
+    await writeFileContent(
+      join(kiroDir, "default.json"),
+      JSON.stringify({
+        allowedTools: ["web_fetch", "web_search", "read"],
+      }),
+    );
+
+    const rulesyncPermissions = new RulesyncPermissions({
+      baseDir: testDir,
+      relativeDirPath: ".rulesync",
+      relativeFilePath: "permissions.json",
+      fileContent: JSON.stringify({
+        permission: {
+          webfetch: { "*": "deny" },
+          websearch: { "*": "deny" },
+        },
+      }),
+    });
+
+    const kiroPermissions = await KiroPermissions.fromRulesyncPermissions({
+      baseDir: testDir,
+      rulesyncPermissions,
+    });
+
+    const content = JSON.parse(kiroPermissions.getFileContent());
+    expect(content.allowedTools).toEqual(["read"]);
+  });
 });

--- a/src/features/permissions/kiro-permissions.ts
+++ b/src/features/permissions/kiro-permissions.ts
@@ -197,8 +197,12 @@ function buildKiroPermissionsFromRulesync({
           );
           continue;
         }
-        if (action === "allow")
-          nextAllowedTools.add(category === "webfetch" ? "web_fetch" : "web_search");
+        const toolName = category === "webfetch" ? "web_fetch" : "web_search";
+        if (action === "allow") {
+          nextAllowedTools.add(toolName);
+        } else {
+          nextAllowedTools.delete(toolName);
+        }
       } else {
         logger?.warn(`Kiro permissions do not support category: ${category}. Skipping.`);
       }


### PR DESCRIPTION
### Motivation
- Kiro agent configs previously only added `web_fetch`/`web_search` when Rulesync permissions used `"*": "allow"`, but did not remove those tools when `"*": "deny"`, causing regenerated `.kiro/agents/default.json` to retain denied web tool entries.

### Description
- Update `buildKiroPermissionsFromRulesync` in `src/features/permissions/kiro-permissions.ts` to remove `web_fetch`/`web_search` from `allowedTools` when the corresponding Rulesync permission is `deny` and keep existing `allow` behavior.
- Add a unit test `should remove web tools from allowedTools when denied` to `src/features/permissions/kiro-permissions.test.ts` that verifies an existing `default.json` loses `web_fetch`/`web_search` when Rulesync permissions deny them.
- Commit message: `fix: handle denied web tools in kiro permissions` and PR created to close the issue.

### Testing
- Ran the focused unit tests with `pnpm vitest run src/features/permissions/kiro-permissions.test.ts`, all tests passed (4 tests).
- Ran full repository checks with `pnpm cicheck`, which completed successfully including formatting, linting, typecheck and the full test suite (`190` test files, `5013` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78098114c833081812f4ad2549434)