### PR TITLE
chore(oxfmt): format rulesync.jsonc and disable trailing commas for JSON/JSONC

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -21,7 +21,14 @@
     ".serena/project.yml",
     ".github/copilot-instructions.md",
     ".github/instructions/**",
-    "rulesync.jsonc",
     "rulesync.local.jsonc"
+  ],
+  "overrides": [
+    {
+      "files": ["**/*.json", "**/*.jsonc"],
+      "options": {
+        "trailingComma": "none"
+      }
+    }
   ]
 }

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -7,32 +7,32 @@
     "copilot": {
       "rules": {
         "ruleDiscoveryMode": "explicit",
-        "includeLocalRoot": false,
+        "includeLocalRoot": false
       },
       "commands": true,
       "mcp": false,
       "subagents": true,
-      "skills": true,
+      "skills": true
     },
     "claudecode": {
       "rules": true,
       "commands": true,
       "mcp": true,
       "subagents": true,
-      "skills": true,
+      "skills": true
     },
     "opencode": {
       "rules": true,
       "commands": true,
       "mcp": true,
       "subagents": true,
-      "skills": true,
+      "skills": true
     },
     "takt": {
       "rules": true,
       "commands": true,
       "subagents": true,
-      "skills": true,
+      "skills": true
     }
   },
 
@@ -50,5 +50,5 @@
 
   // When true (default), `rulesync gitignore` only emits entries for the
   // tools listed in `targets`.
-  "gitignoreTargetsOnly": true,
+  "gitignoreTargetsOnly": true
 }


### PR DESCRIPTION
## Summary
- Remove `rulesync.jsonc` from `ignorePatterns` in `.oxfmtrc.json` so it is covered by oxfmt
- Add an `overrides` entry targeting `**/*.json` and `**/*.jsonc` that sets `trailingComma` to `"none"`, since trailing commas are not valid JSON
- Apply the resulting formatting to `rulesync.jsonc` (trailing commas removed)

## Test plan
- [x] `pnpm cicheck` passes locally (fmt:check, oxlint, eslint, typecheck, tests, cspell, secretlint)
- [x] `pnpm exec oxfmt --check rulesync.jsonc` reports no format issues after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)