### PR TITLE
chore(security): add cooldown for supply chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 1
+      default-days: 7
     open-pull-requests-limit: 2
     groups:
       all-dependencies:
@@ -38,7 +38,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 1
+      default-days: 7
     open-pull-requests-limit: 1
     groups:
       all-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 7
+      default-days: 1
     open-pull-requests-limit: 2
     groups:
       all-dependencies:
@@ -38,7 +38,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 7
+      default-days: 1
     open-pull-requests-limit: 1
     groups:
       all-actions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,1 @@
-minimumReleaseAge: 10080
+minimumReleaseAge: 10080 # 7 days

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,1 @@
-minimumReleaseAge: 10080 # 7 days
+minimumReleaseAge: 1440 # 1 day


### PR DESCRIPTION
## Summary

Adds 7-day cooldown to mitigate supply chain attacks (Trivy/LiteLLM/axios in March 2026).

- `pnpm-workspace.yaml`: `minimumReleaseAge: 10080` (7 days, in minutes)
- `.github/dependabot.yml`: `cooldown.default-days` 1 → 7 (npm + github-actions)

## Refs

- Article: https://zenn.dev/dely_jp/articles/supply-chain-kowai
- pnpm setting: https://pnpm.io/settings#minimumreleaseage (requires pnpm 10.16+, this repo uses 10.33.2)
- Supply chain guide: https://pnpm.io/supply-chain-security