### PR TITLE
feat(mcp, api): add convert support to MCP and JS programmatic APIs

### DIFF
--- a/docs/api/programmatic-api.md
+++ b/docs/api/programmatic-api.md
@@ -20,12 +20,18 @@ const importResult = await importFromTool({
 console.log(`Imported ${importResult.rulesCount} rules`);
 
 // Convert configurations between AI tools without writing intermediate .rulesync/ files
-const convertResult = await convertFromTool({
-  from: "claudecode",
-  to: ["cursor", "copilot"],
-  features: ["rules"],
-});
-console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
+try {
+  const convertResult = await convertFromTool({
+    from: "claudecode",
+    to: ["cursor", "copilot"],
+    features: ["rules"],
+  });
+  console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
+} catch (error) {
+  // Thrown when `from` is empty, `to` is empty, `to` includes `from`,
+  // a source file cannot be parsed, or write fails.
+  console.error("convert failed:", error);
+}
 ```
 
 ## `generate(options?)`
@@ -65,13 +71,13 @@ Imports existing tool configurations into `.rulesync/` directory.
 
 Converts configuration files between AI tools without writing intermediate `.rulesync/` files to disk.
 
-| Option       | Type           | Default          | Description                                |
-| ------------ | -------------- | ---------------- | ------------------------------------------ |
-| `from`       | `ToolTarget`   | (required)       | Source tool to convert configurations from |
-| `to`         | `ToolTarget[]` | (required)       | Destination tools to convert to            |
-| `features`   | `Feature[]`    | from config file | Features to convert                        |
-| `configPath` | `string`       | auto-detected    | Path to `rulesync.jsonc`                   |
-| `verbose`    | `boolean`      | `false`          | Enable verbose logging                     |
-| `silent`     | `boolean`      | `true`           | Suppress all output                        |
-| `global`     | `boolean`      | `false`          | Convert global (user scope) configurations |
-| `dryRun`     | `boolean`      | `false`          | Show changes without writing files         |
+| Option       | Type           | Default       | Description                                                                                 |
+| ------------ | -------------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `from`       | `ToolTarget`   | (required)    | Source tool to convert configurations from                                                  |
+| `to`         | `ToolTarget[]` | (required)    | Destination tools to convert to                                                             |
+| `features`   | `Feature[]`    | `["*"]`       | Features to convert. Matches CLI behavior and overrides any `features` in `rulesync.jsonc`. |
+| `configPath` | `string`       | auto-detected | Path to `rulesync.jsonc`                                                                    |
+| `verbose`    | `boolean`      | `false`       | Enable verbose logging                                                                      |
+| `silent`     | `boolean`      | `true`        | Suppress all output                                                                         |
+| `global`     | `boolean`      | `false`       | Convert global (user scope) configurations                                                  |
+| `dryRun`     | `boolean`      | `false`       | Show changes without writing files                                                          |

--- a/docs/api/programmatic-api.md
+++ b/docs/api/programmatic-api.md
@@ -1,9 +1,9 @@
 # Programmatic API
 
-Rulesync can be used as a library in your Node.js/TypeScript projects. The `generate` and `importFromTool` functions are available as named exports.
+Rulesync can be used as a library in your Node.js/TypeScript projects. The `generate`, `importFromTool`, and `convertFromTool` functions are available as named exports.
 
 ```typescript
-import { generate, importFromTool } from "rulesync";
+import { convertFromTool, generate, importFromTool } from "rulesync";
 
 // Generate configurations
 const result = await generate({
@@ -18,6 +18,14 @@ const importResult = await importFromTool({
   features: ["rules", "commands"],
 });
 console.log(`Imported ${importResult.rulesCount} rules`);
+
+// Convert configurations between AI tools without writing intermediate .rulesync/ files
+const convertResult = await convertFromTool({
+  from: "claudecode",
+  to: ["cursor", "copilot"],
+  features: ["rules"],
+});
+console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
 ```
 
 ## `generate(options?)`
@@ -52,3 +60,18 @@ Imports existing tool configurations into `.rulesync/` directory.
 | `verbose`    | `boolean`    | `false`          | Enable verbose logging                    |
 | `silent`     | `boolean`    | `true`           | Suppress all output                       |
 | `global`     | `boolean`    | `false`          | Import global (user scope) configurations |
+
+## `convertFromTool(options)`
+
+Converts configuration files between AI tools without writing intermediate `.rulesync/` files to disk.
+
+| Option       | Type           | Default          | Description                                |
+| ------------ | -------------- | ---------------- | ------------------------------------------ |
+| `from`       | `ToolTarget`   | (required)       | Source tool to convert configurations from |
+| `to`         | `ToolTarget[]` | (required)       | Destination tools to convert to            |
+| `features`   | `Feature[]`    | from config file | Features to convert                        |
+| `configPath` | `string`       | auto-detected    | Path to `rulesync.jsonc`                   |
+| `verbose`    | `boolean`      | `false`          | Enable verbose logging                     |
+| `silent`     | `boolean`      | `true`           | Suppress all output                        |
+| `global`     | `boolean`      | `false`          | Convert global (user scope) configurations |
+| `dryRun`     | `boolean`      | `false`          | Show changes without writing files         |

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -17,6 +17,18 @@ The single `rulesyncTool` multiplexes by `feature` and `operation`:
 
 The `permissions` feature operates on `.rulesync/permissions.json` and the `hooks` feature operates on `.rulesync/hooks.json`. Both accept a `content` string (valid JSON) on `put`.
 
+### `convert` / `run` options
+
+When invoking `feature: "convert"` with `operation: "run"`, pass `convertOptions` with the following shape:
+
+| Option     | Type       | Required | Description                                                                        |
+| ---------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
+| `from`     | `string`   | Yes      | Source tool name (e.g. `"claudecode"`). Must be a valid `ToolTarget`.              |
+| `to`       | `string[]` | Yes      | One or more destination tool names. Must not be empty and must not include `from`. |
+| `features` | `string[]` | No       | Features to convert (e.g. `["rules", "commands"]`). Defaults to `["*"]`.           |
+| `global`   | `boolean`  | No       | Convert global (user-scope) configurations. Defaults to `false`.                   |
+| `dryRun`   | `boolean`  | No       | Preview changes without writing files. Defaults to `false`.                        |
+
 ## Usage
 
 ### Starting the MCP Server

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -13,6 +13,7 @@ The single `rulesyncTool` multiplexes by `feature` and `operation`:
 - `ignore`, `mcp`, `permissions`, `hooks`: `get`, `put`, `delete`
 - `generate`: `run`
 - `import`: `run`
+- `convert`: `run`
 
 The `permissions` feature operates on `.rulesync/permissions.json` and the `hooks` feature operates on `.rulesync/hooks.json`. Both accept a `content` string (valid JSON) on `put`.
 

--- a/skills/rulesync/mcp-server.md
+++ b/skills/rulesync/mcp-server.md
@@ -17,6 +17,18 @@ The single `rulesyncTool` multiplexes by `feature` and `operation`:
 
 The `permissions` feature operates on `.rulesync/permissions.json` and the `hooks` feature operates on `.rulesync/hooks.json`. Both accept a `content` string (valid JSON) on `put`.
 
+### `convert` / `run` options
+
+When invoking `feature: "convert"` with `operation: "run"`, pass `convertOptions` with the following shape:
+
+| Option     | Type       | Required | Description                                                                        |
+| ---------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
+| `from`     | `string`   | Yes      | Source tool name (e.g. `"claudecode"`). Must be a valid `ToolTarget`.              |
+| `to`       | `string[]` | Yes      | One or more destination tool names. Must not be empty and must not include `from`. |
+| `features` | `string[]` | No       | Features to convert (e.g. `["rules", "commands"]`). Defaults to `["*"]`.           |
+| `global`   | `boolean`  | No       | Convert global (user-scope) configurations. Defaults to `false`.                   |
+| `dryRun`   | `boolean`  | No       | Preview changes without writing files. Defaults to `false`.                        |
+
 ## Usage
 
 ### Starting the MCP Server

--- a/skills/rulesync/mcp-server.md
+++ b/skills/rulesync/mcp-server.md
@@ -13,6 +13,7 @@ The single `rulesyncTool` multiplexes by `feature` and `operation`:
 - `ignore`, `mcp`, `permissions`, `hooks`: `get`, `put`, `delete`
 - `generate`: `run`
 - `import`: `run`
+- `convert`: `run`
 
 The `permissions` feature operates on `.rulesync/permissions.json` and the `hooks` feature operates on `.rulesync/hooks.json`. Both accept a `content` string (valid JSON) on `put`.
 

--- a/skills/rulesync/programmatic-api.md
+++ b/skills/rulesync/programmatic-api.md
@@ -20,12 +20,18 @@ const importResult = await importFromTool({
 console.log(`Imported ${importResult.rulesCount} rules`);
 
 // Convert configurations between AI tools without writing intermediate .rulesync/ files
-const convertResult = await convertFromTool({
-  from: "claudecode",
-  to: ["cursor", "copilot"],
-  features: ["rules"],
-});
-console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
+try {
+  const convertResult = await convertFromTool({
+    from: "claudecode",
+    to: ["cursor", "copilot"],
+    features: ["rules"],
+  });
+  console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
+} catch (error) {
+  // Thrown when `from` is empty, `to` is empty, `to` includes `from`,
+  // a source file cannot be parsed, or write fails.
+  console.error("convert failed:", error);
+}
 ```
 
 ## `generate(options?)`
@@ -65,13 +71,13 @@ Imports existing tool configurations into `.rulesync/` directory.
 
 Converts configuration files between AI tools without writing intermediate `.rulesync/` files to disk.
 
-| Option       | Type           | Default          | Description                                |
-| ------------ | -------------- | ---------------- | ------------------------------------------ |
-| `from`       | `ToolTarget`   | (required)       | Source tool to convert configurations from |
-| `to`         | `ToolTarget[]` | (required)       | Destination tools to convert to            |
-| `features`   | `Feature[]`    | from config file | Features to convert                        |
-| `configPath` | `string`       | auto-detected    | Path to `rulesync.jsonc`                   |
-| `verbose`    | `boolean`      | `false`          | Enable verbose logging                     |
-| `silent`     | `boolean`      | `true`           | Suppress all output                        |
-| `global`     | `boolean`      | `false`          | Convert global (user scope) configurations |
-| `dryRun`     | `boolean`      | `false`          | Show changes without writing files         |
+| Option       | Type           | Default       | Description                                                                                 |
+| ------------ | -------------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `from`       | `ToolTarget`   | (required)    | Source tool to convert configurations from                                                  |
+| `to`         | `ToolTarget[]` | (required)    | Destination tools to convert to                                                             |
+| `features`   | `Feature[]`    | `["*"]`       | Features to convert. Matches CLI behavior and overrides any `features` in `rulesync.jsonc`. |
+| `configPath` | `string`       | auto-detected | Path to `rulesync.jsonc`                                                                    |
+| `verbose`    | `boolean`      | `false`       | Enable verbose logging                                                                      |
+| `silent`     | `boolean`      | `true`        | Suppress all output                                                                         |
+| `global`     | `boolean`      | `false`       | Convert global (user scope) configurations                                                  |
+| `dryRun`     | `boolean`      | `false`       | Show changes without writing files                                                          |

--- a/skills/rulesync/programmatic-api.md
+++ b/skills/rulesync/programmatic-api.md
@@ -1,9 +1,9 @@
 # Programmatic API
 
-Rulesync can be used as a library in your Node.js/TypeScript projects. The `generate` and `importFromTool` functions are available as named exports.
+Rulesync can be used as a library in your Node.js/TypeScript projects. The `generate`, `importFromTool`, and `convertFromTool` functions are available as named exports.
 
 ```typescript
-import { generate, importFromTool } from "rulesync";
+import { convertFromTool, generate, importFromTool } from "rulesync";
 
 // Generate configurations
 const result = await generate({
@@ -18,6 +18,14 @@ const importResult = await importFromTool({
   features: ["rules", "commands"],
 });
 console.log(`Imported ${importResult.rulesCount} rules`);
+
+// Convert configurations between AI tools without writing intermediate .rulesync/ files
+const convertResult = await convertFromTool({
+  from: "claudecode",
+  to: ["cursor", "copilot"],
+  features: ["rules"],
+});
+console.log(`Converted ${convertResult.rulesCount} rule file(s)`);
 ```
 
 ## `generate(options?)`
@@ -52,3 +60,18 @@ Imports existing tool configurations into `.rulesync/` directory.
 | `verbose`    | `boolean`    | `false`          | Enable verbose logging                    |
 | `silent`     | `boolean`    | `true`           | Suppress all output                       |
 | `global`     | `boolean`    | `false`          | Import global (user scope) configurations |
+
+## `convertFromTool(options)`
+
+Converts configuration files between AI tools without writing intermediate `.rulesync/` files to disk.
+
+| Option       | Type           | Default          | Description                                |
+| ------------ | -------------- | ---------------- | ------------------------------------------ |
+| `from`       | `ToolTarget`   | (required)       | Source tool to convert configurations from |
+| `to`         | `ToolTarget[]` | (required)       | Destination tools to convert to            |
+| `features`   | `Feature[]`    | from config file | Features to convert                        |
+| `configPath` | `string`       | auto-detected    | Path to `rulesync.jsonc`                   |
+| `verbose`    | `boolean`      | `false`          | Enable verbose logging                     |
+| `silent`     | `boolean`      | `true`           | Suppress all output                        |
+| `global`     | `boolean`      | `false`          | Convert global (user scope) configurations |
+| `dryRun`     | `boolean`      | `false`          | Show changes without writing files         |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -183,8 +183,34 @@ describe("importFromTool", () => {
 });
 
 describe("convertFromTool", () => {
+  it("should throw when from is empty", async () => {
+    await expect(
+      convertFromTool({ from: "" as unknown as "claudecode", to: ["cursor"] }),
+    ).rejects.toThrow("from is required");
+  });
+
   it("should throw when to is empty", async () => {
     await expect(convertFromTool({ from: "claudecode", to: [] })).rejects.toThrow("to is required");
+  });
+
+  it("should throw when to includes from (self-conversion)", async () => {
+    await expect(
+      convertFromTool({ from: "claudecode", to: ["cursor", "claudecode"] }),
+    ).rejects.toThrow("Destination tools must not include the source tool 'claudecode'");
+  });
+
+  it("should deduplicate to array before forwarding to core convertFromTool", async () => {
+    await convertFromTool({
+      from: "claudecode",
+      to: ["cursor", "cursor", "copilot", "cursor"],
+    });
+
+    expect(coreConvertFromTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromTool: "claudecode",
+        toTools: ["cursor", "copilot"],
+      }),
+    );
   });
 
   it("should default silent to true", async () => {
@@ -199,6 +225,16 @@ describe("convertFromTool", () => {
     expect(ConfigResolver.resolve).toHaveBeenCalledWith(
       expect.objectContaining({
         targets: ["claudecode"],
+      }),
+    );
+  });
+
+  it("should default features to ['*'] when not provided (matches CLI behavior)", async () => {
+    await convertFromTool({ from: "claudecode", to: ["cursor"] });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        features: ["*"],
       }),
     );
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConfigResolver } from "./config/config-resolver.js";
 import type { Config } from "./config/config.js";
-import { generate, importFromTool } from "./index.js";
+import { convertFromTool, generate, importFromTool } from "./index.js";
+import type { ConvertResult } from "./lib/convert.js";
+import { convertFromTool as coreConvertFromTool } from "./lib/convert.js";
 import type { GenerateResult } from "./lib/generate.js";
 import { checkRulesyncDirExists, generate as coreGenerate } from "./lib/generate.js";
 import type { ImportResult } from "./lib/import.js";
@@ -12,6 +14,7 @@ import { ConsoleLogger } from "./utils/logger.js";
 vi.mock("./config/config-resolver.js");
 vi.mock("./lib/generate.js");
 vi.mock("./lib/import.js");
+vi.mock("./lib/convert.js");
 vi.mock("./utils/logger.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./utils/logger.js")>();
   const MockConsoleLogger = vi.fn().mockImplementation(function () {
@@ -66,11 +69,23 @@ const mockImportResult: ImportResult = {
   permissionsCount: 0,
 };
 
+const mockConvertResult: ConvertResult = {
+  rulesCount: 1,
+  ignoreCount: 0,
+  mcpCount: 0,
+  commandsCount: 0,
+  subagentsCount: 0,
+  skillsCount: 0,
+  hooksCount: 0,
+  permissionsCount: 0,
+};
+
 beforeEach(() => {
   vi.mocked(ConfigResolver.resolve).mockResolvedValue(mockConfig as never);
   vi.mocked(checkRulesyncDirExists).mockResolvedValue(true);
   vi.mocked(coreGenerate).mockResolvedValue(mockGenerateResult);
   vi.mocked(coreImportFromTool).mockResolvedValue(mockImportResult);
+  vi.mocked(coreConvertFromTool).mockResolvedValue(mockConvertResult);
 });
 
 afterEach(() => {
@@ -162,6 +177,65 @@ describe("importFromTool", () => {
         features: ["rules", "commands"],
         verbose: true,
         silent: false,
+      }),
+    );
+  });
+});
+
+describe("convertFromTool", () => {
+  it("should throw when to is empty", async () => {
+    await expect(convertFromTool({ from: "claudecode", to: [] })).rejects.toThrow("to is required");
+  });
+
+  it("should default silent to true", async () => {
+    await convertFromTool({ from: "claudecode", to: ["cursor"] });
+
+    expect(ConsoleLogger).toHaveBeenCalledWith({ verbose: false, silent: true });
+  });
+
+  it("should pass from as a single-element targets array to ConfigResolver", async () => {
+    await convertFromTool({ from: "claudecode", to: ["cursor"] });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["claudecode"],
+      }),
+    );
+  });
+
+  it("should call core convertFromTool with correct arguments and return result", async () => {
+    const result = await convertFromTool({
+      from: "claudecode",
+      to: ["cursor", "copilot"],
+    });
+
+    expect(coreConvertFromTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: mockConfig,
+        fromTool: "claudecode",
+        toTools: ["cursor", "copilot"],
+      }),
+    );
+    expect(result).toEqual(mockConvertResult);
+  });
+
+  it("should pass features and other options through", async () => {
+    await convertFromTool({
+      from: "claudecode",
+      to: ["cursor"],
+      features: ["rules", "commands"],
+      verbose: true,
+      silent: false,
+      dryRun: true,
+    });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targets: ["claudecode"],
+        features: ["rules", "commands"],
+        verbose: true,
+        silent: false,
+        dryRun: true,
       }),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,19 +86,41 @@ export async function importFromTool(options: ImportOptions): Promise<ImportResu
 export async function convertFromTool(options: ConvertOptions): Promise<ConvertResult> {
   const { from, to, features, silent = true, verbose = false, ...rest } = options;
 
+  if (!from) {
+    throw new Error("from is required. Please specify a source tool to convert from.");
+  }
+
   if (!to || to.length === 0) {
     throw new Error("to is required and must not be empty. Please specify destination tools.");
   }
 
+  const toTools = Array.from(new Set(to));
+
+  if (toTools.includes(from)) {
+    throw new Error(
+      `Destination tools must not include the source tool '${from}'. ` +
+        `Converting a tool onto itself is likely a mistake and may cause lossy round-trips.`,
+    );
+  }
+
   const logger = new ConsoleLogger({ verbose, silent });
 
+  // NOTE: The CLI and MCP wrappers pass `[from, ...to]` as `targets` so that
+  // per-target feature overrides in `rulesync.jsonc` apply to destinations too.
+  // The JS API intentionally passes only `[from]` here because the public
+  // contract for `convertFromTool` (issue #1557) prescribes this shape:
+  // programmatic callers are expected to supply `features` explicitly when
+  // they need fine-grained control, rather than relying on config-file
+  // per-target maps. Defaulting `features` to `["*"]` below matches the CLI's
+  // "attempt every feature both tools support" behavior so callers who omit
+  // `features` get the same effective coverage as the CLI.
   const config = await ConfigResolver.resolve({
     ...rest,
     targets: [from],
-    features,
+    features: features ?? ["*"],
     verbose,
     silent,
   });
 
-  return coreConvertFromTool({ config, fromTool: from, toTools: to, logger });
+  return coreConvertFromTool({ config, fromTool: from, toTools, logger });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { ConfigResolver } from "./config/config-resolver.js";
+import { convertFromTool as coreConvertFromTool, type ConvertResult } from "./lib/convert.js";
 import {
   checkRulesyncDirExists,
   generate as coreGenerate,
@@ -15,6 +16,7 @@ export { ALL_FEATURES } from "./types/features.js";
 export { ALL_TOOL_TARGETS } from "./types/tool-targets.js";
 export type { GenerateResult } from "./lib/generate.js";
 export type { ImportResult } from "./lib/import.js";
+export type { ConvertResult } from "./lib/convert.js";
 
 type BaseOptions = {
   configPath?: string;
@@ -38,6 +40,13 @@ export type GenerateOptions = BaseOptions & {
 export type ImportOptions = BaseOptions & {
   target: ToolTarget;
   features?: Feature[];
+};
+
+export type ConvertOptions = BaseOptions & {
+  from: ToolTarget;
+  to: ToolTarget[];
+  features?: Feature[];
+  dryRun?: boolean;
 };
 
 export async function generate(options: GenerateOptions = {}): Promise<GenerateResult> {
@@ -72,4 +81,24 @@ export async function importFromTool(options: ImportOptions): Promise<ImportResu
   });
 
   return coreImportFromTool({ config, tool: target, logger });
+}
+
+export async function convertFromTool(options: ConvertOptions): Promise<ConvertResult> {
+  const { from, to, features, silent = true, verbose = false, ...rest } = options;
+
+  if (!to || to.length === 0) {
+    throw new Error("to is required and must not be empty. Please specify destination tools.");
+  }
+
+  const logger = new ConsoleLogger({ verbose, silent });
+
+  const config = await ConfigResolver.resolve({
+    ...rest,
+    targets: [from],
+    features,
+    verbose,
+    silent,
+  });
+
+  return coreConvertFromTool({ config, fromTool: from, toTools: to, logger });
 }

--- a/src/mcp/convert.test.ts
+++ b/src/mcp/convert.test.ts
@@ -1,0 +1,207 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { writeFileContent } from "../utils/file.js";
+import { convertTools, executeConvert, type McpConvertResult } from "./convert.js";
+
+describe("MCP Convert Tools", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("executeConvert", () => {
+    it("should return error when from is not provided", async () => {
+      const result = await executeConvert({ from: "", to: ["cursor"] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("from is required");
+    });
+
+    it("should return error when to is empty", async () => {
+      const result = await executeConvert({ from: "claudecode", to: [] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("to is required");
+    });
+
+    it("should return error when from is an invalid tool name", async () => {
+      const result = await executeConvert({ from: "not-a-tool", to: ["cursor"] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid source tool");
+    });
+
+    it("should return error when to contains an invalid tool name", async () => {
+      const result = await executeConvert({ from: "claudecode", to: ["not-a-tool"] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid destination tool");
+    });
+
+    it("should return error when to includes the same tool as from", async () => {
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["claudecode"],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("must not include the source tool");
+    });
+
+    it("should succeed with valid from and to", async () => {
+      // Create CLAUDE.md file to convert from
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+This is a test rule file.
+`,
+      );
+
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toBeDefined();
+      expect(result.config?.from).toBe("claudecode");
+      expect(result.config?.to).toEqual(["cursor"]);
+    });
+
+    it("should return counts in result", async () => {
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+Body.
+`,
+      );
+
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toMatchObject({
+        rulesCount: expect.any(Number),
+        ignoreCount: expect.any(Number),
+        mcpCount: expect.any(Number),
+        commandsCount: expect.any(Number),
+        subagentsCount: expect.any(Number),
+        skillsCount: expect.any(Number),
+        hooksCount: expect.any(Number),
+        permissionsCount: expect.any(Number),
+        totalCount: expect.any(Number),
+      });
+    });
+
+    it("should return config in result", async () => {
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+Body.
+`,
+      );
+
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.config).toMatchObject({
+        from: "claudecode",
+        to: ["cursor"],
+        features: expect.any(Array),
+        global: expect.any(Boolean),
+        dryRun: expect.any(Boolean),
+      });
+    });
+
+    it("should honor dryRun option", async () => {
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+Body.
+`,
+      );
+
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+        dryRun: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.config?.dryRun).toBe(true);
+    });
+
+    it("should deduplicate to when duplicates are provided", async () => {
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+Body.
+`,
+      );
+
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor", "cursor"],
+        features: ["rules"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.config?.to).toEqual(["cursor"]);
+    });
+
+    it("should format result as JSON string via convertTools.executeConvert.execute", async () => {
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+Body.
+`,
+      );
+
+      const jsonResult = await convertTools.executeConvert.execute({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+      });
+
+      const parsed: McpConvertResult = JSON.parse(jsonResult);
+      expect(parsed.success).toBe(true);
+    });
+
+    it("should succeed with 0 counts when no source files exist", async () => {
+      const result = await executeConvert({
+        from: "claudecode",
+        to: ["cursor"],
+        features: ["rules"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result?.totalCount).toBe(0);
+    });
+  });
+});

--- a/src/mcp/convert.ts
+++ b/src/mcp/convert.ts
@@ -1,0 +1,167 @@
+import { z } from "zod/mini";
+
+import { ConfigResolver } from "../config/config-resolver.js";
+import { Config } from "../config/config.js";
+import { convertFromTool, type ConvertResult } from "../lib/convert.js";
+import { type RulesyncFeatures } from "../types/features.js";
+import { ALL_TOOL_TARGETS, type ToolTarget, ToolTargetSchema } from "../types/tool-targets.js";
+import { formatError } from "../utils/error.js";
+import { ConsoleLogger } from "../utils/logger.js";
+import { calculateTotalCount } from "../utils/result.js";
+import { type McpResultCounts } from "./types.js";
+
+/**
+ * Schema for convert options
+ * Excluded parameters:
+ * - baseDirs: Always use [process.cwd()] in MCP context
+ * - verbose: Meaningless in MCP (no console output)
+ * - silent: Meaningless in MCP
+ * - configPath: Always use default path from process.cwd()
+ */
+export const convertOptionsSchema = z.object({
+  from: z.string(),
+  to: z.array(z.string()),
+  features: z.optional(z.array(z.string())),
+  global: z.optional(z.boolean()),
+  dryRun: z.optional(z.boolean()),
+});
+
+export type ConvertOptions = z.infer<typeof convertOptionsSchema>;
+
+export type McpConvertResult = {
+  success: boolean;
+  result?: McpResultCounts;
+  config?: {
+    from: string;
+    to: string[];
+    features: string[];
+    global: boolean;
+    dryRun: boolean;
+  };
+  error?: string;
+};
+
+function parseToolTarget(value: string, label: string): ToolTarget {
+  const result = ToolTargetSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(
+      `Invalid ${label} tool '${value}'. Must be one of: ${ALL_TOOL_TARGETS.join(", ")}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Execute the rulesync convert command via MCP
+ * Configuration priority: MCP Parameters > rulesync.local.jsonc > rulesync.jsonc > Default values
+ */
+export async function executeConvert(options: ConvertOptions): Promise<McpConvertResult> {
+  try {
+    // Validate from
+    if (!options.from) {
+      return {
+        success: false,
+        error: "from is required. Please specify a source tool to convert from.",
+      };
+    }
+
+    // Validate to
+    if (!options.to || options.to.length === 0) {
+      return {
+        success: false,
+        error: "to is required and must not be empty. Please specify destination tools.",
+      };
+    }
+
+    const fromTool = parseToolTarget(options.from, "source");
+    const toToolsRaw = options.to.map((t) => parseToolTarget(t, "destination"));
+    const toTools = Array.from(new Set(toToolsRaw));
+
+    if (toTools.includes(fromTool)) {
+      return {
+        success: false,
+        error:
+          `Destination tools must not include the source tool '${fromTool}'. ` +
+          `Converting a tool onto itself is likely a mistake and may cause lossy round-trips.`,
+      };
+    }
+
+    // Resolve config with MCP parameters taking precedence
+    // ConfigResolver handles: CLI options > rulesync.local.jsonc > rulesync.jsonc > defaults
+    // In MCP context, options act as CLI options (highest priority)
+    // Pass both source and destinations as `targets` so per-target feature maps
+    // in `rulesync.jsonc` are honored for every tool involved. Default features
+    // to `*` so every feature that both tools support is attempted.
+    const config = await ConfigResolver.resolve({
+      targets: [fromTool, ...toTools],
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      features: (options.features ?? ["*"]) as RulesyncFeatures,
+      global: options.global,
+      dryRun: options.dryRun,
+      // Always use default baseDirs (process.cwd()) and configPath
+      // verbose and silent are meaningless in MCP context
+      verbose: false,
+      silent: true,
+    });
+
+    const logger = new ConsoleLogger({ verbose: false, silent: true });
+    const convertResult = await convertFromTool({ config, fromTool, toTools, logger });
+
+    return buildSuccessResponse({ convertResult, config, fromTool, toTools });
+  } catch (error) {
+    return {
+      success: false,
+      error: formatError(error),
+    };
+  }
+}
+
+function buildSuccessResponse(params: {
+  convertResult: ConvertResult;
+  config: Config;
+  fromTool: ToolTarget;
+  toTools: ToolTarget[];
+}): McpConvertResult {
+  const { convertResult, config, fromTool, toTools } = params;
+
+  const totalCount = calculateTotalCount(convertResult);
+
+  return {
+    success: true,
+    result: {
+      rulesCount: convertResult.rulesCount,
+      ignoreCount: convertResult.ignoreCount,
+      mcpCount: convertResult.mcpCount,
+      commandsCount: convertResult.commandsCount,
+      subagentsCount: convertResult.subagentsCount,
+      skillsCount: convertResult.skillsCount,
+      hooksCount: convertResult.hooksCount,
+      permissionsCount: convertResult.permissionsCount,
+      totalCount,
+    },
+    config: {
+      from: fromTool,
+      to: toTools,
+      features: config.getFeatures(),
+      global: config.getGlobal(),
+      dryRun: config.isPreviewMode(),
+    },
+  };
+}
+
+export const convertToolSchemas = {
+  executeConvert: convertOptionsSchema,
+};
+
+export const convertTools = {
+  executeConvert: {
+    name: "executeConvert",
+    description:
+      "Execute the rulesync convert command to convert configuration files between AI tools without writing intermediate .rulesync/ files. Requires a source tool (from) and one or more destination tools (to).",
+    parameters: convertToolSchemas.executeConvert,
+    execute: async (options: ConvertOptions): Promise<string> => {
+      const result = await executeConvert(options);
+      return JSON.stringify(result, null, 2);
+    },
+  },
+};

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -609,6 +609,105 @@ This is a test rule file.
     });
   });
 
+  describe("convert feature", () => {
+    it("should execute convert with run operation", async () => {
+      // Create CLAUDE.md file to convert from
+      await writeFileContent(
+        join(testDir, "CLAUDE.md"),
+        `# Claude Code Rules
+
+This is a test rule file.
+`,
+      );
+
+      const result = await rulesyncTool.execute({
+        feature: "convert",
+        operation: "run",
+        convertOptions: {
+          from: "claudecode",
+          to: ["cursor"],
+          features: ["rules"],
+        },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed.result).toBeDefined();
+      expect(parsed.config).toBeDefined();
+      expect(parsed.config.from).toBe("claudecode");
+      expect(parsed.config.to).toEqual(["cursor"]);
+    });
+
+    it("should return error when convertOptions is not provided", async () => {
+      await expect(
+        rulesyncTool.execute({
+          feature: "convert",
+          operation: "run",
+        }),
+      ).rejects.toThrow("convertOptions is required for convert feature");
+    });
+
+    it("should return error when from is empty", async () => {
+      const result = await rulesyncTool.execute({
+        feature: "convert",
+        operation: "run",
+        convertOptions: {
+          from: "",
+          to: ["cursor"],
+        },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("from is required");
+    });
+
+    it("should return error when to is empty", async () => {
+      const result = await rulesyncTool.execute({
+        feature: "convert",
+        operation: "run",
+        convertOptions: {
+          from: "claudecode",
+          to: [],
+        },
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("to is required");
+    });
+
+    it("should reject unsupported operations for convert feature", async () => {
+      await expect(
+        rulesyncTool.execute({
+          feature: "convert",
+          operation: "list",
+        }),
+      ).rejects.toThrow(/supported operations/i);
+
+      await expect(
+        rulesyncTool.execute({
+          feature: "convert",
+          operation: "get",
+        }),
+      ).rejects.toThrow(/supported operations/i);
+
+      await expect(
+        rulesyncTool.execute({
+          feature: "convert",
+          operation: "put",
+        }),
+      ).rejects.toThrow(/supported operations/i);
+
+      await expect(
+        rulesyncTool.execute({
+          feature: "convert",
+          operation: "delete",
+        }),
+      ).rejects.toThrow(/supported operations/i);
+    });
+  });
+
   describe("generate feature", () => {
     it("should execute generate with run operation", async () => {
       const rulesyncDir = join(testDir, ".rulesync");

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -17,6 +17,7 @@ import {
   RulesyncSubagentFrontmatterSchema,
 } from "../features/subagents/rulesync-subagent.js";
 import { commandTools } from "./commands.js";
+import { convertOptionsSchema, convertTools } from "./convert.js";
 import { generateOptionsSchema, generateTools } from "./generate.js";
 import { hooksTools } from "./hooks.js";
 import { ignoreTools } from "./ignore.js";
@@ -38,6 +39,7 @@ const rulesyncFeatureSchema = z.enum([
   "hooks",
   "generate",
   "import",
+  "convert",
 ]);
 
 const rulesyncOperationSchema = z.enum(["list", "get", "put", "delete", "run"]);
@@ -57,6 +59,7 @@ const rulesyncToolSchema = z.object({
   content: z.optional(z.string()),
   generateOptions: z.optional(generateOptionsSchema),
   importOptions: z.optional(importOptionsSchema),
+  convertOptions: z.optional(convertOptionsSchema),
 });
 
 type RulesyncFeature = z.infer<typeof rulesyncFeatureSchema>;
@@ -64,7 +67,7 @@ type RulesyncOperation = z.infer<typeof rulesyncOperationSchema>;
 type RulesyncToolArgs = z.infer<typeof rulesyncToolSchema>;
 type RulesyncFrontmatterFeature = Exclude<
   RulesyncFeature,
-  "ignore" | "mcp" | "permissions" | "hooks" | "generate" | "import"
+  "ignore" | "mcp" | "permissions" | "hooks" | "generate" | "import" | "convert"
 >;
 type RulesyncFrontmatterByFeature = {
   rule: RulesyncRuleFrontmatter;
@@ -84,6 +87,7 @@ const supportedOperationsByFeature: Record<RulesyncFeature, RulesyncOperation[]>
   hooks: ["get", "put", "delete"],
   generate: ["run"],
   import: ["run"],
+  convert: ["run"],
 };
 
 function assertSupported({
@@ -181,7 +185,7 @@ function ensureBody({ body, feature, operation }: RulesyncToolArgs): string {
 export const rulesyncTool = {
   name: "rulesyncTool",
   description:
-    "Manage Rulesync files through a single MCP tool. Features: rule/command/subagent/skill support list/get/put/delete; ignore/mcp/permissions/hooks support get/put/delete only; generate supports run only; import supports run only. Parameters: list requires no targetPathFromCwd (lists all items); get/delete require targetPathFromCwd; put requires targetPathFromCwd, frontmatter, and body (or content for ignore/mcp/permissions/hooks); generate/run uses generateOptions to configure generation; import/run uses importOptions to configure import.",
+    "Manage Rulesync files through a single MCP tool. Features: rule/command/subagent/skill support list/get/put/delete; ignore/mcp/permissions/hooks support get/put/delete only; generate supports run only; import supports run only; convert supports run only. Parameters: list requires no targetPathFromCwd (lists all items); get/delete require targetPathFromCwd; put requires targetPathFromCwd, frontmatter, and body (or content for ignore/mcp/permissions/hooks); generate/run uses generateOptions to configure generation; import/run uses importOptions to configure import; convert/run uses convertOptions to configure conversion.",
   parameters: rulesyncToolSchema,
   execute: async (args: RulesyncToolArgs) => {
     const parsed = rulesyncToolSchema.parse(args);
@@ -358,6 +362,13 @@ export const rulesyncTool = {
           throw new Error("importOptions is required for import feature");
         }
         return importTools.executeImport.execute(parsed.importOptions);
+      }
+      case "convert": {
+        // Only "run" operation is supported for convert feature
+        if (!parsed.convertOptions) {
+          throw new Error("convertOptions is required for convert feature");
+        }
+        return convertTools.executeConvert.execute(parsed.convertOptions);
       }
       default: {
         throw new Error(`Unknown feature: ${parsed.feature}`);


### PR DESCRIPTION
## Summary

Expose the `rulesync convert` command through both the MCP programmatic API and the public JavaScript API, giving programmatic consumers feature parity with the CLI.

- Add `src/mcp/convert.ts` with `convertOptionsSchema` and `executeConvert`, mirroring the existing `generate`/`import` MCP tools
- Wire the `convert` feature into the `src/mcp/tools.ts` dispatcher (added to feature enum, supported-operations map, input schema, and switch case)
- Add `convertFromTool` public wrapper to `src/index.ts` with `ConvertOptions` and `ConvertResult` type exports
- Validate inputs in the JS API (non-empty `from`, non-empty `to`, reject self-conversion, dedup `to`) with error messages matching CLI/MCP verbatim
- Default `features` to `["*"]` to match CLI behavior (documented explicitly in the JS API and MCP reference docs)
- Add unit tests for both MCP and JS API wrappers, including validation paths
- Update `docs/api/programmatic-api.md` (with try/catch example and `features` default note) and `docs/reference/mcp-server.md` (with `convertOptions` shape table); synced `skills/rulesync/` copies

Closes #1556
Closes #1557

## Test plan

- [x] `pnpm cicheck` passes (fmt, oxlint, eslint, typecheck, vitest, cspell, secretlint, skill-docs sync)
- [x] `src/mcp/convert.test.ts` covers validation (missing `from` / empty `to`), happy path, `dryRun`, deduplication, and JSON output
- [x] `src/index.test.ts` covers `convertFromTool`: empty `to`, empty `from`, self-conversion rejection, `to` dedup, `silent` default, `features` default of `["*"]`, and forwarding to the core `convertFromTool`
- [x] MCP dispatcher test coverage added in `src/mcp/tools.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)