### PR TITLE
chore: enable takt as a generation target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,11 @@ rulesync.local.jsonc
 **/.opencode/plugins/
 **/.opencode/memories/
 **/.opencode/package-lock.json
+**/.takt/facets/policies/
+**/.takt/facets/knowledge/
+**/.takt/facets/personas/
+**/.takt/facets/instructions/
+**/.takt/runs/
+**/.takt/tasks/
+**/.takt/.cache/
+**/.takt/config.yaml

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -28,6 +28,12 @@
       "subagents": true,
       "skills": true,
     },
+    "takt": {
+      "rules": true,
+      "commands": true,
+      "subagents": true,
+      "skills": true,
+    }
   },
 
   // Base directory or directories for generation.


### PR DESCRIPTION
## Summary
- Add `takt` to the targets in `rulesync.jsonc` so that rules, commands, subagents, and skills are generated for it.
- Extend `.gitignore` to ignore the generated `.takt/` artifacts (facets, runs, tasks, cache, and config) that should not be checked in.

## Test plan
- [x] `pnpm cicheck`