### PR TITLE
fix: drop root frontmatter when building CopilotRule

### DIFF
--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -304,15 +304,15 @@ describe("CopilotRule", () => {
         rulesyncRule: original,
       });
 
-      // Root Copilot file must have no applyTo when the rulesync rule had no globs.
-      expect(copilotRule.getFrontmatter().applyTo).toBeUndefined();
+      // Root Copilot file must have no frontmatter.
+      expect(copilotRule.getFrontmatter()).toEqual({});
 
       const reimported = copilotRule.toRulesyncRule();
       const rf = reimported.getFrontmatter();
 
       expect(rf.root).toBe(true);
       expect(rf.globs).toBeUndefined();
-      expect(rf.description).toBe("Project overview");
+      expect(rf.description).toBeUndefined();
       expect(reimported.getBody()).toBe("Overview content");
     });
 
@@ -407,10 +407,7 @@ describe("CopilotRule", () => {
         validate: true,
       });
 
-      expect(copilotRule.getFrontmatter()).toEqual({
-        description: "Root rule from rulesync",
-        applyTo: "**/*",
-      });
+      expect(copilotRule.getFrontmatter()).toEqual({});
       expect(copilotRule.getBody()).toBe("Root rulesync rule content");
       expect(copilotRule.getRelativeDirPath()).toBe(".github");
       expect(copilotRule.getRelativeFilePath()).toBe("copilot-instructions.md");
@@ -494,7 +491,7 @@ describe("CopilotRule", () => {
         validate: true,
       });
 
-      expect(copilotRule.getFrontmatter().excludeAgent).toBe("coding-agent");
+      expect(copilotRule.getFrontmatter()).toEqual({});
     });
 
     it("should use default baseDir when not provided", () => {

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -171,7 +171,7 @@ export class CopilotRule extends ToolRule {
       // Root file: .github/copilot-instructions.md (no frontmatter for root file)
       return new CopilotRule({
         baseDir: baseDir,
-        frontmatter: copilotFrontmatter,
+        frontmatter: {},
         body,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,


### PR DESCRIPTION
### Motivation
- Ensure root Copilot files do not carry frontmatter in-memory to match the comment and serialized format and to avoid injecting globs/description during generate→import roundtrips. 
- This aligns behavior with the intent documented in code and prevents idempotency issues described in https://github.com/dyoshikawa/rulesync/issues/1545.

### Description
- Stop passing the computed `copilotFrontmatter` for root rules in `CopilotRule.fromRulesyncRule()` and explicitly pass `frontmatter: {}` for root conversions. 
- Keep non-root conversions unchanged and continue to populate `copilotFrontmatter` for non-root files. 
- Update unit tests in `src/features/rules/copilot-rule.test.ts` to assert root conversions return an empty frontmatter and no longer preserve `description`, `globs`, or `copilot.excludeAgent` via the root conversion path. 
- Minor test adjustments to reflect the new expected shapes for root rule roundtrips.

### Testing
- Ran the focused test file with `pnpm vitest run src/features/rules/copilot-rule.test.ts` and it passed (60/60 tests). 
- Ran full CI checks with `pnpm cicheck`, which includes formatting, linting, typecheck and the full test suite, and all automated checks passed (`5260` tests passed, no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb56f666848330b2dc011a3951fbb5)