### PR TITLE
refactor(output-root): rename baseDir to outputRoot for naming symmetry with inputRoot

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -13,7 +13,7 @@ paths:
 - TypeScript file names should be in kebab-case, even for class implementation files.
 - Don't create ballel files. Please always direct import the implementation file.
   - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.
-- The default value of `baseDir` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `baseDir`.
+- The default value of `outputRoot` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `outputRoot`.
 - When logging errors, you must use `formatError` function in `src/utils/error.ts` to format the error message.
 - When writing any filesystem path, you must always use `join` function in `node:path` to join the path because it must support both Windows and Unix-like paths.
 - When writing non-filesystem paths (e.g., API paths, gitignore entries, generated file content), use `path.posix.join` or `toPosixPath` from `src/utils/file.ts` to ensure forward slashes regardless of platform.

--- a/.github/instructions/coding-guidelines.instructions.md
+++ b/.github/instructions/coding-guidelines.instructions.md
@@ -13,7 +13,7 @@ applyTo: '**/*.ts'
 - TypeScript file names should be in kebab-case, even for class implementation files.
 - Don't create ballel files. Please always direct import the implementation file.
   - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.
-- The default value of `baseDir` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `baseDir`.
+- The default value of `outputRoot` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `outputRoot`.
 - When logging errors, you must use `formatError` function in `src/utils/error.ts` to format the error message.
 - When writing any filesystem path, you must always use `join` function in `node:path` to join the path because it must support both Windows and Unix-like paths.
 - When writing non-filesystem paths (e.g., API paths, gitignore entries, generated file content), use `path.posix.join` or `toPosixPath` from `src/utils/file.ts` to ensure forward slashes regardless of platform.

--- a/.github/instructions/testing-guidelines.instructions.md
+++ b/.github/instructions/testing-guidelines.instructions.md
@@ -27,7 +27,7 @@ applyTo: '**/*.test.ts,src/e2e/**/*.spec.ts'
       it("Test Case", async () => {
         // Run test using testDir
         await RulesyncRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test.md",
         });
         // ...

--- a/.opencode/memories/coding-guidelines.md
+++ b/.opencode/memories/coding-guidelines.md
@@ -9,7 +9,7 @@
 - TypeScript file names should be in kebab-case, even for class implementation files.
 - Don't create ballel files. Please always direct import the implementation file.
   - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.
-- The default value of `baseDir` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `baseDir`.
+- The default value of `outputRoot` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `outputRoot`.
 - When logging errors, you must use `formatError` function in `src/utils/error.ts` to format the error message.
 - When writing any filesystem path, you must always use `join` function in `node:path` to join the path because it must support both Windows and Unix-like paths.
 - When writing non-filesystem paths (e.g., API paths, gitignore entries, generated file content), use `path.posix.join` or `toPosixPath` from `src/utils/file.ts` to ensure forward slashes regardless of platform.

--- a/.rulesync/rules/coding-guidelines.md
+++ b/.rulesync/rules/coding-guidelines.md
@@ -16,7 +16,7 @@ globs: ["**/*.ts"]
 - TypeScript file names should be in kebab-case, even for class implementation files.
 - Don't create ballel files. Please always direct import the implementation file.
   - The maintainer thinks that ballel files are harmful to tree-shaking and import path transparency.
-- The default value of `baseDir` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `baseDir`.
+- The default value of `outputRoot` should be `process.cwd()` because it is easier to mock in tests compared to hardcoding `"."`. However, the default value of `relativeDirPath` should be `"."` because it should be relative path to concatenate with `outputRoot`.
 - When logging errors, you must use `formatError` function in `src/utils/error.ts` to format the error message.
 - When writing any filesystem path, you must always use `join` function in `node:path` to join the path because it must support both Windows and Unix-like paths.
 - When writing non-filesystem paths (e.g., API paths, gitignore entries, generated file content), use `path.posix.join` or `toPosixPath` from `src/utils/file.ts` to ensure forward slashes regardless of platform.

--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -30,7 +30,7 @@ globs: ["**/*.test.ts", "src/e2e/**/*.spec.ts"]
       it("Test Case", async () => {
         // Run test using testDir
         await RulesyncRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test.md",
         });
         // ...

--- a/docs/api/programmatic-api.md
+++ b/docs/api/programmatic-api.md
@@ -38,22 +38,23 @@ try {
 
 Generates configuration files for the specified targets and features.
 
-| Option              | Type           | Default           | Description                                                                                                                                                                 |
-| ------------------- | -------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `targets`           | `ToolTarget[]` | from config file  | Tools to generate configurations for                                                                                                                                        |
-| `features`          | `Feature[]`    | from config file  | Features to generate                                                                                                                                                        |
-| `baseDirs`          | `string[]`     | `[process.cwd()]` | Base directories for generation                                                                                                                                             |
-| `inputRoot`         | `string`       | `process.cwd()`   | Directory containing the `.rulesync/` source files. Output still goes to each `baseDirs` entry; only the input source root is redirected. Mirrors the CLI's `--input-root`. |
-| `configPath`        | `string`       | auto-detected     | Path to `rulesync.jsonc`                                                                                                                                                    |
-| `verbose`           | `boolean`      | `false`           | Enable verbose logging                                                                                                                                                      |
-| `silent`            | `boolean`      | `true`            | Suppress all output                                                                                                                                                         |
-| `delete`            | `boolean`      | from config file  | Delete existing files before generating                                                                                                                                     |
-| `global`            | `boolean`      | `false`           | Generate global (user scope) configurations                                                                                                                                 |
-| `simulateCommands`  | `boolean`      | `false`           | Generate simulated commands                                                                                                                                                 |
-| `simulateSubagents` | `boolean`      | `false`           | Generate simulated subagents                                                                                                                                                |
-| `simulateSkills`    | `boolean`      | `false`           | Generate simulated skills                                                                                                                                                   |
-| `dryRun`            | `boolean`      | `false`           | Show changes without writing files                                                                                                                                          |
-| `check`             | `boolean`      | `false`           | Exit with code 1 if files are not up to date                                                                                                                                |
+| Option              | Type           | Default           | Description                                                                                                                                                                    |
+| ------------------- | -------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `targets`           | `ToolTarget[]` | from config file  | Tools to generate configurations for                                                                                                                                           |
+| `features`          | `Feature[]`    | from config file  | Features to generate                                                                                                                                                           |
+| `outputRoots`       | `string[]`     | `[process.cwd()]` | Output root directories to generate files into                                                                                                                                 |
+| `baseDirs`          | `string[]`     | —                 | **Deprecated** alias of `outputRoots`. Still accepted for backward compatibility; emits a one-shot deprecation warning. Will be removed in a future major release.             |
+| `inputRoot`         | `string`       | `process.cwd()`   | Directory containing the `.rulesync/` source files. Output still goes to each `outputRoots` entry; only the input source root is redirected. Mirrors the CLI's `--input-root`. |
+| `configPath`        | `string`       | auto-detected     | Path to `rulesync.jsonc`                                                                                                                                                       |
+| `verbose`           | `boolean`      | `false`           | Enable verbose logging                                                                                                                                                         |
+| `silent`            | `boolean`      | `true`            | Suppress all output                                                                                                                                                            |
+| `delete`            | `boolean`      | from config file  | Delete existing files before generating                                                                                                                                        |
+| `global`            | `boolean`      | `false`           | Generate global (user scope) configurations                                                                                                                                    |
+| `simulateCommands`  | `boolean`      | `false`           | Generate simulated commands                                                                                                                                                    |
+| `simulateSubagents` | `boolean`      | `false`           | Generate simulated subagents                                                                                                                                                   |
+| `simulateSkills`    | `boolean`      | `false`           | Generate simulated skills                                                                                                                                                      |
+| `dryRun`            | `boolean`      | `false`           | Show changes without writing files                                                                                                                                             |
+| `check`             | `boolean`      | `false`           | Exit with code 1 if files are not up to date                                                                                                                                   |
 
 ## `importFromTool(options)`
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -36,10 +36,13 @@ Example:
   //   "cursor": ["rules", "mcp"],
   // },
 
-  // Base directories for generation.
-  // Basically, you can specify a `["."]` only.
-  // However, for example, if your project is a monorepo and you have to launch the AI agent at each package directory, you can specify multiple base directories.
-  "baseDirs": ["."],
+  // Output root directories to generate files into.
+  // Basically, you can specify `["."]` only.
+  // However, for example, if your project is a monorepo and you have to launch the AI agent at each package directory, you can specify multiple output roots.
+  //
+  // The legacy field name `baseDirs` is still accepted as a deprecated alias
+  // and will be removed in a future major release. Migrate to `outputRoots`.
+  "outputRoots": ["."],
 
   // Delete existing files before generating
   "delete": true,

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -36,8 +36,8 @@
     }
   },
 
-  // Base directory or directories for generation.
-  "baseDirs": ["."],
+  // Output root directory or directories for generation.
+  "outputRoots": ["."],
 
   // Delete existing files before generating
   "delete": true,

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -36,10 +36,13 @@ Example:
   //   "cursor": ["rules", "mcp"],
   // },
 
-  // Base directories for generation.
-  // Basically, you can specify a `["."]` only.
-  // However, for example, if your project is a monorepo and you have to launch the AI agent at each package directory, you can specify multiple base directories.
-  "baseDirs": ["."],
+  // Output root directories to generate files into.
+  // Basically, you can specify `["."]` only.
+  // However, for example, if your project is a monorepo and you have to launch the AI agent at each package directory, you can specify multiple output roots.
+  //
+  // The legacy field name `baseDirs` is still accepted as a deprecated alias
+  // and will be removed in a future major release. Migrate to `outputRoots`.
+  "outputRoots": ["."],
 
   // Delete existing files before generating
   "delete": true,

--- a/skills/rulesync/programmatic-api.md
+++ b/skills/rulesync/programmatic-api.md
@@ -38,22 +38,23 @@ try {
 
 Generates configuration files for the specified targets and features.
 
-| Option              | Type           | Default           | Description                                                                                                                                                                 |
-| ------------------- | -------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `targets`           | `ToolTarget[]` | from config file  | Tools to generate configurations for                                                                                                                                        |
-| `features`          | `Feature[]`    | from config file  | Features to generate                                                                                                                                                        |
-| `baseDirs`          | `string[]`     | `[process.cwd()]` | Base directories for generation                                                                                                                                             |
-| `inputRoot`         | `string`       | `process.cwd()`   | Directory containing the `.rulesync/` source files. Output still goes to each `baseDirs` entry; only the input source root is redirected. Mirrors the CLI's `--input-root`. |
-| `configPath`        | `string`       | auto-detected     | Path to `rulesync.jsonc`                                                                                                                                                    |
-| `verbose`           | `boolean`      | `false`           | Enable verbose logging                                                                                                                                                      |
-| `silent`            | `boolean`      | `true`            | Suppress all output                                                                                                                                                         |
-| `delete`            | `boolean`      | from config file  | Delete existing files before generating                                                                                                                                     |
-| `global`            | `boolean`      | `false`           | Generate global (user scope) configurations                                                                                                                                 |
-| `simulateCommands`  | `boolean`      | `false`           | Generate simulated commands                                                                                                                                                 |
-| `simulateSubagents` | `boolean`      | `false`           | Generate simulated subagents                                                                                                                                                |
-| `simulateSkills`    | `boolean`      | `false`           | Generate simulated skills                                                                                                                                                   |
-| `dryRun`            | `boolean`      | `false`           | Show changes without writing files                                                                                                                                          |
-| `check`             | `boolean`      | `false`           | Exit with code 1 if files are not up to date                                                                                                                                |
+| Option              | Type           | Default           | Description                                                                                                                                                                    |
+| ------------------- | -------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `targets`           | `ToolTarget[]` | from config file  | Tools to generate configurations for                                                                                                                                           |
+| `features`          | `Feature[]`    | from config file  | Features to generate                                                                                                                                                           |
+| `outputRoots`       | `string[]`     | `[process.cwd()]` | Output root directories to generate files into                                                                                                                                 |
+| `baseDirs`          | `string[]`     | —                 | **Deprecated** alias of `outputRoots`. Still accepted for backward compatibility; emits a one-shot deprecation warning. Will be removed in a future major release.             |
+| `inputRoot`         | `string`       | `process.cwd()`   | Directory containing the `.rulesync/` source files. Output still goes to each `outputRoots` entry; only the input source root is redirected. Mirrors the CLI's `--input-root`. |
+| `configPath`        | `string`       | auto-detected     | Path to `rulesync.jsonc`                                                                                                                                                       |
+| `verbose`           | `boolean`      | `false`           | Enable verbose logging                                                                                                                                                         |
+| `silent`            | `boolean`      | `true`            | Suppress all output                                                                                                                                                            |
+| `delete`            | `boolean`      | from config file  | Delete existing files before generating                                                                                                                                        |
+| `global`            | `boolean`      | `false`           | Generate global (user scope) configurations                                                                                                                                    |
+| `simulateCommands`  | `boolean`      | `false`           | Generate simulated commands                                                                                                                                                    |
+| `simulateSubagents` | `boolean`      | `false`           | Generate simulated subagents                                                                                                                                                   |
+| `simulateSkills`    | `boolean`      | `false`           | Generate simulated skills                                                                                                                                                      |
+| `dryRun`            | `boolean`      | `false`           | Show changes without writing files                                                                                                                                             |
+| `check`             | `boolean`      | `false`           | Exit with code 1 if files are not up to date                                                                                                                                   |
 
 ## `importFromTool(options)`
 

--- a/src/cli/commands/convert.test.ts
+++ b/src/cli/commands/convert.test.ts
@@ -20,7 +20,7 @@ describe("convertCommand", () => {
   let mockConfig: {
     getVerbose: ReturnType<typeof vi.fn>;
     getSilent: ReturnType<typeof vi.fn>;
-    getBaseDirs: ReturnType<typeof vi.fn>;
+    getOutputRoots: ReturnType<typeof vi.fn>;
     getFeatures: ReturnType<typeof vi.fn>;
     getFeatureOptions: ReturnType<typeof vi.fn>;
     getGlobal: ReturnType<typeof vi.fn>;
@@ -33,7 +33,7 @@ describe("convertCommand", () => {
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
       getSilent: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getFeatures: vi.fn().mockReturnValue(["rules"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
       getGlobal: vi.fn().mockReturnValue(false),

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -8,7 +8,7 @@ import { calculateTotalCount } from "../../utils/result.js";
 
 export type ConvertOptions = Omit<
   ConfigResolverResolveParams,
-  "delete" | "baseDirs" | "targets"
+  "delete" | "outputRoots" | "targets"
 > & {
   from?: string;
   to?: string[];

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -237,6 +237,26 @@ describe("generateCommand", () => {
         expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
+
+    it("should fall back to deprecated baseDir when outputRoots is an empty array", async () => {
+      // A programmatic caller passing `outputRoots: []` together with a
+      // populated `baseDir` must not silently lose the alias's values to
+      // the empty array. The empty array is treated as "not provided" so
+      // the deprecated alias still flows through to the resolver.
+      const options: GenerateOptions = { baseDir: ["a", "b"], outputRoots: [] };
+
+      await generateCommand(mockLogger, options);
+
+      expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ outputRoots: ["a", "b"] }),
+        { logger: mockLogger },
+      );
+      // The override warning must NOT fire here because the empty array is
+      // treated as "not provided" — there is nothing to disagree about.
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
+      );
+    });
   });
 
   describe("rulesync directory check", () => {
@@ -747,13 +767,13 @@ describe("generateCommand", () => {
       );
     });
 
-    it("should log base directories", async () => {
+    it("should log output roots", async () => {
       mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2"]);
       const options: GenerateOptions = {};
 
       await generateCommand(mockLogger, options);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith("Base directories: dir1, dir2");
+      expect(mockLogger.debug).toHaveBeenCalledWith("Output roots: dir1, dir2");
     });
 
     it("should log success for each processor type", async () => {

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -44,7 +44,7 @@ describe("generateCommand", () => {
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
       getSilent: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getTargets: vi.fn().mockReturnValue(["claudecode"]),
       getFeatures: vi.fn().mockReturnValue(["rules", "ignore", "mcp", "commands", "subagents"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
@@ -152,79 +152,89 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating files...");
     });
 
-    it("should map --base-dir (singular) to baseDirs on the resolver call", async () => {
+    it("should map deprecated --base-dir (singular) to outputRoots on the resolver call", async () => {
       const options: GenerateOptions = { baseDir: ["a", "b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(ConfigResolver.resolve).toHaveBeenCalledWith(
-        expect.objectContaining({ baseDirs: ["a", "b"] }),
+        expect.objectContaining({ outputRoots: ["a", "b"] }),
         { logger: mockLogger },
       );
     });
 
-    it("should prefer baseDirs over baseDir when both are provided", async () => {
-      const options: GenerateOptions = { baseDir: ["a"], baseDirs: ["b"] };
+    it("should warn that --base-dir is deprecated whenever it is supplied", async () => {
+      const options: GenerateOptions = { baseDir: ["a"] };
+
+      await generateCommand(mockLogger, options);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("--base-dir is deprecated"),
+      );
+    });
+
+    it("should prefer outputRoots over deprecated baseDir when both are provided", async () => {
+      const options: GenerateOptions = { baseDir: ["a"], outputRoots: ["b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(ConfigResolver.resolve).toHaveBeenCalledWith(
-        expect.objectContaining({ baseDirs: ["b"] }),
+        expect.objectContaining({ outputRoots: ["b"] }),
         { logger: mockLogger },
       );
     });
 
-    it("should warn when baseDir and baseDirs disagree on non-empty values", async () => {
-      const options: GenerateOptions = { baseDir: ["a"], baseDirs: ["b"] };
+    it("should warn when --base-dir and --output-roots disagree on non-empty values", async () => {
+      const options: GenerateOptions = { baseDir: ["a"], outputRoots: ["b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Both 'baseDirs' and 'baseDir'"),
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
 
-    it("should not warn when baseDir and baseDirs match exactly", async () => {
-      const options: GenerateOptions = { baseDir: ["a", "b"], baseDirs: ["a", "b"] };
+    it("should not warn about override when --base-dir and --output-roots match exactly", async () => {
+      const options: GenerateOptions = { baseDir: ["a", "b"], outputRoots: ["a", "b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("Both 'baseDirs' and 'baseDir'"),
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
 
-    it("should not warn when baseDir and baseDirs match as a set (different order)", async () => {
-      // Order is irrelevant — `baseDirs: ["a","b"]` and `baseDir: ["b","a"]`
+    it("should not warn about override when --base-dir and --output-roots match as a set (different order)", async () => {
+      // Order is irrelevant — `outputRoots: ["a","b"]` and `baseDir: ["b","a"]`
       // describe the same set of output roots, so no override is happening.
-      const options: GenerateOptions = { baseDir: ["b", "a"], baseDirs: ["a", "b"] };
+      const options: GenerateOptions = { baseDir: ["b", "a"], outputRoots: ["a", "b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("Both 'baseDirs' and 'baseDir'"),
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
 
-    it("should warn when baseDir and baseDirs differ as sets", async () => {
+    it("should warn about override when --base-dir and --output-roots differ as sets", async () => {
       // Different sets — `["a"]` vs `["a","b"]` — must trigger the override
       // warning even though one is a subset of the other.
-      const options: GenerateOptions = { baseDir: ["a"], baseDirs: ["a", "b"] };
+      const options: GenerateOptions = { baseDir: ["a"], outputRoots: ["a", "b"] };
 
       await generateCommand(mockLogger, options);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Both 'baseDirs' and 'baseDir'"),
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
 
-    it("should not warn when only baseDir is provided", async () => {
+    it("should not warn about override when only deprecated baseDir is provided", async () => {
       const options: GenerateOptions = { baseDir: ["a"] };
 
       await generateCommand(mockLogger, options);
 
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("Both 'baseDirs' and 'baseDir'"),
+        expect.stringContaining("Both '--output-roots' and '--base-dir'"),
       );
     });
   });
@@ -265,7 +275,7 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating rule files...");
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           global: false,
           toolTarget: "claudecode",
           simulateCommands: false,
@@ -286,7 +296,7 @@ describe("generateCommand", () => {
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           global: false,
           toolTarget: "claudecode",
           simulateCommands: true,
@@ -323,14 +333,14 @@ describe("generateCommand", () => {
     });
 
     it("should process multiple base directories", async () => {
-      mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2"]);
+      mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2"]);
       const options: GenerateOptions = {};
 
       await generateCommand(mockLogger, options);
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "dir1",
+          outputRoot: "dir1",
           global: false,
           toolTarget: "claudecode",
           simulateCommands: false,
@@ -342,7 +352,7 @@ describe("generateCommand", () => {
       );
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "dir2",
+          outputRoot: "dir2",
           global: false,
           toolTarget: "claudecode",
           simulateCommands: false,
@@ -377,7 +387,7 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating MCP files...");
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -445,7 +455,7 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating command files...");
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -478,7 +488,7 @@ describe("generateCommand", () => {
   describe("ignore feature", () => {
     beforeEach(() => {
       mockConfig.getFeatures.mockReturnValue(["ignore"]);
-      mockConfig.getBaseDirs.mockReturnValue(["."]);
+      mockConfig.getOutputRoots.mockReturnValue(["."]);
     });
 
     it("should generate ignore files when ignore feature is enabled", async () => {
@@ -489,27 +499,27 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating ignore files...");
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           dryRun: false,
         }),
       );
     });
 
-    it("should pass baseDir verbatim even when it equals current working directory", async () => {
-      // The legacy `baseDir === process.cwd() ? "." : baseDir` heuristic was
+    it("should pass outputRoot verbatim even when it equals current working directory", async () => {
+      // The legacy `outputRoot === process.cwd() ? "." : outputRoot` heuristic was
       // removed to keep ignore processing consistent with every other
       // feature processor — IgnoreProcessor now receives the same absolute
       // path the other processors receive.
       const mockCwd = vi.spyOn(process, "cwd").mockReturnValue("/current/working/dir");
-      mockConfig.getBaseDirs.mockReturnValue(["/current/working/dir"]);
+      mockConfig.getOutputRoots.mockReturnValue(["/current/working/dir"]);
       const options: GenerateOptions = {};
 
       await generateCommand(mockLogger, options);
 
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/current/working/dir",
+          outputRoot: "/current/working/dir",
           toolTarget: "claudecode",
           dryRun: false,
         }),
@@ -555,7 +565,7 @@ describe("generateCommand", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Generating subagent files...");
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -599,7 +609,7 @@ describe("generateCommand", () => {
 
         expect(SubagentsProcessor).toHaveBeenCalledWith(
           expect.objectContaining({
-            baseDir: ".",
+            outputRoot: ".",
             toolTarget: "claudecode",
             global: true,
             dryRun: false,
@@ -621,7 +631,7 @@ describe("generateCommand", () => {
         );
         expect(SubagentsProcessor).toHaveBeenCalledWith(
           expect.objectContaining({
-            baseDir: ".",
+            outputRoot: ".",
             toolTarget: "claudecode",
             global: true,
             dryRun: false,
@@ -645,7 +655,7 @@ describe("generateCommand", () => {
         expect(SubagentsProcessor).toHaveBeenCalledTimes(1);
         expect(SubagentsProcessor).toHaveBeenCalledWith(
           expect.objectContaining({
-            baseDir: ".",
+            outputRoot: ".",
             toolTarget: "claudecode",
             global: true,
             dryRun: false,
@@ -738,7 +748,7 @@ describe("generateCommand", () => {
     });
 
     it("should log base directories", async () => {
-      mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2"]);
+      mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2"]);
       const options: GenerateOptions = {};
 
       await generateCommand(mockLogger, options);
@@ -868,8 +878,8 @@ describe("generateCommand", () => {
       mockConfig.getFeatures.mockReturnValue(["rules", "mcp", "commands", "ignore", "subagents"]);
     });
 
-    it("should check .rulesync directory from process.cwd() not from baseDirs in global mode", async () => {
-      mockConfig.getBaseDirs.mockReturnValue(["/home/user"]);
+    it("should check .rulesync directory from process.cwd() not from outputRoots in global mode", async () => {
+      mockConfig.getOutputRoots.mockReturnValue(["/home/user"]);
       mockConfig.getFeatures.mockReturnValue(["rules"]);
       vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
@@ -877,7 +887,7 @@ describe("generateCommand", () => {
 
       await generateCommand(mockLogger, options);
 
-      // Should check .rulesync in process.cwd(), not in baseDirs[0] (which is /home/user in global mode)
+      // Should check .rulesync in process.cwd(), not in outputRoots[0] (which is /home/user in global mode)
       expect(fileExists).toHaveBeenCalledWith("/test/project/.rulesync");
     });
 
@@ -904,7 +914,7 @@ describe("generateCommand", () => {
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
           simulateCommands: true,
@@ -942,9 +952,9 @@ describe("generateCommand", () => {
       expect(customMockInstance.removeOrphanAiFiles).toHaveBeenCalled();
     });
 
-    it("should use each baseDir in global mode", async () => {
+    it("should use each outputRoot in global mode", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2", "dir3"]);
+      mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2", "dir3"]);
       vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["claudecode", "codexcli"]);
       vi.mocked(intersection).mockReturnValue(["claudecode"]);
       const options: GenerateOptions = {};
@@ -953,7 +963,7 @@ describe("generateCommand", () => {
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "dir1",
+          outputRoot: "dir1",
           toolTarget: "claudecode",
           global: true,
           simulateCommands: false,
@@ -965,7 +975,7 @@ describe("generateCommand", () => {
       );
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "dir2",
+          outputRoot: "dir2",
           toolTarget: "claudecode",
           global: true,
           simulateCommands: false,
@@ -977,7 +987,7 @@ describe("generateCommand", () => {
       );
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "dir3",
+          outputRoot: "dir3",
           toolTarget: "claudecode",
           global: true,
           simulateCommands: false,
@@ -987,7 +997,7 @@ describe("generateCommand", () => {
           dryRun: false,
         }),
       );
-      expect(RulesProcessor).toHaveBeenCalledTimes(3); // Once for each baseDir
+      expect(RulesProcessor).toHaveBeenCalledTimes(3); // Once for each outputRoot
     });
 
     it("should skip MCP generation in global mode when no targets match", async () => {
@@ -1009,7 +1019,7 @@ describe("generateCommand", () => {
 
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
           dryRun: false,
@@ -1039,7 +1049,7 @@ describe("generateCommand", () => {
 
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
           dryRun: false,
@@ -1140,16 +1150,16 @@ describe("generateCommand", () => {
   });
 
   describe("inputRoot decoupling", () => {
-    // Rules source dir (where .rulesync/ lives) is independent of output baseDirs.
+    // Rules source dir (where .rulesync/ lives) is independent of output outputRoots.
     const inputRoot = "/central/rulesync-source";
-    const baseDirs = ["/project/app-one", "/project/app-two"];
+    const outputRoots = ["/project/app-one", "/project/app-two"];
 
     beforeEach(() => {
       mockConfig.getInputRoot.mockReturnValue(inputRoot);
-      mockConfig.getBaseDirs.mockReturnValue(baseDirs);
+      mockConfig.getOutputRoots.mockReturnValue(outputRoots);
     });
 
-    it("should check for .rulesync under inputRoot, not under baseDirs", async () => {
+    it("should check for .rulesync under inputRoot, not under outputRoots", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
 
       await generateCommand(mockLogger, {});
@@ -1159,7 +1169,7 @@ describe("generateCommand", () => {
       expect(fileExists).not.toHaveBeenCalledWith("/project/app-two/.rulesync");
     });
 
-    it("should construct RulesProcessor with inputRoot distinct from baseDir for each output dir", async () => {
+    it("should construct RulesProcessor with inputRoot distinct from outputRoot for each output dir", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
 
       await generateCommand(mockLogger, {});
@@ -1167,98 +1177,98 @@ describe("generateCommand", () => {
       expect(RulesProcessor).toHaveBeenCalledTimes(2);
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-one",
+          outputRoot: "/project/app-one",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-two",
+          outputRoot: "/project/app-two",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
     });
 
-    it("should pass inputRoot to IgnoreProcessor independently of baseDir", async () => {
+    it("should pass inputRoot to IgnoreProcessor independently of outputRoot", async () => {
       mockConfig.getFeatures.mockReturnValue(["ignore"]);
 
       await generateCommand(mockLogger, {});
 
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-one",
+          outputRoot: "/project/app-one",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-two",
+          outputRoot: "/project/app-two",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
     });
 
-    it("should pass inputRoot to McpProcessor independently of baseDir", async () => {
+    it("should pass inputRoot to McpProcessor independently of outputRoot", async () => {
       mockConfig.getFeatures.mockReturnValue(["mcp"]);
 
       await generateCommand(mockLogger, {});
 
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-one",
+          outputRoot: "/project/app-one",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-two",
+          outputRoot: "/project/app-two",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
     });
 
-    it("should pass inputRoot to CommandsProcessor independently of baseDir", async () => {
+    it("should pass inputRoot to CommandsProcessor independently of outputRoot", async () => {
       mockConfig.getFeatures.mockReturnValue(["commands"]);
 
       await generateCommand(mockLogger, {});
 
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-one",
+          outputRoot: "/project/app-one",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-two",
+          outputRoot: "/project/app-two",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
     });
 
-    it("should pass inputRoot to SubagentsProcessor independently of baseDir", async () => {
+    it("should pass inputRoot to SubagentsProcessor independently of outputRoot", async () => {
       mockConfig.getFeatures.mockReturnValue(["subagents"]);
 
       await generateCommand(mockLogger, {});
 
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-one",
+          outputRoot: "/project/app-one",
           inputRoot,
           toolTarget: "claudecode",
         }),
       );
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/project/app-two",
+          outputRoot: "/project/app-two",
           inputRoot,
           toolTarget: "claudecode",
         }),
@@ -1386,7 +1396,7 @@ describe("generateCommand", () => {
 
     it("should handle multiple targets and base directories", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2"]);
+      mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2"]);
       mockConfig.getTargets.mockReturnValue(["claudecode", "cursor"]);
       vi.mocked(intersection).mockReturnValue(["claudecode", "cursor"]);
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -70,7 +70,12 @@ export async function generateCommand(logger: Logger, options: GenerateOptions):
         "It will be removed in a future major release.",
     );
   }
-  const outputRootsResolved = outputRoots ?? baseDir;
+  // Treat `outputRoots: []` as "not provided" so a programmatic caller
+  // passing an empty array does not silently win over a non-empty `baseDir`.
+  // Without this, `outputRoots ?? baseDir` would resolve to `[]` and override
+  // the deprecated alias even when the alias carried real values.
+  const outputRootsResolved =
+    outputRoots !== undefined && outputRoots.length > 0 ? outputRoots : baseDir;
   if (
     baseDir !== undefined &&
     outputRoots !== undefined &&
@@ -97,14 +102,14 @@ export async function generateCommand(logger: Logger, options: GenerateOptions):
 
   logger.debug("Generating files...");
 
-  if (!(await checkRulesyncDirExists({ outputRoot: config.getInputRoot() }))) {
+  if (!(await checkRulesyncDirExists({ inputRoot: config.getInputRoot() }))) {
     throw new CLIError(
       ".rulesync directory not found. Run 'rulesync init' first.",
       ErrorCodes.RULESYNC_DIR_NOT_FOUND,
     );
   }
 
-  logger.debug(`Base directories: ${config.getOutputRoots().join(", ")}`);
+  logger.debug(`Output roots: ${config.getOutputRoots().join(", ")}`);
 
   const features = config.getFeatures();
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -5,17 +5,19 @@ import type { Logger } from "../../utils/logger.js";
 import { calculateTotalCount } from "../../utils/result.js";
 
 export type GenerateOptions = ConfigResolverResolveParams & {
-  // Commander maps `--base-dir` to `baseDir` (camelCase, singular) while the
-  // resolver reads `baseDirs` (plural). Accept the CLI shape here and
-  // normalize at the command boundary.
+  // Commander maps `--base-dir <paths>` to `baseDir` (camelCase, singular)
+  // while the resolver canonical field is `outputRoots` (plural). The CLI
+  // flag is a deprecated alias retained for backward compatibility — accept
+  // the CLI shape here and normalize at the command boundary, emitting a
+  // one-shot deprecation warning when it is used.
   baseDir?: string[];
 };
 
 /**
- * Compares two `baseDir` lists as sets — order-insensitive and
- * duplicate-insensitive. Used to decide whether `--base-dir` and the
- * programmatic `baseDirs` actually differ. Identical sets like
- * `["a", "b"]` vs `["b", "a"]` should NOT trigger the override warning.
+ * Compares two output-root lists as sets — order-insensitive and
+ * duplicate-insensitive. Used to decide whether `--base-dir` and
+ * `--output-roots` actually differ. Identical sets like `["a", "b"]` vs
+ * `["b", "a"]` should NOT trigger the override warning.
  */
 function sameDirSets(a: readonly string[], b: readonly string[]): boolean {
   const aSet = new Set(a);
@@ -54,29 +56,39 @@ function logFeatureResult(
 }
 
 export async function generateCommand(logger: Logger, options: GenerateOptions): Promise<void> {
-  const { baseDir, baseDirs, ...rest } = options;
+  const { baseDir, outputRoots, ...rest } = options;
 
-  // When both the CLI singular `baseDir` (from `--base-dir`) and the
-  // programmatic plural `baseDirs` are supplied with non-empty, differing
-  // values, prefer the explicit programmatic field but warn the user so the
-  // override is visible. Identical (as a set, order-insensitive) or empty
-  // inputs are silently merged.
-  const baseDirsResolved = baseDirs ?? baseDir;
+  // The deprecated `--base-dir` CLI flag is accepted as an alias of
+  // `--output-roots`. Emit a deprecation warning whenever it is used so the
+  // user sees a clear migration prompt at the call site. When both are
+  // supplied with non-empty, differing values, prefer `--output-roots` but
+  // also surface the override to the user. Identical (set-equal, order-
+  // insensitive) or empty inputs are silently merged.
+  if (baseDir !== undefined) {
+    logger.warn(
+      "--base-dir is deprecated; use --output-roots instead. " +
+        "It will be removed in a future major release.",
+    );
+  }
+  const outputRootsResolved = outputRoots ?? baseDir;
   if (
     baseDir !== undefined &&
-    baseDirs !== undefined &&
+    outputRoots !== undefined &&
     baseDir.length > 0 &&
-    baseDirs.length > 0 &&
-    !sameDirSets(baseDirs, baseDir)
+    outputRoots.length > 0 &&
+    !sameDirSets(outputRoots, baseDir)
   ) {
     logger.warn(
-      `Both 'baseDirs' and 'baseDir' (from --base-dir) were provided with ` +
-        `differing values; using 'baseDirs' (${JSON.stringify(baseDirs)}) ` +
-        `and ignoring 'baseDir' (${JSON.stringify(baseDir)}).`,
+      `Both '--output-roots' and '--base-dir' were provided with differing ` +
+        `values; using '--output-roots' (${JSON.stringify(outputRoots)}) and ` +
+        `ignoring '--base-dir' (${JSON.stringify(baseDir)}).`,
     );
   }
 
-  const config = await ConfigResolver.resolve({ ...rest, baseDirs: baseDirsResolved }, { logger });
+  const config = await ConfigResolver.resolve(
+    { ...rest, outputRoots: outputRootsResolved },
+    { logger },
+  );
 
   const check = config.getCheck();
 
@@ -85,14 +97,14 @@ export async function generateCommand(logger: Logger, options: GenerateOptions):
 
   logger.debug("Generating files...");
 
-  if (!(await checkRulesyncDirExists({ baseDir: config.getInputRoot() }))) {
+  if (!(await checkRulesyncDirExists({ outputRoot: config.getInputRoot() }))) {
     throw new CLIError(
       ".rulesync directory not found. Run 'rulesync init' first.",
       ErrorCodes.RULESYNC_DIR_NOT_FOUND,
     );
   }
 
-  logger.debug(`Base directories: ${config.getBaseDirs().join(", ")}`);
+  logger.debug(`Base directories: ${config.getOutputRoots().join(", ")}`);
 
   const features = config.getFeatures();
 

--- a/src/cli/commands/import.test.ts
+++ b/src/cli/commands/import.test.ts
@@ -31,7 +31,7 @@ describe("importCommand", () => {
       getFeatures: vi.fn().mockReturnValue(["rules", "ignore", "mcp", "subagents", "commands"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
       getGlobal: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getInputRoot: vi.fn().mockReturnValue(process.cwd()),
     };
 
@@ -137,7 +137,7 @@ describe("importCommand", () => {
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -165,7 +165,7 @@ describe("importCommand", () => {
 
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
         }),
       );
@@ -192,7 +192,7 @@ describe("importCommand", () => {
 
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -226,7 +226,7 @@ describe("importCommand", () => {
       });
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -260,7 +260,7 @@ describe("importCommand", () => {
       });
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -446,7 +446,7 @@ describe("importCommand", () => {
 
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),
@@ -503,28 +503,28 @@ describe("importCommand", () => {
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),
       );
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),
       );
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),
       );
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -8,9 +8,14 @@ import { calculateTotalCount } from "../../utils/result.js";
 // are *read from* during `generate`, and `import` does not consume them. Keeping
 // it in the option type would be misleading and would surface a noisy
 // "Ignoring global: true" warning from the resolver during `import`.
+//
+// The deprecated `baseDirs` programmatic alias is also excluded so that the
+// CLI's import options never expose a deprecated field — `outputRoots` is the
+// only canonical name imports were ever supposed to omit, and `baseDirs` is
+// exclusively a backwards-compat input on the resolver boundary.
 export type ImportOptions = Omit<
   ConfigResolverResolveParams,
-  "delete" | "outputRoots" | "inputRoot"
+  "delete" | "outputRoots" | "baseDirs" | "inputRoot"
 >;
 
 export async function importCommand(logger: Logger, options: ImportOptions): Promise<void> {

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -8,7 +8,10 @@ import { calculateTotalCount } from "../../utils/result.js";
 // are *read from* during `generate`, and `import` does not consume them. Keeping
 // it in the option type would be misleading and would surface a noisy
 // "Ignoring global: true" warning from the resolver during `import`.
-export type ImportOptions = Omit<ConfigResolverResolveParams, "delete" | "baseDirs" | "inputRoot">;
+export type ImportOptions = Omit<
+  ConfigResolverResolveParams,
+  "delete" | "outputRoots" | "inputRoot"
+>;
 
 export async function importCommand(logger: Logger, options: ImportOptions): Promise<void> {
   if (!options.targets) {

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -49,7 +49,7 @@ describe("installCommand", () => {
       expect(resolveAndFetchSources).toHaveBeenCalledWith(
         expect.objectContaining({
           sources,
-          outputRoot: process.cwd(),
+          projectRoot: process.cwd(),
           options: {
             updateSources: undefined,
             frozen: undefined,
@@ -182,7 +182,7 @@ describe("installCommand", () => {
 
       expect(installApm).toHaveBeenCalledWith(
         expect.objectContaining({
-          outputRoot: process.cwd(),
+          projectRoot: process.cwd(),
           options: expect.objectContaining({ update: true, token: "tok" }),
         }),
       );
@@ -235,7 +235,7 @@ describe("installCommand", () => {
       expect(installGh).toHaveBeenCalledWith(
         expect.objectContaining({
           sources,
-          outputRoot: process.cwd(),
+          projectRoot: process.cwd(),
           options: { update: undefined, frozen: undefined, token: undefined },
         }),
       );

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -49,7 +49,7 @@ describe("installCommand", () => {
       expect(resolveAndFetchSources).toHaveBeenCalledWith(
         expect.objectContaining({
           sources,
-          baseDir: process.cwd(),
+          outputRoot: process.cwd(),
           options: {
             updateSources: undefined,
             frozen: undefined,
@@ -182,7 +182,7 @@ describe("installCommand", () => {
 
       expect(installApm).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: process.cwd(),
+          outputRoot: process.cwd(),
           options: expect.objectContaining({ update: true, token: "tok" }),
         }),
       );
@@ -235,7 +235,7 @@ describe("installCommand", () => {
       expect(installGh).toHaveBeenCalledWith(
         expect.objectContaining({
           sources,
-          baseDir: process.cwd(),
+          outputRoot: process.cwd(),
           options: { update: undefined, frozen: undefined, token: undefined },
         }),
       );

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -38,11 +38,11 @@ export async function installCommand(
 }
 
 async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const baseDir = process.cwd();
+  const outputRoot = process.cwd();
 
   // If both apm.yml and rulesync.jsonc sources are defined, refuse to guess.
   // `--mode apm` is required to opt into the APM layout.
-  const apmExists = await apmManifestExists(baseDir);
+  const apmExists = await apmManifestExists(outputRoot);
 
   const config = await ConfigResolver.resolve({
     configPath: options.configPath,
@@ -72,7 +72,7 @@ async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions
 
   const result = await resolveAndFetchSources({
     sources,
-    baseDir,
+    outputRoot,
     options: {
       updateSources: options.update,
       frozen: options.frozen,
@@ -96,16 +96,16 @@ async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions
 }
 
 async function runApmInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const baseDir = process.cwd();
+  const outputRoot = process.cwd();
 
-  if (!(await apmManifestExists(baseDir))) {
+  if (!(await apmManifestExists(outputRoot))) {
     throw new Error(
       "--mode apm requires an apm.yml at the project root. Create one or drop --mode apm to fall back to rulesync mode.",
     );
   }
 
   const result = await installApm({
-    baseDir,
+    outputRoot,
     options: {
       update: options.update,
       frozen: options.frozen,
@@ -136,7 +136,7 @@ async function runApmInstall(logger: Logger, options: InstallCommandOptions): Pr
 }
 
 async function runGhInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const baseDir = process.cwd();
+  const outputRoot = process.cwd();
 
   // gh mode reads sources from `rulesync.jsonc`, never from `apm.yml`. The
   // disambiguation between rulesync/apm modes lives in `runRulesyncInstall`;
@@ -154,7 +154,7 @@ async function runGhInstall(logger: Logger, options: InstallCommandOptions): Pro
   }
 
   const result = await installGh({
-    baseDir,
+    outputRoot,
     sources,
     options: {
       update: options.update,

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -38,11 +38,11 @@ export async function installCommand(
 }
 
 async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const outputRoot = process.cwd();
+  const projectRoot = process.cwd();
 
   // If both apm.yml and rulesync.jsonc sources are defined, refuse to guess.
   // `--mode apm` is required to opt into the APM layout.
-  const apmExists = await apmManifestExists(outputRoot);
+  const apmExists = await apmManifestExists(projectRoot);
 
   const config = await ConfigResolver.resolve({
     configPath: options.configPath,
@@ -72,7 +72,7 @@ async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions
 
   const result = await resolveAndFetchSources({
     sources,
-    outputRoot,
+    projectRoot,
     options: {
       updateSources: options.update,
       frozen: options.frozen,
@@ -96,16 +96,16 @@ async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions
 }
 
 async function runApmInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const outputRoot = process.cwd();
+  const projectRoot = process.cwd();
 
-  if (!(await apmManifestExists(outputRoot))) {
+  if (!(await apmManifestExists(projectRoot))) {
     throw new Error(
       "--mode apm requires an apm.yml at the project root. Create one or drop --mode apm to fall back to rulesync mode.",
     );
   }
 
   const result = await installApm({
-    outputRoot,
+    projectRoot,
     options: {
       update: options.update,
       frozen: options.frozen,
@@ -136,7 +136,7 @@ async function runApmInstall(logger: Logger, options: InstallCommandOptions): Pr
 }
 
 async function runGhInstall(logger: Logger, options: InstallCommandOptions): Promise<void> {
-  const outputRoot = process.cwd();
+  const projectRoot = process.cwd();
 
   // gh mode reads sources from `rulesync.jsonc`, never from `apm.yml`. The
   // disambiguation between rulesync/apm modes lives in `runRulesyncInstall`;
@@ -154,7 +154,7 @@ async function runGhInstall(logger: Logger, options: InstallCommandOptions): Pro
   }
 
   const result = await installGh({
-    outputRoot,
+    projectRoot,
     sources,
     options: {
       update: options.update,

--- a/src/cli/commands/mcp.test.ts
+++ b/src/cli/commands/mcp.test.ts
@@ -28,7 +28,7 @@ describe("MCP Server", () => {
     it("should list rules with frontmatter", async () => {
       // Create sample rule files
       const rule1 = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_OVERVIEW_FILE_NAME,
         frontmatter: {
@@ -41,7 +41,7 @@ describe("MCP Server", () => {
       });
 
       const rule2 = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "coding-style.md",
         frontmatter: {
@@ -102,7 +102,7 @@ describe("MCP Server", () => {
   describe("getRule functionality", () => {
     it("should get detailed rule information", async () => {
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test-rule.md",
         frontmatter: {
@@ -146,7 +146,7 @@ describe("MCP Server", () => {
 
       // Create and write the rule
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "new-rule.md",
         frontmatter,
@@ -170,7 +170,7 @@ describe("MCP Server", () => {
     it("should update an existing rule", async () => {
       // Create initial rule
       const initialRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "update-rule.md",
         frontmatter: {
@@ -187,7 +187,7 @@ describe("MCP Server", () => {
 
       // Update the rule
       const updatedRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "update-rule.md",
         frontmatter: {
@@ -216,7 +216,7 @@ describe("MCP Server", () => {
   describe("deleteRule functionality", () => {
     it("should delete a rule file", async () => {
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "delete-me.md",
         frontmatter: {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -231,8 +231,13 @@ const main = async () => {
     )
     .option("--delete", "Delete all existing files in output directories before generating")
     .option(
+      "-o, --output-roots <paths>",
+      "Output root directories to generate files into (comma-separated for multiple paths)",
+      parseCommaSeparatedList,
+    )
+    .option(
       "-b, --base-dir <paths>",
-      "Base directories to generate files (comma-separated for multiple paths)",
+      "[Deprecated] Use --output-roots instead. Output root directories (comma-separated for multiple paths)",
       parseCommaSeparatedList,
     )
     .option("-V, --verbose", "Verbose output")

--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -45,7 +45,7 @@ describe("config-resolver", () => {
   describe("global configuration", () => {
     it("should load global: true from config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         global: true,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -59,7 +59,7 @@ describe("config-resolver", () => {
 
     it("should load global: false from config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         global: false,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -73,7 +73,7 @@ describe("config-resolver", () => {
 
     it("should default global to false when not specified", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
 
@@ -86,7 +86,7 @@ describe("config-resolver", () => {
 
     it("should allow CLI flag to override config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         global: false,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -103,7 +103,7 @@ describe("config-resolver", () => {
   describe("silent configuration", () => {
     it("should load silent: true from config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         silent: true,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -117,7 +117,7 @@ describe("config-resolver", () => {
 
     it("should load silent: false from config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         silent: false,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -131,7 +131,7 @@ describe("config-resolver", () => {
 
     it("should default silent to false when not specified", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
 
@@ -144,7 +144,7 @@ describe("config-resolver", () => {
 
     it("should allow CLI flag to override config file for silent", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         silent: false,
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -159,9 +159,9 @@ describe("config-resolver", () => {
   });
 
   describe("base directory resolution", () => {
-    it("should load configured baseDirs from file", async () => {
+    it("should load configured outputRoots from file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./src", "./packages"],
+        outputRoots: ["./src", "./packages"],
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
 
@@ -169,14 +169,14 @@ describe("config-resolver", () => {
         configPath: join(testDir, "rulesync.jsonc"),
       });
 
-      // baseDirs are now resolved to absolute paths
-      expect(config.getBaseDirs()).toContain(resolve("./src"));
-      expect(config.getBaseDirs()).toContain(resolve("./packages"));
+      // outputRoots are now resolved to absolute paths
+      expect(config.getOutputRoots()).toContain(resolve("./src"));
+      expect(config.getOutputRoots()).toContain(resolve("./packages"));
     });
 
-    it("should handle multiple baseDirs", async () => {
+    it("should handle multiple outputRoots", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./app1", "./app2", "./app3"],
+        outputRoots: ["./app1", "./app2", "./app3"],
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
 
@@ -184,18 +184,18 @@ describe("config-resolver", () => {
         configPath: join(testDir, "rulesync.jsonc"),
       });
 
-      // baseDirs are now resolved to absolute paths
-      expect(config.getBaseDirs()).toHaveLength(3);
-      expect(config.getBaseDirs()).toContain(resolve("./app1"));
-      expect(config.getBaseDirs()).toContain(resolve("./app2"));
-      expect(config.getBaseDirs()).toContain(resolve("./app3"));
+      // outputRoots are now resolved to absolute paths
+      expect(config.getOutputRoots()).toHaveLength(3);
+      expect(config.getOutputRoots()).toContain(resolve("./app1"));
+      expect(config.getOutputRoots()).toContain(resolve("./app2"));
+      expect(config.getOutputRoots()).toContain(resolve("./app3"));
     });
   });
 
   describe("local configuration (rulesync.local.jsonc)", () => {
     it("should use rulesync.local.jsonc to override rulesync.jsonc", async () => {
       const baseConfigContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: ["cursor"],
         verbose: false,
       });
@@ -216,7 +216,7 @@ describe("config-resolver", () => {
 
     it("should preserve rulesync.jsonc values not overridden by rulesync.local.jsonc", async () => {
       const baseConfigContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: ["cursor"],
         features: ["rules", "mcp"],
         verbose: false,
@@ -240,7 +240,7 @@ describe("config-resolver", () => {
 
     it("should allow CLI options to override rulesync.local.jsonc", async () => {
       const baseConfigContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: ["cursor"],
       });
       const localConfigContent = JSON.stringify({
@@ -262,7 +262,7 @@ describe("config-resolver", () => {
 
     it("should work without rulesync.local.jsonc", async () => {
       const baseConfigContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: ["cursor"],
         verbose: true,
       });
@@ -293,7 +293,10 @@ describe("config-resolver", () => {
 
     it("should load rulesync.local.jsonc from the same directory as the base config", async () => {
       const subDir = join(testDir, "subdir");
-      await writeFileContent(join(subDir, "rulesync.jsonc"), JSON.stringify({ baseDirs: ["./"] }));
+      await writeFileContent(
+        join(subDir, "rulesync.jsonc"),
+        JSON.stringify({ outputRoots: ["./"] }),
+      );
       await writeFileContent(
         join(subDir, "rulesync.local.jsonc"),
         JSON.stringify({ targets: ["cline"] }),
@@ -310,7 +313,7 @@ describe("config-resolver", () => {
   describe("configPath security", () => {
     it("should accept configPath within current directory", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
 
@@ -318,7 +321,7 @@ describe("config-resolver", () => {
         configPath: join(testDir, "rulesync.jsonc"),
       });
 
-      expect(config.getBaseDirs()).toHaveLength(1);
+      expect(config.getOutputRoots()).toHaveLength(1);
     });
 
     it("should reject configPath with path traversal attempting to escape current directory", async () => {
@@ -349,7 +352,7 @@ describe("config-resolver", () => {
   describe("object-form targets end-to-end", () => {
     it("should load object-form targets from rulesync.jsonc without reintroducing default features", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: {
           claudecode: { rules: true, ignore: { fileMode: "local" } },
           cursor: ["rules", "mcp"],
@@ -369,7 +372,7 @@ describe("config-resolver", () => {
 
     it("should reject merged config when base has array-form features and local has object-form targets", async () => {
       const baseConfigContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         features: ["rules"],
       });
       const localConfigContent = JSON.stringify({
@@ -385,7 +388,7 @@ describe("config-resolver", () => {
 
     it("should reject object-form targets combined with features from a config file", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: { claudecode: ["rules"] },
         features: ["rules"],
       });
@@ -477,7 +480,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
 
       const config = await ConfigResolver.resolve({
@@ -492,7 +495,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
       const logger = { warn: vi.fn() } as unknown as Logger;
 
@@ -511,7 +514,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
       const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -556,7 +559,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
       const logger = { warn: vi.fn() } as unknown as Logger;
 
@@ -575,7 +578,7 @@ describe("config-resolver", () => {
     it("should honor config file global: true when inputRoot is omitted", async () => {
       await writeFileContent(
         join(testDir, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
 
       const config = await ConfigResolver.resolve({
@@ -589,7 +592,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
 
       const config = await ConfigResolver.resolve({
@@ -605,7 +608,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"], global: true }),
+        JSON.stringify({ outputRoots: ["./"], global: true }),
       );
 
       const config = await ConfigResolver.resolve({
@@ -621,7 +624,7 @@ describe("config-resolver", () => {
       const inputRoot = join(testDir, "central-rules");
       await writeFileContent(
         join(inputRoot, "rulesync.jsonc"),
-        JSON.stringify({ baseDirs: ["./"] }),
+        JSON.stringify({ outputRoots: ["./"] }),
       );
 
       const config = await ConfigResolver.resolve({
@@ -667,10 +670,10 @@ describe("config-resolver", () => {
       expect(config.getInputRoot()).toBe(localRoot);
     });
 
-    it("should reject a config-file inputRoot that fails validateBaseDir", async () => {
-      // This test specifically pins the symmetric `validateBaseDir` block that
+    it("should reject a config-file inputRoot that fails validateOutputRoot", async () => {
+      // This test specifically pins the symmetric `validateOutputRoot` block that
       // runs on `configByFile.inputRoot` (config-resolver.ts ~line 181). The
-      // `configBaseDir` pre-check is unaffected here because cwd is inside the
+      // `configOutputRoot` pre-check is unaffected here because cwd is inside the
       // test temp dir and CLI `inputRoot` is unset; only the config-file
       // inputRoot triggers validation. Picking the filesystem root forces the
       // dedicated "filesystem root" error message — distinct from the
@@ -683,7 +686,7 @@ describe("config-resolver", () => {
         ConfigResolver.resolve({
           configPath: join(testDir, "rulesync.jsonc"),
         }),
-      ).rejects.toThrow(/baseDir must not be the filesystem root/);
+      ).rejects.toThrow(/outputRoot must not be the filesystem root/);
     });
   });
 
@@ -702,7 +705,7 @@ describe("config-resolver", () => {
 
     it("emits the deprecation warning once when features is in object form", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         features: { claudecode: ["rules"] },
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -718,7 +721,7 @@ describe("config-resolver", () => {
 
     it("does not emit the warning when features is in array form", async () => {
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         targets: ["claudecode"],
         features: ["rules"],
       });
@@ -735,7 +738,7 @@ describe("config-resolver", () => {
     it("suppresses the warning when RULESYNC_SILENT_DEPRECATION is set", async () => {
       process.env.RULESYNC_SILENT_DEPRECATION = "1";
       const configContent = JSON.stringify({
-        baseDirs: ["./"],
+        outputRoots: ["./"],
         features: { claudecode: ["rules"] },
       });
       await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
@@ -744,6 +747,110 @@ describe("config-resolver", () => {
 
       const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
         String(call[0]).includes("DEPRECATED: 'features' object form"),
+      );
+      expect(deprecationCalls).toHaveLength(0);
+    });
+  });
+
+  describe("deprecation alias: 'baseDirs' config field", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      resetDeprecationWarningForTests();
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      delete process.env.RULESYNC_SILENT_DEPRECATION;
+    });
+
+    it("maps 'baseDirs' from a config file to outputRoots and emits a warning", async () => {
+      const configContent = JSON.stringify({
+        baseDirs: [testDir],
+        targets: ["claudecode"],
+        features: ["rules"],
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      expect(config.getOutputRoots()).toEqual([testDir]);
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: 'baseDirs' config field"),
+      );
+      expect(deprecationCalls).toHaveLength(1);
+    });
+
+    it("prefers 'outputRoots' over 'baseDirs' when both are present in a config file", async () => {
+      const otherDir = join(testDir, "other");
+      const configContent = JSON.stringify({
+        baseDirs: [otherDir],
+        outputRoots: [testDir],
+        targets: ["claudecode"],
+        features: ["rules"],
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      expect(config.getOutputRoots()).toEqual([testDir]);
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: 'baseDirs' config field"),
+      );
+      expect(deprecationCalls).toHaveLength(1);
+    });
+
+    it("maps programmatic 'baseDirs' resolver param to outputRoots and emits a warning", async () => {
+      const config = await ConfigResolver.resolve({
+        baseDirs: [testDir],
+        targets: ["claudecode"],
+        features: ["rules"],
+      });
+
+      expect(config.getOutputRoots()).toEqual([testDir]);
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: 'baseDirs' config field"),
+      );
+      expect(deprecationCalls).toHaveLength(1);
+    });
+
+    it("does not emit the warning when only 'outputRoots' is used", async () => {
+      const configContent = JSON.stringify({
+        outputRoots: [testDir],
+        targets: ["claudecode"],
+        features: ["rules"],
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      await ConfigResolver.resolve({ configPath: join(testDir, "rulesync.jsonc") });
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: 'baseDirs' config field"),
+      );
+      expect(deprecationCalls).toHaveLength(0);
+    });
+
+    it("suppresses the warning when RULESYNC_SILENT_DEPRECATION is set", async () => {
+      process.env.RULESYNC_SILENT_DEPRECATION = "1";
+      const configContent = JSON.stringify({
+        baseDirs: [testDir],
+        targets: ["claudecode"],
+        features: ["rules"],
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      await ConfigResolver.resolve({ configPath: join(testDir, "rulesync.jsonc") });
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: 'baseDirs' config field"),
       );
       expect(deprecationCalls).toHaveLength(0);
     });

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -11,7 +11,7 @@ import {
   getHomeDirectory,
   readFileContent,
   resolvePath,
-  validateBaseDir,
+  validateOutputRoot,
 } from "../utils/file.js";
 import { type Logger, warnWithFallback } from "../utils/logger.js";
 import {
@@ -23,14 +23,24 @@ import {
   PartialConfigParams,
   RequiredConfigParams,
 } from "./config.js";
-import { emitFeaturesObjectFormDeprecationWarning } from "./deprecation-warnings.js";
+import {
+  emitBaseDirsConfigFieldDeprecationWarning,
+  emitFeaturesObjectFormDeprecationWarning,
+} from "./deprecation-warnings.js";
 
 /**
  * CLI-resolvable params exclude `sources` — sources are config-file-only.
+ *
+ * `baseDirs` is a deprecated alias for `outputRoots` accepted at the resolver
+ * boundary for backward compatibility. When provided, the resolver emits a
+ * one-shot deprecation warning and maps it to `outputRoots`. If both are
+ * present, `outputRoots` wins. Will be removed in a future major release.
  */
 export type ConfigResolverResolveParams = Partial<
   Omit<ConfigParams, "sources"> & {
     configPath: string;
+    /** @deprecated Use `outputRoots` instead. */
+    baseDirs: string[];
   }
 >;
 
@@ -48,7 +58,7 @@ const getDefaults = (): ConfigDefaults => ({
   features: ["rules"],
   verbose: false,
   delete: false,
-  baseDirs: [process.cwd()],
+  outputRoots: [process.cwd()],
   configPath: RULESYNC_CONFIG_RELATIVE_FILE_PATH,
   global: false,
   silent: false,
@@ -72,7 +82,17 @@ const loadConfigFromFile = async (filePath: string): Promise<PartialConfigParams
   // Parse with ConfigFileSchema to allow $schema property, then extract config params
   const parsed: ConfigFile = ConfigFileSchema.parse(jsonData);
   // Exclude $schema from config params
-  const { $schema: _schema, ...configParams } = parsed;
+  const { $schema: _schema, baseDirs: deprecatedBaseDirs, ...configParams } = parsed;
+  // Map the deprecated `baseDirs` field to the canonical `outputRoots`.
+  // If both are present, `outputRoots` wins (consistent with the precedence
+  // rule documented at the resolver boundary). Either way, emit a one-shot
+  // deprecation warning so users know to migrate.
+  if (deprecatedBaseDirs !== undefined) {
+    emitBaseDirsConfigFieldDeprecationWarning();
+    if (configParams.outputRoots === undefined) {
+      configParams.outputRoots = deprecatedBaseDirs;
+    }
+  }
   // Enforce mutual-exclusivity between object-form `targets` and
   // `features` on the user-authored file (before defaults are merged).
   assertTargetsFeaturesExclusive({
@@ -87,7 +107,7 @@ const loadConfigFromFile = async (filePath: string): Promise<PartialConfigParams
 // lives in a separate module so `Config` (in `./config.js`) can also invoke
 // it without creating a circular import on the resolver.
 export { resetDeprecationWarningForTests } from "./deprecation-warnings.js";
-export { emitFeaturesObjectFormDeprecationWarning };
+export { emitBaseDirsConfigFieldDeprecationWarning, emitFeaturesObjectFormDeprecationWarning };
 
 const mergeConfigs = (
   baseConfig: PartialConfigParams,
@@ -100,7 +120,7 @@ const mergeConfigs = (
     features: localConfig.features ?? baseConfig.features,
     verbose: localConfig.verbose ?? baseConfig.verbose,
     delete: localConfig.delete ?? baseConfig.delete,
-    baseDirs: localConfig.baseDirs ?? baseConfig.baseDirs,
+    outputRoots: localConfig.outputRoots ?? baseConfig.outputRoots,
     global: localConfig.global ?? baseConfig.global,
     silent: localConfig.silent ?? baseConfig.silent,
     simulateCommands: localConfig.simulateCommands ?? baseConfig.simulateCommands,
@@ -123,7 +143,8 @@ export class ConfigResolver {
       features,
       verbose,
       delete: isDelete,
-      baseDirs,
+      outputRoots,
+      baseDirs: deprecatedBaseDirs,
       configPath = getDefaults().configPath,
       global,
       silent,
@@ -138,6 +159,15 @@ export class ConfigResolver {
     }: ConfigResolverResolveParams,
     { logger }: { logger?: Logger } = {},
   ): Promise<Config> {
+    // Map the deprecated programmatic `baseDirs` alias to `outputRoots`.
+    // If both are supplied, `outputRoots` wins; either way emit a one-shot
+    // deprecation warning so callers know to migrate.
+    if (deprecatedBaseDirs !== undefined) {
+      emitBaseDirsConfigFieldDeprecationWarning();
+      if (outputRoots === undefined) {
+        outputRoots = deprecatedBaseDirs;
+      }
+    }
     // Capture cwd once at the entry point so the resolved config is
     // deterministic and independent of any later `process.chdir()` calls.
     const cwd = resolve(process.cwd());
@@ -150,10 +180,10 @@ export class ConfigResolver {
     // not validate cwd itself because cwd is trusted process state, not
     // attacker-controlled input.
     if (inputRoot !== undefined) {
-      validateBaseDir(inputRoot);
+      validateOutputRoot(inputRoot);
     }
-    const configBaseDir = resolve(inputRoot ?? cwd);
-    const validatedConfigPath = resolvePath(configPath, configBaseDir);
+    const configOutputRoot = resolve(inputRoot ?? cwd);
+    const validatedConfigPath = resolvePath(configPath, configOutputRoot);
 
     // Load base config (rulesync.jsonc)
     const baseConfig = await loadConfigFromFile(validatedConfigPath);
@@ -168,11 +198,11 @@ export class ConfigResolver {
     const configByFile = mergeConfigs(baseConfig, localConfig);
 
     // Validate `inputRoot` coming from a config file too — symmetric with the
-    // CLI/programmatic flow, which validates the resolved `configBaseDir`
+    // CLI/programmatic flow, which validates the resolved `configOutputRoot`
     // above. We only validate when CLI/programmatic `inputRoot` is not set
-    // (otherwise `configBaseDir` already covered that case).
+    // (otherwise `configOutputRoot` already covered that case).
     if (inputRoot === undefined && configByFile.inputRoot !== undefined) {
-      validateBaseDir(configByFile.inputRoot);
+      validateOutputRoot(configByFile.inputRoot);
     }
 
     // Per-file `assertTargetsFeaturesExclusive` in `loadConfigFromFile` only
@@ -257,8 +287,8 @@ export class ConfigResolver {
       features: resolvedFeatures,
       verbose: verbose ?? configByFile.verbose ?? getDefaults().verbose,
       delete: isDelete ?? configByFile.delete ?? getDefaults().delete,
-      baseDirs: getBaseDirsInLightOfGlobal({
-        baseDirs: baseDirs ?? configByFile.baseDirs ?? getDefaults().baseDirs,
+      outputRoots: getOutputRootsInLightOfGlobal({
+        outputRoots: outputRoots ?? configByFile.outputRoots ?? getDefaults().outputRoots,
         global: resolvedGlobal,
       }),
       global: resolvedGlobal,
@@ -284,11 +314,11 @@ export class ConfigResolver {
   }
 }
 
-function getBaseDirsInLightOfGlobal({
-  baseDirs,
+function getOutputRootsInLightOfGlobal({
+  outputRoots,
   global,
 }: {
-  baseDirs: string[];
+  outputRoots: string[];
   global: boolean;
 }): string[] {
   if (global) {
@@ -299,9 +329,9 @@ function getBaseDirsInLightOfGlobal({
   // Validate the *raw* user input first so traversal patterns like
   // `/foo/../bar` cannot slip through `resolve()`'s normalization. Then
   // resolve to absolute for downstream consumers.
-  baseDirs.forEach((baseDir) => {
-    validateBaseDir(baseDir);
+  outputRoots.forEach((outputRoot) => {
+    validateOutputRoot(outputRoot);
   });
 
-  return baseDirs.map((baseDir) => resolve(baseDir));
+  return outputRoots.map((outputRoot) => resolve(outputRoot));
 }

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,14 +1,15 @@
 import { isAbsolute, resolve } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ALL_FEATURES } from "../types/features.js";
 import { ALL_TOOL_TARGETS } from "../types/tool-targets.js";
 import { assertTargetsFeaturesExclusive, Config, type ConfigParams } from "./config.js";
+import { resetDeprecationWarningForTests } from "./deprecation-warnings.js";
 
 describe("Config", () => {
   const defaultConfig: ConfigParams = {
-    baseDirs: ["."],
+    outputRoots: ["."],
     targets: ["cursor"],
     features: ["rules"],
     verbose: false,
@@ -597,7 +598,7 @@ describe("Config", () => {
       expect(
         () =>
           new Config({
-            baseDirs: ["."],
+            outputRoots: ["."],
             verbose: false,
             delete: false,
             silent: false,
@@ -644,6 +645,59 @@ describe("Config", () => {
       const parent = resolve(originalCwd, "..");
       process.chdir(parent);
       expect(config.getInputRoot()).toBe(expected);
+    });
+  });
+
+  describe("getBaseDirs (deprecated alias for getOutputRoots)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      resetDeprecationWarningForTests();
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      delete process.env.RULESYNC_SILENT_DEPRECATION;
+    });
+
+    it("returns the same array as getOutputRoots()", () => {
+      const config = createConfig({ outputRoots: ["./out-a", "./out-b"] });
+      expect(config.getBaseDirs()).toEqual(config.getOutputRoots());
+      expect(config.getBaseDirs()).toEqual(["./out-a", "./out-b"]);
+    });
+
+    it("emits the deprecation warning the first time it is called per process", () => {
+      const config = createConfig({ outputRoots: ["./out"] });
+      config.getBaseDirs();
+      config.getBaseDirs();
+      config.getBaseDirs();
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: Config.getBaseDirs()"),
+      );
+      expect(deprecationCalls).toHaveLength(1);
+    });
+
+    it("does not emit the warning when getOutputRoots() is called instead", () => {
+      const config = createConfig({ outputRoots: ["./out"] });
+      config.getOutputRoots();
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: Config.getBaseDirs()"),
+      );
+      expect(deprecationCalls).toHaveLength(0);
+    });
+
+    it("suppresses the warning when RULESYNC_SILENT_DEPRECATION is set", () => {
+      process.env.RULESYNC_SILENT_DEPRECATION = "1";
+      const config = createConfig({ outputRoots: ["./out"] });
+      config.getBaseDirs();
+
+      const deprecationCalls = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0]).includes("DEPRECATED: Config.getBaseDirs()"),
+      );
+      expect(deprecationCalls).toHaveLength(0);
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -27,6 +27,7 @@ import {
   ToolTargets,
 } from "../types/tool-targets.js";
 import { hasControlCharacters } from "../utils/validation.js";
+import { emitGetBaseDirsDeprecationWarning } from "./deprecation-warnings.js";
 
 export const GITIGNORE_DESTINATION_KEY = "gitignoreDestination";
 
@@ -61,7 +62,7 @@ export const SourceEntrySchema = z.object({
 export type SourceEntry = z.infer<typeof SourceEntrySchema>;
 
 export const ConfigParamsSchema = z.object({
-  baseDirs: z.array(z.string()),
+  outputRoots: z.array(z.string()),
   targets: RulesyncConfigTargetsSchema,
   features: RulesyncFeaturesSchema,
   verbose: z.boolean(),
@@ -113,10 +114,17 @@ export type PartialConfigParams = Omit<InferredPartialConfigParams, "targets" | 
   features?: RulesyncFeatures;
 };
 
-// Schema for config file that includes $schema property for editor support
+// Schema for config file that includes $schema property for editor support.
+//
+// The deprecated alias `baseDirs` is accepted here for backward compatibility
+// — it maps to `outputRoots` at load time (see `loadConfigFromFile` in
+// `./config-resolver.ts`). The deprecation warning fires once per process.
+// Will be removed in a future major release.
 export const ConfigFileSchema = z.object({
   $schema: optional(z.string()),
   ...z.partial(ConfigParamsSchema).shape,
+  /** @deprecated Use `outputRoots` instead. */
+  baseDirs: optional(z.array(z.string())),
 });
 type InferredConfigFile = z.infer<typeof ConfigFileSchema>;
 export type ConfigFile = Omit<InferredConfigFile, "targets" | "features"> & {
@@ -205,7 +213,7 @@ const assertTargetsOrFeaturesProvided = ({
 };
 
 export class Config {
-  private readonly baseDirs: string[];
+  private readonly outputRoots: string[];
   private readonly targets: RulesyncConfigTargets;
   private readonly features: RulesyncFeatures;
   /**
@@ -230,7 +238,7 @@ export class Config {
   private readonly sources: SourceEntry[];
 
   constructor({
-    baseDirs,
+    outputRoots,
     targets,
     features,
     verbose,
@@ -279,7 +287,7 @@ export class Config {
       throw new Error("--dry-run and --check cannot be used together");
     }
 
-    this.baseDirs = baseDirs;
+    this.outputRoots = outputRoots;
     this.targets = resolvedTargets;
     this.features = resolvedFeatures;
     this.objectFormTargetKeys = isRulesyncConfigTargetsObject(resolvedTargets)
@@ -362,8 +370,18 @@ export class Config {
     }
   }
 
+  public getOutputRoots(): string[] {
+    return this.outputRoots;
+  }
+
+  /**
+   * @deprecated Use {@link Config.getOutputRoots} instead. This alias remains
+   * for backward compatibility and will be removed in a future major release.
+   * Calling it emits a one-shot deprecation warning per process.
+   */
   public getBaseDirs(): string[] {
-    return this.baseDirs;
+    emitGetBaseDirsDeprecationWarning();
+    return this.outputRoots;
   }
 
   /**

--- a/src/config/deprecation-warnings.ts
+++ b/src/config/deprecation-warnings.ts
@@ -1,25 +1,27 @@
 /**
- * One-shot deprecation warning for the object form under `features`.
+ * One-shot deprecation warnings.
  *
- * Emitted at most once per Node.js process to avoid repeat logs when the
- * resolver is invoked from multiple commands within the same run, or when a
- * programmatic `new Config(...)` call triggers the same warning path.
+ * Each guard is emitted at most once per Node.js process to avoid repeat logs
+ * when the resolver is invoked from multiple commands within the same run, or
+ * when a programmatic `new Config(...)` call triggers the same warning path.
  *
  * NOTE: Vitest runs all tests within a single Node process and does not
  * reset module state between test files by default, so the "once" guard
  * would carry across tests. Tests that need to assert on the warning must
  * call `resetDeprecationWarningForTests()` in a `beforeEach` hook.
  *
- * The warning can be silenced by setting the `RULESYNC_SILENT_DEPRECATION`
+ * Warnings can be silenced by setting the `RULESYNC_SILENT_DEPRECATION`
  * environment variable so CI pipelines that intentionally run on the
  * deprecated form can opt out.
  */
-let deprecationWarningEmitted = false;
+let featuresObjectFormWarningEmitted = false;
+let getBaseDirsWarningEmitted = false;
+let baseDirsConfigFieldWarningEmitted = false;
 
 export const emitFeaturesObjectFormDeprecationWarning = (): void => {
-  if (deprecationWarningEmitted) return;
+  if (featuresObjectFormWarningEmitted) return;
   if (process.env.RULESYNC_SILENT_DEPRECATION) return;
-  deprecationWarningEmitted = true;
+  featuresObjectFormWarningEmitted = true;
   // oxlint-disable-next-line no-console
   console.warn(
     "[rulesync] DEPRECATED: 'features' object form is deprecated. " +
@@ -30,10 +32,34 @@ export const emitFeaturesObjectFormDeprecationWarning = (): void => {
   );
 };
 
+export const emitGetBaseDirsDeprecationWarning = (): void => {
+  if (getBaseDirsWarningEmitted) return;
+  if (process.env.RULESYNC_SILENT_DEPRECATION) return;
+  getBaseDirsWarningEmitted = true;
+  // oxlint-disable-next-line no-console
+  console.warn(
+    "[rulesync] DEPRECATED: Config.getBaseDirs() is deprecated; " +
+      "use Config.getOutputRoots() instead. " +
+      "It will be removed in a future major release.",
+  );
+};
+
+export const emitBaseDirsConfigFieldDeprecationWarning = (): void => {
+  if (baseDirsConfigFieldWarningEmitted) return;
+  if (process.env.RULESYNC_SILENT_DEPRECATION) return;
+  baseDirsConfigFieldWarningEmitted = true;
+  // oxlint-disable-next-line no-console
+  console.warn(
+    "[rulesync] DEPRECATED: 'baseDirs' config field is deprecated; " +
+      "use 'outputRoots' instead. " +
+      "It will be removed in a future major release.",
+  );
+};
+
 /**
- * Test-only helper to reset the one-shot emission guard between test runs.
+ * Test-only helper to reset the one-shot emission guards between test runs.
  * Throws in non-test environments so production bundles cannot accidentally
- * reset the guard.
+ * reset the guards.
  */
 export const resetDeprecationWarningForTests = (): void => {
   if (process.env.NODE_ENV !== "test") {
@@ -41,5 +67,7 @@ export const resetDeprecationWarningForTests = (): void => {
       "resetDeprecationWarningForTests is a test-only helper; do not call it outside NODE_ENV=test.",
     );
   }
-  deprecationWarningEmitted = false;
+  featuresObjectFormWarningEmitted = false;
+  getBaseDirsWarningEmitted = false;
+  baseDirsConfigFieldWarningEmitted = false;
 };

--- a/src/features/commands/agentsmd-command.test.ts
+++ b/src/features/commands/agentsmd-command.test.ts
@@ -52,7 +52,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -73,7 +73,7 @@ Body content`;
 
     it("should create instance with empty description", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -91,7 +91,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -106,7 +106,7 @@ Body content`;
 
     it("should accept frontmatter without description (description is optional)", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "no-desc-command.md",
         frontmatter: {} as SimulatedCommandFrontmatter,
@@ -122,7 +122,7 @@ Body content`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -139,7 +139,7 @@ Body content`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with description", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -159,7 +159,7 @@ Body content`;
   describe("toRulesyncCommand", () => {
     it("should throw error as it is a simulated file", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -178,7 +178,7 @@ Body content`;
   describe("fromRulesyncCommand", () => {
     it("should create AgentsmdCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -191,7 +191,7 @@ Body content`;
       });
 
       const agentsmdCommand = AgentsmdCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -207,7 +207,7 @@ Body content`;
 
     it("should handle RulesyncCommand with different file extensions", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-command.txt",
         frontmatter: {
@@ -220,7 +220,7 @@ Body content`;
       });
 
       const agentsmdCommand = AgentsmdCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -230,7 +230,7 @@ Body content`;
 
     it("should handle empty description", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -243,7 +243,7 @@ Body content`;
       });
 
       const agentsmdCommand = AgentsmdCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -262,7 +262,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const command = await AgentsmdCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-command.md",
         validate: true,
       });
@@ -284,7 +284,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const command = await AgentsmdCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-command.md",
         validate: true,
       });
@@ -295,7 +295,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         AgentsmdCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-command.md",
           validate: true,
         }),
@@ -310,7 +310,7 @@ Body content`;
 
       await expect(
         AgentsmdCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-command.md",
           validate: true,
         }),
@@ -324,7 +324,7 @@ Body content`;
       await writeFileContent(filePath, markdownWithoutFrontmatter);
 
       const command = await AgentsmdCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-frontmatter.md",
         validate: true,
       });
@@ -337,7 +337,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "valid-command.md",
         frontmatter: {
@@ -354,7 +354,7 @@ Body content`;
 
     it("should handle frontmatter with additional properties", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "command-with-extras.md",
         frontmatter: {
@@ -375,7 +375,7 @@ Body content`;
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "empty-body.md",
         frontmatter: {
@@ -396,7 +396,7 @@ Body content`;
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "special-char.md",
         frontmatter: {
@@ -416,7 +416,7 @@ Body content`;
       const longContent = "A".repeat(10000);
 
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "long-content.md",
         frontmatter: {
@@ -432,7 +432,7 @@ Body content`;
 
     it("should handle multi-line description", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "multiline-desc.md",
         frontmatter: {
@@ -451,7 +451,7 @@ Body content`;
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "windows-lines.md",
         frontmatter: {
@@ -468,7 +468,7 @@ Body content`;
   describe("integration with base classes", () => {
     it("should properly inherit from SimulatedCommand", () => {
       const command = new AgentsmdCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -484,10 +484,10 @@ Body content`;
       expect(command.getRelativeFilePath()).toBe("test.md");
     });
 
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
+    it("should handle outputRoot correctly", () => {
+      const customOutputRoot = "/custom/base/dir";
       const command = new AgentsmdCommand({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: ".agents/commands",
         relativeFilePath: "test.md",
         frontmatter: {

--- a/src/features/commands/agentsmd-command.ts
+++ b/src/features/commands/agentsmd-command.ts
@@ -20,22 +20,22 @@ export class AgentsmdCommand extends SimulatedCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): AgentsmdCommand {
     return new AgentsmdCommand(
-      this.fromRulesyncCommandDefault({ baseDir, rulesyncCommand, validate }),
+      this.fromRulesyncCommandDefault({ outputRoot, rulesyncCommand, validate }),
     );
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<AgentsmdCommand> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       AgentsmdCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
     );
@@ -48,7 +48,7 @@ export class AgentsmdCommand extends SimulatedCommand {
     }
 
     return new AgentsmdCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: AgentsmdCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -65,12 +65,12 @@ export class AgentsmdCommand extends SimulatedCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): AgentsmdCommand {
     return new AgentsmdCommand(
-      this.forDeletionDefault({ baseDir, relativeDirPath, relativeFilePath }),
+      this.forDeletionDefault({ outputRoot, relativeDirPath, relativeFilePath }),
     );
   }
 }

--- a/src/features/commands/antigravity-command.test.ts
+++ b/src/features/commands/antigravity-command.test.ts
@@ -18,7 +18,7 @@ describe("AntigravityCommand", () => {
       const body = "This is a test workflow body";
 
       const command = new AntigravityCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "test.md",
         frontmatter,
@@ -39,7 +39,7 @@ describe("AntigravityCommand", () => {
 
       expect(() => {
         new AntigravityCommand({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: ".agent/workflows",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -57,7 +57,7 @@ describe("AntigravityCommand", () => {
 
       expect(() => {
         new AntigravityCommand({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: ".agent/workflows",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -76,7 +76,7 @@ describe("AntigravityCommand", () => {
       };
 
       const command = new AntigravityCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "test.md",
         frontmatter,
@@ -91,7 +91,7 @@ describe("AntigravityCommand", () => {
 
     it("should return error for invalid frontmatter", () => {
       const command = new AntigravityCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 } as any,
@@ -107,7 +107,7 @@ describe("AntigravityCommand", () => {
 
     it("should return success when frontmatter is undefined", () => {
       const command = new AntigravityCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "test.md",
         frontmatter: { description: "test" },
@@ -133,7 +133,7 @@ describe("AntigravityCommand", () => {
       const body = "This workflow will be converted";
 
       const antigravityCommand = new AntigravityCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "convert-test.md",
         frontmatter,
@@ -151,7 +151,7 @@ describe("AntigravityCommand", () => {
       });
       expect(rulesyncCommand.getRelativeDirPath()).toBe(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(rulesyncCommand.getRelativeFilePath()).toBe("convert-test.md");
-      expect(rulesyncCommand.getBaseDir()).toBe(".");
+      expect(rulesyncCommand.getOutputRoot()).toBe(".");
     });
 
     it("should preserve trigger and turbo fields in antigravity section", () => {
@@ -163,7 +163,7 @@ describe("AntigravityCommand", () => {
       const body = "# Workflow: /my-workflow\n\nWorkflow content\n\n// turbo";
 
       const antigravityCommand = new AntigravityCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "my-workflow.md",
         frontmatter,
@@ -191,7 +191,7 @@ describe("AntigravityCommand", () => {
       const body = "Simple workflow content";
 
       const antigravityCommand = new AntigravityCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".agent/workflows",
         relativeFilePath: "simple.md",
         frontmatter,
@@ -218,7 +218,7 @@ describe("AntigravityCommand", () => {
       const body = "Workflow converted from rulesync";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "from-rulesync.md",
         frontmatter: rulesyncFrontmatter,
@@ -227,7 +227,7 @@ describe("AntigravityCommand", () => {
       });
 
       const antigravityCommand = AntigravityCommand.fromRulesyncCommand({
-        baseDir: "/converted/base",
+        outputRoot: "/converted/base",
         rulesyncCommand,
         validate: true,
       });
@@ -245,15 +245,15 @@ describe("AntigravityCommand", () => {
       expect(antigravityCommand.getRelativeFilePath()).toBe("from-rulesync.md");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncFrontmatter = {
         targets: ["antigravity" as const],
-        description: "Default baseDir test",
+        description: "Default outputRoot test",
       };
       const body = "Test workflow";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "default-base.md",
         frontmatter: rulesyncFrontmatter,
@@ -265,7 +265,7 @@ describe("AntigravityCommand", () => {
         rulesyncCommand,
       });
 
-      expect(antigravityCommand.getBaseDir()).toBe(process.cwd());
+      expect(antigravityCommand.getOutputRoot()).toBe(process.cwd());
     });
 
     it("should handle validation parameter", () => {
@@ -277,7 +277,7 @@ describe("AntigravityCommand", () => {
 
       // Testing runtime validation: force invalid type through TS
       const invalidCommandParams = {
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "validation.md",
         frontmatter: rulesyncFrontmatter as unknown as RulesyncCommandFrontmatter,
@@ -325,7 +325,7 @@ describe("AntigravityCommand", () => {
       const body = "Step 1: Do something";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "original-file.md",
         frontmatter: rulesyncFrontmatter,
@@ -365,7 +365,7 @@ describe("AntigravityCommand", () => {
       const body = "Simple body";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "root.md",
         frontmatter: rulesyncFrontmatter,
@@ -389,7 +389,7 @@ describe("AntigravityCommand", () => {
       const body = "Just a command";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "standard.md",
         frontmatter: rulesyncFrontmatter,
@@ -427,7 +427,7 @@ describe("AntigravityCommand", () => {
       const body = "Workflow without auto-execution";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "no-turbo.md",
         frontmatter: rulesyncFrontmatter,
@@ -469,7 +469,7 @@ Actual command content`;
       };
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "dirty.md",
         frontmatter: rulesyncFrontmatter,
@@ -501,7 +501,7 @@ Actual command content`;
       };
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "crlf.md",
         frontmatter: rulesyncFrontmatter,
@@ -526,7 +526,7 @@ Actual command content`;
       };
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "evil.md",
         frontmatter: rulesyncFrontmatter,
@@ -555,7 +555,7 @@ Actual command content`;
       };
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "empty.md",
         frontmatter: rulesyncFrontmatter,
@@ -584,7 +584,7 @@ Actual command content`;
         await writeFileContent(join(workflowsDir, "test-file.md"), fileContent);
 
         const command = await AntigravityCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test-file.md",
         });
 
@@ -604,7 +604,7 @@ Actual command content`;
       try {
         await expect(
           AntigravityCommand.fromFile({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeFilePath: "nonexistent.md",
           }),
         ).rejects.toThrow();
@@ -623,7 +623,7 @@ Actual command content`;
 
         await expect(
           AntigravityCommand.fromFile({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeFilePath: "invalid.md",
             validate: true,
           }),

--- a/src/features/commands/antigravity-command.ts
+++ b/src/features/commands/antigravity-command.ts
@@ -96,7 +96,7 @@ export class AntigravityCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -114,7 +114,7 @@ export class AntigravityCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): AntigravityCommand {
@@ -167,7 +167,7 @@ export class AntigravityCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(body, antigravityFrontmatter);
 
     return new AntigravityCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: antigravityFrontmatter,
       body,
       relativeDirPath: AntigravityCommand.getSettablePaths().relativeDirPath,
@@ -235,12 +235,12 @@ export class AntigravityCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<AntigravityCommand> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       AntigravityCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
     );
@@ -255,7 +255,7 @@ export class AntigravityCommand extends ToolCommand {
     }
 
     return new AntigravityCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: AntigravityCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -266,12 +266,12 @@ export class AntigravityCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): AntigravityCommand {
     return new AntigravityCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/claudecode-command.test.ts
+++ b/src/features/commands/claudecode-command.test.ts
@@ -31,7 +31,7 @@ describe("ClaudecodeCommand", () => {
   describe("constructor", () => {
     it("should create a valid ClaudecodeCommand instance", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -46,7 +46,7 @@ describe("ClaudecodeCommand", () => {
     it("should validate frontmatter during construction by default", () => {
       expect(() => {
         new ClaudecodeCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claude/commands",
           relativeFilePath: "test.md",
           frontmatter: { description: 123 as any },
@@ -58,7 +58,7 @@ describe("ClaudecodeCommand", () => {
 
     it("should skip validation when validate is false", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 as any },
@@ -72,7 +72,7 @@ describe("ClaudecodeCommand", () => {
 
     it("should generate correct file content with frontmatter", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -89,7 +89,7 @@ describe("ClaudecodeCommand", () => {
   describe("getBody", () => {
     it("should return the command body", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -104,7 +104,7 @@ describe("ClaudecodeCommand", () => {
     it("should return the frontmatter", () => {
       const frontmatter = { description: "Test command description" };
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -118,7 +118,7 @@ describe("ClaudecodeCommand", () => {
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Valid description" },
@@ -133,7 +133,7 @@ describe("ClaudecodeCommand", () => {
     it("should return success when frontmatter is undefined", () => {
       // Create command with validation disabled to avoid constructor validation
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: {} as any,
@@ -151,7 +151,7 @@ describe("ClaudecodeCommand", () => {
 
     it("should return error for invalid frontmatter", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 as any },
@@ -168,7 +168,7 @@ describe("ClaudecodeCommand", () => {
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand correctly", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -189,7 +189,7 @@ describe("ClaudecodeCommand", () => {
 
     it("should generate proper file content for RulesyncCommand", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "example.md",
         frontmatter: { description: "Example command" },
@@ -209,7 +209,7 @@ describe("ClaudecodeCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("should create ClaudecodeCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "sync-test.md",
         frontmatter: {
@@ -221,7 +221,7 @@ describe("ClaudecodeCommand", () => {
       });
 
       const claudecodeCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -232,12 +232,12 @@ describe("ClaudecodeCommand", () => {
       });
       expect(claudecodeCommand.getRelativeDirPath()).toBe(".claude/commands");
       expect(claudecodeCommand.getRelativeFilePath()).toBe("sync-test.md");
-      expect(claudecodeCommand.getBaseDir()).toBe(testDir);
+      expect(claudecodeCommand.getOutputRoot()).toBe(testDir);
     });
 
     it("should use global paths when global is true", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "global-test.md",
         frontmatter: {
@@ -249,7 +249,7 @@ describe("ClaudecodeCommand", () => {
       });
 
       const claudecodeCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: true,
       });
@@ -261,7 +261,7 @@ describe("ClaudecodeCommand", () => {
 
     it("should use local paths when global is false", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "local-test.md",
         frontmatter: {
@@ -273,7 +273,7 @@ describe("ClaudecodeCommand", () => {
       });
 
       const claudecodeCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: false,
       });
@@ -283,7 +283,7 @@ describe("ClaudecodeCommand", () => {
       expect(claudecodeCommand.getBody()).toBe("Local command body");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncCommand = new RulesyncCommand({
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
@@ -299,7 +299,7 @@ describe("ClaudecodeCommand", () => {
         rulesyncCommand,
       });
 
-      expect(claudecodeCommand.getBaseDir()).toBe(testDir);
+      expect(claudecodeCommand.getOutputRoot()).toBe(testDir);
     });
 
     it("should disable validation when specified", () => {
@@ -338,7 +338,7 @@ This is the command body from file`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "file-test.md",
       });
 
@@ -349,10 +349,10 @@ This is the command body from file`;
       });
       expect(command.getRelativeFilePath()).toBe("file-test.md");
       expect(command.getRelativeDirPath()).toBe(".claude/commands");
-      expect(command.getBaseDir()).toBe(testDir);
+      expect(command.getOutputRoot()).toBe(testDir);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const commandsDir = join(testDir, ".claude", "commands");
       await ensureDir(commandsDir);
 
@@ -368,7 +368,7 @@ Command body`;
         relativeFilePath: "default-test.md",
       });
 
-      expect(command.getBaseDir()).toBe(testDir);
+      expect(command.getOutputRoot()).toBe(testDir);
     });
 
     it("should throw error for invalid frontmatter", async () => {
@@ -386,7 +386,7 @@ Command body`;
 
       await expect(
         ClaudecodeCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-test.md",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -409,7 +409,7 @@ It has several paragraphs and formatting.
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "complex-test.md",
       });
 
@@ -438,7 +438,7 @@ description: Whitespace test
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "whitespace-test.md",
       });
 
@@ -458,7 +458,7 @@ Global command body`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global-test.md",
         global: true,
       });
@@ -484,7 +484,7 @@ Local command body`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "local-test.md",
         global: false,
       });
@@ -507,7 +507,7 @@ Command body`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -528,7 +528,7 @@ Subdirectory command body`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: join("pj", "sub-test.md"),
       });
 
@@ -551,7 +551,7 @@ Roundtrip body`;
       await writeFileContent(filePath, fileContent);
 
       const command = await ClaudecodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: join("pj", "roundtrip.md"),
       });
 
@@ -651,7 +651,7 @@ Roundtrip body`;
   describe("integration with ToolCommand", () => {
     it("should inherit from ToolCommand", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -660,14 +660,14 @@ Roundtrip body`;
 
       expect(command.getRelativeDirPath()).toBe(".claude/commands");
       expect(command.getRelativeFilePath()).toBe("test.md");
-      expect(command.getBaseDir()).toBe(testDir);
+      expect(command.getOutputRoot()).toBe(testDir);
       expect(typeof command.getFilePath).toBe("function");
       expect(typeof command.validate).toBe("function");
     });
 
     it("should support round-trip conversion with RulesyncCommand", () => {
       const originalCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "roundtrip.md",
         frontmatter: { description: "Round trip test" },
@@ -676,7 +676,7 @@ Roundtrip body`;
 
       const rulesyncCommand = originalCommand.toRulesyncCommand();
       const convertedCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -692,7 +692,7 @@ Roundtrip body`;
     it("should handle file reading errors gracefully", async () => {
       await expect(
         ClaudecodeCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent.md",
         }),
       ).rejects.toThrow();
@@ -712,7 +712,7 @@ Body`;
 
       await expect(
         ClaudecodeCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "error-test.md",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -722,7 +722,7 @@ Body`;
   describe("type definitions", () => {
     it("should have proper ClaudecodeCommandParams type", () => {
       const params = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test" },
@@ -746,7 +746,7 @@ Body`;
       await writeFileContent(filePath, fileContent);
 
       const params: ToolCommandFromFileParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "type-test.md",
       };
 
@@ -764,7 +764,7 @@ Body`;
       });
 
       const params: ToolCommandFromRulesyncCommandParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       };
 
@@ -776,7 +776,7 @@ Body`;
   describe("tool-specific field passthrough", () => {
     it("fromRulesyncCommand should preserve claudecode fields", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "passthrough-test.md",
         frontmatter: {
@@ -795,7 +795,7 @@ Body`;
       });
 
       const claudecodeCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -810,7 +810,7 @@ Body`;
 
     it("toRulesyncCommand should preserve extra fields in claudecode section", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -839,7 +839,7 @@ Body`;
 
     it("round-trip should preserve all fields", () => {
       const original = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -873,7 +873,7 @@ Body`;
 
     it("should not include claudecode section when no extra fields", () => {
       const command = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -890,7 +890,7 @@ Body`;
 
     it("should handle empty claudecode fields in RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "empty-test.md",
         frontmatter: {
@@ -903,7 +903,7 @@ Body`;
       });
 
       const claudecodeCommand = ClaudecodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 

--- a/src/features/commands/claudecode-command.ts
+++ b/src/features/commands/claudecode-command.ts
@@ -83,7 +83,7 @@ export class ClaudecodeCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -94,7 +94,7 @@ export class ClaudecodeCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -115,7 +115,7 @@ export class ClaudecodeCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new ClaudecodeCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: claudecodeFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -151,13 +151,13 @@ export class ClaudecodeCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<ClaudecodeCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     // Read file content
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -169,7 +169,7 @@ export class ClaudecodeCommand extends ToolCommand {
     }
 
     return new ClaudecodeCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -179,12 +179,12 @@ export class ClaudecodeCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): ClaudecodeCommand {
     return new ClaudecodeCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/cline-command.test.ts
+++ b/src/features/commands/cline-command.test.ts
@@ -60,7 +60,7 @@ Step 1`;
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const command = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -73,7 +73,7 @@ Step 1`;
 
     it("should allow empty content", () => {
       const command = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -85,7 +85,7 @@ Step 1`;
 
     it("should skip validation when validate is false", () => {
       const command = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -100,7 +100,7 @@ Step 1`;
   describe("getBody", () => {
     it("should return the command body", () => {
       const command = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -113,7 +113,7 @@ Step 1`;
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand", () => {
       const clineCommand = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -132,7 +132,7 @@ Step 1`;
   describe("fromRulesyncCommand", () => {
     it("should create ClineCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "workflow.md",
         frontmatter: { targets: ["cline"], description: "" },
@@ -142,7 +142,7 @@ Step 1`;
       });
 
       const clineCommand = ClineCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -155,7 +155,7 @@ Step 1`;
   describe("validate", () => {
     it("should always pass validation", () => {
       const command = new ClineCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -173,7 +173,7 @@ Step 1`;
       await writeFileContent(filePath, markdownWithFrontmatter);
 
       const command = await ClineCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "workflow.md",
       });
 
@@ -189,7 +189,7 @@ Step 1`;
       await writeFileContent(filePath, validContent);
 
       const command = await ClineCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global.md",
         global: true,
       });
@@ -202,7 +202,7 @@ Step 1`;
   describe("isTargetedByRulesyncCommand", () => {
     it("should return true when targets include cline", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "workflow.md",
         frontmatter: { targets: ["cline"], description: "" },
@@ -216,7 +216,7 @@ Step 1`;
 
     it("should return false when targets exclude cline", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "workflow.md",
         frontmatter: { targets: ["cursor"], description: "" },
@@ -232,7 +232,7 @@ Step 1`;
   describe("forDeletion", () => {
     it("should create deletable command", () => {
       const command = ClineCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules/workflows",
         relativeFilePath: "obsolete.md",
       });

--- a/src/features/commands/cline-command.ts
+++ b/src/features/commands/cline-command.ts
@@ -33,7 +33,7 @@ export class ClineCommand extends ToolCommand {
     };
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -44,7 +44,7 @@ export class ClineCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -52,7 +52,7 @@ export class ClineCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new ClineCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       fileContent: rulesyncCommand.getBody(),
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath(),
@@ -76,19 +76,19 @@ export class ClineCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<ClineCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { body: content } = parseFrontmatter(fileContent, filePath);
 
     return new ClineCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       fileContent: content.trim(),
@@ -97,12 +97,12 @@ export class ClineCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): ClineCommand {
     return new ClineCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/commands/codexcli-command.test.ts
+++ b/src/features/commands/codexcli-command.test.ts
@@ -43,7 +43,7 @@ It can be multiline.`;
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const command = new CodexcliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/prompts",
         relativeFilePath: "test-command.md",
         fileContent: "This is the body of the codexcli command.\nIt can be multiline.",
@@ -58,7 +58,7 @@ It can be multiline.`;
 
     it("should create instance without validation when validate is false", () => {
       const command = new CodexcliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/prompts",
         relativeFilePath: "test-command.md",
         fileContent: "Test body",
@@ -72,7 +72,7 @@ It can be multiline.`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const command = new CodexcliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/prompts",
         relativeFilePath: "test-command.md",
         fileContent: "This is the body content.\nWith multiple lines.",
@@ -86,7 +86,7 @@ It can be multiline.`;
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand", () => {
       const command = new CodexcliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/prompts",
         relativeFilePath: "test-command.md",
         fileContent: "Test body",
@@ -102,7 +102,7 @@ It can be multiline.`;
   describe("fromRulesyncCommand", () => {
     it("should create CodexcliCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -115,7 +115,7 @@ It can be multiline.`;
       });
 
       const codexcliCommand = CodexcliCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
         global: true,
@@ -129,7 +129,7 @@ It can be multiline.`;
 
     it("should handle RulesyncCommand with different file extensions", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-command.txt",
         frontmatter: {
@@ -142,7 +142,7 @@ It can be multiline.`;
       });
 
       const codexcliCommand = CodexcliCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
         global: true,
@@ -153,7 +153,7 @@ It can be multiline.`;
 
     it("should handle empty body", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -166,7 +166,7 @@ It can be multiline.`;
       });
 
       const codexcliCommand = CodexcliCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
         global: true,
@@ -184,7 +184,7 @@ It can be multiline.`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const command = await CodexcliCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-command.md",
         validate: true,
         global: true,
@@ -200,7 +200,7 @@ It can be multiline.`;
     it("should throw error when file does not exist", async () => {
       await expect(
         CodexcliCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-command.md",
           validate: true,
           global: true,
@@ -212,7 +212,7 @@ It can be multiline.`;
   describe("validate", () => {
     it("should return success", () => {
       const command = new CodexcliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/prompts",
         relativeFilePath: "valid-command.md",
         fileContent: "Valid body",

--- a/src/features/commands/codexcli-command.ts
+++ b/src/features/commands/codexcli-command.ts
@@ -30,7 +30,7 @@ export class CodexcliCommand extends ToolCommand {
     };
 
     return new RulesyncCommand({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -41,7 +41,7 @@ export class CodexcliCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -49,7 +49,7 @@ export class CodexcliCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new CodexcliCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       fileContent: rulesyncCommand.getBody(),
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath(),
@@ -73,19 +73,19 @@ export class CodexcliCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<CodexcliCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { body: content } = parseFrontmatter(fileContent, filePath);
 
     return new CodexcliCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       fileContent: content.trim(),
@@ -94,12 +94,12 @@ export class CodexcliCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): CodexcliCommand {
     return new CodexcliCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -87,7 +87,7 @@ vi.mocked(RulesyncCommand).mockImplementation(function (config: any) {
   Object.assign(instance, config);
   instance.getRelativeFilePath = () => config.relativeFilePath;
   instance.getRelativeDirPath = () => config.relativeDirPath;
-  instance.getBaseDir = () => config.baseDir;
+  instance.getOutputRoot = () => config.outputRoot;
   instance.getFrontmatter = () => config.frontmatter;
   instance.getBody = () => config.body;
   instance.getFileContent = () => config.fileContent;
@@ -227,14 +227,14 @@ describe("CommandsProcessor", () => {
 
   describe("constructor", () => {
     it("should create instance with valid tool target", () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
       expect(processor).toBeInstanceOf(CommandsProcessor);
     });
 
     it("should create instance with claudecode-legacy tool target", () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -245,13 +245,13 @@ describe("CommandsProcessor", () => {
       expect(() => {
         processor = new CommandsProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid" as CommandsProcessorToolTarget,
         });
       }).toThrow();
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       processor = new CommandsProcessor({ logger, toolTarget: "claudecode" });
       expect(processor).toBeInstanceOf(CommandsProcessor);
     });
@@ -259,7 +259,7 @@ describe("CommandsProcessor", () => {
     it("should accept global parameter", () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -267,19 +267,19 @@ describe("CommandsProcessor", () => {
     });
 
     it("should default global to false", () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
       expect((processor as any).global).toBe(false);
     });
   });
 
   describe("convertRulesyncFilesToToolFiles", () => {
     beforeEach(() => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
     });
 
     it("should convert rulesync commands to claudecode commands", async () => {
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -291,7 +291,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockClaudecodeCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -305,7 +305,7 @@ describe("CommandsProcessor", () => {
       const result = await processor.convertRulesyncFilesToToolFiles([mockRulesyncCommand]);
 
       expect(ClaudecodeCommand.fromRulesyncCommand).toHaveBeenCalledWith({
-        baseDir: expect.any(String),
+        outputRoot: expect.any(String),
         rulesyncCommand: mockRulesyncCommand,
         global: false,
       });
@@ -315,13 +315,13 @@ describe("CommandsProcessor", () => {
     it("should pass global parameter to ClaudecodeCommand.fromRulesyncCommand", async () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -333,7 +333,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockClaudecodeCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -347,17 +347,17 @@ describe("CommandsProcessor", () => {
       await processor.convertRulesyncFilesToToolFiles([mockRulesyncCommand]);
 
       expect(ClaudecodeCommand.fromRulesyncCommand).toHaveBeenCalledWith({
-        baseDir: expect.any(String),
+        outputRoot: expect.any(String),
         rulesyncCommand: mockRulesyncCommand,
         global: true,
       });
     });
 
     it("should convert rulesync commands to geminicli commands", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "geminicli" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "geminicli" });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -369,7 +369,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockGeminiCliCommand = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "commands"),
         relativeFilePath: "test.md",
         fileContent: `description = "test description"\nprompt = """\nconverted content\n"""`,
@@ -380,7 +380,7 @@ describe("CommandsProcessor", () => {
       const result = await processor.convertRulesyncFilesToToolFiles([mockRulesyncCommand]);
 
       expect(GeminiCliCommand.fromRulesyncCommand).toHaveBeenCalledWith({
-        baseDir: expect.any(String),
+        outputRoot: expect.any(String),
         rulesyncCommand: mockRulesyncCommand,
         global: false,
       });
@@ -388,10 +388,10 @@ describe("CommandsProcessor", () => {
     });
 
     it("should convert rulesync commands to roo commands", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "roo" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "roo" });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -403,7 +403,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockRooCommand = new RooCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".roo", "commands"),
         relativeFilePath: "test.md",
         fileContent: "converted content",
@@ -418,7 +418,7 @@ describe("CommandsProcessor", () => {
       const result = await processor.convertRulesyncFilesToToolFiles([mockRulesyncCommand]);
 
       expect(RooCommand.fromRulesyncCommand).toHaveBeenCalledWith({
-        baseDir: expect.any(String),
+        outputRoot: expect.any(String),
         rulesyncCommand: mockRulesyncCommand,
         global: false,
       });
@@ -428,13 +428,13 @@ describe("CommandsProcessor", () => {
     it("should pass global parameter to CursorCommand.fromRulesyncCommand", async () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
         global: true,
       });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -446,7 +446,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockCursorCommand = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cursor", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -458,17 +458,17 @@ describe("CommandsProcessor", () => {
       await processor.convertRulesyncFilesToToolFiles([mockRulesyncCommand]);
 
       expect(CursorCommand.fromRulesyncCommand).toHaveBeenCalledWith({
-        baseDir: expect.any(String),
+        outputRoot: expect.any(String),
         rulesyncCommand: mockRulesyncCommand,
         global: true,
       });
     });
 
     it("should flatten subdirectory path for supportsSubdirectory=false tools (generate)", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: join("pj", "test.md"),
         fileContent: "test content",
@@ -480,7 +480,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockCursorCommand = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cursor", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -496,10 +496,10 @@ describe("CommandsProcessor", () => {
     });
 
     it("should preserve subdirectory path for supportsSubdirectory=true tools (generate)", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: join("pj", "test.md"),
         fileContent: "test content",
@@ -511,7 +511,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockClaudecodeCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: join("pj", "test.md"),
         frontmatter: {
@@ -529,10 +529,10 @@ describe("CommandsProcessor", () => {
     });
 
     it("should warn when flattened command paths collide for supportsSubdirectory=false tools", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const commandInPj = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: join("pj", "test.md"),
         fileContent: "content from pj",
@@ -543,7 +543,7 @@ describe("CommandsProcessor", () => {
         body: "content from pj",
       });
       const commandInOps = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: join("ops", "test.md"),
         fileContent: "content from ops",
@@ -557,7 +557,7 @@ describe("CommandsProcessor", () => {
       vi.mocked(CursorCommand.fromRulesyncCommand)
         .mockReturnValueOnce(
           new CursorCommand({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".cursor", "commands"),
             relativeFilePath: "test.md",
             frontmatter: {},
@@ -566,7 +566,7 @@ describe("CommandsProcessor", () => {
         )
         .mockReturnValueOnce(
           new CursorCommand({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".cursor", "commands"),
             relativeFilePath: "test.md",
             frontmatter: {},
@@ -586,7 +586,7 @@ describe("CommandsProcessor", () => {
 
     it("should filter out non-rulesync command files", async () => {
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -598,7 +598,7 @@ describe("CommandsProcessor", () => {
       });
 
       const mockClaudecodeCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -622,7 +622,7 @@ describe("CommandsProcessor", () => {
 
   describe("convertToolFilesToRulesyncFiles", () => {
     beforeEach(() => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
     });
 
     it("should convert tool commands to rulesync commands", async () => {
@@ -705,7 +705,7 @@ describe("CommandsProcessor", () => {
 
   describe("loadRulesyncFiles", () => {
     beforeEach(() => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
     });
 
     it("should load rulesync command files successfully", async () => {
@@ -715,7 +715,7 @@ describe("CommandsProcessor", () => {
       ];
       const mockRulesyncCommands = [
         new RulesyncCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
           relativeFilePath: "test1.md",
           fileContent: "content1",
@@ -726,7 +726,7 @@ describe("CommandsProcessor", () => {
           body: "content1",
         }),
         new RulesyncCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
           relativeFilePath: "test2.md",
           fileContent: "content2",
@@ -750,11 +750,11 @@ describe("CommandsProcessor", () => {
       );
       expect(RulesyncCommand.fromFile).toHaveBeenCalledTimes(2);
       expect(RulesyncCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test1.md",
       });
       expect(RulesyncCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test2.md",
       });
       expect(logger.debug).toHaveBeenCalledWith("Successfully loaded 2 rulesync commands");
@@ -767,7 +767,7 @@ describe("CommandsProcessor", () => {
         join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "test2.md"),
       ];
       const mockRulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test1.md",
         fileContent: "content1",
@@ -802,7 +802,7 @@ describe("CommandsProcessor", () => {
       ];
       const mockRulesyncCommands = [
         new RulesyncCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
           relativeFilePath: join("pj", "foo.md"),
           fileContent: "content1",
@@ -813,7 +813,7 @@ describe("CommandsProcessor", () => {
           body: "content1",
         }),
         new RulesyncCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
           relativeFilePath: "bar.md",
           fileContent: "content2",
@@ -833,11 +833,11 @@ describe("CommandsProcessor", () => {
       const result = await processor.loadRulesyncFiles();
 
       expect(RulesyncCommand.fromFile).toHaveBeenNthCalledWith(1, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: join("pj", "foo.md"),
       });
       expect(RulesyncCommand.fromFile).toHaveBeenNthCalledWith(2, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "bar.md",
       });
       expect(result).toEqual(mockRulesyncCommands);
@@ -854,11 +854,11 @@ describe("CommandsProcessor", () => {
 
   describe("loadToolFiles", () => {
     it("should load claudecode commands with correct parameters", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       const mockPaths = [join(testDir, ".claude", "commands", "test.md")];
       const mockCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -876,7 +876,7 @@ describe("CommandsProcessor", () => {
         expect.stringContaining(join(".claude", "commands", "**", "*.md")),
       );
       expect(ClaudecodeCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
         global: false,
       });
@@ -885,11 +885,11 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load geminicli commands with correct parameters", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "geminicli" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "geminicli" });
 
       const mockPaths = [join(testDir, ".gemini", "commands", "test.toml")];
       const mockCommand = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "commands"),
         relativeFilePath: "test.toml",
         fileContent: `description = "test description"\nprompt = """\ncontent\n"""`,
@@ -904,11 +904,11 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load roo commands with correct parameters", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "roo" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "roo" });
 
       const mockPaths = [join(testDir, ".roo", "commands", "test.md")];
       const mockCommand = new RooCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".roo", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -927,14 +927,14 @@ describe("CommandsProcessor", () => {
     });
 
     it("should throw error when file loading fails", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       const mockPaths = [
         join(testDir, ".claude", "commands", "test1.md"),
         join(testDir, ".claude", "commands", "test2.md"),
       ];
       const mockCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test1.md",
         frontmatter: {
@@ -954,14 +954,14 @@ describe("CommandsProcessor", () => {
     it("should pass global parameter when loading claudecode commands", async () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
 
       const mockPaths = [join(testDir, ".claude", "commands", "test.md")];
       const mockCommand = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -976,7 +976,7 @@ describe("CommandsProcessor", () => {
       await processor.loadToolFiles();
 
       expect(ClaudecodeCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
         global: true,
       });
@@ -985,14 +985,14 @@ describe("CommandsProcessor", () => {
     it("should pass global parameter when loading cursor commands", async () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
         global: true,
       });
 
       const mockPaths = [join(testDir, ".cursor", "commands", "test.md")];
       const mockCommand = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cursor", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -1005,28 +1005,28 @@ describe("CommandsProcessor", () => {
       await processor.loadToolFiles();
 
       expect(CursorCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
         global: true,
       });
     });
 
     it("should load tool commands from subdirectories", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       const mockPaths = [
         join(testDir, ".claude", "commands", "pj", "foo.md"),
         join(testDir, ".claude", "commands", "bar.md"),
       ];
       const mockCommand1 = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: join("pj", "foo.md"),
         frontmatter: { description: "subdirectory command" },
         body: "content1",
       });
       const mockCommand2 = new ClaudecodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "bar.md",
         frontmatter: { description: "flat command" },
@@ -1041,12 +1041,12 @@ describe("CommandsProcessor", () => {
       const result = await processor.loadToolFiles();
 
       expect(ClaudecodeCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: join("pj", "foo.md"),
         global: false,
       });
       expect(ClaudecodeCommand.fromFile).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "bar.md",
         global: false,
       });
@@ -1054,7 +1054,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should load tool commands from subdirectories for deletion", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([
         join(testDir, ".claude", "commands", "pj", "foo.md"),
@@ -1065,14 +1065,14 @@ describe("CommandsProcessor", () => {
       expect(filesToDelete).toHaveLength(1);
       expect(vi.mocked(ClaudecodeCommand).forDeletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: join("pj", "foo.md"),
         }),
       );
     });
 
     it("should produce correct relative paths for deeply nested files in forDeletion mode", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([
         join(testDir, ".claude", "commands", "pj", "sub", "deep.md"),
@@ -1082,7 +1082,7 @@ describe("CommandsProcessor", () => {
 
       expect(vi.mocked(ClaudecodeCommand).forDeletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: join("pj", "sub", "deep.md"),
         }),
       );
@@ -1091,7 +1091,7 @@ describe("CommandsProcessor", () => {
     it("should throw error for unsupported tool target", async () => {
       processor = new CommandsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         getFactory: createMockGetFactoryThatThrowsUnsupported,
       });
@@ -1102,7 +1102,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should use top-level only glob for supportsSubdirectory=false tools (import)", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       mockFindFilesByGlobs.mockResolvedValue([]);
 
@@ -1117,7 +1117,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should use recursive glob for supportsSubdirectory=true tools (import)", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([]);
 
@@ -1200,7 +1200,7 @@ describe("CommandsProcessor", () => {
 
   describe("loadToolFiles with forDeletion: true", () => {
     it("should return files with correct paths for deletion", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([join(testDir, ".claude", "commands", "test.md")]);
 
@@ -1210,7 +1210,7 @@ describe("CommandsProcessor", () => {
       expect(filesToDelete[0]?.getRelativeFilePath()).toBe("test.md");
       expect(vi.mocked(ClaudecodeCommand).forDeletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test.md",
         }),
       );
@@ -1228,7 +1228,7 @@ describe("CommandsProcessor", () => {
       ];
 
       for (const target of targets) {
-        processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: target });
+        processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: target });
 
         mockFindFilesByGlobs.mockResolvedValue([]);
 
@@ -1238,7 +1238,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should filter out non-deletable files when forDeletion is true", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([
         join(testDir, ".claude", "commands", "deletable.md"),
@@ -1260,7 +1260,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should reject path traversal in loadToolFiles", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([
         join(testDir, ".claude", "commands", "..", "..", "etc", "passwd"),
@@ -1270,7 +1270,7 @@ describe("CommandsProcessor", () => {
     });
 
     it("should reject path traversal in loadToolFiles with forDeletion", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       mockFindFilesByGlobs.mockResolvedValue([
         join(testDir, ".claude", "commands", "..", "..", "etc", "passwd"),
@@ -1282,16 +1282,16 @@ describe("CommandsProcessor", () => {
     });
 
     it("should return all files when forDeletion is false regardless of isDeletable", async () => {
-      processor = new CommandsProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });
 
       const deletableCommand = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "deletable.md",
         isDeletable: () => true,
       };
       const nonDeletableCommand = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "commands"),
         relativeFilePath: "non-deletable.md",
         isDeletable: () => false,

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -357,7 +357,7 @@ export class CommandsProcessor extends FeatureProcessor {
   private readonly getFactory: GetFactory;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
@@ -365,7 +365,7 @@ export class CommandsProcessor extends FeatureProcessor {
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
@@ -373,7 +373,7 @@ export class CommandsProcessor extends FeatureProcessor {
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = CommandsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -414,7 +414,7 @@ export class CommandsProcessor extends FeatureProcessor {
           }
         }
         return factory.class.fromRulesyncCommand({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           rulesyncCommand: commandToConvert,
           global: this.global,
         });
@@ -459,7 +459,7 @@ export class CommandsProcessor extends FeatureProcessor {
     const rulesyncCommands = await Promise.all(
       rulesyncCommandPaths.map((path) =>
         RulesyncCommand.fromFile({
-          baseDir: this.inputRoot,
+          outputRoot: this.inputRoot,
           relativeFilePath: this.safeRelativePath(basePath, path),
         }),
       ),
@@ -481,19 +481,19 @@ export class CommandsProcessor extends FeatureProcessor {
     const factory = this.getFactory(this.toolTarget);
     const paths = factory.class.getSettablePaths({ global: this.global });
 
-    const baseDirFull = join(this.baseDir, paths.relativeDirPath);
+    const outputRootFull = join(this.outputRoot, paths.relativeDirPath);
     const globPattern = factory.meta.supportsSubdirectory
-      ? join(baseDirFull, "**", `*.${factory.meta.extension}`)
-      : join(baseDirFull, `*.${factory.meta.extension}`);
+      ? join(outputRootFull, "**", `*.${factory.meta.extension}`)
+      : join(outputRootFull, `*.${factory.meta.extension}`);
     const commandFilePaths = await findFilesByGlobs(globPattern);
 
     if (forDeletion) {
       const toolCommands = commandFilePaths
         .map((path) =>
           factory.class.forDeletion({
-            baseDir: this.baseDir,
+            outputRoot: this.outputRoot,
             relativeDirPath: paths.relativeDirPath,
-            relativeFilePath: this.safeRelativePath(baseDirFull, path),
+            relativeFilePath: this.safeRelativePath(outputRootFull, path),
             global: this.global,
           }),
         )
@@ -508,8 +508,8 @@ export class CommandsProcessor extends FeatureProcessor {
     const toolCommands = await Promise.all(
       commandFilePaths.map((path) =>
         factory.class.fromFile({
-          baseDir: this.baseDir,
-          relativeFilePath: this.safeRelativePath(baseDirFull, path),
+          outputRoot: this.outputRoot,
+          relativeFilePath: this.safeRelativePath(outputRootFull, path),
           global: this.global,
         }),
       ),

--- a/src/features/commands/copilot-command.test.ts
+++ b/src/features/commands/copilot-command.test.ts
@@ -57,7 +57,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -80,7 +80,7 @@ Body content`;
 
     it("should create instance with empty description", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -100,7 +100,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -116,7 +116,7 @@ Body content`;
 
     it("should accept frontmatter without description (description is optional)", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "no-desc-command.prompt.md",
         frontmatter: {} as CopilotCommandFrontmatter,
@@ -132,7 +132,7 @@ Body content`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -150,7 +150,7 @@ Body content`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with mode and description", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -172,7 +172,7 @@ Body content`;
   describe("toRulesyncCommand", () => {
     it("should convert CopilotCommand to RulesyncCommand", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test-command.prompt.md",
         frontmatter: {
@@ -196,7 +196,7 @@ Body content`;
 
     it("should strip .prompt.md extension when converting to RulesyncCommand", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "example.prompt.md",
         frontmatter: {
@@ -216,7 +216,7 @@ Body content`;
   describe("fromRulesyncCommand", () => {
     it("should create CopilotCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -244,7 +244,7 @@ Body content`;
 
     it("should convert .md extension to .prompt.md", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-command.md",
         frontmatter: {
@@ -266,7 +266,7 @@ Body content`;
 
     it("should handle empty description", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -368,7 +368,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "valid-command.prompt.md",
         frontmatter: {
@@ -386,7 +386,7 @@ Body content`;
 
     it("should handle frontmatter with additional properties", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "command-with-extras.prompt.md",
         frontmatter: {
@@ -458,7 +458,7 @@ Body content`;
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "empty-body.prompt.md",
         frontmatter: {
@@ -481,7 +481,7 @@ Body content`;
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "special-char.prompt.md",
         frontmatter: {
@@ -502,7 +502,7 @@ Body content`;
       const longContent = "A".repeat(10000);
 
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "long-content.prompt.md",
         frontmatter: {
@@ -519,7 +519,7 @@ Body content`;
 
     it("should handle multi-line description", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "multiline-desc.prompt.md",
         frontmatter: {
@@ -540,7 +540,7 @@ Body content`;
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "windows-lines.prompt.md",
         frontmatter: {
@@ -558,7 +558,7 @@ Body content`;
   describe("integration with base classes", () => {
     it("should properly inherit from ToolCommand", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test.prompt.md",
         frontmatter: {
@@ -575,10 +575,10 @@ Body content`;
       expect(command.getRelativeFilePath()).toBe("test.prompt.md");
     });
 
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
+    it("should handle outputRoot correctly", () => {
+      const customOutputRoot = "/custom/base/dir";
       const command = new CopilotCommand({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test.prompt.md",
         frontmatter: {
@@ -596,7 +596,7 @@ Body content`;
   describe("tool-specific field passthrough", () => {
     it("fromRulesyncCommand should preserve copilot fields", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "passthrough-test.md",
         frontmatter: {
@@ -612,7 +612,7 @@ Body content`;
       });
 
       const copilotCommand = CopilotCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -625,7 +625,7 @@ Body content`;
 
     it("toRulesyncCommand should preserve extra fields in copilot section", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test.prompt.md",
         frontmatter: {
@@ -648,7 +648,7 @@ Body content`;
 
     it("round-trip should preserve all fields except mode", () => {
       const original = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -674,7 +674,7 @@ Body content`;
 
     it("should not include copilot section when no extra fields", () => {
       const command = new CopilotCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "prompts"),
         relativeFilePath: "test.prompt.md",
         frontmatter: {

--- a/src/features/commands/copilot-command.ts
+++ b/src/features/commands/copilot-command.ts
@@ -80,7 +80,7 @@ export class CopilotCommand extends ToolCommand {
     const relativeFilePath = originalFilePath.replace(/\.prompt\.md$/, ".md");
 
     return new RulesyncCommand({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -109,7 +109,7 @@ export class CopilotCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): CopilotCommand {
@@ -131,7 +131,7 @@ export class CopilotCommand extends ToolCommand {
     const relativeFilePath = originalFilePath.replace(/\.md$/, ".prompt.md");
 
     return new CopilotCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: copilotFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -141,12 +141,12 @@ export class CopilotCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<CopilotCommand> {
     const paths = this.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -157,7 +157,7 @@ export class CopilotCommand extends ToolCommand {
     }
 
     return new CopilotCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -174,12 +174,12 @@ export class CopilotCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): CopilotCommand {
     return new CopilotCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/cursor-command.test.ts
+++ b/src/features/commands/cursor-command.test.ts
@@ -45,7 +45,7 @@ describe("CursorCommand", () => {
   describe("constructor", () => {
     it("should create instance with valid content and frontmatter", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
         frontmatter: { description: "Test description" },
@@ -62,7 +62,7 @@ describe("CursorCommand", () => {
 
     it("should create instance with empty frontmatter", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {},
@@ -76,7 +76,7 @@ describe("CursorCommand", () => {
 
     it("should create instance without validation when validate is false", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
         frontmatter: {},
@@ -89,7 +89,7 @@ describe("CursorCommand", () => {
 
     it("should generate correct file content with frontmatter", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test cursor command" },
@@ -106,7 +106,7 @@ describe("CursorCommand", () => {
   describe("getBody", () => {
     it("should return the command body", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
         frontmatter: { description: "Test" },
@@ -121,7 +121,7 @@ describe("CursorCommand", () => {
     it("should return the frontmatter", () => {
       const frontmatter = { description: "Test cursor command description" };
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -135,7 +135,7 @@ describe("CursorCommand", () => {
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand with description", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test-command.md",
         frontmatter: { description: "Test cursor description" },
@@ -154,7 +154,7 @@ describe("CursorCommand", () => {
 
     it("should propagate undefined description when not set", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -168,7 +168,7 @@ describe("CursorCommand", () => {
 
     it("should preserve handoffs in cursor section", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -188,7 +188,7 @@ describe("CursorCommand", () => {
 
     it("should not include cursor section when no extra fields", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Just a description" },
@@ -204,7 +204,7 @@ describe("CursorCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("should create CursorCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -217,7 +217,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -233,7 +233,7 @@ describe("CursorCommand", () => {
 
     it("should handle RulesyncCommand with different file extensions", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-command.txt",
         frontmatter: {
@@ -246,7 +246,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -256,7 +256,7 @@ describe("CursorCommand", () => {
 
     it("should handle empty description", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -269,7 +269,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -281,7 +281,7 @@ describe("CursorCommand", () => {
 
     it("should use global paths when global is true", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "global-test.md",
         frontmatter: {
@@ -293,7 +293,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: true,
       });
@@ -305,7 +305,7 @@ describe("CursorCommand", () => {
 
     it("should use local paths when global is false", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "local-test.md",
         frontmatter: {
@@ -317,7 +317,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: false,
       });
@@ -329,7 +329,7 @@ describe("CursorCommand", () => {
 
     it("should preserve cursor-specific fields from rulesync frontmatter", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "passthrough-test.md",
         frontmatter: {
@@ -344,7 +344,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -357,7 +357,7 @@ describe("CursorCommand", () => {
 
     it("should handle empty cursor fields in RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "empty-test.md",
         frontmatter: {
@@ -370,7 +370,7 @@ describe("CursorCommand", () => {
       });
 
       const cursorCommand = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -397,7 +397,7 @@ It can be multiline.`;
       await writeFileContent(filePath, fileContent);
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-command.md",
         validate: true,
       });
@@ -434,7 +434,7 @@ This is the body.`;
       await writeFileContent(filePath, fileContent);
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "with-handoffs.md",
         validate: true,
       });
@@ -464,7 +464,7 @@ This is the body.`;
       );
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-frontmatter.md",
         validate: true,
       });
@@ -487,7 +487,7 @@ Body content`,
       );
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-command.md",
         validate: true,
       });
@@ -499,7 +499,7 @@ Body content`,
     it("should throw error when file does not exist", async () => {
       await expect(
         CursorCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-command.md",
           validate: true,
         }),
@@ -523,7 +523,7 @@ description: Whitespace test
       await writeFileContent(join(commandsDir, "whitespace.md"), fileContent);
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "whitespace.md",
         validate: true,
       });
@@ -544,7 +544,7 @@ Global command body`,
       );
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global-test.md",
         global: true,
       });
@@ -567,7 +567,7 @@ Local command body`,
       );
 
       const command = await CursorCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "local-test.md",
         global: false,
       });
@@ -581,7 +581,7 @@ Local command body`,
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "valid-command.md",
         frontmatter: { description: "Valid description" },
@@ -595,7 +595,7 @@ Local command body`,
 
     it("should return success for empty frontmatter", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "empty-fm.md",
         frontmatter: {},
@@ -609,7 +609,7 @@ Local command body`,
 
     it("should return success when frontmatter is undefined", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: {} as any,
@@ -628,7 +628,7 @@ Local command body`,
   describe("forDeletion", () => {
     it("should create a minimal instance for deletion", () => {
       const command = CursorCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "to-delete.md",
       });
@@ -642,7 +642,7 @@ Local command body`,
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "empty-body.md",
         frontmatter: {},
@@ -658,7 +658,7 @@ Local command body`,
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "special-char.md",
         frontmatter: { description: "Special chars" },
@@ -676,7 +676,7 @@ Local command body`,
       const longContent = "A".repeat(10000);
 
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "long-content.md",
         frontmatter: {},
@@ -692,7 +692,7 @@ Local command body`,
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "windows-lines.md",
         frontmatter: {},
@@ -707,7 +707,7 @@ Local command body`,
   describe("integration with base classes", () => {
     it("should properly inherit from ToolCommand", () => {
       const command = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test" },
@@ -720,10 +720,10 @@ Local command body`,
       expect(command.getRelativeFilePath()).toBe("test.md");
     });
 
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
+    it("should handle outputRoot correctly", () => {
+      const customOutputRoot = "/custom/base/dir";
       const command = new CursorCommand({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -738,7 +738,7 @@ Local command body`,
   describe("isTargetedByRulesyncCommand", () => {
     it("should return true for rulesync command with wildcard target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["*"], description: "Test" },
@@ -752,7 +752,7 @@ Local command body`,
 
     it("should return true for rulesync command with cursor target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["cursor"], description: "Test" },
@@ -766,7 +766,7 @@ Local command body`,
 
     it("should return true for rulesync command with cursor and other targets", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["claudecode", "cursor", "cline"], description: "Test" },
@@ -780,7 +780,7 @@ Local command body`,
 
     it("should return false for rulesync command with different target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["claudecode"], description: "Test" },
@@ -794,7 +794,7 @@ Local command body`,
 
     it("should return false for rulesync command with empty targets", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: [], description: "Test" },
@@ -808,7 +808,7 @@ Local command body`,
 
     it("should return true for rulesync command with undefined targets (defaults to true)", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: undefined as any, description: "Test" },
@@ -865,7 +865,7 @@ Local command body`,
   describe("tool-specific field passthrough", () => {
     it("round-trip should preserve description + handoffs", () => {
       const original = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -908,7 +908,7 @@ Local command body`,
 
     it("round-trip should preserve description-only (no cursor section)", () => {
       const original = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "desc-only.md",
         frontmatter: { description: "Just a description" },
@@ -918,7 +918,7 @@ Local command body`,
 
       const rulesyncCommand = original.toRulesyncCommand();
       const back = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -928,7 +928,7 @@ Local command body`,
 
     it("round-trip should work for commands with no frontmatter", () => {
       const original = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "no-fm.md",
         frontmatter: {},
@@ -938,7 +938,7 @@ Local command body`,
 
       const rulesyncCommand = original.toRulesyncCommand();
       const back = CursorCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -947,7 +947,7 @@ Local command body`,
 
     it("unknown fields should pass through via looseObject", () => {
       const original = new CursorCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/commands",
         relativeFilePath: "unknown.md",
         frontmatter: {
@@ -981,7 +981,7 @@ Local command body`,
 
     it("double round-trip should produce stable output", () => {
       const original = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "stable.md",
         frontmatter: {
@@ -1024,7 +1024,7 @@ Body`,
       );
 
       const params: ToolCommandFromFileParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "type-test.md",
       };
 
@@ -1042,7 +1042,7 @@ Body`,
       });
 
       const params: ToolCommandFromRulesyncCommandParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       };
 

--- a/src/features/commands/cursor-command.ts
+++ b/src/features/commands/cursor-command.ts
@@ -89,7 +89,7 @@ export class CursorCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -100,7 +100,7 @@ export class CursorCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -121,7 +121,7 @@ export class CursorCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new CursorCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: cursorFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -157,13 +157,13 @@ export class CursorCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<CursorCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -175,7 +175,7 @@ export class CursorCommand extends ToolCommand {
     }
 
     return new CursorCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -185,12 +185,12 @@ export class CursorCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): CursorCommand {
     return new CursorCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},

--- a/src/features/commands/factorydroid-command.test.ts
+++ b/src/features/commands/factorydroid-command.test.ts
@@ -49,7 +49,7 @@ Body content`;
   describe("fromRulesyncCommand", () => {
     it("should create FactorydroidCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -62,7 +62,7 @@ Body content`;
       });
 
       const factorydroidCommand = FactorydroidCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       }) as FactorydroidCommand;
@@ -84,7 +84,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const command = await FactorydroidCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-command.md",
         validate: true,
       });
@@ -101,7 +101,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         FactorydroidCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-command.md",
           validate: true,
         }),
@@ -116,7 +116,7 @@ Body content`;
 
       await expect(
         FactorydroidCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-command.md",
           validate: true,
         }),
@@ -168,7 +168,7 @@ Body content`;
   describe("forDeletion", () => {
     it("should create deletion marker", () => {
       const command = FactorydroidCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/commands",
         relativeFilePath: "to-delete.md",
       });

--- a/src/features/commands/factorydroid-command.ts
+++ b/src/features/commands/factorydroid-command.ts
@@ -20,24 +20,24 @@ export class FactorydroidCommand extends SimulatedCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
   }: ToolCommandFromRulesyncCommandParams): FactorydroidCommand {
     return new FactorydroidCommand(
-      this.fromRulesyncCommandDefault({ baseDir, rulesyncCommand, validate, global }),
+      this.fromRulesyncCommandDefault({ outputRoot, rulesyncCommand, validate, global }),
     );
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<FactorydroidCommand> {
     const paths = FactorydroidCommand.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -47,7 +47,7 @@ export class FactorydroidCommand extends SimulatedCommand {
     }
 
     return new FactorydroidCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -64,12 +64,12 @@ export class FactorydroidCommand extends SimulatedCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): FactorydroidCommand {
     return new FactorydroidCommand(
-      this.forDeletionDefault({ baseDir, relativeDirPath, relativeFilePath }),
+      this.forDeletionDefault({ outputRoot, relativeDirPath, relativeFilePath }),
     );
   }
 }

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -47,7 +47,7 @@ prompt = "Unclosed string`;
   describe("constructor", () => {
     it("should create instance with valid TOML content", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlContent,
@@ -66,7 +66,7 @@ prompt = "Unclosed string`;
 
     it("should create instance with TOML content without description", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlWithoutDescription,
@@ -84,7 +84,7 @@ prompt = "Unclosed string`;
       expect(
         () =>
           new GeminiCliCommand({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".gemini/commands",
             relativeFilePath: "invalid-command.toml",
             fileContent: invalidTomlContent,
@@ -97,7 +97,7 @@ prompt = "Unclosed string`;
       expect(
         () =>
           new GeminiCliCommand({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".gemini/commands",
             relativeFilePath: "malformed-command.toml",
             fileContent: malformedTomlContent,
@@ -110,7 +110,7 @@ prompt = "Unclosed string`;
   describe("parseTomlContent", () => {
     it("should parse valid TOML with all fields", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlContent,
@@ -126,7 +126,7 @@ prompt = "Unclosed string`;
 
     it("should parse TOML with optional description missing", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlWithoutDescription,
@@ -142,7 +142,7 @@ prompt = "Unclosed string`;
       expect(
         () =>
           new GeminiCliCommand({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".gemini/commands",
             relativeFilePath: "invalid-command.toml",
             fileContent: `description = "Test description"`,
@@ -155,7 +155,7 @@ prompt = "Unclosed string`;
   describe("getBody", () => {
     it("should return the prompt content as body", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlContent,
@@ -171,7 +171,7 @@ prompt = "Unclosed string`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with description and prompt", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlContent,
@@ -189,7 +189,7 @@ prompt = "Unclosed string`;
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand with correct frontmatter", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlContent,
@@ -212,7 +212,7 @@ prompt = "Unclosed string`;
 
     it("should convert to RulesyncCommand with empty description", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "test-command.toml",
         fileContent: validTomlWithoutDescription,
@@ -231,7 +231,7 @@ prompt = "Unclosed string`;
   describe("fromRulesyncCommand", () => {
     it("should create GeminiCliCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-command.md",
         frontmatter: {
@@ -244,7 +244,7 @@ prompt = "Unclosed string`;
       });
 
       const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -261,7 +261,7 @@ prompt = "Unclosed string`;
 
     it("should handle RulesyncCommand with .md extension replacement", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-command.md",
         frontmatter: {
@@ -274,7 +274,7 @@ prompt = "Unclosed string`;
       });
 
       const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         validate: true,
       });
@@ -291,7 +291,7 @@ prompt = "Unclosed string`;
       await writeFileContent(filePath, validTomlContent);
 
       const command = await GeminiCliCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-command.toml",
         validate: true,
       });
@@ -314,7 +314,7 @@ prompt = "Unclosed string`;
       await writeFileContent(filePath, validTomlContent);
 
       const command = await GeminiCliCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-command.toml",
         validate: true,
       });
@@ -325,7 +325,7 @@ prompt = "Unclosed string`;
     it("should throw error when file does not exist", async () => {
       await expect(
         GeminiCliCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-command.toml",
           validate: true,
         }),
@@ -340,7 +340,7 @@ prompt = "Unclosed string`;
 
       await expect(
         GeminiCliCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-command.toml",
           validate: true,
         }),
@@ -351,7 +351,7 @@ prompt = "Unclosed string`;
   describe("validate", () => {
     it("should return success for valid TOML content", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "valid-command.toml",
         fileContent: validTomlContent,
@@ -365,7 +365,7 @@ prompt = "Unclosed string`;
 
     it("should return error for invalid TOML content", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "invalid-command.toml",
         fileContent: `prompt = """
@@ -385,7 +385,7 @@ Valid prompt content
 
     it("should return error for malformed TOML content", () => {
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "malformed-command.toml",
         fileContent: validTomlContent,
@@ -447,7 +447,7 @@ Valid prompt content
 prompt = ""`;
 
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "empty-prompt.toml",
         fileContent: emptyPromptToml,
@@ -470,7 +470,7 @@ And escaped quotes: "Hello "World""
 """`;
 
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "special-char.toml",
         fileContent: specialCharToml,
@@ -490,7 +490,7 @@ ${longPrompt}
 """`;
 
       const command = new GeminiCliCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "long-prompt.toml",
         fileContent: longPromptToml,
@@ -505,7 +505,7 @@ ${longPrompt}
   describe("isTargetedByRulesyncCommand", () => {
     it("should return true for rulesync command with wildcard target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["*"], description: "Test" },
@@ -519,7 +519,7 @@ ${longPrompt}
 
     it("should return true for rulesync command with geminicli target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["geminicli"], description: "Test" },
@@ -533,7 +533,7 @@ ${longPrompt}
 
     it("should return true for rulesync command with geminicli and other targets", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["cursor", "geminicli", "cline"], description: "Test" },
@@ -547,7 +547,7 @@ ${longPrompt}
 
     it("should return false for rulesync command with different target", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["cursor"], description: "Test" },
@@ -561,7 +561,7 @@ ${longPrompt}
 
     it("should return true for rulesync command with no targets specified", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: undefined, description: "Test" } as any,
@@ -577,7 +577,7 @@ ${longPrompt}
   describe("forDeletion", () => {
     it("should create instance for deletion with empty content", () => {
       const command = GeminiCliCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "to-delete.toml",
       });
@@ -592,14 +592,14 @@ ${longPrompt}
       expect(command.getRelativeFilePath()).toBe("to-delete.toml");
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const command = GeminiCliCommand.forDeletion({
         relativeDirPath: ".gemini/commands",
         relativeFilePath: "to-delete.toml",
       });
 
       expect(command).toBeInstanceOf(GeminiCliCommand);
-      expect(command.getBaseDir()).toBe(testDir); // testDir is mocked as process.cwd()
+      expect(command.getOutputRoot()).toBe(testDir); // testDir is mocked as process.cwd()
     });
   });
 });

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -93,7 +93,7 @@ export class GeminiCliCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      outputRoot: process.cwd(), // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -104,7 +104,7 @@ export class GeminiCliCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -134,7 +134,7 @@ ${geminiFrontmatter.prompt}
     const paths = this.getSettablePaths({ global });
 
     return new GeminiCliCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath().replace(".md", ".toml"),
       fileContent: tomlContent,
@@ -143,18 +143,18 @@ ${geminiFrontmatter.prompt}
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<GeminiCliCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     // Read file content
     const fileContent = await readFileContent(filePath);
 
     return new GeminiCliCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -179,7 +179,7 @@ ${geminiFrontmatter.prompt}
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): GeminiCliCommand {
@@ -188,7 +188,7 @@ ${geminiFrontmatter.prompt}
     const placeholderToml = `description = ""
 prompt = ""`;
     return new GeminiCliCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: placeholderToml,

--- a/src/features/commands/junie-command.test.ts
+++ b/src/features/commands/junie-command.test.ts
@@ -27,7 +27,7 @@ describe("JunieCommand", () => {
   describe("constructor", () => {
     it("should create a valid JunieCommand instance", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -42,7 +42,7 @@ describe("JunieCommand", () => {
     it("should validate frontmatter during construction by default", () => {
       expect(() => {
         new JunieCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".junie/commands",
           relativeFilePath: "test.md",
           frontmatter: { description: 123 as any },
@@ -54,7 +54,7 @@ describe("JunieCommand", () => {
 
     it("should skip validation when validate is false", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 as any },
@@ -68,7 +68,7 @@ describe("JunieCommand", () => {
 
     it("should generate correct file content with frontmatter", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -85,7 +85,7 @@ describe("JunieCommand", () => {
   describe("getBody", () => {
     it("should return the command body", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test command" },
@@ -100,7 +100,7 @@ describe("JunieCommand", () => {
     it("should return the frontmatter", () => {
       const frontmatter = { description: "Test command description" };
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -114,7 +114,7 @@ describe("JunieCommand", () => {
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Valid description" },
@@ -129,7 +129,7 @@ describe("JunieCommand", () => {
 
     it("should return error for invalid frontmatter", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 as any },
@@ -144,7 +144,7 @@ describe("JunieCommand", () => {
 
     it("should return success for frontmatter with extra fields", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test", extra: "field" } as any,
@@ -173,7 +173,7 @@ describe("JunieCommand", () => {
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand correctly", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "Test description" },
@@ -193,7 +193,7 @@ describe("JunieCommand", () => {
 
     it("should preserve extra fields in junie section", () => {
       const command = new JunieCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -216,7 +216,7 @@ describe("JunieCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("should create JunieCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test-command.md",
         fileContent: "",
@@ -240,7 +240,7 @@ describe("JunieCommand", () => {
 
     it("should merge junie-specific fields from rulesync frontmatter", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test-command.md",
         fileContent: "",
@@ -275,7 +275,7 @@ describe("JunieCommand", () => {
       await writeFileContent(join(testDir, relativeDirPath, relativeFilePath), fileContent);
 
       const command = await JunieCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath,
       });
 
@@ -294,7 +294,7 @@ describe("JunieCommand", () => {
 
       await expect(
         JunieCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath,
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -304,7 +304,7 @@ describe("JunieCommand", () => {
   describe("isTargetedByRulesyncCommand", () => {
     it("should return true if targets includes *", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -317,7 +317,7 @@ describe("JunieCommand", () => {
 
     it("should return true if targets includes junie", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -330,7 +330,7 @@ describe("JunieCommand", () => {
 
     it("should return false if targets does not include junie or *", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -343,7 +343,7 @@ describe("JunieCommand", () => {
 
     it("should return true if targets is undefined", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/command",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -358,7 +358,7 @@ describe("JunieCommand", () => {
   describe("forDeletion", () => {
     it("should create a minimal JunieCommand for deletion", () => {
       const command = JunieCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/commands",
         relativeFilePath: "test.md",
       });

--- a/src/features/commands/junie-command.ts
+++ b/src/features/commands/junie-command.ts
@@ -82,7 +82,7 @@ export class JunieCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(), // RulesyncCommand baseDir is always the project root directory
+      outputRoot: process.cwd(), // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -93,7 +93,7 @@ export class JunieCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -114,7 +114,7 @@ export class JunieCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new JunieCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: junieFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -150,13 +150,13 @@ export class JunieCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<JunieCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     // Read file content
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -168,7 +168,7 @@ export class JunieCommand extends ToolCommand {
     }
 
     return new JunieCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -178,12 +178,12 @@ export class JunieCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): JunieCommand {
     return new JunieCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/kilo-command.test.ts
+++ b/src/features/commands/kilo-command.test.ts
@@ -28,7 +28,7 @@ describe("KiloCommand", () => {
   describe("constructor", () => {
     it("should create a command with optional Kilo fields", () => {
       const command = new KiloCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "commands"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -52,7 +52,7 @@ describe("KiloCommand", () => {
     it("should validate frontmatter when enabled", () => {
       expect(() => {
         new KiloCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".kilo", "commands"),
           relativeFilePath: "invalid.md",
           frontmatter: { description: 123 as unknown as string },
@@ -77,7 +77,7 @@ describe("KiloCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("should merge kilo frontmatter fields and respect global paths", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "custom.md",
         frontmatter: {
@@ -94,7 +94,7 @@ describe("KiloCommand", () => {
       });
 
       const command = KiloCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: true,
       });
@@ -107,7 +107,7 @@ describe("KiloCommand", () => {
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand with kilo metadata", () => {
       const command = new KiloCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "commands"),
         relativeFilePath: "custom.md",
         frontmatter: { description: "Create component", agent: "plan" },
@@ -137,7 +137,7 @@ describe("KiloCommand", () => {
       );
 
       const command = await KiloCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "task.md",
       });
 

--- a/src/features/commands/kilo-command.ts
+++ b/src/features/commands/kilo-command.ts
@@ -78,7 +78,7 @@ export class KiloCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -89,7 +89,7 @@ export class KiloCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -106,7 +106,7 @@ export class KiloCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new KiloCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: kiloFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -129,13 +129,13 @@ export class KiloCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<KiloCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -145,7 +145,7 @@ export class KiloCommand extends ToolCommand {
     }
 
     return new KiloCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -162,12 +162,12 @@ export class KiloCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): KiloCommand {
     return new KiloCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/kiro-command.test.ts
+++ b/src/features/commands/kiro-command.test.ts
@@ -48,7 +48,7 @@ Step 1`;
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand with default frontmatter", () => {
       const kiroCommand = new KiroCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/prompts",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -67,7 +67,7 @@ Step 1`;
   describe("fromRulesyncCommand", () => {
     it("should create KiroCommand from RulesyncCommand", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "prompt.md",
         frontmatter: { targets: ["kiro"], description: "" },
@@ -77,7 +77,7 @@ Step 1`;
       });
 
       const kiroCommand = KiroCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -90,7 +90,7 @@ Step 1`;
   describe("validate", () => {
     it("should always succeed", () => {
       const command = new KiroCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/prompts",
         relativeFilePath: "test.md",
         fileContent: validContent,
@@ -108,7 +108,7 @@ Step 1`;
       await writeFileContent(filePath, markdownWithFrontmatter);
 
       const command = await KiroCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "prompt.md",
       });
 
@@ -123,7 +123,7 @@ Step 1`;
       await writeFileContent(filePath, validContent);
 
       const command = await KiroCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global.md",
         global: true,
       });
@@ -136,7 +136,7 @@ Step 1`;
   describe("isTargetedByRulesyncCommand", () => {
     it("should return true when rulesync targets include kiro", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "prompt.md",
         frontmatter: { targets: ["kiro"], description: "" },
@@ -150,7 +150,7 @@ Step 1`;
 
     it("should return false when kiro is not targeted", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "prompt.md",
         frontmatter: { targets: ["cursor"], description: "" },
@@ -166,7 +166,7 @@ Step 1`;
   describe("forDeletion", () => {
     it("should create deletable command placeholder", () => {
       const command = KiroCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/prompts",
         relativeFilePath: "obsolete.md",
       });

--- a/src/features/commands/kiro-command.ts
+++ b/src/features/commands/kiro-command.ts
@@ -25,7 +25,7 @@ export class KiroCommand extends ToolCommand {
     };
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -36,14 +36,14 @@ export class KiroCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): KiroCommand {
     const paths = this.getSettablePaths();
 
     return new KiroCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       fileContent: rulesyncCommand.getBody(),
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: rulesyncCommand.getRelativeFilePath(),
@@ -67,18 +67,18 @@ export class KiroCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<KiroCommand> {
     const paths = this.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
 
     const fileContent = await readFileContent(filePath);
     const { body: content } = parseFrontmatter(fileContent, filePath);
 
     return new KiroCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       fileContent: content.trim(),
@@ -87,12 +87,12 @@ export class KiroCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): KiroCommand {
     return new KiroCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/commands/opencode-command.test.ts
+++ b/src/features/commands/opencode-command.test.ts
@@ -28,7 +28,7 @@ describe("OpenCodeCommand", () => {
   describe("constructor", () => {
     it("should create a command with optional OpenCode fields", () => {
       const command = new OpenCodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "command"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -52,7 +52,7 @@ describe("OpenCodeCommand", () => {
     it("should validate frontmatter when enabled", () => {
       expect(() => {
         new OpenCodeCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".opencode", "command"),
           relativeFilePath: "invalid.md",
           frontmatter: { description: 123 as unknown as string },
@@ -77,7 +77,7 @@ describe("OpenCodeCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("should merge opencode frontmatter fields and respect global paths", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "custom.md",
         frontmatter: {
@@ -94,7 +94,7 @@ describe("OpenCodeCommand", () => {
       });
 
       const command = OpenCodeCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: true,
       });
@@ -107,7 +107,7 @@ describe("OpenCodeCommand", () => {
   describe("toRulesyncCommand", () => {
     it("should convert to RulesyncCommand with opencode metadata", () => {
       const command = new OpenCodeCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "command"),
         relativeFilePath: "custom.md",
         frontmatter: { description: "Create component", agent: "plan" },
@@ -137,7 +137,7 @@ describe("OpenCodeCommand", () => {
       );
 
       const command = await OpenCodeCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "task.md",
       });
 

--- a/src/features/commands/opencode-command.ts
+++ b/src/features/commands/opencode-command.ts
@@ -80,7 +80,7 @@ export class OpenCodeCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -91,7 +91,7 @@ export class OpenCodeCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -108,7 +108,7 @@ export class OpenCodeCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new OpenCodeCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: opencodeFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -135,13 +135,13 @@ export class OpenCodeCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<OpenCodeCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -151,7 +151,7 @@ export class OpenCodeCommand extends ToolCommand {
     }
 
     return new OpenCodeCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -168,12 +168,12 @@ export class OpenCodeCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): OpenCodeCommand {
     return new OpenCodeCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/pi-command.test.ts
+++ b/src/features/commands/pi-command.test.ts
@@ -38,7 +38,7 @@ describe("PiCommand", () => {
   describe("constructor", () => {
     it("should create a PiCommand with frontmatter", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: "Test" },
@@ -52,7 +52,7 @@ describe("PiCommand", () => {
 
     it("should emit body-only content when frontmatter is empty", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -64,7 +64,7 @@ describe("PiCommand", () => {
 
     it("should emit frontmatter block when frontmatter has fields", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: "Test", "argument-hint": "[args]" },
@@ -80,7 +80,7 @@ describe("PiCommand", () => {
     it("should throw when validating invalid frontmatter", () => {
       expect(() => {
         new PiCommand({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".pi", "prompts"),
           relativeFilePath: "test.md",
           frontmatter: { description: 42 as any },
@@ -94,7 +94,7 @@ describe("PiCommand", () => {
   describe("validate", () => {
     it("should succeed for valid frontmatter", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: "Valid" },
@@ -108,7 +108,7 @@ describe("PiCommand", () => {
 
     it("should fail for invalid frontmatter when validation deferred", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: 123 as any },
@@ -136,7 +136,7 @@ Body`,
       );
 
       const command = await PiCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -160,7 +160,7 @@ Body`,
       );
 
       const command = await PiCommand.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
         global: true,
       });
@@ -182,7 +182,7 @@ Body`,
 
       await expect(
         PiCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "bad.md",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -192,7 +192,7 @@ Body`,
   describe("fromRulesyncCommand", () => {
     it("should copy description from rulesync frontmatter", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -204,7 +204,7 @@ Body`,
       });
 
       const command = PiCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -215,7 +215,7 @@ Body`,
 
     it("should propagate argument-hint from rulesync pi section", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -230,7 +230,7 @@ Body`,
       });
 
       const command = PiCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -242,7 +242,7 @@ Body`,
 
     it("should emit to the global path when global is true", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -254,7 +254,7 @@ Body`,
       });
 
       const command = PiCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
         global: true,
       });
@@ -266,7 +266,7 @@ Body`,
   describe("toRulesyncCommand", () => {
     it("should produce rulesync frontmatter with wildcard targets", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: "Desc" },
@@ -282,7 +282,7 @@ Body`,
 
     it("should preserve argument-hint in the pi section on round-trip", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: { description: "Desc", "argument-hint": "[message]" },
@@ -298,7 +298,7 @@ Body`,
 
     it("should preserve arbitrary extra fields in the pi section", () => {
       const command = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "test.md",
         frontmatter: {
@@ -320,7 +320,7 @@ Body`,
 
     it("should round-trip argument-hint through pi section", () => {
       const original = new PiCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "roundtrip.md",
         frontmatter: { description: "Desc", "argument-hint": "[arg]" },
@@ -339,7 +339,7 @@ Body`,
       });
 
       const restored = PiCommand.fromRulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncCommand,
       });
 
@@ -353,7 +353,7 @@ Body`,
   describe("forDeletion", () => {
     it("should create a deletion stub", () => {
       const command = PiCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "prompts"),
         relativeFilePath: "to-delete.md",
       });

--- a/src/features/commands/pi-command.ts
+++ b/src/features/commands/pi-command.ts
@@ -108,7 +108,7 @@ export class PiCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -119,7 +119,7 @@ export class PiCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -137,7 +137,7 @@ export class PiCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new PiCommand({
-      baseDir,
+      outputRoot,
       frontmatter: piFrontmatter,
       body: rulesyncCommand.getBody(),
       relativeDirPath: paths.relativeDirPath,
@@ -170,13 +170,13 @@ export class PiCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<PiCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -186,7 +186,7 @@ export class PiCommand extends ToolCommand {
     }
 
     return new PiCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -196,12 +196,12 @@ export class PiCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): PiCommand {
     return new PiCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},

--- a/src/features/commands/roo-command.test.ts
+++ b/src/features/commands/roo-command.test.ts
@@ -18,7 +18,7 @@ describe("RooCommand", () => {
       const body = "This is a test command body";
 
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -40,7 +40,7 @@ describe("RooCommand", () => {
       const body = "Command with argument hint";
 
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test-with-hint.md",
         frontmatter,
@@ -58,7 +58,7 @@ describe("RooCommand", () => {
 
       expect(() => {
         new RooCommand({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: ".roo/commands",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -76,7 +76,7 @@ describe("RooCommand", () => {
 
       expect(() => {
         new RooCommand({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: ".roo/commands",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter as any,
@@ -95,7 +95,7 @@ describe("RooCommand", () => {
       };
 
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -110,7 +110,7 @@ describe("RooCommand", () => {
 
     it("should return error for invalid frontmatter", () => {
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: 123 } as any,
@@ -127,7 +127,7 @@ describe("RooCommand", () => {
     it("should return success when frontmatter is undefined", () => {
       // Create a command with undefined frontmatter by manipulating the private field
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "test" },
@@ -153,7 +153,7 @@ describe("RooCommand", () => {
       const body = "This command will be converted";
 
       const rooCommand = new RooCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "convert-test.md",
         frontmatter,
@@ -171,7 +171,7 @@ describe("RooCommand", () => {
       });
       expect(rulesyncCommand.getRelativeDirPath()).toBe(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(rulesyncCommand.getRelativeFilePath()).toBe("convert-test.md");
-      expect(rulesyncCommand.getBaseDir()).toBe(".");
+      expect(rulesyncCommand.getOutputRoot()).toBe(".");
     });
   });
 
@@ -184,7 +184,7 @@ describe("RooCommand", () => {
       const body = "Command converted from rulesync";
 
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "from-rulesync.md",
         frontmatter: rulesyncFrontmatter,
@@ -193,7 +193,7 @@ describe("RooCommand", () => {
       });
 
       const rooCommand = RooCommand.fromRulesyncCommand({
-        baseDir: "/converted/base",
+        outputRoot: "/converted/base",
         rulesyncCommand,
         validate: true,
       });
@@ -205,16 +205,16 @@ describe("RooCommand", () => {
       });
       expect(rooCommand.getRelativeDirPath()).toBe(".roo/commands");
       expect(rooCommand.getRelativeFilePath()).toBe("from-rulesync.md");
-      expect(rooCommand.getBaseDir()).toBe("/converted/base");
+      expect(rooCommand.getOutputRoot()).toBe("/converted/base");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const mockCwd = "/mock/cwd";
       const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
 
       try {
         const rulesyncCommand = new RulesyncCommand({
-          baseDir: "/test/base",
+          outputRoot: "/test/base",
           relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
           relativeFilePath: "test.md",
           frontmatter: { targets: ["roo" as const], description: "test" },
@@ -226,7 +226,7 @@ describe("RooCommand", () => {
           rulesyncCommand,
         });
 
-        expect(rooCommand.getBaseDir()).toBe(mockCwd);
+        expect(rooCommand.getOutputRoot()).toBe(mockCwd);
       } finally {
         cwdSpy.mockRestore();
       }
@@ -234,7 +234,7 @@ describe("RooCommand", () => {
 
     it("should handle validation parameter", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { targets: ["roo" as const], description: "test" },
@@ -270,7 +270,7 @@ describe("RooCommand", () => {
         await writeFileContent(filePath, fileContent);
 
         const command = await RooCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "from-file.md",
           validate: true,
         });
@@ -280,13 +280,13 @@ describe("RooCommand", () => {
         expect(command.getFrontmatter()).toEqual(frontmatter);
         expect(command.getRelativeDirPath()).toBe(".roo/commands");
         expect(command.getRelativeFilePath()).toBe("from-file.md");
-        expect(command.getBaseDir()).toBe(testDir);
+        expect(command.getOutputRoot()).toBe(testDir);
       } finally {
         await cleanup();
       }
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const testSetup = await setupTestDirectory();
       const { testDir, cleanup } = testSetup;
 
@@ -295,7 +295,7 @@ describe("RooCommand", () => {
 
       try {
         const frontmatter: RooCommandFrontmatter = {
-          description: "Command with default baseDir",
+          description: "Command with default outputRoot",
         };
         const body = "Test body";
         const fileContent = stringifyFrontmatter(body, frontmatter);
@@ -309,7 +309,7 @@ describe("RooCommand", () => {
           relativeFilePath: "default-base.md",
         });
 
-        expect(command.getBaseDir()).toBe(testDir);
+        expect(command.getOutputRoot()).toBe(testDir);
       } finally {
         cwdSpy.mockRestore();
         await cleanup();
@@ -332,7 +332,7 @@ describe("RooCommand", () => {
         await writeFileContent(filePath, fileContent);
 
         const command = await RooCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-validation.md",
           validate: false,
         });
@@ -359,7 +359,7 @@ This file has invalid frontmatter`;
 
         await expect(
           RooCommand.fromFile({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeFilePath: "invalid.md",
           }),
         ).rejects.toThrow("Invalid frontmatter");
@@ -384,7 +384,7 @@ This file has invalid frontmatter`;
         await writeFileContent(filePath, fileContent);
 
         const command = await RooCommand.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "subfolder/nested.md",
         });
 
@@ -477,7 +477,7 @@ This file has invalid frontmatter`;
     it("should return correct body", () => {
       const body = "Test command body content";
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: { description: "test" },
@@ -494,7 +494,7 @@ This file has invalid frontmatter`;
         "argument-hint": "Test hint",
       };
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter,
@@ -513,7 +513,7 @@ This file has invalid frontmatter`;
       const expectedFileContent = stringifyFrontmatter(body, frontmatter);
 
       const command = new RooCommand({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "integration.md",
         frontmatter,
@@ -522,7 +522,7 @@ This file has invalid frontmatter`;
       });
 
       // Test inherited methods
-      expect(command.getBaseDir()).toBe("/test/base");
+      expect(command.getOutputRoot()).toBe("/test/base");
       expect(command.getRelativeDirPath()).toBe(".roo/commands");
       expect(command.getRelativeFilePath()).toBe("integration.md");
       expect(command.getFileContent()).toBe(expectedFileContent);
@@ -533,7 +533,7 @@ This file has invalid frontmatter`;
   describe("tool-specific field passthrough", () => {
     it("fromRulesyncCommand should preserve roo fields", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "passthrough-test.md",
         frontmatter: {
@@ -549,7 +549,7 @@ This file has invalid frontmatter`;
       });
 
       const rooCommand = RooCommand.fromRulesyncCommand({
-        baseDir: ".",
+        outputRoot: ".",
         rulesyncCommand,
       });
 
@@ -561,7 +561,7 @@ This file has invalid frontmatter`;
 
     it("toRulesyncCommand should preserve extra fields in roo section", () => {
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -584,7 +584,7 @@ This file has invalid frontmatter`;
 
     it("round-trip should preserve all fields", () => {
       const original = new RulesyncCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -612,7 +612,7 @@ This file has invalid frontmatter`;
 
     it("should not include roo section when no extra fields", () => {
       const command = new RooCommand({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".roo/commands",
         relativeFilePath: "test.md",
         frontmatter: {

--- a/src/features/commands/roo-command.ts
+++ b/src/features/commands/roo-command.ts
@@ -83,7 +83,7 @@ export class RooCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
 
     return new RulesyncCommand({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -94,7 +94,7 @@ export class RooCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): RooCommand {
@@ -113,7 +113,7 @@ export class RooCommand extends ToolCommand {
     const fileContent = stringifyFrontmatter(body, rooFrontmatter);
 
     return new RooCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: rooFrontmatter,
       body,
       relativeDirPath: RooCommand.getSettablePaths().relativeDirPath,
@@ -150,11 +150,15 @@ export class RooCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<RooCommand> {
-    const filePath = join(baseDir, RooCommand.getSettablePaths().relativeDirPath, relativeFilePath);
+    const filePath = join(
+      outputRoot,
+      RooCommand.getSettablePaths().relativeDirPath,
+      relativeFilePath,
+    );
     // Read file content
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -166,7 +170,7 @@ export class RooCommand extends ToolCommand {
     }
 
     return new RooCommand({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: RooCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -177,12 +181,12 @@ export class RooCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): RooCommand {
     return new RooCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/rulesync-command.test.ts
+++ b/src/features/commands/rulesync-command.test.ts
@@ -29,7 +29,7 @@ describe("RulesyncCommand", () => {
     vi.spyOn(process, "cwd").mockReturnValue(testDir);
 
     validParams = {
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
       relativeFilePath: "test-command.md",
       frontmatter: validFrontmatter,
@@ -267,7 +267,7 @@ describe("RulesyncCommand", () => {
       // Should have all RulesyncFile methods
       expect(command.getRelativeDirPath()).toBe(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(command.getRelativeFilePath()).toBe("test-command.md");
-      expect(command.getBaseDir()).toBe(testDir);
+      expect(command.getOutputRoot()).toBe(testDir);
       expect(typeof command.getFilePath).toBe("function");
       expect(typeof command.getFileContent).toBe("function");
       expect(typeof command.validate).toBe("function");

--- a/src/features/commands/rulesync-command.ts
+++ b/src/features/commands/rulesync-command.ts
@@ -51,7 +51,7 @@ export class RulesyncCommand extends RulesyncFile {
     const parseResult = RulesyncCommandFrontmatterSchema.safeParse(frontmatter);
     if (!parseResult.success && rest.validate) {
       throw new Error(
-        `Invalid frontmatter in ${join(rest.baseDir ?? process.cwd(), rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(parseResult.error)}`,
+        `Invalid frontmatter in ${join(rest.outputRoot ?? process.cwd(), rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(parseResult.error)}`,
       );
     }
     // Apply defaults manually when validation is disabled but parsing failed
@@ -85,7 +85,7 @@ export class RulesyncCommand extends RulesyncFile {
 
   withRelativeFilePath(newRelativeFilePath: string): RulesyncCommand {
     return new RulesyncCommand({
-      baseDir: this.getBaseDir(),
+      outputRoot: this.getOutputRoot(),
       relativeDirPath: this.getRelativeDirPath(),
       relativeFilePath: newRelativeFilePath,
       frontmatter: this.getFrontmatter(),
@@ -115,12 +115,12 @@ export class RulesyncCommand extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
   }: RulesyncFileFromFileParams): Promise<RulesyncCommand> {
     // Read file content
     const filePath = join(
-      baseDir,
+      outputRoot,
       RulesyncCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
     );
@@ -134,7 +134,7 @@ export class RulesyncCommand extends RulesyncFile {
     }
 
     return new RulesyncCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,

--- a/src/features/commands/simulated-command.ts
+++ b/src/features/commands/simulated-command.ts
@@ -61,7 +61,7 @@ export abstract class SimulatedCommand extends ToolCommand {
   }
 
   protected static fromRulesyncCommandDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
   }: ToolCommandFromRulesyncCommandParams): ConstructorParameters<typeof SimulatedCommand>[0] {
@@ -74,7 +74,7 @@ export abstract class SimulatedCommand extends ToolCommand {
     const body = rulesyncCommand.getBody();
 
     return {
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: claudecodeFrontmatter,
       body,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
@@ -102,12 +102,12 @@ export abstract class SimulatedCommand extends ToolCommand {
   }
 
   protected static async fromFileDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<ConstructorParameters<typeof SimulatedCommand>[0]> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       SimulatedCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
     );
@@ -120,7 +120,7 @@ export abstract class SimulatedCommand extends ToolCommand {
     }
 
     return {
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: SimulatedCommand.getSettablePaths().relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -130,12 +130,12 @@ export abstract class SimulatedCommand extends ToolCommand {
   }
 
   protected static forDeletionDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): ConstructorParameters<typeof SimulatedCommand>[0] {
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "" },

--- a/src/features/commands/takt-command.test.ts
+++ b/src/features/commands/takt-command.test.ts
@@ -33,7 +33,7 @@ describe("TaktCommand", () => {
   describe("fromRulesyncCommand", () => {
     it("emits a plain Markdown body under instructions/", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "review.md",
         frontmatter: { targets: ["*"], description: "Review PR" },
@@ -41,7 +41,7 @@ describe("TaktCommand", () => {
         fileContent: "",
       });
 
-      const cmd = TaktCommand.fromRulesyncCommand({ baseDir: testDir, rulesyncCommand });
+      const cmd = TaktCommand.fromRulesyncCommand({ outputRoot: testDir, rulesyncCommand });
       expect(cmd.getRelativeDirPath()).toBe(join(".takt", "facets", "instructions"));
       expect(cmd.getRelativeFilePath()).toBe("review.md");
       expect(cmd.getFileContent()).toBe("Run review steps.");
@@ -49,7 +49,7 @@ describe("TaktCommand", () => {
 
     it("renames the stem with takt.name", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "long-source.md",
         frontmatter: {
@@ -59,14 +59,14 @@ describe("TaktCommand", () => {
         body: "body",
         fileContent: "",
       });
-      const cmd = TaktCommand.fromRulesyncCommand({ baseDir: testDir, rulesyncCommand });
+      const cmd = TaktCommand.fromRulesyncCommand({ outputRoot: testDir, rulesyncCommand });
       expect(cmd.getRelativeFilePath()).toBe("short.md");
       expect(cmd.getRelativeDirPath()).toBe(join(".takt", "facets", "instructions"));
     });
 
     it("throws on an unsafe takt.name value", () => {
       const rulesyncCommand = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "src.md",
         frontmatter: {
@@ -76,9 +76,9 @@ describe("TaktCommand", () => {
         body: "x",
         fileContent: "",
       });
-      expect(() => TaktCommand.fromRulesyncCommand({ baseDir: testDir, rulesyncCommand })).toThrow(
-        /Invalid takt\.name/,
-      );
+      expect(() =>
+        TaktCommand.fromRulesyncCommand({ outputRoot: testDir, rulesyncCommand }),
+      ).toThrow(/Invalid takt\.name/);
     });
   });
 
@@ -87,7 +87,7 @@ describe("TaktCommand", () => {
       const dir = join(testDir, ".takt", "facets", "instructions");
       await ensureDir(dir);
       await writeFileContent(join(dir, "x.md"), "body\n");
-      const cmd = await TaktCommand.fromFile({ baseDir: testDir, relativeFilePath: "x.md" });
+      const cmd = await TaktCommand.fromFile({ outputRoot: testDir, relativeFilePath: "x.md" });
       expect(cmd.getBody()).toBe("body");
     });
   });
@@ -95,7 +95,7 @@ describe("TaktCommand", () => {
   describe("forDeletion", () => {
     it("constructs a deletable empty instance", () => {
       const cmd = TaktCommand.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "instructions"),
         relativeFilePath: "x.md",
       });
@@ -110,7 +110,7 @@ describe("TaktCommand", () => {
       [["claudecode"], false],
     ] as const)("targets=%j → %s", (targets, expected) => {
       const r = new RulesyncCommand({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         relativeFilePath: "x.md",
         frontmatter: { targets: [...targets] },

--- a/src/features/commands/takt-command.ts
+++ b/src/features/commands/takt-command.ts
@@ -57,7 +57,7 @@ export class TaktCommand extends ToolCommand {
       targets: ["*"],
     };
     return new RulesyncCommand({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
@@ -68,7 +68,7 @@ export class TaktCommand extends ToolCommand {
   }
 
   static fromRulesyncCommand({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncCommand,
     validate = true,
     global = false,
@@ -86,7 +86,7 @@ export class TaktCommand extends ToolCommand {
     const paths = this.getSettablePaths({ global });
 
     return new TaktCommand({
-      baseDir,
+      outputRoot,
       body: rulesyncCommand.getBody(),
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
@@ -106,18 +106,18 @@ export class TaktCommand extends ToolCommand {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolCommandFromFileParams): Promise<TaktCommand> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { body } = parseFrontmatter(fileContent, filePath);
 
     return new TaktCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       body: body.trim(),
@@ -126,12 +126,12 @@ export class TaktCommand extends ToolCommand {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolCommandForDeletionParams): TaktCommand {
     return new TaktCommand({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: "",

--- a/src/features/commands/tool-command.ts
+++ b/src/features/commands/tool-command.ts
@@ -16,7 +16,7 @@ export type ToolCommandSettablePaths = {
 };
 
 export type ToolCommandForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -52,7 +52,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -60,7 +60,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -86,7 +86,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -94,7 +94,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -131,7 +131,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -139,7 +139,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -157,7 +157,7 @@ describe("ClaudecodeHooks", () => {
 
       const config = { version: 1, hooks: {} };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -166,7 +166,7 @@ describe("ClaudecodeHooks", () => {
 
       await expect(
         ClaudecodeHooks.fromRulesyncHooks({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncHooks,
           validate: false,
         }),
@@ -185,7 +185,7 @@ describe("ClaudecodeHooks", () => {
         hooks: { sessionStart: [{ command: "echo" }] },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -193,7 +193,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -209,7 +209,7 @@ describe("ClaudecodeHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should throw error with descriptive message when content contains invalid JSON", () => {
       const claudecodeHooks = new ClaudecodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: "invalid json {",
@@ -223,7 +223,7 @@ describe("ClaudecodeHooks", () => {
 
     it("should convert Claude PascalCase hooks to canonical camelCase", () => {
       const claudecodeHooks = new ClaudecodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -254,7 +254,7 @@ describe("ClaudecodeHooks", () => {
       );
 
       const claudecodeHooks = await ClaudecodeHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(claudecodeHooks).toBeInstanceOf(ClaudecodeHooks);
@@ -265,7 +265,7 @@ describe("ClaudecodeHooks", () => {
 
     it("should initialize empty hooks when .claude/settings.json does not exist", async () => {
       const claudecodeHooks = await ClaudecodeHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(claudecodeHooks).toBeInstanceOf(ClaudecodeHooks);
@@ -278,7 +278,7 @@ describe("ClaudecodeHooks", () => {
   describe("isDeletable", () => {
     it("should return false", () => {
       const hooks = new ClaudecodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: "{}",
@@ -301,7 +301,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -309,7 +309,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -334,7 +334,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -342,7 +342,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -369,7 +369,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -377,7 +377,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
         logger,
@@ -407,7 +407,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -415,7 +415,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -437,7 +437,7 @@ describe("ClaudecodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -445,7 +445,7 @@ describe("ClaudecodeHooks", () => {
       });
 
       const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -460,7 +460,7 @@ describe("ClaudecodeHooks", () => {
   describe("toRulesyncHooks - worktree events", () => {
     it("should import WorktreeCreate and WorktreeRemove back to canonical names", () => {
       const claudecodeHooks = new ClaudecodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -488,7 +488,7 @@ describe("ClaudecodeHooks", () => {
   describe("forDeletion", () => {
     it("should return ClaudecodeHooks instance with empty hooks for deletion path", () => {
       const hooks = ClaudecodeHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
       });

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -51,15 +51,15 @@ export class ClaudecodeHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<ClaudecodeHooks> {
     const paths = ClaudecodeHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new ClaudecodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -68,7 +68,7 @@ export class ClaudecodeHooks extends ToolHooks {
   }
 
   static async fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -78,7 +78,7 @@ export class ClaudecodeHooks extends ToolHooks {
     logger?: Logger;
   }): Promise<ClaudecodeHooks> {
     const paths = ClaudecodeHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = await readOrInitializeFileContent(
       filePath,
       JSON.stringify({}, null, 2),
@@ -102,7 +102,7 @@ export class ClaudecodeHooks extends ToolHooks {
     const merged = { ...settings, hooks: claudeHooks };
     const fileContent = JSON.stringify(merged, null, 2);
     return new ClaudecodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -136,12 +136,12 @@ export class ClaudecodeHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): ClaudecodeHooks {
     return new ClaudecodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: {} }, null, 2),

--- a/src/features/hooks/codexcli-hooks.test.ts
+++ b/src/features/hooks/codexcli-hooks.test.ts
@@ -11,7 +11,7 @@ function createMockAiFileParams(
   override: Partial<ConstructorParameters<typeof RulesyncHooks>[0]> = {},
 ) {
   return {
-    baseDir: "/mock",
+    outputRoot: "/mock",
     relativeDirPath: ".rulesync",
     relativeFilePath: "hooks.json",
     fileContent: "{}",
@@ -45,7 +45,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -75,7 +75,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -98,7 +98,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -125,7 +125,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -149,7 +149,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -177,7 +177,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -203,7 +203,7 @@ describe("CodexcliHooks", () => {
       );
 
       await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -229,7 +229,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -377,7 +377,7 @@ describe("CodexcliHooks", () => {
       );
 
       const codexHooks = await CodexcliHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(codexHooks).toBeInstanceOf(CodexcliHooks);
@@ -388,7 +388,7 @@ describe("CodexcliHooks", () => {
 
     it("should initialize empty hooks when hooks.json does not exist", async () => {
       const codexHooks = await CodexcliHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(codexHooks).toBeInstanceOf(CodexcliHooks);
@@ -435,7 +435,7 @@ describe("CodexcliConfigToml", () => {
   });
 
   it("should generate config.toml with codex_hooks feature flag", async () => {
-    const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
+    const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     expect(configToml.getFileContent()).toContain("codex_hooks");
   });
 
@@ -446,7 +446,7 @@ describe("CodexcliConfigToml", () => {
       '[mcp_servers.myserver]\ncommand = "node"\n',
     );
 
-    const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
+    const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     const content = configToml.getFileContent();
     expect(content).toContain("codex_hooks");
     expect(content).toContain("mcp_servers");
@@ -457,7 +457,7 @@ describe("CodexcliConfigToml", () => {
     await ensureDir(join(testDir, ".codex"));
     await writeFileContent(join(testDir, ".codex", "config.toml"), "[features]\nverbose = true\n");
 
-    const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
+    const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     const content = configToml.getFileContent();
     expect(content).toContain("codex_hooks = true");
     expect(content).toContain("verbose = true");
@@ -467,13 +467,13 @@ describe("CodexcliConfigToml", () => {
     await ensureDir(join(testDir, ".codex"));
     await writeFileContent(join(testDir, ".codex", "config.toml"), "[features");
 
-    await expect(CodexcliConfigToml.fromBaseDir({ baseDir: testDir })).rejects.toThrow(
+    await expect(CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir })).rejects.toThrow(
       "Failed to parse existing Codex CLI config",
     );
   });
 
   it("should set correct file paths", async () => {
-    const configToml = await CodexcliConfigToml.fromBaseDir({ baseDir: testDir });
+    const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     expect(configToml.getRelativeDirPath()).toBe(".codex");
     expect(configToml.getRelativeFilePath()).toBe("config.toml");
   });

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -36,8 +36,12 @@ const CODEXCLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
  * Reads the existing file (if any), parses TOML, sets the flag, and returns the content
  * without writing to disk. The caller is responsible for writing via the normal write phase.
  */
-async function buildCodexConfigTomlContent({ baseDir }: { baseDir: string }): Promise<string> {
-  const configPath = join(baseDir, ".codex", "config.toml");
+async function buildCodexConfigTomlContent({
+  outputRoot,
+}: {
+  outputRoot: string;
+}): Promise<string> {
+  const configPath = join(outputRoot, ".codex", "config.toml");
   const existingContent = (await readFileContentOrNull(configPath)) ?? smolToml.stringify({});
   let configToml: smolToml.TomlPrimitive;
   try {
@@ -70,10 +74,10 @@ export class CodexcliConfigToml extends ToolFile {
     return { success: true, error: null };
   }
 
-  static async fromBaseDir({ baseDir }: { baseDir: string }): Promise<CodexcliConfigToml> {
-    const fileContent = await buildCodexConfigTomlContent({ baseDir });
+  static async fromOutputRoot({ outputRoot }: { outputRoot: string }): Promise<CodexcliConfigToml> {
+    const fileContent = await buildCodexConfigTomlContent({ outputRoot });
     return new CodexcliConfigToml({
-      baseDir,
+      outputRoot,
       relativeDirPath: ".codex",
       relativeFilePath: "config.toml",
       fileContent,
@@ -94,15 +98,15 @@ export class CodexcliHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<CodexcliHooks> {
     const paths = CodexcliHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new CodexcliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -111,7 +115,7 @@ export class CodexcliHooks extends ToolHooks {
   }
 
   static async fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -126,7 +130,7 @@ export class CodexcliHooks extends ToolHooks {
     const fileContent = JSON.stringify({ hooks: codexHooks }, null, 2);
 
     return new CodexcliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -160,12 +164,12 @@ export class CodexcliHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): CodexcliHooks {
     return new CodexcliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: {} }, null, 2),
@@ -174,11 +178,11 @@ export class CodexcliHooks extends ToolHooks {
   }
 
   static async getAuxiliaryFiles({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     global?: boolean;
   } = {}): Promise<ToolFile[]> {
-    return [await CodexcliConfigToml.fromBaseDir({ baseDir })];
+    return [await CodexcliConfigToml.fromOutputRoot({ outputRoot })];
   }
 }

--- a/src/features/hooks/copilot-hooks.test.ts
+++ b/src/features/hooks/copilot-hooks.test.ts
@@ -57,7 +57,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -65,7 +65,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -92,7 +92,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -100,7 +100,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -126,7 +126,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -134,7 +134,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -157,7 +157,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -165,7 +165,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -188,7 +188,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -196,7 +196,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -219,7 +219,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -227,7 +227,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -253,7 +253,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -261,7 +261,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -283,7 +283,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -291,7 +291,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -315,7 +315,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -323,7 +323,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -347,7 +347,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -355,7 +355,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -383,7 +383,7 @@ describe("CopilotHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -391,7 +391,7 @@ describe("CopilotHooks", () => {
       });
 
       const copilotHooks = await CopilotHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -416,7 +416,7 @@ describe("CopilotHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should throw error with descriptive message when content contains invalid JSON", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: "invalid json {",
@@ -428,7 +428,7 @@ describe("CopilotHooks", () => {
 
     it("should convert Copilot hooks with bash-only to canonical format", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -455,7 +455,7 @@ describe("CopilotHooks", () => {
 
     it("should convert Copilot hooks with powershell-only to canonical format", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -479,7 +479,7 @@ describe("CopilotHooks", () => {
       const logger = createMockLogger();
 
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -506,7 +506,7 @@ describe("CopilotHooks", () => {
       const logger = createMockLogger();
 
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -530,7 +530,7 @@ describe("CopilotHooks", () => {
 
     it("should handle empty hooks", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({ version: 1, hooks: {} }),
@@ -544,7 +544,7 @@ describe("CopilotHooks", () => {
 
     it("should skip invalid hook entries", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -570,7 +570,7 @@ describe("CopilotHooks", () => {
 
     it("should not import unknown keys when converting to canonical hooks", () => {
       const copilotHooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: JSON.stringify({
@@ -604,7 +604,7 @@ describe("CopilotHooks", () => {
       );
 
       const copilotHooks = await CopilotHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(copilotHooks).toBeInstanceOf(CopilotHooks);
@@ -615,7 +615,7 @@ describe("CopilotHooks", () => {
 
     it("should initialize empty hooks when copilot-hooks.json does not exist", async () => {
       const copilotHooks = await CopilotHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(copilotHooks).toBeInstanceOf(CopilotHooks);
@@ -628,7 +628,7 @@ describe("CopilotHooks", () => {
   describe("isDeletable", () => {
     it("should return true (default from ToolFile)", () => {
       const hooks = new CopilotHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
         fileContent: '{"version":1,"hooks":{}}',
@@ -642,7 +642,7 @@ describe("CopilotHooks", () => {
   describe("forDeletion", () => {
     it("should return CopilotHooks instance with empty hooks for deletion path", () => {
       const hooks = CopilotHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".github", "hooks"),
         relativeFilePath: "copilot-hooks.json",
       });

--- a/src/features/hooks/copilot-hooks.ts
+++ b/src/features/hooks/copilot-hooks.ts
@@ -170,15 +170,15 @@ export class CopilotHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<CopilotHooks> {
     const paths = CopilotHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new CopilotHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -187,7 +187,7 @@ export class CopilotHooks extends ToolHooks {
   }
 
   static async fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
   }: ToolHooksFromRulesyncHooksParams & {
@@ -198,7 +198,7 @@ export class CopilotHooks extends ToolHooks {
     const copilotHooks = canonicalToCopilotHooks(config);
     const fileContent = JSON.stringify({ version: 1, hooks: copilotHooks }, null, 2);
     return new CopilotHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -229,12 +229,12 @@ export class CopilotHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): CopilotHooks {
     return new CopilotHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: {} }, null, 2),

--- a/src/features/hooks/cursor-hooks.test.ts
+++ b/src/features/hooks/cursor-hooks.test.ts
@@ -40,7 +40,7 @@ describe("CursorHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -48,7 +48,7 @@ describe("CursorHooks", () => {
       });
 
       const cursorHooks = CursorHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -74,7 +74,7 @@ describe("CursorHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -82,7 +82,7 @@ describe("CursorHooks", () => {
       });
 
       const cursorHooks = CursorHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -97,7 +97,7 @@ describe("CursorHooks", () => {
     it("should preserve version from config", () => {
       const config = { version: 2, hooks: { sessionStart: [] } };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -105,7 +105,7 @@ describe("CursorHooks", () => {
       });
 
       const cursorHooks = CursorHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -119,7 +119,7 @@ describe("CursorHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should convert Cursor hooks JSON to canonical rulesync format", () => {
       const cursorHooks = new CursorHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor",
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify({
@@ -150,7 +150,7 @@ describe("CursorHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -158,14 +158,14 @@ describe("CursorHooks", () => {
       });
 
       const cursorHooks = CursorHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
       await ensureDir(join(testDir, ".cursor"));
       await writeFileContent(cursorHooks.getFilePath(), cursorHooks.getFileContent());
 
-      const loaded = await CursorHooks.fromFile({ baseDir: testDir, validate: false });
+      const loaded = await CursorHooks.fromFile({ outputRoot: testDir, validate: false });
       const backToRulesync = loaded.toRulesyncHooks();
       const json = backToRulesync.getJson();
       expect(json.hooks.sessionStart).toHaveLength(1);
@@ -183,7 +183,7 @@ describe("CursorHooks", () => {
         JSON.stringify({ version: 1, hooks: { sessionStart: [] } }),
       );
 
-      const cursorHooks = await CursorHooks.fromFile({ baseDir: testDir, validate: false });
+      const cursorHooks = await CursorHooks.fromFile({ outputRoot: testDir, validate: false });
       expect(cursorHooks).toBeInstanceOf(CursorHooks);
       const content = cursorHooks.getFileContent();
       const parsed = JSON.parse(content);
@@ -195,7 +195,7 @@ describe("CursorHooks", () => {
   describe("forDeletion", () => {
     it("should return CursorHooks instance with empty hooks for deletion path", () => {
       const hooks = CursorHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor",
         relativeFilePath: "hooks.json",
       });

--- a/src/features/hooks/cursor-hooks.ts
+++ b/src/features/hooks/cursor-hooks.ts
@@ -39,15 +39,15 @@ export class CursorHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolHooksFromFileParams): Promise<CursorHooks> {
     const paths = CursorHooks.getSettablePaths();
     const fileContent = await readFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
     );
     return new CursorHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -56,7 +56,7 @@ export class CursorHooks extends ToolHooks {
   }
 
   static fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
   }: ToolHooksFromRulesyncHooksParams): CursorHooks {
@@ -95,7 +95,7 @@ export class CursorHooks extends ToolHooks {
     const fileContent = JSON.stringify(cursorConfig, null, 2);
     const paths = CursorHooks.getSettablePaths();
     return new CursorHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -127,12 +127,12 @@ export class CursorHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): CursorHooks {
     return new CursorHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/hooks/deepagents-hooks.test.ts
+++ b/src/features/hooks/deepagents-hooks.test.ts
@@ -55,12 +55,12 @@ describe("DeepagentsHooks", () => {
       });
       await writeFileContent(join(deepagentsDir, "hooks.json"), content);
 
-      const hooks = await DeepagentsHooks.fromFile({ baseDir: testDir });
+      const hooks = await DeepagentsHooks.fromFile({ outputRoot: testDir });
       expect(hooks.getFileContent()).toContain("session.start");
     });
 
     it("should return empty hooks if file does not exist", async () => {
-      const hooks = await DeepagentsHooks.fromFile({ baseDir: testDir });
+      const hooks = await DeepagentsHooks.fromFile({ outputRoot: testDir });
       const parsed = JSON.parse(hooks.getFileContent());
       expect(parsed.hooks).toEqual([]);
     });
@@ -77,13 +77,13 @@ describe("DeepagentsHooks", () => {
       });
 
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "hooks.json",
         fileContent: rulesyncHooksContent,
       });
 
-      const hooks = DeepagentsHooks.fromRulesyncHooks({ baseDir: testDir, rulesyncHooks });
+      const hooks = DeepagentsHooks.fromRulesyncHooks({ outputRoot: testDir, rulesyncHooks });
       const parsed = JSON.parse(hooks.getFileContent());
 
       expect(Array.isArray(parsed.hooks)).toBe(true);
@@ -112,13 +112,13 @@ describe("DeepagentsHooks", () => {
       });
 
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "hooks.json",
         fileContent: rulesyncHooksContent,
       });
 
-      const hooks = DeepagentsHooks.fromRulesyncHooks({ baseDir: testDir, rulesyncHooks });
+      const hooks = DeepagentsHooks.fromRulesyncHooks({ outputRoot: testDir, rulesyncHooks });
       const parsed = JSON.parse(hooks.getFileContent());
 
       // Only the command hook should be present
@@ -137,13 +137,13 @@ describe("DeepagentsHooks", () => {
       });
 
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "hooks.json",
         fileContent: rulesyncHooksContent,
       });
 
-      const hooks = DeepagentsHooks.fromRulesyncHooks({ baseDir: testDir, rulesyncHooks });
+      const hooks = DeepagentsHooks.fromRulesyncHooks({ outputRoot: testDir, rulesyncHooks });
       const parsed = JSON.parse(hooks.getFileContent());
 
       expect(parsed.hooks.length).toBe(1);
@@ -164,13 +164,13 @@ describe("DeepagentsHooks", () => {
       });
 
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "hooks.json",
         fileContent: rulesyncHooksContent,
       });
 
-      const hooks = DeepagentsHooks.fromRulesyncHooks({ baseDir: testDir, rulesyncHooks });
+      const hooks = DeepagentsHooks.fromRulesyncHooks({ outputRoot: testDir, rulesyncHooks });
       const parsed = JSON.parse(hooks.getFileContent());
 
       // The override replaces the shared hook for sessionStart
@@ -192,7 +192,7 @@ describe("DeepagentsHooks", () => {
       });
 
       const hooks = new DeepagentsHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "hooks.json",
         fileContent: deepagentsContent,
@@ -218,7 +218,7 @@ describe("DeepagentsHooks", () => {
       });
 
       const hooks = new DeepagentsHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "hooks.json",
         fileContent: deepagentsContent,
@@ -233,7 +233,7 @@ describe("DeepagentsHooks", () => {
 
     it("should skip malformed hook entries", () => {
       const hooks = new DeepagentsHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify({
@@ -248,7 +248,7 @@ describe("DeepagentsHooks", () => {
 
     it("should join command parts when bash fallback pattern is not used", () => {
       const hooks = new DeepagentsHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify({
@@ -267,7 +267,7 @@ describe("DeepagentsHooks", () => {
   describe("forDeletion", () => {
     it("should create a placeholder hooks file for deletion", () => {
       const hooks = DeepagentsHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "hooks.json",
       });

--- a/src/features/hooks/deepagents-hooks.ts
+++ b/src/features/hooks/deepagents-hooks.ts
@@ -131,16 +131,16 @@ export class DeepagentsHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<DeepagentsHooks> {
     const paths = DeepagentsHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent =
       (await readFileContentOrNull(filePath)) ?? JSON.stringify({ hooks: [] }, null, 2);
     return new DeepagentsHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -149,7 +149,7 @@ export class DeepagentsHooks extends ToolHooks {
   }
 
   static fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -160,7 +160,7 @@ export class DeepagentsHooks extends ToolHooks {
     const paths = DeepagentsHooks.getSettablePaths({ global });
 
     return new DeepagentsHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -192,12 +192,12 @@ export class DeepagentsHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): DeepagentsHooks {
     return new DeepagentsHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: [] }, null, 2),

--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -48,7 +48,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -56,7 +56,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -79,7 +79,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -87,7 +87,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -114,7 +114,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -122,7 +122,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -156,7 +156,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -164,7 +164,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -198,7 +198,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -206,7 +206,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -228,7 +228,7 @@ describe("FactorydroidHooks", () => {
 
       const config = { version: 1, hooks: {} };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -237,7 +237,7 @@ describe("FactorydroidHooks", () => {
 
       await expect(
         FactorydroidHooks.fromRulesyncHooks({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncHooks,
           validate: false,
         }),
@@ -256,7 +256,7 @@ describe("FactorydroidHooks", () => {
         hooks: { sessionStart: [{ command: "echo" }] },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -264,7 +264,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -291,7 +291,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -299,7 +299,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -332,7 +332,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -340,7 +340,7 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -357,7 +357,7 @@ describe("FactorydroidHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should throw error with descriptive message when content contains invalid JSON", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: "invalid json {",
@@ -371,7 +371,7 @@ describe("FactorydroidHooks", () => {
 
     it("should convert Factory Droid PascalCase hooks to canonical camelCase", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -394,7 +394,7 @@ describe("FactorydroidHooks", () => {
 
     it("should strip $FACTORY_PROJECT_DIR prefix from commands", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -418,7 +418,7 @@ describe("FactorydroidHooks", () => {
 
     it("should preserve matcher from entries", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -442,7 +442,7 @@ describe("FactorydroidHooks", () => {
 
     it("should handle empty hooks object", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({ hooks: {} }),
@@ -456,7 +456,7 @@ describe("FactorydroidHooks", () => {
 
     it("should handle missing hooks key", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({}),
@@ -470,7 +470,7 @@ describe("FactorydroidHooks", () => {
 
     it("should skip entries that are not valid matcher entries", () => {
       const factorydroidHooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -501,7 +501,7 @@ describe("FactorydroidHooks", () => {
       );
 
       const factorydroidHooks = await FactorydroidHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(factorydroidHooks).toBeInstanceOf(FactorydroidHooks);
@@ -512,7 +512,7 @@ describe("FactorydroidHooks", () => {
 
     it("should initialize empty hooks when .factory/settings.json does not exist", async () => {
       const factorydroidHooks = await FactorydroidHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(factorydroidHooks).toBeInstanceOf(FactorydroidHooks);
@@ -525,7 +525,7 @@ describe("FactorydroidHooks", () => {
   describe("isDeletable", () => {
     it("should return false", () => {
       const hooks = new FactorydroidHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
         fileContent: "{}",
@@ -538,7 +538,7 @@ describe("FactorydroidHooks", () => {
   describe("forDeletion", () => {
     it("should return FactorydroidHooks instance with empty hooks for deletion path", () => {
       const hooks = FactorydroidHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "settings.json",
       });
@@ -558,7 +558,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -566,14 +566,14 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
       await ensureDir(join(testDir, ".factory"));
       await writeFileContent(factorydroidHooks.getFilePath(), factorydroidHooks.getFileContent());
 
-      const loaded = await FactorydroidHooks.fromFile({ baseDir: testDir, validate: false });
+      const loaded = await FactorydroidHooks.fromFile({ outputRoot: testDir, validate: false });
       const backToRulesync = loaded.toRulesyncHooks();
       const json = backToRulesync.getJson();
       expect(json.hooks.sessionStart).toHaveLength(1);
@@ -600,7 +600,7 @@ describe("FactorydroidHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -608,14 +608,14 @@ describe("FactorydroidHooks", () => {
       });
 
       const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
       await ensureDir(join(testDir, ".factory"));
       await writeFileContent(factorydroidHooks.getFilePath(), factorydroidHooks.getFileContent());
 
-      const loaded = await FactorydroidHooks.fromFile({ baseDir: testDir, validate: false });
+      const loaded = await FactorydroidHooks.fromFile({ outputRoot: testDir, validate: false });
       const backToRulesync = loaded.toRulesyncHooks();
       const json = backToRulesync.getJson();
 

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -45,15 +45,15 @@ export class FactorydroidHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<FactorydroidHooks> {
     const paths = FactorydroidHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new FactorydroidHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -62,7 +62,7 @@ export class FactorydroidHooks extends ToolHooks {
   }
 
   static async fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -72,7 +72,7 @@ export class FactorydroidHooks extends ToolHooks {
     logger?: Logger;
   }): Promise<FactorydroidHooks> {
     const paths = FactorydroidHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = await readOrInitializeFileContent(
       filePath,
       JSON.stringify({}, null, 2),
@@ -96,7 +96,7 @@ export class FactorydroidHooks extends ToolHooks {
     const merged = { ...settings, hooks: factorydroidHooks };
     const fileContent = JSON.stringify(merged, null, 2);
     return new FactorydroidHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -130,12 +130,12 @@ export class FactorydroidHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): FactorydroidHooks {
     return new FactorydroidHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: {} }, null, 2),

--- a/src/features/hooks/geminicli-hooks.test.ts
+++ b/src/features/hooks/geminicli-hooks.test.ts
@@ -11,7 +11,7 @@ function createMockAiFileParams(
   override: Partial<ConstructorParameters<typeof RulesyncHooks>[0]> = {},
 ) {
   return {
-    baseDir: "/mock",
+    outputRoot: "/mock",
     relativeDirPath: ".rulesync",
     relativeFilePath: "hooks.json",
     fileContent: "{}",
@@ -47,7 +47,7 @@ describe("GeminicliHooks", () => {
       );
 
       const geminiHooks = await GeminicliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -73,7 +73,7 @@ describe("GeminicliHooks", () => {
       );
 
       const geminiHooks = await GeminicliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -107,7 +107,7 @@ describe("GeminicliHooks", () => {
       );
 
       const geminiHooks = await GeminicliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -136,7 +136,7 @@ describe("GeminicliHooks", () => {
       );
 
       const geminiHooks = await GeminicliHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: true,
       });
@@ -253,7 +253,7 @@ describe("GeminicliHooks", () => {
       );
 
       const geminiHooks = await GeminicliHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(geminiHooks).toBeInstanceOf(GeminicliHooks);
@@ -264,7 +264,7 @@ describe("GeminicliHooks", () => {
 
     it("should initialize empty hooks when settings.json does not exist", async () => {
       const geminiHooks = await GeminicliHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(geminiHooks).toBeInstanceOf(GeminicliHooks);

--- a/src/features/hooks/geminicli-hooks.ts
+++ b/src/features/hooks/geminicli-hooks.ts
@@ -162,15 +162,15 @@ export class GeminicliHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<GeminicliHooks> {
     const paths = GeminicliHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
     return new GeminicliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -179,13 +179,13 @@ export class GeminicliHooks extends ToolHooks {
   }
 
   static async fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
   }: ToolHooksFromRulesyncHooksParams & { global?: boolean }): Promise<GeminicliHooks> {
     const paths = GeminicliHooks.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = await readOrInitializeFileContent(
       filePath,
       JSON.stringify({}, null, 2),
@@ -204,7 +204,7 @@ export class GeminicliHooks extends ToolHooks {
     const merged = { ...settings, hooks: geminiHooks };
     const fileContent = JSON.stringify(merged, null, 2);
     return new GeminicliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -235,12 +235,12 @@ export class GeminicliHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): GeminicliHooks {
     return new GeminicliHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ hooks: {} }, null, 2),

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -33,17 +33,21 @@ describe("HooksProcessor", () => {
 
   describe("constructor", () => {
     it("should create instance with cursor target", () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       expect(processor).toBeInstanceOf(HooksProcessor);
     });
 
     it("should create instance with claudecode target", () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       expect(processor).toBeInstanceOf(HooksProcessor);
     });
 
     it("should create instance with opencode target", () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "opencode" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "opencode" });
       expect(processor).toBeInstanceOf(HooksProcessor);
     });
 
@@ -51,7 +55,7 @@ describe("HooksProcessor", () => {
       expect(() => {
         const _p = new HooksProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid" as "cursor",
         });
       }).toThrow("Invalid tool target for HooksProcessor");
@@ -60,7 +64,7 @@ describe("HooksProcessor", () => {
     it("should accept global option for claudecode", () => {
       const processor = new HooksProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -79,7 +83,7 @@ describe("HooksProcessor", () => {
         }),
       );
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const files = await processor.loadRulesyncFiles();
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(RulesyncHooks);
@@ -87,7 +91,7 @@ describe("HooksProcessor", () => {
     });
 
     it("should return empty array when hooks file does not exist", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const files = await processor.loadRulesyncFiles();
       expect(files).toHaveLength(0);
       expect(logger.error).toHaveBeenCalledWith(
@@ -95,7 +99,7 @@ describe("HooksProcessor", () => {
       );
     });
 
-    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+    it("should load rulesync files from cwd even when outputRoot is different (global mode)", async () => {
       await ensureDir(join(testDir, RULESYNC_RELATIVE_DIR_PATH));
       await writeFileContent(
         join(testDir, RULESYNC_HOOKS_RELATIVE_FILE_PATH),
@@ -105,13 +109,13 @@ describe("HooksProcessor", () => {
         }),
       );
 
-      // Use a different baseDir to simulate global mode (baseDir = homeDir)
-      const differentBaseDir = join(testDir, "fake-home");
-      await ensureDir(differentBaseDir);
+      // Use a different outputRoot to simulate global mode (outputRoot = homeDir)
+      const differentOutputRoot = join(testDir, "fake-home");
+      await ensureDir(differentOutputRoot);
 
       const processor = new HooksProcessor({
         logger,
-        baseDir: differentBaseDir,
+        outputRoot: differentOutputRoot,
         toolTarget: "claudecode",
         global: true,
       });
@@ -129,14 +133,14 @@ describe("HooksProcessor", () => {
         JSON.stringify({ version: 1, hooks: { sessionStart: [] } }),
       );
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(CursorHooks);
     });
 
     it("should return empty array when Cursor hooks file does not exist", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(0);
       expect(logger.debug).toHaveBeenCalledWith(
@@ -151,14 +155,22 @@ describe("HooksProcessor", () => {
         JSON.stringify({ hooks: { SessionStart: [] } }),
       );
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(ClaudecodeHooks);
     });
 
     it("should load Claudecode hooks when .claude/settings.json does not exist (initializes empty)", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(ClaudecodeHooks);
@@ -167,7 +179,7 @@ describe("HooksProcessor", () => {
 
   describe("loadToolFiles with forDeletion", () => {
     it("should return Cursor hooks file for deletion when path exists", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const files = await processor.loadToolFiles({ forDeletion: true });
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(CursorHooks);
@@ -175,7 +187,11 @@ describe("HooksProcessor", () => {
     });
 
     it("should return empty array for claudecode when forDeletion (not deletable)", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       const files = await processor.loadToolFiles({ forDeletion: true });
       expect(files).toHaveLength(0);
     });
@@ -191,14 +207,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const toolFiles = await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBeInstanceOf(CursorHooks);
@@ -221,14 +237,18 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       const toolFiles = await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBeInstanceOf(ClaudecodeHooks);
@@ -247,14 +267,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "codexcli" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "codexcli" });
       const toolFiles = await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
       expect(toolFiles).toHaveLength(2);
       expect(toolFiles[0]).toBeInstanceOf(CodexcliHooks);
@@ -262,7 +282,7 @@ describe("HooksProcessor", () => {
     });
 
     it("should throw when no rulesync hooks file in list", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       await expect(processor.convertRulesyncFilesToToolFiles([])).rejects.toThrow(
         `No ${RULESYNC_HOOKS_RELATIVE_FILE_PATH} found.`,
       );
@@ -277,14 +297,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -304,14 +324,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "opencode" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "opencode" });
       await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -332,14 +352,18 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
       await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
 
       expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("prompt-type"));
@@ -357,14 +381,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "copilot" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "copilot" });
       await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -382,14 +406,14 @@ describe("HooksProcessor", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "opencode" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "opencode" });
       await processor.convertRulesyncFilesToToolFiles([rulesyncHooks]);
 
       expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("matcher"));
@@ -399,7 +423,7 @@ describe("HooksProcessor", () => {
   describe("convertToolFilesToRulesyncFiles", () => {
     it("should convert tool hooks to rulesync hooks", async () => {
       const cursorHooks = new CursorHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor",
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify({
@@ -409,7 +433,7 @@ describe("HooksProcessor", () => {
         validate: false,
       });
 
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const rulesyncFiles = await processor.convertToolFilesToRulesyncFiles([cursorHooks]);
       expect(rulesyncFiles).toHaveLength(1);
       expect(rulesyncFiles[0]).toBeInstanceOf(RulesyncHooks);
@@ -418,7 +442,7 @@ describe("HooksProcessor", () => {
     });
 
     it("should filter out non-ToolHooks files", async () => {
-      const processor = new HooksProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new HooksProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
       const rulesyncFiles = await processor.convertToolFilesToRulesyncFiles([
         { getFilePath: () => "/path" } as ToolHooks,
       ]);

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -66,7 +66,7 @@ type ToolHooksFactory = {
     };
     isDeletable?: (instance: ToolHooks) => boolean;
     getAuxiliaryFiles?: (params: {
-      baseDir?: string;
+      outputRoot?: string;
       global?: boolean;
     }) => ToolFile[] | Promise<ToolFile[]>;
   };
@@ -222,21 +222,21 @@ export class HooksProcessor extends FeatureProcessor {
   private readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = HooksProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -251,7 +251,7 @@ export class HooksProcessor extends FeatureProcessor {
     try {
       return [
         await RulesyncHooks.fromFile({
-          baseDir: this.inputRoot,
+          outputRoot: this.inputRoot,
           validate: true,
         }),
       ];
@@ -275,7 +275,7 @@ export class HooksProcessor extends FeatureProcessor {
 
       if (forDeletion) {
         const toolHooks = factory.class.forDeletion({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.relativeDirPath,
           relativeFilePath: paths.relativeFilePath,
           global: this.global,
@@ -288,7 +288,7 @@ export class HooksProcessor extends FeatureProcessor {
       }
 
       const toolHooks = await factory.class.fromFile({
-        baseDir: this.baseDir,
+        outputRoot: this.outputRoot,
         validate: true,
         global: this.global,
       });
@@ -372,7 +372,7 @@ export class HooksProcessor extends FeatureProcessor {
     }
 
     const toolHooks = await factory.class.fromRulesyncHooks({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       rulesyncHooks,
       validate: true,
       global: this.global,
@@ -380,7 +380,7 @@ export class HooksProcessor extends FeatureProcessor {
 
     const result: ToolFile[] = [toolHooks];
     const auxiliaryFiles = await factory.class.getAuxiliaryFiles?.({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       global: this.global,
     });
     if (auxiliaryFiles && auxiliaryFiles.length > 0) {

--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -57,7 +57,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -65,7 +65,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -101,7 +101,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -109,7 +109,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -129,7 +129,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -137,7 +137,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -160,7 +160,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -168,7 +168,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -194,7 +194,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -202,7 +202,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -219,7 +219,7 @@ describe("KiloHooks", () => {
         hooks: {},
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -227,7 +227,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -251,7 +251,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -259,7 +259,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -281,7 +281,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -289,7 +289,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -309,7 +309,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -318,7 +318,7 @@ describe("KiloHooks", () => {
 
       expect(() =>
         KiloHooks.fromRulesyncHooks({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncHooks,
           validate: false,
         }),
@@ -333,7 +333,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -341,7 +341,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -361,7 +361,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -369,7 +369,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -386,7 +386,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -394,7 +394,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -414,7 +414,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -422,7 +422,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -440,7 +440,7 @@ describe("KiloHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -448,7 +448,7 @@ describe("KiloHooks", () => {
       });
 
       const kiloHooks = KiloHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -462,7 +462,7 @@ describe("KiloHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should throw because Kilo hooks cannot be converted back", () => {
       const kiloHooks = new KiloHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
         fileContent: "export const Plugin = async ({ $ }) => { return {} }",
@@ -487,7 +487,7 @@ describe("KiloHooks", () => {
       await writeFileContent(join(pluginsDir, "rulesync-hooks.js"), content);
 
       const kiloHooks = await KiloHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(kiloHooks).toBeInstanceOf(KiloHooks);
@@ -498,7 +498,7 @@ describe("KiloHooks", () => {
   describe("forDeletion", () => {
     it("should return KiloHooks instance with empty content for deletion", () => {
       const hooks = KiloHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
       });
@@ -510,7 +510,7 @@ describe("KiloHooks", () => {
   describe("isDeletable", () => {
     it("should return true (plugin file is standalone and deletable)", () => {
       const hooks = new KiloHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
         fileContent: "",

--- a/src/features/hooks/kilo-hooks.ts
+++ b/src/features/hooks/kilo-hooks.ts
@@ -31,16 +31,16 @@ export class KiloHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<KiloHooks> {
     const paths = KiloHooks.getSettablePaths({ global });
     const fileContent = await readFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
     );
     return new KiloHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -49,7 +49,7 @@ export class KiloHooks extends ToolHooks {
   }
 
   static fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -63,7 +63,7 @@ export class KiloHooks extends ToolHooks {
     );
     const paths = KiloHooks.getSettablePaths({ global });
     return new KiloHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -80,12 +80,12 @@ export class KiloHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): KiloHooks {
     return new KiloHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -57,7 +57,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -65,7 +65,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -101,7 +101,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -109,7 +109,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -129,7 +129,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -137,7 +137,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -160,7 +160,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -168,7 +168,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -194,7 +194,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -202,7 +202,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -219,7 +219,7 @@ describe("OpencodeHooks", () => {
         hooks: {},
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -227,7 +227,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -251,7 +251,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -259,7 +259,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -281,7 +281,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -289,7 +289,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -309,7 +309,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -318,7 +318,7 @@ describe("OpencodeHooks", () => {
 
       expect(() =>
         OpencodeHooks.fromRulesyncHooks({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncHooks,
           validate: false,
         }),
@@ -333,7 +333,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -341,7 +341,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -361,7 +361,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -369,7 +369,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -386,7 +386,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -394,7 +394,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -414,7 +414,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -422,7 +422,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -440,7 +440,7 @@ describe("OpencodeHooks", () => {
         },
       };
       const rulesyncHooks = new RulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "hooks.json",
         fileContent: JSON.stringify(config),
@@ -448,7 +448,7 @@ describe("OpencodeHooks", () => {
       });
 
       const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncHooks,
         validate: false,
       });
@@ -462,7 +462,7 @@ describe("OpencodeHooks", () => {
   describe("toRulesyncHooks", () => {
     it("should throw because OpenCode hooks cannot be converted back", () => {
       const opencodeHooks = new OpencodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
         fileContent: "export const Plugin = async ({ $ }) => { return {} }",
@@ -487,7 +487,7 @@ describe("OpencodeHooks", () => {
       await writeFileContent(join(pluginsDir, "rulesync-hooks.js"), content);
 
       const opencodeHooks = await OpencodeHooks.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
       expect(opencodeHooks).toBeInstanceOf(OpencodeHooks);
@@ -498,7 +498,7 @@ describe("OpencodeHooks", () => {
   describe("forDeletion", () => {
     it("should return OpencodeHooks instance with empty content for deletion", () => {
       const hooks = OpencodeHooks.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
       });
@@ -510,7 +510,7 @@ describe("OpencodeHooks", () => {
   describe("isDeletable", () => {
     it("should return true (plugin file is standalone and deletable)", () => {
       const hooks = new OpencodeHooks({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "plugins"),
         relativeFilePath: "rulesync-hooks.js",
         fileContent: "",

--- a/src/features/hooks/opencode-hooks.ts
+++ b/src/features/hooks/opencode-hooks.ts
@@ -31,16 +31,16 @@ export class OpencodeHooks extends ToolHooks {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<OpencodeHooks> {
     const paths = OpencodeHooks.getSettablePaths({ global });
     const fileContent = await readFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
     );
     return new OpencodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -49,7 +49,7 @@ export class OpencodeHooks extends ToolHooks {
   }
 
   static fromRulesyncHooks({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncHooks,
     validate = true,
     global = false,
@@ -63,7 +63,7 @@ export class OpencodeHooks extends ToolHooks {
     );
     const paths = OpencodeHooks.getSettablePaths({ global });
     return new OpencodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -80,12 +80,12 @@ export class OpencodeHooks extends ToolHooks {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolHooksForDeletionParams): OpencodeHooks {
     return new OpencodeHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/hooks/rulesync-hooks.ts
+++ b/src/features/hooks/rulesync-hooks.ts
@@ -12,7 +12,10 @@ import { fileExists, readFileContent } from "../../utils/file.js";
 
 export type RulesyncHooksParams = RulesyncFileParams;
 
-export type RulesyncHooksFromFileParams = Pick<RulesyncFileFromFileParams, "baseDir" | "validate">;
+export type RulesyncHooksFromFileParams = Pick<
+  RulesyncFileFromFileParams,
+  "outputRoot" | "validate"
+>;
 
 export type RulesyncHooksSettablePaths = {
   relativeDirPath: string;
@@ -50,11 +53,11 @@ export class RulesyncHooks extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: RulesyncHooksFromFileParams): Promise<RulesyncHooks> {
     const paths = RulesyncHooks.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
 
     if (!(await fileExists(filePath))) {
       throw new Error(`No ${RULESYNC_HOOKS_RELATIVE_FILE_PATH} found.`);
@@ -62,7 +65,7 @@ export class RulesyncHooks extends RulesyncFile {
 
     const fileContent = await readFileContent(filePath);
     return new RulesyncHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,

--- a/src/features/hooks/tool-hooks.ts
+++ b/src/features/hooks/tool-hooks.ts
@@ -13,10 +13,13 @@ export type ToolHooksFromRulesyncHooksParams = Omit<
   rulesyncHooks: RulesyncHooks;
 };
 
-export type ToolHooksFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate" | "global">;
+export type ToolHooksFromFileParams = Pick<
+  AiFileFromFileParams,
+  "outputRoot" | "validate" | "global"
+>;
 
 export type ToolHooksForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;
@@ -54,7 +57,7 @@ export abstract class ToolHooks extends ToolFile {
     fileContent?: string;
   } = {}): RulesyncHooks {
     return new RulesyncHooks({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: "hooks.json",
       fileContent: fileContent ?? this.fileContent,
@@ -70,7 +73,7 @@ export abstract class ToolHooks extends ToolFile {
   }
 
   static async getAuxiliaryFiles(_params: {
-    baseDir?: string;
+    outputRoot?: string;
     global?: boolean;
   }): Promise<ToolFile[]> {
     return [];

--- a/src/features/ignore/augmentcode-ignore.test.ts
+++ b/src/features/ignore/augmentcode-ignore.test.ts
@@ -38,9 +38,9 @@ describe("AugmentcodeIgnore", () => {
       expect(augmentcodeIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".augmentignore",
         fileContent: "*.tmp",
@@ -75,7 +75,7 @@ describe("AugmentcodeIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent,
@@ -91,7 +91,7 @@ describe("AugmentcodeIgnore", () => {
 
     it("should handle empty content", () => {
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent: "",
@@ -105,7 +105,7 @@ describe("AugmentcodeIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("AugmentcodeIgnore", () => {
     it("should preserve negation patterns (! prefix)", () => {
       const fileContent = "*.log\nnode_modules/\n!important.log\n!keep.txt";
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent,
@@ -132,7 +132,7 @@ describe("AugmentcodeIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create AugmentcodeIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create AugmentcodeIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -145,13 +145,13 @@ describe("AugmentcodeIgnore", () => {
       });
 
       expect(augmentcodeIgnore).toBeInstanceOf(AugmentcodeIgnore);
-      expect(augmentcodeIgnore.getBaseDir()).toBe(testDir);
+      expect(augmentcodeIgnore.getOutputRoot()).toBe(testDir);
       expect(augmentcodeIgnore.getRelativeDirPath()).toBe(".");
       expect(augmentcodeIgnore.getRelativeFilePath()).toBe(".augmentignore");
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create AugmentcodeIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create AugmentcodeIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -160,11 +160,11 @@ describe("AugmentcodeIgnore", () => {
       });
 
       const augmentcodeIgnore = AugmentcodeIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(augmentcodeIgnore.getBaseDir()).toBe("/custom/base");
+      expect(augmentcodeIgnore.getOutputRoot()).toBe("/custom/base");
       expect(augmentcodeIgnore.getFilePath()).toBe("/custom/base/.augmentignore");
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
     });
@@ -217,17 +217,17 @@ describe("AugmentcodeIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .augmentignore file from baseDir with default baseDir", async () => {
+    it("should read .augmentignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const augmentignorePath = join(testDir, ".augmentignore");
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(augmentcodeIgnore).toBeInstanceOf(AugmentcodeIgnore);
-      expect(augmentcodeIgnore.getBaseDir()).toBe(testDir);
+      expect(augmentcodeIgnore.getOutputRoot()).toBe(testDir);
       expect(augmentcodeIgnore.getRelativeDirPath()).toBe(".");
       expect(augmentcodeIgnore.getRelativeFilePath()).toBe(".augmentignore");
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -239,7 +239,7 @@ describe("AugmentcodeIgnore", () => {
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -251,7 +251,7 @@ describe("AugmentcodeIgnore", () => {
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -263,7 +263,7 @@ describe("AugmentcodeIgnore", () => {
       await writeFileContent(augmentignorePath, "");
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(augmentcodeIgnore.getFileContent()).toBe("");
@@ -315,27 +315,27 @@ desktop.ini
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       const fileContent = "*.log\nnode_modules/";
       const augmentignorePath = join(testDir, ".augmentignore");
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({});
 
-      expect(augmentcodeIgnore.getBaseDir()).toBe(testDir);
+      expect(augmentcodeIgnore.getOutputRoot()).toBe(testDir);
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .augmentignore file does not exist", async () => {
       await expect(
         AugmentcodeIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -346,7 +346,7 @@ desktop.ini
       await writeFileContent(augmentignorePath, fileContent);
 
       const augmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(augmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -383,13 +383,13 @@ desktop.ini
 
     it("should inherit file path methods from ToolFile", () => {
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".augmentignore",
         fileContent: "*.log",
       });
 
-      expect(augmentcodeIgnore.getBaseDir()).toBe("/test/base");
+      expect(augmentcodeIgnore.getOutputRoot()).toBe("/test/base");
       expect(augmentcodeIgnore.getRelativeDirPath()).toBe("subdir");
       expect(augmentcodeIgnore.getRelativeFilePath()).toBe(".augmentignore");
       expect(augmentcodeIgnore.getFilePath()).toBe("/test/base/subdir/.augmentignore");
@@ -410,7 +410,7 @@ dist/
 
       // AugmentcodeIgnore -> RulesyncIgnore -> AugmentcodeIgnore
       const originalAugmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent: originalContent,
@@ -418,12 +418,12 @@ dist/
 
       const rulesyncIgnore = originalAugmentcodeIgnore.toRulesyncIgnore();
       const roundTripAugmentcodeIgnore = AugmentcodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripAugmentcodeIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripAugmentcodeIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripAugmentcodeIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripAugmentcodeIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripAugmentcodeIgnore.getRelativeFilePath()).toBe(".augmentignore");
     });
@@ -505,7 +505,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augmentignore",
         fileContent,
@@ -516,7 +516,7 @@ dist/
 
       // Read file back
       const readAugmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readAugmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -529,7 +529,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const augmentcodeIgnore = new AugmentcodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".augmentignore",
         fileContent,
@@ -539,7 +539,7 @@ dist/
       await writeFileContent(augmentcodeIgnore.getFilePath(), augmentcodeIgnore.getFileContent());
 
       const readAugmentcodeIgnore = await AugmentcodeIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readAugmentcodeIgnore.getFileContent()).toBe(fileContent);
@@ -621,7 +621,7 @@ build/
 
     it("should work in repository root context", () => {
       const augmentcodeIgnore = AugmentcodeIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/augmentcode-ignore.ts
+++ b/src/features/ignore/augmentcode-ignore.ts
@@ -52,11 +52,11 @@ export class AugmentcodeIgnore extends ToolIgnore {
    * Supports conversion from unified rulesync format to AugmentCode specific format
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): AugmentcodeIgnore {
     return new AugmentcodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -68,19 +68,19 @@ export class AugmentcodeIgnore extends ToolIgnore {
    * Reads and parses .augmentignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<AugmentcodeIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new AugmentcodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -89,12 +89,12 @@ export class AugmentcodeIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): AugmentcodeIgnore {
     return new AugmentcodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/claudecode-ignore.test.ts
+++ b/src/features/ignore/claudecode-ignore.test.ts
@@ -100,7 +100,7 @@ describe("ClaudecodeIgnore", () => {
       expect(claudecodeIgnore.getPatterns()).toEqual([]);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const jsonContent = JSON.stringify(
         {
           permissions: {
@@ -112,7 +112,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -178,7 +178,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
         options: { fileMode: "local" },
       });
@@ -207,7 +207,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
         options: { fileMode: "local" },
       });
@@ -243,7 +243,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -270,7 +270,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -293,7 +293,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -316,7 +316,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -338,12 +338,12 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(claudecodeIgnore).toBeInstanceOf(ClaudecodeIgnore);
-      expect(claudecodeIgnore.getBaseDir()).toBe(testDir);
+      expect(claudecodeIgnore.getOutputRoot()).toBe(testDir);
       expect(claudecodeIgnore.getRelativeDirPath()).toBe(".claude");
       expect(claudecodeIgnore.getRelativeFilePath()).toBe("settings.json");
 
@@ -378,7 +378,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -400,7 +400,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -437,7 +437,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -470,7 +470,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -500,7 +500,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -517,7 +517,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -537,7 +537,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -549,7 +549,7 @@ describe("ClaudecodeIgnore", () => {
       });
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
@@ -557,11 +557,11 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
-      expect(claudecodeIgnore.getBaseDir()).toBe(testDir);
+      expect(claudecodeIgnore.getOutputRoot()).toBe(testDir);
 
       const jsonValue = JSON.parse(claudecodeIgnore.getFileContent());
       expect(jsonValue.permissions.deny).toEqual(["Read(*.tmp)"]);
@@ -585,11 +585,11 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(join(claudeDir, "settings.json"), jsonContent);
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeIgnore).toBeInstanceOf(ClaudecodeIgnore);
-      expect(claudecodeIgnore.getBaseDir()).toBe(testDir);
+      expect(claudecodeIgnore.getOutputRoot()).toBe(testDir);
       expect(claudecodeIgnore.getRelativeDirPath()).toBe(".claude");
       expect(claudecodeIgnore.getRelativeFilePath()).toBe("settings.json");
       expect(claudecodeIgnore.getPatterns()).toEqual(["Read(*.log)", "Read(node_modules/**)"]);
@@ -611,7 +611,7 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(join(claudeDir, "settings.json"), jsonContent);
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeIgnore.getFileContent()).toBe(jsonContent);
@@ -633,7 +633,7 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(join(claudeDir, "settings.json"), jsonContent);
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -661,14 +661,14 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(join(claudeDir, "settings.json"), jsonContent);
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeIgnore.getFileContent()).toBe(jsonContent);
       expect(claudecodeIgnore.getPatterns()).toEqual(["Read(*.log)", "Read(secrets/**)"]);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const jsonContent = JSON.stringify(
         {
@@ -686,14 +686,14 @@ describe("ClaudecodeIgnore", () => {
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({});
 
-      expect(claudecodeIgnore.getBaseDir()).toBe(testDir);
+      expect(claudecodeIgnore.getOutputRoot()).toBe(testDir);
       expect(claudecodeIgnore.getPatterns()).toEqual(["Read(*.log)"]);
     });
 
     it("should throw error when shared settings file does not exist", async () => {
       await expect(
         ClaudecodeIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow("File not found");
     });
@@ -710,7 +710,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         options: { fileMode: "local" },
       });
 
@@ -727,7 +727,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         options: { fileMode: "local" },
       });
 
@@ -748,7 +748,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -779,7 +779,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -982,13 +982,13 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
       });
 
-      expect(claudecodeIgnore.getBaseDir()).toBe("/test/base");
+      expect(claudecodeIgnore.getOutputRoot()).toBe("/test/base");
       expect(claudecodeIgnore.getRelativeDirPath()).toBe(".claude");
       expect(claudecodeIgnore.getRelativeFilePath()).toBe("settings.json");
       expect(claudecodeIgnore.getFilePath()).toBe("/test/base/.claude/settings.json");
@@ -1009,7 +1009,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -1020,7 +1020,7 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(claudecodeIgnore.getFilePath(), claudecodeIgnore.getFileContent());
 
       const readClaudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readClaudecodeIgnore.getFileContent()).toBe(jsonContent);
@@ -1042,7 +1042,7 @@ describe("ClaudecodeIgnore", () => {
       );
 
       const claudecodeIgnore = new ClaudecodeIgnore({
-        baseDir: subDir,
+        outputRoot: subDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -1053,7 +1053,7 @@ describe("ClaudecodeIgnore", () => {
       await writeFileContent(claudecodeIgnore.getFilePath(), claudecodeIgnore.getFileContent());
 
       const readClaudecodeIgnore = await ClaudecodeIgnore.fromFile({
-        baseDir: subDir,
+        outputRoot: subDir,
       });
 
       expect(readClaudecodeIgnore.getFileContent()).toBe(jsonContent);
@@ -1090,7 +1090,7 @@ describe("ClaudecodeIgnore", () => {
       });
 
       const claudecodeIgnore = await ClaudecodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -112,7 +112,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
     const fileContent = rulesyncPatterns.join("\n");
 
     return new RulesyncIgnore({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RulesyncIgnore.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath: RulesyncIgnore.getSettablePaths().recommended.relativeFilePath,
       fileContent,
@@ -120,7 +120,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
   }
 
   static async fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
     options,
   }: ToolIgnoreFromRulesyncIgnoreParams): Promise<ClaudecodeIgnore> {
@@ -133,7 +133,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
     const deniedValues = patterns.map((pattern) => `Read(${pattern})`);
 
     const paths = this.getSettablePaths({ options });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const exists = await fileExists(filePath);
     const existingFileContent = exists ? await readFileContent(filePath) : "{}";
     const existingJsonValue: ClaudeSettingsJson = JSON.parse(existingFileContent);
@@ -156,7 +156,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
     };
 
     return new ClaudecodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(jsonValue, null, 2),
@@ -165,13 +165,13 @@ export class ClaudecodeIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     options,
   }: ToolIgnoreFromFileParams): Promise<ClaudecodeIgnore> {
     const fileMode = resolveFileMode(options);
     const paths = this.getSettablePaths({ options });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     // When `fileMode: "local"` is configured but the user has not yet created
     // `.claude/settings.local.json` (a common case during `rulesync import`),
     // gracefully fall back to an empty settings document instead of throwing.
@@ -184,7 +184,7 @@ export class ClaudecodeIgnore extends ToolIgnore {
     const fileContent = exists ? await readFileContent(filePath) : "{}";
 
     return new ClaudecodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: fileContent,
@@ -193,12 +193,12 @@ export class ClaudecodeIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): ClaudecodeIgnore {
     return new ClaudecodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/ignore/cline-ignore.test.ts
+++ b/src/features/ignore/cline-ignore.test.ts
@@ -39,9 +39,9 @@ describe("ClineIgnore", () => {
       expect(clineIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const clineIgnore = new ClineIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".clineignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("ClineIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const clineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("ClineIgnore", () => {
 
     it("should handle empty content", () => {
       const clineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("ClineIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const clineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("ClineIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create ClineIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create ClineIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("ClineIgnore", () => {
       });
 
       expect(clineIgnore).toBeInstanceOf(ClineIgnore);
-      expect(clineIgnore.getBaseDir()).toBe(testDir);
+      expect(clineIgnore.getOutputRoot()).toBe(testDir);
       expect(clineIgnore.getRelativeDirPath()).toBe(".");
       expect(clineIgnore.getRelativeFilePath()).toBe(".clineignore");
       expect(clineIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create ClineIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create ClineIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("ClineIgnore", () => {
       });
 
       const clineIgnore = ClineIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(clineIgnore.getBaseDir()).toBe("/custom/base");
+      expect(clineIgnore.getOutputRoot()).toBe("/custom/base");
       expect(clineIgnore.getFilePath()).toBe("/custom/base/.clineignore");
       expect(clineIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("ClineIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .clineignore file from baseDir with default baseDir", async () => {
+    it("should read .clineignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const clineignorePath = join(testDir, ".clineignore");
       await writeFileContent(clineignorePath, fileContent);
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineIgnore).toBeInstanceOf(ClineIgnore);
-      expect(clineIgnore.getBaseDir()).toBe(testDir);
+      expect(clineIgnore.getOutputRoot()).toBe(testDir);
       expect(clineIgnore.getRelativeDirPath()).toBe(".");
       expect(clineIgnore.getRelativeFilePath()).toBe(".clineignore");
       expect(clineIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("ClineIgnore", () => {
       await writeFileContent(clineignorePath, fileContent);
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("ClineIgnore", () => {
       await writeFileContent(clineignorePath, fileContent);
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("ClineIgnore", () => {
       await writeFileContent(clineignorePath, "");
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(clineignorePath, fileContent);
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const clineignorePath = join(testDir, ".clineignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const clineIgnore = await ClineIgnore.fromFile({});
 
-      expect(clineIgnore.getBaseDir()).toBe(testDir);
+      expect(clineIgnore.getOutputRoot()).toBe(testDir);
       expect(clineIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .clineignore file does not exist", async () => {
       await expect(
         ClineIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(clineignorePath, fileContent);
 
       const clineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const clineIgnore = new ClineIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".clineignore",
         fileContent: "*.log",
       });
 
-      expect(clineIgnore.getBaseDir()).toBe("/test/base");
+      expect(clineIgnore.getOutputRoot()).toBe("/test/base");
       expect(clineIgnore.getRelativeDirPath()).toBe("subdir");
       expect(clineIgnore.getRelativeFilePath()).toBe(".clineignore");
       expect(clineIgnore.getFilePath()).toBe("/test/base/subdir/.clineignore");
@@ -369,7 +369,7 @@ dist/
 
       // ClineIgnore -> RulesyncIgnore -> ClineIgnore
       const originalClineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalClineIgnore.toRulesyncIgnore();
       const roundTripClineIgnore = ClineIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripClineIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripClineIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripClineIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripClineIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripClineIgnore.getRelativeFilePath()).toBe(".clineignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const clineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readClineIgnore = await ClineIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readClineIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const clineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".clineignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(clineIgnore.getFilePath(), clineIgnore.getFileContent());
 
       const readClineIgnore = await ClineIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readClineIgnore.getFileContent()).toBe(fileContent);
@@ -560,7 +560,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const clineIgnore = ClineIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/cline-ignore.ts
+++ b/src/features/ignore/cline-ignore.ts
@@ -39,13 +39,13 @@ export class ClineIgnore extends ToolIgnore {
    * Create ClineIgnore from RulesyncIgnore
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): ClineIgnore {
     const body = rulesyncIgnore.getFileContent();
 
     return new ClineIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: body,
@@ -56,19 +56,19 @@ export class ClineIgnore extends ToolIgnore {
    * Load ClineIgnore from .clineignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<ClineIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new ClineIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -77,12 +77,12 @@ export class ClineIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): ClineIgnore {
     return new ClineIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/cursor-ignore.test.ts
+++ b/src/features/ignore/cursor-ignore.test.ts
@@ -36,9 +36,9 @@ describe("CursorIgnore", () => {
       expect(cursorIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const cursorIgnore = new CursorIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".cursorignore",
         fileContent: "*.tmp",
@@ -73,7 +73,7 @@ describe("CursorIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent,
@@ -89,7 +89,7 @@ describe("CursorIgnore", () => {
 
     it("should handle empty content", () => {
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent: "",
@@ -103,7 +103,7 @@ describe("CursorIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent,
@@ -116,7 +116,7 @@ describe("CursorIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create CursorIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create CursorIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -129,13 +129,13 @@ describe("CursorIgnore", () => {
       });
 
       expect(cursorIgnore).toBeInstanceOf(CursorIgnore);
-      expect(cursorIgnore.getBaseDir()).toBe(testDir);
+      expect(cursorIgnore.getOutputRoot()).toBe(testDir);
       expect(cursorIgnore.getRelativeDirPath()).toBe(".");
       expect(cursorIgnore.getRelativeFilePath()).toBe(".cursorignore");
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create CursorIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create CursorIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -144,11 +144,11 @@ describe("CursorIgnore", () => {
       });
 
       const cursorIgnore = CursorIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(cursorIgnore.getBaseDir()).toBe("/custom/base");
+      expect(cursorIgnore.getOutputRoot()).toBe("/custom/base");
       expect(cursorIgnore.getFilePath()).toBe("/custom/base/.cursorignore");
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
     });
@@ -184,17 +184,17 @@ describe("CursorIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .cursorignore file from baseDir with default baseDir", async () => {
+    it("should read .cursorignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const cursorignorePath = join(testDir, ".cursorignore");
       await writeFileContent(cursorignorePath, fileContent);
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorIgnore).toBeInstanceOf(CursorIgnore);
-      expect(cursorIgnore.getBaseDir()).toBe(testDir);
+      expect(cursorIgnore.getOutputRoot()).toBe(testDir);
       expect(cursorIgnore.getRelativeDirPath()).toBe(".");
       expect(cursorIgnore.getRelativeFilePath()).toBe(".cursorignore");
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
@@ -206,7 +206,7 @@ describe("CursorIgnore", () => {
       await writeFileContent(cursorignorePath, fileContent);
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
@@ -218,7 +218,7 @@ describe("CursorIgnore", () => {
       await writeFileContent(cursorignorePath, fileContent);
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -230,7 +230,7 @@ describe("CursorIgnore", () => {
       await writeFileContent(cursorignorePath, "");
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorIgnore.getFileContent()).toBe("");
@@ -271,13 +271,13 @@ Thumbs.db`;
       await writeFileContent(cursorignorePath, fileContent);
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const cursorignorePath = join(testDir, ".cursorignore");
@@ -285,14 +285,14 @@ Thumbs.db`;
 
       const cursorIgnore = await CursorIgnore.fromFile({});
 
-      expect(cursorIgnore.getBaseDir()).toBe(testDir);
+      expect(cursorIgnore.getOutputRoot()).toBe(testDir);
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .cursorignore file does not exist", async () => {
       await expect(
         CursorIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -303,7 +303,7 @@ Thumbs.db`;
       await writeFileContent(cursorignorePath, fileContent);
 
       const cursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorIgnore.getFileContent()).toBe(fileContent);
@@ -340,13 +340,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const cursorIgnore = new CursorIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".cursorignore",
         fileContent: "*.log",
       });
 
-      expect(cursorIgnore.getBaseDir()).toBe("/test/base");
+      expect(cursorIgnore.getOutputRoot()).toBe("/test/base");
       expect(cursorIgnore.getRelativeDirPath()).toBe("subdir");
       expect(cursorIgnore.getRelativeFilePath()).toBe(".cursorignore");
       expect(cursorIgnore.getFilePath()).toBe("/test/base/subdir/.cursorignore");
@@ -366,7 +366,7 @@ dist/
 
       // CursorIgnore -> RulesyncIgnore -> CursorIgnore
       const originalCursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent: originalContent,
@@ -374,12 +374,12 @@ dist/
 
       const rulesyncIgnore = originalCursorIgnore.toRulesyncIgnore();
       const roundTripCursorIgnore = CursorIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripCursorIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripCursorIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripCursorIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripCursorIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripCursorIgnore.getRelativeFilePath()).toBe(".cursorignore");
     });
@@ -456,7 +456,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent,
@@ -467,7 +467,7 @@ dist/
 
       // Read file back
       const readCursorIgnore = await CursorIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readCursorIgnore.getFileContent()).toBe(fileContent);
@@ -480,7 +480,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".cursorignore",
         fileContent,
@@ -490,7 +490,7 @@ dist/
       await writeFileContent(cursorIgnore.getFilePath(), cursorIgnore.getFileContent());
 
       const readCursorIgnore = await CursorIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readCursorIgnore.getFileContent()).toBe(fileContent);
@@ -557,7 +557,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const cursorIgnore = CursorIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: ".rulesync",
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/cursor-ignore.ts
+++ b/src/features/ignore/cursor-ignore.ts
@@ -21,7 +21,7 @@ export class CursorIgnore extends ToolIgnore {
 
   toRulesyncIgnore(): RulesyncIgnore {
     return new RulesyncIgnore({
-      baseDir: ".",
+      outputRoot: ".",
       relativeDirPath: ".",
       relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
       fileContent: this.fileContent,
@@ -29,13 +29,13 @@ export class CursorIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): CursorIgnore {
     const body = rulesyncIgnore.getFileContent();
 
     return new CursorIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: body,
@@ -43,19 +43,19 @@ export class CursorIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<CursorIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new CursorIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -64,12 +64,12 @@ export class CursorIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): CursorIgnore {
     return new CursorIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/geminicli-ignore.test.ts
+++ b/src/features/ignore/geminicli-ignore.test.ts
@@ -39,9 +39,9 @@ describe("GeminiCliIgnore", () => {
       expect(geminiCliIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".geminiignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("GeminiCliIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("GeminiCliIgnore", () => {
 
     it("should handle empty content", () => {
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("GeminiCliIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("GeminiCliIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create GeminiCliIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create GeminiCliIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -132,13 +132,13 @@ describe("GeminiCliIgnore", () => {
       });
 
       expect(geminiCliIgnore).toBeInstanceOf(GeminiCliIgnore);
-      expect(geminiCliIgnore.getBaseDir()).toBe(testDir);
+      expect(geminiCliIgnore.getOutputRoot()).toBe(testDir);
       expect(geminiCliIgnore.getRelativeDirPath()).toBe(".");
       expect(geminiCliIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create GeminiCliIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create GeminiCliIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -147,11 +147,11 @@ describe("GeminiCliIgnore", () => {
       });
 
       const geminiCliIgnore = GeminiCliIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(geminiCliIgnore.getBaseDir()).toBe("/custom/base");
+      expect(geminiCliIgnore.getOutputRoot()).toBe("/custom/base");
       expect(geminiCliIgnore.getFilePath()).toBe("/custom/base/.geminiignore");
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("GeminiCliIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .geminiignore file from baseDir with default baseDir", async () => {
+    it("should read .geminiignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const aiexcludePath = join(testDir, ".geminiignore");
       await writeFileContent(aiexcludePath, fileContent);
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliIgnore).toBeInstanceOf(GeminiCliIgnore);
-      expect(geminiCliIgnore.getBaseDir()).toBe(testDir);
+      expect(geminiCliIgnore.getOutputRoot()).toBe(testDir);
       expect(geminiCliIgnore.getRelativeDirPath()).toBe(".");
       expect(geminiCliIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("GeminiCliIgnore", () => {
       await writeFileContent(aiexcludePath, fileContent);
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("GeminiCliIgnore", () => {
       await writeFileContent(aiexcludePath, fileContent);
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("GeminiCliIgnore", () => {
       await writeFileContent(aiexcludePath, "");
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(aiexcludePath, fileContent);
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const aiexcludePath = join(testDir, ".geminiignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({});
 
-      expect(geminiCliIgnore.getBaseDir()).toBe(testDir);
+      expect(geminiCliIgnore.getOutputRoot()).toBe(testDir);
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .geminiignore file does not exist", async () => {
       await expect(
         GeminiCliIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(aiexcludePath, fileContent);
 
       const geminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".geminiignore",
         fileContent: "*.log",
       });
 
-      expect(geminiCliIgnore.getBaseDir()).toBe("/test/base");
+      expect(geminiCliIgnore.getOutputRoot()).toBe("/test/base");
       expect(geminiCliIgnore.getRelativeDirPath()).toBe("subdir");
       expect(geminiCliIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(geminiCliIgnore.getFilePath()).toBe("/test/base/subdir/.geminiignore");
@@ -369,7 +369,7 @@ dist/
 
       // GeminiCliIgnore -> RulesyncIgnore -> GeminiCliIgnore
       const originalGeminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalGeminiCliIgnore.toRulesyncIgnore();
       const roundTripGeminiCliIgnore = GeminiCliIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripGeminiCliIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripGeminiCliIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripGeminiCliIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripGeminiCliIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripGeminiCliIgnore.getRelativeFilePath()).toBe(".geminiignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readGeminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readGeminiCliIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const geminiCliIgnore = new GeminiCliIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(geminiCliIgnore.getFilePath(), geminiCliIgnore.getFileContent());
 
       const readGeminiCliIgnore = await GeminiCliIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readGeminiCliIgnore.getFileContent()).toBe(fileContent);

--- a/src/features/ignore/geminicli-ignore.ts
+++ b/src/features/ignore/geminicli-ignore.ts
@@ -23,11 +23,11 @@ export class GeminiCliIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): GeminiCliIgnore {
     return new GeminiCliIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -35,19 +35,19 @@ export class GeminiCliIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<GeminiCliIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new GeminiCliIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -56,12 +56,12 @@ export class GeminiCliIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): GeminiCliIgnore {
     return new GeminiCliIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/goose-ignore.test.ts
+++ b/src/features/ignore/goose-ignore.test.ts
@@ -39,9 +39,9 @@ describe("GooseIgnore", () => {
       expect(gooseIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const gooseIgnore = new GooseIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".gooseignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("GooseIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const gooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("GooseIgnore", () => {
 
     it("should handle empty content", () => {
       const gooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("GooseIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const gooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("GooseIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create GooseIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create GooseIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("GooseIgnore", () => {
       });
 
       expect(gooseIgnore).toBeInstanceOf(GooseIgnore);
-      expect(gooseIgnore.getBaseDir()).toBe(testDir);
+      expect(gooseIgnore.getOutputRoot()).toBe(testDir);
       expect(gooseIgnore.getRelativeDirPath()).toBe(".");
       expect(gooseIgnore.getRelativeFilePath()).toBe(".gooseignore");
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create GooseIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create GooseIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("GooseIgnore", () => {
       });
 
       const gooseIgnore = GooseIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(gooseIgnore.getBaseDir()).toBe("/custom/base");
+      expect(gooseIgnore.getOutputRoot()).toBe("/custom/base");
       expect(gooseIgnore.getFilePath()).toBe("/custom/base/.gooseignore");
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("GooseIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .gooseignore file from baseDir with default baseDir", async () => {
+    it("should read .gooseignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const gooseignorePath = join(testDir, ".gooseignore");
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(gooseIgnore).toBeInstanceOf(GooseIgnore);
-      expect(gooseIgnore.getBaseDir()).toBe(testDir);
+      expect(gooseIgnore.getOutputRoot()).toBe(testDir);
       expect(gooseIgnore.getRelativeDirPath()).toBe(".");
       expect(gooseIgnore.getRelativeFilePath()).toBe(".gooseignore");
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("GooseIgnore", () => {
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("GooseIgnore", () => {
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("GooseIgnore", () => {
       await writeFileContent(gooseignorePath, "");
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(gooseIgnore.getFileContent()).toBe("");
@@ -274,27 +274,27 @@ Thumbs.db`;
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       const fileContent = "*.log\nnode_modules/";
       const gooseignorePath = join(testDir, ".gooseignore");
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({});
 
-      expect(gooseIgnore.getBaseDir()).toBe(testDir);
+      expect(gooseIgnore.getOutputRoot()).toBe(testDir);
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .gooseignore file does not exist", async () => {
       await expect(
         GooseIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -305,7 +305,7 @@ Thumbs.db`;
       await writeFileContent(gooseignorePath, fileContent);
 
       const gooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(gooseIgnore.getFileContent()).toBe(fileContent);
@@ -342,13 +342,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const gooseIgnore = new GooseIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".gooseignore",
         fileContent: "*.log",
       });
 
-      expect(gooseIgnore.getBaseDir()).toBe("/test/base");
+      expect(gooseIgnore.getOutputRoot()).toBe("/test/base");
       expect(gooseIgnore.getRelativeDirPath()).toBe("subdir");
       expect(gooseIgnore.getRelativeFilePath()).toBe(".gooseignore");
       expect(gooseIgnore.getFilePath()).toBe("/test/base/subdir/.gooseignore");
@@ -367,7 +367,7 @@ dist/
 *.tmp`;
 
       const originalGooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
         fileContent: originalContent,
@@ -375,12 +375,12 @@ dist/
 
       const rulesyncIgnore = originalGooseIgnore.toRulesyncIgnore();
       const roundTripGooseIgnore = GooseIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripGooseIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripGooseIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripGooseIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripGooseIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripGooseIgnore.getRelativeFilePath()).toBe(".gooseignore");
     });
@@ -456,7 +456,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const gooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
         fileContent,
@@ -465,7 +465,7 @@ dist/
       await writeFileContent(gooseIgnore.getFilePath(), gooseIgnore.getFileContent());
 
       const readGooseIgnore = await GooseIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readGooseIgnore.getFileContent()).toBe(fileContent);
@@ -478,7 +478,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const gooseIgnore = new GooseIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".gooseignore",
         fileContent,
@@ -487,7 +487,7 @@ dist/
       await writeFileContent(gooseIgnore.getFilePath(), gooseIgnore.getFileContent());
 
       const readGooseIgnore = await GooseIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readGooseIgnore.getFileContent()).toBe(fileContent);
@@ -558,7 +558,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const gooseIgnore = GooseIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",
@@ -636,31 +636,31 @@ credentials/`;
   describe("forDeletion", () => {
     it("should create instance for deletion with minimal params", () => {
       const gooseIgnore = GooseIgnore.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
       });
 
       expect(gooseIgnore).toBeInstanceOf(GooseIgnore);
-      expect(gooseIgnore.getBaseDir()).toBe(testDir);
+      expect(gooseIgnore.getOutputRoot()).toBe(testDir);
       expect(gooseIgnore.getRelativeDirPath()).toBe(".");
       expect(gooseIgnore.getRelativeFilePath()).toBe(".gooseignore");
       expect(gooseIgnore.getFileContent()).toBe("");
     });
 
-    it("should create instance for deletion with default baseDir", () => {
+    it("should create instance for deletion with default outputRoot", () => {
       const gooseIgnore = GooseIgnore.forDeletion({
         relativeDirPath: ".",
         relativeFilePath: ".gooseignore",
       });
 
-      expect(gooseIgnore.getBaseDir()).toBe(testDir);
+      expect(gooseIgnore.getOutputRoot()).toBe(testDir);
     });
 
     it("should skip validation for deletion instances", () => {
       expect(() => {
         GooseIgnore.forDeletion({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".",
           relativeFilePath: ".gooseignore",
         });

--- a/src/features/ignore/goose-ignore.ts
+++ b/src/features/ignore/goose-ignore.ts
@@ -39,13 +39,13 @@ export class GooseIgnore extends ToolIgnore {
    * Create GooseIgnore from RulesyncIgnore
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): GooseIgnore {
     const body = rulesyncIgnore.getFileContent();
 
     return new GooseIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: body,
@@ -56,19 +56,19 @@ export class GooseIgnore extends ToolIgnore {
    * Load GooseIgnore from .gooseignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<GooseIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new GooseIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -77,12 +77,12 @@ export class GooseIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): GooseIgnore {
     return new GooseIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -54,14 +54,14 @@ describe("IgnoreProcessor", () => {
   });
 
   describe("constructor", () => {
-    it("should create instance with default baseDir", () => {
+    it("should create instance with default outputRoot", () => {
       const processor = new IgnoreProcessor({ logger, toolTarget: "cursor" });
 
       expect(processor).toBeInstanceOf(IgnoreProcessor);
     });
 
-    it("should create instance with custom baseDir", () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+    it("should create instance with custom outputRoot", () => {
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       expect(processor).toBeInstanceOf(IgnoreProcessor);
     });
@@ -70,7 +70,7 @@ describe("IgnoreProcessor", () => {
       expect(() => {
         const _instance = new IgnoreProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid-target" as any,
         });
       }).toThrow();
@@ -93,7 +93,11 @@ describe("IgnoreProcessor", () => {
 
       for (const target of validTargets) {
         expect(() => {
-          const _instance = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: target });
+          const _instance = new IgnoreProcessor({
+            logger,
+            outputRoot: testDir,
+            toolTarget: target,
+          });
         }).not.toThrow();
       }
     });
@@ -102,7 +106,7 @@ describe("IgnoreProcessor", () => {
   describe("loadRulesyncFiles", () => {
     it("should load rulesync ignore file when it exists", async () => {
       const mockRulesyncIgnore = new MockRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
@@ -110,7 +114,7 @@ describe("IgnoreProcessor", () => {
 
       (RulesyncIgnoreMock as any).fromFile.mockResolvedValue(mockRulesyncIgnore as any);
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const files = await processor.loadRulesyncFiles();
       expect(files).toHaveLength(1);
@@ -120,7 +124,7 @@ describe("IgnoreProcessor", () => {
     it("should return empty array when no rulesync ignore file exists", async () => {
       (RulesyncIgnoreMock as any).fromFile.mockRejectedValue(new Error("File not found"));
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const files = await processor.loadRulesyncFiles();
       expect(files).toHaveLength(0);
@@ -135,7 +139,7 @@ describe("IgnoreProcessor", () => {
       // Create .cursorignore file
       await writeFileContent(join(testDir, ".cursorignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(1);
@@ -143,7 +147,7 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should return empty array when no tool files exist", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const files = await processor.loadToolFiles();
       expect(files).toHaveLength(0);
@@ -159,7 +163,7 @@ describe("IgnoreProcessor", () => {
 
       const processor = new IgnoreProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "augmentcode",
       });
 
@@ -171,7 +175,7 @@ describe("IgnoreProcessor", () => {
     it("should load ClineIgnore for cline target", async () => {
       await writeFileContent(join(testDir, ".clineignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cline" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cline" });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -181,7 +185,7 @@ describe("IgnoreProcessor", () => {
     it("should load CursorIgnore for cursor target", async () => {
       await writeFileContent(join(testDir, ".cursorignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -191,7 +195,11 @@ describe("IgnoreProcessor", () => {
     it("should load GeminiCliIgnore for geminicli target", async () => {
       await writeFileContent(join(testDir, ".geminiignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "geminicli" });
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "geminicli",
+      });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -201,7 +209,7 @@ describe("IgnoreProcessor", () => {
     it("should load JunieIgnore for junie target", async () => {
       await writeFileContent(join(testDir, ".aiignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "junie" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "junie" });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -211,7 +219,7 @@ describe("IgnoreProcessor", () => {
     it("should load KiroIgnore for kiro target", async () => {
       await writeFileContent(join(testDir, ".aiignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "kiro" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "kiro" });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -221,7 +229,11 @@ describe("IgnoreProcessor", () => {
     it("should load QwencodeIgnore for qwencode target", async () => {
       await writeFileContent(join(testDir, ".geminiignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "qwencode" });
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "qwencode",
+      });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -231,7 +243,7 @@ describe("IgnoreProcessor", () => {
     it("should load RooIgnore for roo target", async () => {
       await writeFileContent(join(testDir, ".rooignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "roo" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "roo" });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -241,7 +253,11 @@ describe("IgnoreProcessor", () => {
     it("should load WindsurfIgnore for windsurf target", async () => {
       await writeFileContent(join(testDir, ".codeiumignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "windsurf" });
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "windsurf",
+      });
 
       const ignores = await processor.loadToolIgnores();
       expect(ignores).toHaveLength(1);
@@ -249,7 +265,7 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should throw error for unsupported tool target", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       // Mock the toolTarget property to an unsupported value
       (processor as any).toolTarget = "unsupported";
@@ -265,7 +281,7 @@ describe("IgnoreProcessor", () => {
       // Create a mock that extends RulesyncIgnore so instanceof works
       const mockRulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       Object.assign(mockRulesyncIgnore, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
@@ -285,7 +301,7 @@ describe("IgnoreProcessor", () => {
       ] as const;
 
       for (const target of targets) {
-        const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: target });
+        const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: target });
 
         const toolFiles = await processor.convertRulesyncFilesToToolFiles([mockRulesyncIgnore]);
         expect(toolFiles).toHaveLength(1);
@@ -294,7 +310,7 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should throw error when no rulesync ignore found", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       await expect(processor.convertRulesyncFilesToToolFiles([])).rejects.toThrow(
         "No .rulesync/.aiignore found.",
@@ -304,14 +320,14 @@ describe("IgnoreProcessor", () => {
     it("should throw error for unsupported tool target in conversion", async () => {
       const mockRulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       Object.assign(mockRulesyncIgnore, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
         getFileContent: () => "*.log\nnode_modules/",
       });
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       // Mock the toolTarget property to an unsupported value
       (processor as any).toolTarget = "unsupported";
@@ -325,7 +341,7 @@ describe("IgnoreProcessor", () => {
   describe("convertToolFilesToRulesyncFiles", () => {
     it("should convert tool ignores to rulesync ignores", async () => {
       const cursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent: "*.log\nnode_modules/",
@@ -335,7 +351,7 @@ describe("IgnoreProcessor", () => {
       const mockRulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       vi.spyOn(cursorIgnore, "toRulesyncIgnore").mockReturnValue(mockRulesyncIgnore);
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const rulesyncFiles = await processor.convertToolFilesToRulesyncFiles([cursorIgnore]);
       expect(rulesyncFiles).toHaveLength(1);
@@ -347,7 +363,7 @@ describe("IgnoreProcessor", () => {
         getFilePath: () => "/path/to/file",
       } as any;
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const rulesyncFiles = await processor.convertToolFilesToRulesyncFiles([mockFile]);
       expect(rulesyncFiles).toHaveLength(0);
@@ -358,14 +374,14 @@ describe("IgnoreProcessor", () => {
     it("should convert and write tool ignores from rulesync ignores", async () => {
       const mockRulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       Object.assign(mockRulesyncIgnore, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
         getFileContent: () => "*.log\nnode_modules/",
       });
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       // Mock the writeAiFiles method
       const writeAiFilesSpy = vi.spyOn(processor as any, "writeAiFiles");
@@ -416,7 +432,11 @@ describe("IgnoreProcessor", () => {
         }),
       );
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       // Load all tool files (should include ClaudecodeIgnore)
       const allFiles = await processor.loadToolFiles();
@@ -441,7 +461,7 @@ describe("IgnoreProcessor", () => {
 
       const processor = new IgnoreProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -457,7 +477,7 @@ describe("IgnoreProcessor", () => {
     it("should return deletable files with correct paths", async () => {
       await writeFileContent(join(testDir, ".cursorignore"), "*.log\nnode_modules/");
 
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
 
@@ -469,7 +489,7 @@ describe("IgnoreProcessor", () => {
 
     it("should return instance for standard path even when file does not exist on disk", async () => {
       // No file created on disk
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
 
@@ -488,7 +508,7 @@ describe("IgnoreProcessor", () => {
 
       const processor = new IgnoreProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         featureOptions: { fileMode: "local" },
       });
@@ -496,7 +516,7 @@ describe("IgnoreProcessor", () => {
       // Create a proper RulesyncIgnore instance
       const rulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       Object.assign(rulesyncIgnore, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.secret",
@@ -520,13 +540,13 @@ describe("IgnoreProcessor", () => {
     it("should use settings.json by default when no featureOptions provided", async () => {
       const processor = new IgnoreProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
       const rulesyncIgnore = Object.create(RulesyncIgnore.prototype);
       Object.assign(rulesyncIgnore, {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.secret",
@@ -555,7 +575,7 @@ describe("IgnoreProcessor", () => {
 
       const processor = new IgnoreProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         featureOptions: { fileMode: "local" },
       });
@@ -568,11 +588,11 @@ describe("IgnoreProcessor", () => {
 
   describe("writeAiFiles with trailing newlines", () => {
     it("should write ignore files with exactly one trailing newline", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       // Create a mock CursorIgnore file
       const mockCursorIgnore = new CursorIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".cursorignore",
         fileContent: "*.log\nnode_modules/\n*.tmp",
@@ -594,11 +614,11 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should handle files already ending with newline", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "cline" });
+      const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "cline" });
 
       // Create a mock ClineIgnore file with trailing newline
       const mockClineIgnore = new ClineIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".clineignore",
         fileContent: "*.log\nnode_modules/\n",
@@ -616,11 +636,15 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should handle files with multiple trailing newlines", async () => {
-      const processor = new IgnoreProcessor({ logger, baseDir: testDir, toolTarget: "windsurf" });
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "windsurf",
+      });
 
       // Create a mock WindsurfIgnore file with multiple trailing newlines
       const mockWindsurfIgnore = new WindsurfIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".windsurfignore",
         fileContent: "*.log\n\n\n",

--- a/src/features/ignore/ignore-processor.ts
+++ b/src/features/ignore/ignore-processor.ts
@@ -96,7 +96,7 @@ export class IgnoreProcessor extends FeatureProcessor {
   private readonly featureOptions: FeatureOptions | undefined;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     getFactory = defaultGetFactory,
@@ -104,7 +104,7 @@ export class IgnoreProcessor extends FeatureProcessor {
     logger,
     featureOptions,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     getFactory?: GetFactory;
@@ -112,7 +112,7 @@ export class IgnoreProcessor extends FeatureProcessor {
     logger: Logger;
     featureOptions?: FeatureOptions;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = IgnoreProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -135,7 +135,7 @@ export class IgnoreProcessor extends FeatureProcessor {
    */
   async loadRulesyncFiles(): Promise<RulesyncFile[]> {
     try {
-      return [await RulesyncIgnore.fromFile({ baseDir: this.inputRoot })];
+      return [await RulesyncIgnore.fromFile({ outputRoot: this.inputRoot })];
     } catch (error) {
       this.logger.error(
         `Failed to load rulesync ignore file (${RULESYNC_AIIGNORE_RELATIVE_FILE_PATH}): ${formatError(error)}`,
@@ -159,7 +159,7 @@ export class IgnoreProcessor extends FeatureProcessor {
 
       if (forDeletion) {
         const toolIgnore = factory.class.forDeletion({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.relativeDirPath,
           relativeFilePath: paths.relativeFilePath,
         });
@@ -183,7 +183,9 @@ export class IgnoreProcessor extends FeatureProcessor {
 
   async loadToolIgnores(): Promise<ToolIgnore[]> {
     const factory = this.getFactory(this.toolTarget);
-    return [await factory.class.fromFile({ baseDir: this.baseDir, options: this.featureOptions })];
+    return [
+      await factory.class.fromFile({ outputRoot: this.outputRoot, options: this.featureOptions }),
+    ];
   }
 
   /**
@@ -201,7 +203,7 @@ export class IgnoreProcessor extends FeatureProcessor {
 
     const factory = this.getFactory(this.toolTarget);
     const toolIgnore = await factory.class.fromRulesyncIgnore({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       rulesyncIgnore,
       options: this.featureOptions,
     });

--- a/src/features/ignore/junie-ignore.test.ts
+++ b/src/features/ignore/junie-ignore.test.ts
@@ -39,9 +39,9 @@ describe("JunieIgnore", () => {
       expect(junieIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const junieIgnore = new JunieIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".aiignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("JunieIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const junieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("JunieIgnore", () => {
 
     it("should handle empty content", () => {
       const junieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("JunieIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const junieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("JunieIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create JunieIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create JunieIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("JunieIgnore", () => {
       });
 
       expect(junieIgnore).toBeInstanceOf(JunieIgnore);
-      expect(junieIgnore.getBaseDir()).toBe(testDir);
+      expect(junieIgnore.getOutputRoot()).toBe(testDir);
       expect(junieIgnore.getRelativeDirPath()).toBe(".");
       expect(junieIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(junieIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create JunieIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create JunieIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("JunieIgnore", () => {
       });
 
       const junieIgnore = JunieIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(junieIgnore.getBaseDir()).toBe("/custom/base");
+      expect(junieIgnore.getOutputRoot()).toBe("/custom/base");
       expect(junieIgnore.getFilePath()).toBe("/custom/base/.aiignore");
       expect(junieIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("JunieIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .aiignore file from baseDir with default baseDir", async () => {
+    it("should read .aiignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const junieignorePath = join(testDir, ".aiignore");
       await writeFileContent(junieignorePath, fileContent);
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(junieIgnore).toBeInstanceOf(JunieIgnore);
-      expect(junieIgnore.getBaseDir()).toBe(testDir);
+      expect(junieIgnore.getOutputRoot()).toBe(testDir);
       expect(junieIgnore.getRelativeDirPath()).toBe(".");
       expect(junieIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(junieIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("JunieIgnore", () => {
       await writeFileContent(junieignorePath, fileContent);
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(junieIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("JunieIgnore", () => {
       await writeFileContent(junieignorePath, fileContent);
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("JunieIgnore", () => {
       await writeFileContent(junieignorePath, "");
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(junieIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(junieignorePath, fileContent);
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(junieIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const junieignorePath = join(testDir, ".aiignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const junieIgnore = await JunieIgnore.fromFile({});
 
-      expect(junieIgnore.getBaseDir()).toBe(testDir);
+      expect(junieIgnore.getOutputRoot()).toBe(testDir);
       expect(junieIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .aiignore file does not exist", async () => {
       await expect(
         JunieIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(junieignorePath, fileContent);
 
       const junieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(junieIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const junieIgnore = new JunieIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".aiignore",
         fileContent: "*.log",
       });
 
-      expect(junieIgnore.getBaseDir()).toBe("/test/base");
+      expect(junieIgnore.getOutputRoot()).toBe("/test/base");
       expect(junieIgnore.getRelativeDirPath()).toBe("subdir");
       expect(junieIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(junieIgnore.getFilePath()).toBe("/test/base/subdir/.aiignore");
@@ -369,7 +369,7 @@ dist/
 
       // JunieIgnore -> RulesyncIgnore -> JunieIgnore
       const originalJunieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalJunieIgnore.toRulesyncIgnore();
       const roundTripJunieIgnore = JunieIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripJunieIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripJunieIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripJunieIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripJunieIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripJunieIgnore.getRelativeFilePath()).toBe(".aiignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const junieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readJunieIgnore = await JunieIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readJunieIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const junieIgnore = new JunieIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(junieIgnore.getFilePath(), junieIgnore.getFileContent());
 
       const readJunieIgnore = await JunieIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readJunieIgnore.getFileContent()).toBe(fileContent);
@@ -560,7 +560,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const junieIgnore = JunieIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/junie-ignore.ts
+++ b/src/features/ignore/junie-ignore.ts
@@ -23,11 +23,11 @@ export class JunieIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): JunieIgnore {
     return new JunieIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -35,19 +35,19 @@ export class JunieIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<JunieIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new JunieIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -56,12 +56,12 @@ export class JunieIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): JunieIgnore {
     return new JunieIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/kilo-ignore.test.ts
+++ b/src/features/ignore/kilo-ignore.test.ts
@@ -39,9 +39,9 @@ describe("KiloIgnore", () => {
       expect(kiloIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const kiloIgnore = new KiloIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".kiloignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("KiloIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".kiloignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("KiloIgnore", () => {
 
     it("should handle empty content", () => {
       const kiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".kiloignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("KiloIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const kiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".kiloignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("KiloIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create KiloIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create KiloIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("KiloIgnore", () => {
       });
 
       expect(kiloIgnore).toBeInstanceOf(KiloIgnore);
-      expect(kiloIgnore.getBaseDir()).toBe(testDir);
+      expect(kiloIgnore.getOutputRoot()).toBe(testDir);
       expect(kiloIgnore.getRelativeDirPath()).toBe(".");
       expect(kiloIgnore.getRelativeFilePath()).toBe(".kiloignore");
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create KiloIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create KiloIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("KiloIgnore", () => {
       });
 
       const kiloIgnore = KiloIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(kiloIgnore.getBaseDir()).toBe("/custom/base");
+      expect(kiloIgnore.getOutputRoot()).toBe("/custom/base");
       expect(kiloIgnore.getFilePath()).toBe("/custom/base/.kiloignore");
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("KiloIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .kiloignore file from baseDir with default baseDir", async () => {
+    it("should read .kiloignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiloignorePath = join(testDir, ".kiloignore");
       await writeFileContent(kiloignorePath, fileContent);
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloIgnore).toBeInstanceOf(KiloIgnore);
-      expect(kiloIgnore.getBaseDir()).toBe(testDir);
+      expect(kiloIgnore.getOutputRoot()).toBe(testDir);
       expect(kiloIgnore.getRelativeDirPath()).toBe(".");
       expect(kiloIgnore.getRelativeFilePath()).toBe(".kiloignore");
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("KiloIgnore", () => {
       await writeFileContent(kiloignorePath, fileContent);
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("KiloIgnore", () => {
       await writeFileContent(kiloignorePath, fileContent);
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("KiloIgnore", () => {
       await writeFileContent(kiloignorePath, "");
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(kiloignorePath, fileContent);
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const kiloignorePath = join(testDir, ".kiloignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const kiloIgnore = await KiloIgnore.fromFile({});
 
-      expect(kiloIgnore.getBaseDir()).toBe(testDir);
+      expect(kiloIgnore.getOutputRoot()).toBe(testDir);
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .kiloignore file does not exist", async () => {
       await expect(
         KiloIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(kiloignorePath, fileContent);
 
       const kiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const kiloIgnore = new KiloIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".kiloignore",
         fileContent: "*.log",
       });
 
-      expect(kiloIgnore.getBaseDir()).toBe("/test/base");
+      expect(kiloIgnore.getOutputRoot()).toBe("/test/base");
       expect(kiloIgnore.getRelativeDirPath()).toBe("subdir");
       expect(kiloIgnore.getRelativeFilePath()).toBe(".kiloignore");
       expect(kiloIgnore.getFilePath()).toBe("/test/base/subdir/.kiloignore");
@@ -369,7 +369,7 @@ dist/
 
       // KiloIgnore -> RulesyncIgnore -> KiloIgnore
       const originalKiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".kiloignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalKiloIgnore.toRulesyncIgnore();
       const roundTripKiloIgnore = KiloIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripKiloIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripKiloIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripKiloIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripKiloIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripKiloIgnore.getRelativeFilePath()).toBe(".kiloignore");
     });
@@ -464,7 +464,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".kiloignore",
         fileContent,
@@ -475,7 +475,7 @@ dist/
 
       // Read file back
       const readKiloIgnore = await KiloIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readKiloIgnore.getFileContent()).toBe(fileContent);
@@ -488,7 +488,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const kiloIgnore = new KiloIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".kiloignore",
         fileContent,
@@ -498,7 +498,7 @@ dist/
       await writeFileContent(kiloIgnore.getFilePath(), kiloIgnore.getFileContent());
 
       const readKiloIgnore = await KiloIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readKiloIgnore.getFileContent()).toBe(fileContent);
@@ -565,7 +565,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const kiloIgnore = KiloIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/kilo-ignore.ts
+++ b/src/features/ignore/kilo-ignore.ts
@@ -39,13 +39,13 @@ export class KiloIgnore extends ToolIgnore {
    * Create KiloIgnore from RulesyncIgnore
    */
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): KiloIgnore {
     const body = rulesyncIgnore.getFileContent();
 
     return new KiloIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: body,
@@ -56,19 +56,19 @@ export class KiloIgnore extends ToolIgnore {
    * Load KiloIgnore from .kiloignore file
    */
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<KiloIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new KiloIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -77,12 +77,12 @@ export class KiloIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): KiloIgnore {
     return new KiloIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/kiro-ignore.test.ts
+++ b/src/features/ignore/kiro-ignore.test.ts
@@ -39,9 +39,9 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const kiroIgnore = new KiroIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".aiignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("KiroIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("KiroIgnore", () => {
 
     it("should handle empty content", () => {
       const kiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("KiroIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const kiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("KiroIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create KiroIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create KiroIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("KiroIgnore", () => {
       });
 
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
-      expect(kiroIgnore.getBaseDir()).toBe(testDir);
+      expect(kiroIgnore.getOutputRoot()).toBe(testDir);
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
       expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create KiroIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create KiroIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("KiroIgnore", () => {
       });
 
       const kiroIgnore = KiroIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(kiroIgnore.getBaseDir()).toBe("/custom/base");
+      expect(kiroIgnore.getOutputRoot()).toBe("/custom/base");
       expect(kiroIgnore.getFilePath()).toBe("/custom/base/.aiignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("KiroIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .aiignore file from baseDir with default baseDir", async () => {
+    it("should read .aiignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const aiignorePath = join(testDir, ".aiignore");
       await writeFileContent(aiignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
-      expect(kiroIgnore.getBaseDir()).toBe(testDir);
+      expect(kiroIgnore.getOutputRoot()).toBe(testDir);
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
       expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("KiroIgnore", () => {
       await writeFileContent(aiignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("KiroIgnore", () => {
       await writeFileContent(aiignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("KiroIgnore", () => {
       await writeFileContent(aiignorePath, "");
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiroIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(aiignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const aiignorePath = join(testDir, ".aiignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const kiroIgnore = await KiroIgnore.fromFile({});
 
-      expect(kiroIgnore.getBaseDir()).toBe(testDir);
+      expect(kiroIgnore.getOutputRoot()).toBe(testDir);
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .aiignore file does not exist", async () => {
       await expect(
         KiroIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(aiignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const kiroIgnore = new KiroIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".aiignore",
         fileContent: "*.log",
       });
 
-      expect(kiroIgnore.getBaseDir()).toBe("/test/base");
+      expect(kiroIgnore.getOutputRoot()).toBe("/test/base");
       expect(kiroIgnore.getRelativeDirPath()).toBe("subdir");
       expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
       expect(kiroIgnore.getFilePath()).toBe("/test/base/subdir/.aiignore");
@@ -369,7 +369,7 @@ dist/
 
       // KiroIgnore -> RulesyncIgnore -> KiroIgnore
       const originalKiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalKiroIgnore.toRulesyncIgnore();
       const roundTripKiroIgnore = KiroIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripKiroIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripKiroIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripKiroIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripKiroIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripKiroIgnore.getRelativeFilePath()).toBe(".aiignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readKiroIgnore = await KiroIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readKiroIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const kiroIgnore = new KiroIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".aiignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(kiroIgnore.getFilePath(), kiroIgnore.getFileContent());
 
       const readKiroIgnore = await KiroIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readKiroIgnore.getFileContent()).toBe(fileContent);
@@ -560,7 +560,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const kiroIgnore = KiroIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/kiro-ignore.ts
+++ b/src/features/ignore/kiro-ignore.ts
@@ -23,11 +23,11 @@ export class KiroIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): KiroIgnore {
     return new KiroIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -35,19 +35,19 @@ export class KiroIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<KiroIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new KiroIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -56,12 +56,12 @@ export class KiroIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): KiroIgnore {
     return new KiroIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/qwencode-ignore.test.ts
+++ b/src/features/ignore/qwencode-ignore.test.ts
@@ -39,9 +39,9 @@ describe("QwencodeIgnore", () => {
       expect(qwencodeIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".geminiignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("QwencodeIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("QwencodeIgnore", () => {
 
     it("should handle empty content", () => {
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("QwencodeIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("QwencodeIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create QwencodeIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create QwencodeIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -132,13 +132,13 @@ describe("QwencodeIgnore", () => {
       });
 
       expect(qwencodeIgnore).toBeInstanceOf(QwencodeIgnore);
-      expect(qwencodeIgnore.getBaseDir()).toBe(testDir);
+      expect(qwencodeIgnore.getOutputRoot()).toBe(testDir);
       expect(qwencodeIgnore.getRelativeDirPath()).toBe(".");
       expect(qwencodeIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create QwencodeIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create QwencodeIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".rulesync",
@@ -147,11 +147,11 @@ describe("QwencodeIgnore", () => {
       });
 
       const qwencodeIgnore = QwencodeIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(qwencodeIgnore.getBaseDir()).toBe("/custom/base");
+      expect(qwencodeIgnore.getOutputRoot()).toBe("/custom/base");
       expect(qwencodeIgnore.getFilePath()).toBe("/custom/base/.geminiignore");
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("QwencodeIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .geminiignore file from baseDir with default baseDir", async () => {
+    it("should read .geminiignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const geminiignorePath = join(testDir, ".geminiignore");
       await writeFileContent(geminiignorePath, fileContent);
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(qwencodeIgnore).toBeInstanceOf(QwencodeIgnore);
-      expect(qwencodeIgnore.getBaseDir()).toBe(testDir);
+      expect(qwencodeIgnore.getOutputRoot()).toBe(testDir);
       expect(qwencodeIgnore.getRelativeDirPath()).toBe(".");
       expect(qwencodeIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("QwencodeIgnore", () => {
       await writeFileContent(geminiignorePath, fileContent);
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("QwencodeIgnore", () => {
       await writeFileContent(geminiignorePath, fileContent);
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("QwencodeIgnore", () => {
       await writeFileContent(geminiignorePath, "");
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(qwencodeIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(geminiignorePath, fileContent);
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const geminiignorePath = join(testDir, ".geminiignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({});
 
-      expect(qwencodeIgnore.getBaseDir()).toBe(testDir);
+      expect(qwencodeIgnore.getOutputRoot()).toBe(testDir);
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .geminiignore file does not exist", async () => {
       await expect(
         QwencodeIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(geminiignorePath, fileContent);
 
       const qwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(qwencodeIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".geminiignore",
         fileContent: "*.log",
       });
 
-      expect(qwencodeIgnore.getBaseDir()).toBe("/test/base");
+      expect(qwencodeIgnore.getOutputRoot()).toBe("/test/base");
       expect(qwencodeIgnore.getRelativeDirPath()).toBe("subdir");
       expect(qwencodeIgnore.getRelativeFilePath()).toBe(".geminiignore");
       expect(qwencodeIgnore.getFilePath()).toBe("/test/base/subdir/.geminiignore");
@@ -369,7 +369,7 @@ dist/
 
       // QwencodeIgnore -> RulesyncIgnore -> QwencodeIgnore
       const originalQwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalQwencodeIgnore.toRulesyncIgnore();
       const roundTripQwencodeIgnore = QwencodeIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripQwencodeIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripQwencodeIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripQwencodeIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripQwencodeIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripQwencodeIgnore.getRelativeFilePath()).toBe(".geminiignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readQwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readQwencodeIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const qwencodeIgnore = new QwencodeIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".geminiignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(qwencodeIgnore.getFilePath(), qwencodeIgnore.getFileContent());
 
       const readQwencodeIgnore = await QwencodeIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readQwencodeIgnore.getFileContent()).toBe(fileContent);

--- a/src/features/ignore/qwencode-ignore.ts
+++ b/src/features/ignore/qwencode-ignore.ts
@@ -23,11 +23,11 @@ export class QwencodeIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): QwencodeIgnore {
     return new QwencodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -35,19 +35,19 @@ export class QwencodeIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<QwencodeIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new QwencodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -56,12 +56,12 @@ export class QwencodeIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): QwencodeIgnore {
     return new QwencodeIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/roo-ignore.test.ts
+++ b/src/features/ignore/roo-ignore.test.ts
@@ -39,9 +39,9 @@ describe("RooIgnore", () => {
       expect(rooIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const rooIgnore = new RooIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".rooignore",
         fileContent: "*.tmp",
@@ -76,7 +76,7 @@ describe("RooIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".rooignore",
         fileContent,
@@ -92,7 +92,7 @@ describe("RooIgnore", () => {
 
     it("should handle empty content", () => {
       const rooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".rooignore",
         fileContent: "",
@@ -106,7 +106,7 @@ describe("RooIgnore", () => {
     it("should preserve patterns and formatting", () => {
       const fileContent = "# Generated files\n*.log\n*.tmp\n\n# Dependencies\nnode_modules/\n.env*";
       const rooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".rooignore",
         fileContent,
@@ -119,7 +119,7 @@ describe("RooIgnore", () => {
   });
 
   describe("fromRulesyncIgnore", () => {
-    it("should create RooIgnore from RulesyncIgnore with default baseDir", () => {
+    it("should create RooIgnore from RulesyncIgnore with default outputRoot", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -132,13 +132,13 @@ describe("RooIgnore", () => {
       });
 
       expect(rooIgnore).toBeInstanceOf(RooIgnore);
-      expect(rooIgnore.getBaseDir()).toBe(testDir);
+      expect(rooIgnore.getOutputRoot()).toBe(testDir);
       expect(rooIgnore.getRelativeDirPath()).toBe(".");
       expect(rooIgnore.getRelativeFilePath()).toBe(".rooignore");
       expect(rooIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should create RooIgnore from RulesyncIgnore with custom baseDir", () => {
+    it("should create RooIgnore from RulesyncIgnore with custom outputRoot", () => {
       const fileContent = "*.tmp\nbuild/";
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -147,11 +147,11 @@ describe("RooIgnore", () => {
       });
 
       const rooIgnore = RooIgnore.fromRulesyncIgnore({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncIgnore,
       });
 
-      expect(rooIgnore.getBaseDir()).toBe("/custom/base");
+      expect(rooIgnore.getOutputRoot()).toBe("/custom/base");
       expect(rooIgnore.getFilePath()).toBe("/custom/base/.rooignore");
       expect(rooIgnore.getFileContent()).toBe(fileContent);
     });
@@ -187,17 +187,17 @@ describe("RooIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .rooignore file from baseDir with default baseDir", async () => {
+    it("should read .rooignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rooignorePath = join(testDir, ".rooignore");
       await writeFileContent(rooignorePath, fileContent);
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(rooIgnore).toBeInstanceOf(RooIgnore);
-      expect(rooIgnore.getBaseDir()).toBe(testDir);
+      expect(rooIgnore.getOutputRoot()).toBe(testDir);
       expect(rooIgnore.getRelativeDirPath()).toBe(".");
       expect(rooIgnore.getRelativeFilePath()).toBe(".rooignore");
       expect(rooIgnore.getFileContent()).toBe(fileContent);
@@ -209,7 +209,7 @@ describe("RooIgnore", () => {
       await writeFileContent(rooignorePath, fileContent);
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(rooIgnore.getFileContent()).toBe(fileContent);
@@ -221,7 +221,7 @@ describe("RooIgnore", () => {
       await writeFileContent(rooignorePath, fileContent);
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -233,7 +233,7 @@ describe("RooIgnore", () => {
       await writeFileContent(rooignorePath, "");
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(rooIgnore.getFileContent()).toBe("");
@@ -274,13 +274,13 @@ Thumbs.db`;
       await writeFileContent(rooignorePath, fileContent);
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(rooIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const rooignorePath = join(testDir, ".rooignore");
@@ -288,14 +288,14 @@ Thumbs.db`;
 
       const rooIgnore = await RooIgnore.fromFile({});
 
-      expect(rooIgnore.getBaseDir()).toBe(testDir);
+      expect(rooIgnore.getOutputRoot()).toBe(testDir);
       expect(rooIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .rooignore file does not exist", async () => {
       await expect(
         RooIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -306,7 +306,7 @@ Thumbs.db`;
       await writeFileContent(rooignorePath, fileContent);
 
       const rooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(rooIgnore.getFileContent()).toBe(fileContent);
@@ -343,13 +343,13 @@ Thumbs.db`;
 
     it("should inherit file path methods from ToolFile", () => {
       const rooIgnore = new RooIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".rooignore",
         fileContent: "*.log",
       });
 
-      expect(rooIgnore.getBaseDir()).toBe("/test/base");
+      expect(rooIgnore.getOutputRoot()).toBe("/test/base");
       expect(rooIgnore.getRelativeDirPath()).toBe("subdir");
       expect(rooIgnore.getRelativeFilePath()).toBe(".rooignore");
       expect(rooIgnore.getFilePath()).toBe("/test/base/subdir/.rooignore");
@@ -369,7 +369,7 @@ dist/
 
       // RooIgnore -> RulesyncIgnore -> RooIgnore
       const originalRooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".rooignore",
         fileContent: originalContent,
@@ -377,12 +377,12 @@ dist/
 
       const rulesyncIgnore = originalRooIgnore.toRulesyncIgnore();
       const roundTripRooIgnore = RooIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(roundTripRooIgnore.getFileContent()).toBe(originalContent);
-      expect(roundTripRooIgnore.getBaseDir()).toBe(testDir);
+      expect(roundTripRooIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripRooIgnore.getRelativeDirPath()).toBe(".");
       expect(roundTripRooIgnore.getRelativeFilePath()).toBe(".rooignore");
     });
@@ -459,7 +459,7 @@ dist/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".rooignore",
         fileContent,
@@ -470,7 +470,7 @@ dist/
 
       // Read file back
       const readRooIgnore = await RooIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readRooIgnore.getFileContent()).toBe(fileContent);
@@ -483,7 +483,7 @@ dist/
 
       const fileContent = "*.log\nbuild/";
       const rooIgnore = new RooIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "project/config",
         relativeFilePath: ".rooignore",
         fileContent,
@@ -493,7 +493,7 @@ dist/
       await writeFileContent(rooIgnore.getFilePath(), rooIgnore.getFileContent());
 
       const readRooIgnore = await RooIgnore.fromFile({
-        baseDir: join(testDir, "project/config"),
+        outputRoot: join(testDir, "project/config"),
       });
 
       expect(readRooIgnore.getFileContent()).toBe(fileContent);
@@ -560,7 +560,7 @@ temp*/
 
     it("should work in workspace root context", () => {
       const rooIgnore = RooIgnore.fromRulesyncIgnore({
-        baseDir: "/workspace/root",
+        outputRoot: "/workspace/root",
         rulesyncIgnore: new RulesyncIgnore({
           relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
           relativeFilePath: ".rulesignore",

--- a/src/features/ignore/roo-ignore.ts
+++ b/src/features/ignore/roo-ignore.ts
@@ -35,11 +35,11 @@ export class RooIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): RooIgnore {
     return new RooIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -47,19 +47,19 @@ export class RooIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<RooIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new RooIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -68,12 +68,12 @@ export class RooIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): RooIgnore {
     return new RooIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/rulesync-ignore.test.ts
+++ b/src/features/ignore/rulesync-ignore.test.ts
@@ -40,9 +40,9 @@ describe("RulesyncIgnore", () => {
       expect(rulesyncIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.tmp",
@@ -170,7 +170,7 @@ Thumbs.db`;
       const rulesyncIgnore = await RulesyncIgnore.fromFile();
 
       expect(rulesyncIgnore).toBeInstanceOf(RulesyncIgnore);
-      expect(rulesyncIgnore.getBaseDir()).toBe(testDir);
+      expect(rulesyncIgnore.getOutputRoot()).toBe(testDir);
       expect(rulesyncIgnore.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_FILE_NAME);
       expect(rulesyncIgnore.getFileContent()).toBe(fileContent);
@@ -257,13 +257,13 @@ Thumbs.db`;
   describe("inheritance from RulesyncFile", () => {
     it("should inherit file path methods from AiFile", () => {
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log",
       });
 
-      expect(rulesyncIgnore.getBaseDir()).toBe("/test/base");
+      expect(rulesyncIgnore.getOutputRoot()).toBe("/test/base");
       expect(rulesyncIgnore.getRelativeDirPath()).toBe("subdir");
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_RELATIVE_FILE_PATH);
       expect(rulesyncIgnore.getFilePath()).toBe(
@@ -340,7 +340,7 @@ Thumbs.db`;
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent,
@@ -366,7 +366,7 @@ dist/
 *.tmp`;
 
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: originalContent,
@@ -443,7 +443,7 @@ desktop.ini`;
 
     it("should work in project root context", () => {
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: "/project/root",
+        outputRoot: "/project/root",
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
@@ -490,7 +490,7 @@ build/`;
       const rulesyncIgnore = await RulesyncIgnore.fromFile();
 
       // fromFile always uses these fixed parameters
-      expect(rulesyncIgnore.getBaseDir()).toBe(testDir);
+      expect(rulesyncIgnore.getOutputRoot()).toBe(testDir);
       expect(rulesyncIgnore.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_FILE_NAME);
     });
@@ -527,7 +527,7 @@ build/`;
 
       const rulesyncIgnore = await RulesyncIgnore.fromFile();
 
-      expect(rulesyncIgnore.getBaseDir()).toBe(testDir);
+      expect(rulesyncIgnore.getOutputRoot()).toBe(testDir);
       expect(rulesyncIgnore.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_FILE_NAME);
       expect(rulesyncIgnore.getFileContent()).toBe(content);

--- a/src/features/ignore/rulesync-ignore.ts
+++ b/src/features/ignore/rulesync-ignore.ts
@@ -9,7 +9,7 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { RulesyncFile, RulesyncFileFromFileParams } from "../../types/rulesync-file.js";
 import { fileExists, readFileContent } from "../../utils/file.js";
 
-export type RulesyncIgnoreFromFileParams = Pick<RulesyncFileFromFileParams, "baseDir">;
+export type RulesyncIgnoreFromFileParams = Pick<RulesyncFileFromFileParams, "outputRoot">;
 
 export type RulesyncIgnoreSettablePaths = {
   recommended: {
@@ -41,20 +41,24 @@ export class RulesyncIgnore extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
   }: RulesyncIgnoreFromFileParams = {}): Promise<RulesyncIgnore> {
     const paths = this.getSettablePaths();
     const recommendedPath = join(
-      baseDir,
+      outputRoot,
       paths.recommended.relativeDirPath,
       paths.recommended.relativeFilePath,
     );
-    const legacyPath = join(baseDir, paths.legacy.relativeDirPath, paths.legacy.relativeFilePath);
+    const legacyPath = join(
+      outputRoot,
+      paths.legacy.relativeDirPath,
+      paths.legacy.relativeFilePath,
+    );
 
     if (await fileExists(recommendedPath)) {
       const fileContent = await readFileContent(recommendedPath);
       return new RulesyncIgnore({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.recommended.relativeDirPath,
         relativeFilePath: paths.recommended.relativeFilePath,
         fileContent,
@@ -64,7 +68,7 @@ export class RulesyncIgnore extends RulesyncFile {
     if (await fileExists(legacyPath)) {
       const fileContent = await readFileContent(legacyPath);
       return new RulesyncIgnore({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.legacy.relativeDirPath,
         relativeFilePath: paths.legacy.relativeFilePath,
         fileContent,
@@ -74,7 +78,7 @@ export class RulesyncIgnore extends RulesyncFile {
     // If neither exists, try to read recommended path (will throw appropriate error)
     const fileContent = await readFileContent(recommendedPath);
     return new RulesyncIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.recommended.relativeDirPath,
       relativeFilePath: paths.recommended.relativeFilePath,
       fileContent,

--- a/src/features/ignore/tool-ignore.test.ts
+++ b/src/features/ignore/tool-ignore.test.ts
@@ -23,11 +23,11 @@ class TestToolIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): TestToolIgnore {
     return new TestToolIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: ".",
       relativeFilePath: ".testignore",
       fileContent: rulesyncIgnore.getFileContent(),
@@ -35,13 +35,13 @@ class TestToolIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<TestToolIgnore> {
     const fileContent = "*.test\n# comment\n  \n\nnode_modules/\n*.log";
 
     return new TestToolIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: ".",
       relativeFilePath: ".testignore",
       fileContent,
@@ -78,9 +78,9 @@ describe("ToolIgnore", () => {
       expect(toolIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const toolIgnore = new TestToolIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".testignore",
         fileContent: "*.tmp",
@@ -244,14 +244,14 @@ describe("ToolIgnore", () => {
       await writeFileContent(rulesyncIgnorePath, fileContent);
 
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: rulesyncDir,
+        outputRoot: rulesyncDir,
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent,
       });
 
       const toolIgnore = TestToolIgnore.fromRulesyncIgnore({
-        baseDir: rulesyncDir,
+        outputRoot: rulesyncDir,
         rulesyncIgnore,
       });
 
@@ -261,7 +261,7 @@ describe("ToolIgnore", () => {
       expect(toolIgnore.getRelativeFilePath()).toBe(".testignore");
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
@@ -279,7 +279,7 @@ describe("ToolIgnore", () => {
   describe("fromFile", () => {
     it("should create instance from file using static method", async () => {
       const toolIgnore = await TestToolIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -321,14 +321,14 @@ describe("ToolIgnore", () => {
     it("should create RulesyncIgnore with default parameters", () => {
       const fileContent = "*.log\nnode_modules/";
       const toolIgnore = new TestToolIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".testignore",
         fileContent,
       });
 
       const rulesyncIgnore = toolIgnore.toRulesyncIgnore();
-      expect(rulesyncIgnore.getBaseDir()).toBe(".");
+      expect(rulesyncIgnore.getOutputRoot()).toBe(".");
       expect(rulesyncIgnore.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_FILE_NAME);
       expect(rulesyncIgnore.getFileContent()).toBe(fileContent);

--- a/src/features/ignore/tool-ignore.ts
+++ b/src/features/ignore/tool-ignore.ts
@@ -29,12 +29,12 @@ export type ToolIgnoreSettablePaths = {
   relativeFilePath: string;
 };
 
-export type ToolIgnoreFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate"> & {
+export type ToolIgnoreFromFileParams = Pick<AiFileFromFileParams, "outputRoot" | "validate"> & {
   options?: ToolIgnoreFeatureOptions;
 };
 
 export type ToolIgnoreForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
 };
@@ -86,7 +86,7 @@ export abstract class ToolIgnore extends ToolFile {
 
   protected toRulesyncIgnoreDefault(): RulesyncIgnore {
     return new RulesyncIgnore({
-      baseDir: ".",
+      outputRoot: ".",
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_AIIGNORE_FILE_NAME,
       fileContent: this.fileContent,

--- a/src/features/ignore/windsurf-ignore.test.ts
+++ b/src/features/ignore/windsurf-ignore.test.ts
@@ -40,9 +40,9 @@ describe("WindsurfIgnore", () => {
       expect(windsurfIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: "subdir",
         relativeFilePath: ".codeiumignore",
         fileContent: "*.tmp",
@@ -77,7 +77,7 @@ describe("WindsurfIgnore", () => {
     it("should convert to RulesyncIgnore with same content", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".codeiumignore",
         fileContent,
@@ -169,25 +169,25 @@ desktop.ini`;
     it("should create WindsurfIgnore from RulesyncIgnore", () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: "/test/project",
+        outputRoot: "/test/project",
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent,
       });
 
       const windsurfIgnore = WindsurfIgnore.fromRulesyncIgnore({
-        baseDir: "/test/project",
+        outputRoot: "/test/project",
         rulesyncIgnore,
       });
 
       expect(windsurfIgnore).toBeInstanceOf(WindsurfIgnore);
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
-      expect(windsurfIgnore.getBaseDir()).toBe("/test/project");
+      expect(windsurfIgnore.getOutputRoot()).toBe("/test/project");
       expect(windsurfIgnore.getRelativeDirPath()).toBe(".");
       expect(windsurfIgnore.getRelativeFilePath()).toBe(".codeiumignore");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
@@ -198,7 +198,7 @@ desktop.ini`;
         rulesyncIgnore,
       });
 
-      expect(windsurfIgnore.getBaseDir()).toBe(testDir);
+      expect(windsurfIgnore.getOutputRoot()).toBe(testDir);
     });
 
     it("should preserve complex content from RulesyncIgnore", () => {
@@ -272,17 +272,17 @@ Thumbs.db`;
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(windsurfIgnore).toBeInstanceOf(WindsurfIgnore);
-      expect(windsurfIgnore.getBaseDir()).toBe(testDir);
+      expect(windsurfIgnore.getOutputRoot()).toBe(testDir);
       expect(windsurfIgnore.getRelativeDirPath()).toBe(".");
       expect(windsurfIgnore.getRelativeFilePath()).toBe(".codeiumignore");
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
       const codeiumIgnorePath = join(testDir, ".codeiumignore");
@@ -290,7 +290,7 @@ Thumbs.db`;
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({});
 
-      expect(windsurfIgnore.getBaseDir()).toBe(testDir);
+      expect(windsurfIgnore.getOutputRoot()).toBe(testDir);
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
     });
 
@@ -299,7 +299,7 @@ Thumbs.db`;
       await writeFileContent(codeiumIgnorePath, "");
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(windsurfIgnore.getFileContent()).toBe("");
@@ -401,14 +401,14 @@ jspm_packages/
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
     });
 
     it("should throw error when .codeiumignore file does not exist", async () => {
-      await expect(WindsurfIgnore.fromFile({ baseDir: testDir })).rejects.toThrow();
+      await expect(WindsurfIgnore.fromFile({ outputRoot: testDir })).rejects.toThrow();
     });
 
     it("should handle file with Windows line endings", async () => {
@@ -417,7 +417,7 @@ jspm_packages/
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
@@ -429,7 +429,7 @@ jspm_packages/
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(windsurfIgnore.getFileContent()).toBe(fileContent);
@@ -441,12 +441,12 @@ jspm_packages/
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnoreValidated = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
       const windsurfIgnoreNotValidated = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -458,13 +458,13 @@ jspm_packages/
   describe("inheritance from ToolIgnore", () => {
     it("should inherit file path methods from AiFile", () => {
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: "subdir",
         relativeFilePath: ".codeiumignore",
         fileContent: "*.log",
       });
 
-      expect(windsurfIgnore.getBaseDir()).toBe("/test/base");
+      expect(windsurfIgnore.getOutputRoot()).toBe("/test/base");
       expect(windsurfIgnore.getRelativeDirPath()).toBe("subdir");
       expect(windsurfIgnore.getRelativeFilePath()).toBe(".codeiumignore");
       expect(windsurfIgnore.getFilePath()).toBe("/test/base/subdir/.codeiumignore");
@@ -563,7 +563,7 @@ jspm_packages/
     it("should write and read file correctly", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".codeiumignore",
         fileContent,
@@ -574,7 +574,7 @@ jspm_packages/
 
       // Read file back
       const readWindsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readWindsurfIgnore.getFileContent()).toBe(fileContent);
@@ -590,7 +590,7 @@ dist/
 *.tmp`;
 
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".codeiumignore",
         fileContent: originalContent,
@@ -599,7 +599,7 @@ dist/
       await writeFileContent(windsurfIgnore.getFilePath(), windsurfIgnore.getFileContent());
 
       const readWindsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readWindsurfIgnore.getFileContent()).toBe(originalContent);
@@ -646,7 +646,7 @@ coverage/
 
     it("should work in project root context", () => {
       const windsurfIgnore = new WindsurfIgnore({
-        baseDir: "/project/root",
+        outputRoot: "/project/root",
         relativeDirPath: ".",
         relativeFilePath: ".codeiumignore",
         fileContent: "*.log\nnode_modules/",
@@ -790,7 +790,7 @@ dist
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // fromFile always uses these fixed parameters for relativeDirPath and relativeFilePath
@@ -804,7 +804,7 @@ dist
       await writeFileContent(codeiumIgnorePath, fileContent);
 
       const windsurfIgnore = await WindsurfIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Should have been validated during construction
@@ -813,18 +813,18 @@ dist
 
     it("should handle fromRulesyncIgnore with different base directories", () => {
       const rulesyncIgnore = new RulesyncIgnore({
-        baseDir: "/different/path",
+        outputRoot: "/different/path",
         relativeDirPath: ".",
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
         fileContent: "*.log\nnode_modules/",
       });
 
       const windsurfIgnore = WindsurfIgnore.fromRulesyncIgnore({
-        baseDir: "/target/path",
+        outputRoot: "/target/path",
         rulesyncIgnore,
       });
 
-      expect(windsurfIgnore.getBaseDir()).toBe("/target/path");
+      expect(windsurfIgnore.getOutputRoot()).toBe("/target/path");
       expect(windsurfIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
   });

--- a/src/features/ignore/windsurf-ignore.ts
+++ b/src/features/ignore/windsurf-ignore.ts
@@ -28,11 +28,11 @@ export class WindsurfIgnore extends ToolIgnore {
   }
 
   static fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): WindsurfIgnore {
     return new WindsurfIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncIgnore.getFileContent(),
@@ -40,19 +40,19 @@ export class WindsurfIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<WindsurfIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new WindsurfIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -61,12 +61,12 @@ export class WindsurfIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): WindsurfIgnore {
     return new WindsurfIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/ignore/zed-ignore.test.ts
+++ b/src/features/ignore/zed-ignore.test.ts
@@ -96,7 +96,7 @@ describe("ZedIgnore", () => {
       expect(zedIgnore.getPatterns()).toEqual([]);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const jsonContent = JSON.stringify(
         {
           private_files: ["*.tmp"],
@@ -106,7 +106,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -151,7 +151,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -175,7 +175,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -196,7 +196,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -218,12 +218,12 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
       expect(zedIgnore).toBeInstanceOf(ZedIgnore);
-      expect(zedIgnore.getBaseDir()).toBe(testDir);
+      expect(zedIgnore.getOutputRoot()).toBe(testDir);
       expect(zedIgnore.getRelativeDirPath()).toBe(".zed");
       expect(zedIgnore.getRelativeFilePath()).toBe("settings.json");
 
@@ -251,7 +251,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -268,7 +268,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -298,7 +298,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -328,7 +328,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -345,7 +345,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -361,7 +361,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -371,7 +371,7 @@ describe("ZedIgnore", () => {
       });
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const rulesyncIgnore = new RulesyncIgnore({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
@@ -379,11 +379,11 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
-      expect(zedIgnore.getBaseDir()).toBe(testDir);
+      expect(zedIgnore.getOutputRoot()).toBe(testDir);
 
       const jsonValue = JSON.parse(zedIgnore.getFileContent());
       expect(jsonValue.private_files).toEqual(["*.tmp"]);
@@ -405,11 +405,11 @@ describe("ZedIgnore", () => {
       await writeFileContent(join(zedDir, "settings.json"), jsonContent);
 
       const zedIgnore = await ZedIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(zedIgnore).toBeInstanceOf(ZedIgnore);
-      expect(zedIgnore.getBaseDir()).toBe(testDir);
+      expect(zedIgnore.getOutputRoot()).toBe(testDir);
       expect(zedIgnore.getRelativeDirPath()).toBe(".zed");
       expect(zedIgnore.getRelativeFilePath()).toBe("settings.json");
       expect(zedIgnore.getPatterns()).toEqual(["*.log", "node_modules/**"]);
@@ -429,7 +429,7 @@ describe("ZedIgnore", () => {
       await writeFileContent(join(zedDir, "settings.json"), jsonContent);
 
       const zedIgnore = await ZedIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(zedIgnore.getFileContent()).toBe(jsonContent);
@@ -449,7 +449,7 @@ describe("ZedIgnore", () => {
       await writeFileContent(join(zedDir, "settings.json"), jsonContent);
 
       const zedIgnore = await ZedIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -474,14 +474,14 @@ describe("ZedIgnore", () => {
       await writeFileContent(join(zedDir, "settings.json"), jsonContent);
 
       const zedIgnore = await ZedIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(zedIgnore.getFileContent()).toBe(jsonContent);
       expect(zedIgnore.getPatterns()).toEqual(["*.log", "secrets/**"]);
     });
 
-    it("should default baseDir to process.cwd() when not provided", async () => {
+    it("should default outputRoot to process.cwd() when not provided", async () => {
       const jsonContent = JSON.stringify(
         {
           private_files: ["*.log"],
@@ -496,14 +496,14 @@ describe("ZedIgnore", () => {
 
       const zedIgnore = await ZedIgnore.fromFile({});
 
-      expect(zedIgnore.getBaseDir()).toBe(testDir);
+      expect(zedIgnore.getOutputRoot()).toBe(testDir);
       expect(zedIgnore.getPatterns()).toEqual(["*.log"]);
     });
 
     it("should throw error when file does not exist", async () => {
       await expect(
         ZedIgnore.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -521,7 +521,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -552,7 +552,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 
@@ -701,13 +701,13 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
       });
 
-      expect(zedIgnore.getBaseDir()).toBe("/test/base");
+      expect(zedIgnore.getOutputRoot()).toBe("/test/base");
       expect(zedIgnore.getRelativeDirPath()).toBe(".zed");
       expect(zedIgnore.getRelativeFilePath()).toBe("settings.json");
       expect(zedIgnore.getFilePath()).toBe("/test/base/.zed/settings.json");
@@ -726,7 +726,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -737,7 +737,7 @@ describe("ZedIgnore", () => {
       await writeFileContent(zedIgnore.getFilePath(), zedIgnore.getFileContent());
 
       const readZedIgnore = await ZedIgnore.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(readZedIgnore.getFileContent()).toBe(jsonContent);
@@ -757,7 +757,7 @@ describe("ZedIgnore", () => {
       );
 
       const zedIgnore = new ZedIgnore({
-        baseDir: subDir,
+        outputRoot: subDir,
         relativeDirPath: ".zed",
         relativeFilePath: "settings.json",
         fileContent: jsonContent,
@@ -768,7 +768,7 @@ describe("ZedIgnore", () => {
       await writeFileContent(zedIgnore.getFilePath(), zedIgnore.getFileContent());
 
       const readZedIgnore = await ZedIgnore.fromFile({
-        baseDir: subDir,
+        outputRoot: subDir,
       });
 
       expect(readZedIgnore.getFileContent()).toBe(jsonContent);
@@ -803,7 +803,7 @@ describe("ZedIgnore", () => {
       });
 
       const zedIgnore = await ZedIgnore.fromRulesyncIgnore({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncIgnore,
       });
 

--- a/src/features/ignore/zed-ignore.ts
+++ b/src/features/ignore/zed-ignore.ts
@@ -51,7 +51,7 @@ export class ZedIgnore extends ToolIgnore {
     const fileContent = rulesyncPatterns.join("\n");
 
     return new RulesyncIgnore({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RulesyncIgnore.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath: RulesyncIgnore.getSettablePaths().recommended.relativeFilePath,
       fileContent,
@@ -59,7 +59,7 @@ export class ZedIgnore extends ToolIgnore {
   }
 
   static async fromRulesyncIgnore({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncIgnore,
   }: ToolIgnoreFromRulesyncIgnoreParams): Promise<ZedIgnore> {
     const fileContent = rulesyncIgnore.getFileContent();
@@ -70,7 +70,7 @@ export class ZedIgnore extends ToolIgnore {
       .filter((line) => line.length > 0 && !line.startsWith("#"));
 
     const filePath = join(
-      baseDir,
+      outputRoot,
       this.getSettablePaths().relativeDirPath,
       this.getSettablePaths().relativeFilePath,
     );
@@ -88,7 +88,7 @@ export class ZedIgnore extends ToolIgnore {
     };
 
     return new ZedIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: JSON.stringify(jsonValue, null, 2),
@@ -97,19 +97,19 @@ export class ZedIgnore extends ToolIgnore {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<ZedIgnore> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new ZedIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: fileContent,
@@ -118,12 +118,12 @@ export class ZedIgnore extends ToolIgnore {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolIgnoreForDeletionParams): ZedIgnore {
     return new ZedIgnore({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/claudecode-mcp.test.ts
+++ b/src/features/mcp/claudecode-mcp.test.ts
@@ -98,13 +98,13 @@ describe("ClaudecodeMcp", () => {
       expect(claudecodeMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const claudecodeMcp = new ClaudecodeMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".",
         relativeFilePath: ".mcp.json",
         fileContent: validJsonContent,
@@ -203,7 +203,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData, null, 2));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeMcp).toBeInstanceOf(ClaudecodeMcp);
@@ -213,7 +213,7 @@ describe("ClaudecodeMcp", () => {
 
     it("should initialize empty mcpServers if file does not exist", async () => {
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeMcp).toBeInstanceOf(ClaudecodeMcp);
@@ -230,7 +230,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeMcp.getJson()).toEqual({
@@ -241,7 +241,7 @@ describe("ClaudecodeMcp", () => {
       });
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       await ensureDir(customDir);
 
@@ -256,7 +256,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(customDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(claudecodeMcp.getFilePath()).toBe(join(customDir, ".mcp.json"));
@@ -275,7 +275,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -289,7 +289,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -312,7 +312,7 @@ describe("ClaudecodeMcp", () => {
       );
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -334,7 +334,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -344,7 +344,7 @@ describe("ClaudecodeMcp", () => {
 
     it("should initialize global config file if it does not exist", async () => {
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -374,7 +374,7 @@ describe("ClaudecodeMcp", () => {
       );
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -410,7 +410,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -420,7 +420,7 @@ describe("ClaudecodeMcp", () => {
       expect(claudecodeMcp.getRelativeFilePath()).toBe(".mcp.json");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", async () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -433,7 +433,7 @@ describe("ClaudecodeMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -442,7 +442,7 @@ describe("ClaudecodeMcp", () => {
       const customDir = join(testDir, "target");
       await ensureDir(customDir);
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         rulesyncMcp,
       });
 
@@ -466,7 +466,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -485,7 +485,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: false,
       });
@@ -504,7 +504,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -527,7 +527,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -555,7 +555,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -600,7 +600,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -653,7 +653,7 @@ describe("ClaudecodeMcp", () => {
       });
 
       const claudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -725,7 +725,7 @@ describe("ClaudecodeMcp", () => {
         },
       };
       const claudecodeMcp = new ClaudecodeMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".",
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -733,7 +733,7 @@ describe("ClaudecodeMcp", () => {
 
       const rulesyncMcp = claudecodeMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...jsonData,
@@ -893,7 +893,7 @@ describe("ClaudecodeMcp", () => {
 
       // Step 1: Load from file
       const originalClaudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp
@@ -901,7 +901,7 @@ describe("ClaudecodeMcp", () => {
 
       // Step 3: Create new ClaudecodeMcp from RulesyncMcp
       const newClaudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -939,7 +939,7 @@ describe("ClaudecodeMcp", () => {
 
       // Create ClaudecodeMcp
       const claudecodeMcp = new ClaudecodeMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -971,7 +971,7 @@ describe("ClaudecodeMcp", () => {
 
       // Step 1: Load from global config
       const originalClaudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -980,7 +980,7 @@ describe("ClaudecodeMcp", () => {
 
       // Step 3: Create new ClaudecodeMcp from RulesyncMcp in global mode
       const newClaudecodeMcp = await ClaudecodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -997,7 +997,7 @@ describe("ClaudecodeMcp", () => {
 
       await expect(
         ClaudecodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -1008,7 +1008,7 @@ describe("ClaudecodeMcp", () => {
 
       await expect(
         ClaudecodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           global: true,
         }),
       ).rejects.toThrow();
@@ -1021,7 +1021,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeMcp.getJson().mcpServers).toEqual({});
@@ -1034,7 +1034,7 @@ describe("ClaudecodeMcp", () => {
       await writeFileContent(join(testDir, ".mcp.json"), JSON.stringify(jsonData));
 
       const claudecodeMcp = await ClaudecodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(claudecodeMcp.getJson().mcpServers).toEqual({});
@@ -1046,7 +1046,7 @@ describe("ClaudecodeMcp", () => {
 
       await expect(
         ClaudecodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -1056,7 +1056,7 @@ describe("ClaudecodeMcp", () => {
 
       await expect(
         ClaudecodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });

--- a/src/features/mcp/claudecode-mcp.ts
+++ b/src/features/mcp/claudecode-mcp.ts
@@ -47,19 +47,20 @@ export class ClaudecodeMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<ClaudecodeMcp> {
     const paths = this.getSettablePaths({ global });
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      '{"mcpServers":{}}';
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new ClaudecodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -69,7 +70,7 @@ export class ClaudecodeMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -77,7 +78,7 @@ export class ClaudecodeMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = JSON.parse(fileContent);
@@ -85,7 +86,7 @@ export class ClaudecodeMcp extends ToolMcp {
     const mcpJson = { ...json, mcpServers: rulesyncMcp.getMcpServers() };
 
     return new ClaudecodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(mcpJson, null, 2),
@@ -105,13 +106,13 @@ export class ClaudecodeMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): ClaudecodeMcp {
     return new ClaudecodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/cline-mcp.test.ts
+++ b/src/features/mcp/cline-mcp.test.ts
@@ -48,13 +48,13 @@ describe("ClineMcp", () => {
       expect(clineMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const clineMcp = new ClineMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".cline",
         relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
@@ -156,7 +156,7 @@ describe("ClineMcp", () => {
       await writeFileContent(join(clineDir, "mcp.json"), JSON.stringify(jsonData, null, 2));
 
       const clineMcp = await ClineMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(clineMcp).toBeInstanceOf(ClineMcp);
@@ -164,7 +164,7 @@ describe("ClineMcp", () => {
       expect(clineMcp.getFilePath()).toBe(join(testDir, ".cline", "mcp.json"));
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       const clineDir = join(customDir, ".cline");
       await ensureDir(clineDir);
@@ -180,7 +180,7 @@ describe("ClineMcp", () => {
       await writeFileContent(join(clineDir, "mcp.json"), JSON.stringify(jsonData));
 
       const clineMcp = await ClineMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(clineMcp.getFilePath()).toBe(join(customDir, ".cline", "mcp.json"));
@@ -202,7 +202,7 @@ describe("ClineMcp", () => {
       await writeFileContent(join(clineDir, "mcp.json"), JSON.stringify(jsonData));
 
       const clineMcp = await ClineMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -219,7 +219,7 @@ describe("ClineMcp", () => {
       await writeFileContent(join(clineDir, "mcp.json"), JSON.stringify(jsonData));
 
       const clineMcp = await ClineMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -229,7 +229,7 @@ describe("ClineMcp", () => {
     it("should throw error if file does not exist", async () => {
       await expect(
         ClineMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -261,7 +261,7 @@ describe("ClineMcp", () => {
       expect(clineMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -274,14 +274,14 @@ describe("ClineMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: ".rulesync",
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
       const clineMcp = ClineMcp.fromRulesyncMcp({
-        baseDir: "/target/dir",
+        outputRoot: "/target/dir",
         rulesyncMcp,
       });
 
@@ -399,7 +399,7 @@ describe("ClineMcp", () => {
         },
       };
       const clineMcp = new ClineMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".cline",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -407,7 +407,7 @@ describe("ClineMcp", () => {
 
       const rulesyncMcp = clineMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...jsonData,
@@ -535,7 +535,7 @@ describe("ClineMcp", () => {
 
       // Step 1: Load from file
       const originalClineMcp = await ClineMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp
@@ -543,7 +543,7 @@ describe("ClineMcp", () => {
 
       // Step 3: Create new ClineMcp from RulesyncMcp
       const newClineMcp = ClineMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -584,7 +584,7 @@ describe("ClineMcp", () => {
 
       // Create ClineMcp
       const clineMcp = new ClineMcp({
-        baseDir: "/project",
+        outputRoot: "/project",
         relativeDirPath: ".cline",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -593,7 +593,7 @@ describe("ClineMcp", () => {
       // Convert to RulesyncMcp and back
       const rulesyncMcp = clineMcp.toRulesyncMcp();
       const newClineMcp = ClineMcp.fromRulesyncMcp({
-        baseDir: "/project",
+        outputRoot: "/project",
         rulesyncMcp,
       });
 

--- a/src/features/mcp/cline-mcp.ts
+++ b/src/features/mcp/cline-mcp.ts
@@ -34,19 +34,19 @@ export class ClineMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<ClineMcp> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new ClineMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -55,12 +55,12 @@ export class ClineMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): ClineMcp {
     return new ClineMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncMcp.getFileContent(),
@@ -77,12 +77,12 @@ export class ClineMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): ClineMcp {
     return new ClineMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -57,12 +57,12 @@ args = ["-y", "@anthropic-ai/mcp-server-filesystem", "/workspace"]
       expect(codexcliMcp.getFileContent()).toBe(validTomlContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validTomlContent = `[mcpServers]
 `;
 
       const codexcliMcp = new CodexcliMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".codex",
         relativeFilePath: "config.toml",
         fileContent: validTomlContent,
@@ -181,7 +181,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "${testDir}"]
       await writeFileContent(join(testDir, ".codex/config.toml"), tomlData);
 
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -199,7 +199,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "${testDir}"]
       await writeFileContent(join(testDir, ".codex/config.toml"), tomlData);
 
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -208,7 +208,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "${testDir}"]
       expect(codexcliMcp.getFilePath()).toBe(join(testDir, ".codex/config.toml"));
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       await ensureDir(join(customDir, ".codex"));
 
@@ -219,7 +219,7 @@ args = ["git-server.js"]
       await writeFileContent(join(customDir, ".codex/config.toml"), tomlData);
 
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
         global: true,
       });
 
@@ -236,7 +236,7 @@ args = ["server.js"]
       await writeFileContent(join(testDir, ".codex/config.toml"), tomlData);
 
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
         global: true,
       });
@@ -251,7 +251,7 @@ args = ["server.js"]
       await writeFileContent(join(testDir, ".codex/config.toml"), tomlData);
 
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
         global: true,
       });
@@ -261,7 +261,7 @@ args = ["server.js"]
 
     it("should return empty instance if file does not exist", async () => {
       const codexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -287,7 +287,7 @@ args = ["server.js"]
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -314,7 +314,7 @@ args = ["server.js"]
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -352,7 +352,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -363,7 +363,7 @@ fontSize = 14
       expect(json.mcp_servers).toEqual(jsonData.mcpServers);
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", async () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -376,14 +376,14 @@ fontSize = 14
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -408,7 +408,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
         global: true,
@@ -428,7 +428,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: false,
         global: true,
@@ -448,7 +448,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -473,7 +473,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -500,7 +500,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -527,7 +527,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -555,7 +555,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -587,7 +587,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -613,7 +613,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -644,7 +644,7 @@ fontSize = 14
       });
 
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -689,7 +689,7 @@ command = "python"
 args = ["another-server.py"]
 `;
       const codexcliMcp = new CodexcliMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".codex",
         relativeFilePath: "config.toml",
         fileContent: tomlContent,
@@ -697,7 +697,7 @@ args = ["another-server.py"]
 
       const rulesyncMcp = codexcliMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
 
       const json = JSON.parse(rulesyncMcp.getFileContent());
       expect(json.mcpServers?.["complex-server"]).toEqual({
@@ -971,7 +971,7 @@ NODE_ENV = "test"
 
       // Step 1: Load from file
       const originalCodexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -980,7 +980,7 @@ NODE_ENV = "test"
 
       // Step 3: Create new CodexcliMcp from RulesyncMcp
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1012,7 +1012,7 @@ PYTHONPATH = "/app/lib"
 
       // Create CodexcliMcp
       const codexcliMcp = new CodexcliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex",
         relativeFilePath: "config.toml",
         fileContent: complexTomlData,
@@ -1021,7 +1021,7 @@ PYTHONPATH = "/app/lib"
       // Convert to RulesyncMcp and back
       const rulesyncMcp = codexcliMcp.toRulesyncMcp();
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1050,7 +1050,7 @@ fontSize = 14
 
       // Load from file
       const originalCodexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -1059,7 +1059,7 @@ fontSize = 14
 
       // Create new CodexcliMcp from RulesyncMcp (this should preserve existing content)
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1085,7 +1085,7 @@ disabled_tools = ["write"]
 
       // Step 1: Load from file
       const originalCodexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -1099,7 +1099,7 @@ disabled_tools = ["write"]
 
       // Step 3: Convert back to CodexcliMcp
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1121,7 +1121,7 @@ enabled = false
 
       // Step 1: Load from file
       const originalCodexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -1134,7 +1134,7 @@ enabled = false
 
       // Step 3: Convert back to CodexcliMcp
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1170,7 +1170,7 @@ enabled = false
 
       // Step 1: Convert to CodexcliMcp
       const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1203,7 +1203,7 @@ enabled_tools = ["search"]
 
       // Step 1: Load from local file (no global flag)
       const originalCodexcliMcp = await CodexcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -1216,7 +1216,7 @@ enabled_tools = ["search"]
 
       // Step 3: Convert back to CodexcliMcp in local mode
       const newCodexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -94,7 +94,7 @@ export class CodexcliMcp extends ToolMcp {
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolMcpSettablePaths {
     // Both global (~/.codex/config.toml) and local (.codex/config.toml) use the same
-    // relative path. The difference is resolved by the baseDir passed to the processor.
+    // relative path. The difference is resolved by the outputRoot passed to the processor.
     return {
       relativeDirPath: ".codex",
       relativeFilePath: "config.toml",
@@ -109,17 +109,18 @@ export class CodexcliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<CodexcliMcp> {
     const paths = this.getSettablePaths({ global });
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      smolToml.stringify({});
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? smolToml.stringify({});
 
     return new CodexcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -128,14 +129,14 @@ export class CodexcliMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
   }: ToolMcpFromRulesyncMcpParams): Promise<CodexcliMcp> {
     const paths = this.getSettablePaths({ global });
 
-    const configTomlFilePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const configTomlFilePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const configTomlFileContent = await readOrInitializeFileContent(
       configTomlFilePath,
       smolToml.stringify({}),
@@ -151,7 +152,7 @@ export class CodexcliMcp extends ToolMcp {
     configToml["mcp_servers"] = filteredMcpServers as smolToml.TomlTable;
 
     return new CodexcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: smolToml.stringify(configToml),
@@ -192,12 +193,12 @@ export class CodexcliMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): CodexcliMcp {
     return new CodexcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/mcp/copilot-mcp.test.ts
+++ b/src/features/mcp/copilot-mcp.test.ts
@@ -48,13 +48,13 @@ describe("CopilotMcp", () => {
       expect(copilotMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         servers: {},
       });
 
       const copilotMcp = new CopilotMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".vscode",
         relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
@@ -156,7 +156,7 @@ describe("CopilotMcp", () => {
       await writeFileContent(join(vscodeDir, "mcp.json"), JSON.stringify(jsonData, null, 2));
 
       const copilotMcp = await CopilotMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(copilotMcp).toBeInstanceOf(CopilotMcp);
@@ -164,7 +164,7 @@ describe("CopilotMcp", () => {
       expect(copilotMcp.getFilePath()).toBe(join(testDir, ".vscode/mcp.json"));
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       const vscodeDir = join(customDir, ".vscode");
       await ensureDir(vscodeDir);
@@ -180,7 +180,7 @@ describe("CopilotMcp", () => {
       await writeFileContent(join(vscodeDir, "mcp.json"), JSON.stringify(jsonData));
 
       const copilotMcp = await CopilotMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(copilotMcp.getFilePath()).toBe(join(customDir, ".vscode/mcp.json"));
@@ -202,7 +202,7 @@ describe("CopilotMcp", () => {
       await writeFileContent(join(vscodeDir, "mcp.json"), JSON.stringify(jsonData));
 
       const copilotMcp = await CopilotMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -219,7 +219,7 @@ describe("CopilotMcp", () => {
       await writeFileContent(join(vscodeDir, "mcp.json"), JSON.stringify(jsonData));
 
       const copilotMcp = await CopilotMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -229,7 +229,7 @@ describe("CopilotMcp", () => {
     it("should throw error if file does not exist", async () => {
       await expect(
         CopilotMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -261,7 +261,7 @@ describe("CopilotMcp", () => {
       expect(copilotMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", () => {
       const inputMcpServers = {
         "custom-server": {
           command: "python",
@@ -272,14 +272,14 @@ describe("CopilotMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: inputMcpServers }),
       });
 
       const copilotMcp = CopilotMcp.fromRulesyncMcp({
-        baseDir: "/target/dir",
+        outputRoot: "/target/dir",
         rulesyncMcp,
       });
 
@@ -381,7 +381,7 @@ describe("CopilotMcp", () => {
         },
       };
       const copilotMcp = new CopilotMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".vscode",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: inputServers }),
@@ -389,7 +389,7 @@ describe("CopilotMcp", () => {
 
       const rulesyncMcp = copilotMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(rulesyncMcp.getJson()).toEqual({
         mcpServers: inputServers,
         $schema: RULESYNC_MCP_SCHEMA_URL,
@@ -530,7 +530,7 @@ describe("CopilotMcp", () => {
 
       // Step 1: Load from file (has servers key)
       const originalCopilotMcp = await CopilotMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
       expect(originalCopilotMcp.getJson()).toEqual({ servers: originalServers });
 
@@ -543,7 +543,7 @@ describe("CopilotMcp", () => {
 
       // Step 3: Create new CopilotMcp from RulesyncMcp (should have servers key again)
       const newCopilotMcp = CopilotMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -574,7 +574,7 @@ describe("CopilotMcp", () => {
 
       // Create CopilotMcp with servers key
       const copilotMcp = new CopilotMcp({
-        baseDir: "/project",
+        outputRoot: "/project",
         relativeDirPath: ".vscode",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: originalServers }),
@@ -589,7 +589,7 @@ describe("CopilotMcp", () => {
       });
 
       const newCopilotMcp = CopilotMcp.fromRulesyncMcp({
-        baseDir: "/project",
+        outputRoot: "/project",
         rulesyncMcp,
       });
 

--- a/src/features/mcp/copilot-mcp.ts
+++ b/src/features/mcp/copilot-mcp.ts
@@ -46,19 +46,19 @@ export class CopilotMcp extends ToolMcp {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<CopilotMcp> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new CopilotMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -67,13 +67,13 @@ export class CopilotMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): CopilotMcp {
     const copilotConfig = convertToCopilotFormat(rulesyncMcp.getMcpServers());
     return new CopilotMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: JSON.stringify(copilotConfig, null, 2),
@@ -93,12 +93,12 @@ export class CopilotMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): CopilotMcp {
     return new CopilotMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/copilotcli-mcp.test.ts
+++ b/src/features/mcp/copilotcli-mcp.test.ts
@@ -50,13 +50,13 @@ describe("CopilotcliMcp", () => {
       expect(copilotCliMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const copilotCliMcp = new CopilotcliMcp({
-        baseDir: join(testDir, "custom"),
+        outputRoot: join(testDir, "custom"),
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         fileContent: validJsonContent,
@@ -160,7 +160,7 @@ describe("CopilotcliMcp", () => {
       );
 
       const copilotCliMcp = await CopilotcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(copilotCliMcp).toBeInstanceOf(CopilotcliMcp);
@@ -168,7 +168,7 @@ describe("CopilotcliMcp", () => {
       expect(copilotCliMcp.getFilePath()).toBe(join(testDir, ".copilot/mcp-config.json"));
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       const copilotDir = join(customDir, ".copilot");
       await ensureDir(copilotDir);
@@ -185,7 +185,7 @@ describe("CopilotcliMcp", () => {
       await writeFileContent(join(copilotDir, "mcp-config.json"), JSON.stringify(jsonData));
 
       const copilotCliMcp = await CopilotcliMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(copilotCliMcp.getFilePath()).toBe(join(customDir, ".copilot/mcp-config.json"));
@@ -194,7 +194,7 @@ describe("CopilotcliMcp", () => {
 
     it("should return default empty config if file does not exist", async () => {
       const copilotCliMcp = await CopilotcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(copilotCliMcp.getJson()).toEqual({ mcpServers: {} });
@@ -219,7 +219,7 @@ describe("CopilotcliMcp", () => {
       );
 
       const copilotCliMcp = await CopilotcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -280,7 +280,7 @@ describe("CopilotcliMcp", () => {
 
       const targetDir = join(testDir, "target");
       const copilotCliMcp = await CopilotcliMcp.fromRulesyncMcp({
-        baseDir: targetDir,
+        outputRoot: targetDir,
         rulesyncMcp,
       });
 
@@ -327,7 +327,7 @@ describe("CopilotcliMcp", () => {
       });
 
       const copilotCliMcp = await CopilotcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -606,7 +606,7 @@ describe("CopilotcliMcp", () => {
         },
       };
       const copilotCliMcp = new CopilotcliMcp({
-        baseDir: join(testDir, "test"),
+        outputRoot: join(testDir, "test"),
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         fileContent: JSON.stringify({ mcpServers: inputMcpServers }),
@@ -614,7 +614,7 @@ describe("CopilotcliMcp", () => {
 
       const rulesyncMcp = copilotCliMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe(join(testDir, "test"));
+      expect(rulesyncMcp.getOutputRoot()).toBe(join(testDir, "test"));
       expect(rulesyncMcp.getJson()).toEqual({
         mcpServers: {
           "complex-server": {
@@ -747,7 +747,7 @@ describe("CopilotcliMcp", () => {
   describe("forDeletion", () => {
     it("should create instance for deletion", () => {
       const copilotCliMcp = CopilotcliMcp.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
       });
@@ -758,7 +758,7 @@ describe("CopilotcliMcp", () => {
 
     it("should create instance for deletion with global mode", () => {
       const copilotCliMcp = CopilotcliMcp.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         global: true,
@@ -791,7 +791,7 @@ describe("CopilotcliMcp", () => {
 
       // Step 1: Load from file
       const originalCopilotcliMcp = await CopilotcliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
       expect(originalCopilotcliMcp.getJson()).toEqual({ mcpServers: originalServers });
 
@@ -812,7 +812,7 @@ describe("CopilotcliMcp", () => {
 
       // Step 3: Create new CopilotcliMcp from RulesyncMcp (should add type field)
       const newCopilotcliMcp = await CopilotcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -834,14 +834,14 @@ describe("CopilotcliMcp", () => {
       };
 
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_MCP_FILE_NAME,
         fileContent: JSON.stringify({ mcpServers: originalServers }, null, 2),
       });
 
       const copilotCliMcp = await CopilotcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -881,7 +881,7 @@ describe("CopilotcliMcp", () => {
 
       // Create CopilotcliMcp
       const copilotCliMcp = new CopilotcliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         fileContent: JSON.stringify({ mcpServers: originalServers }),
@@ -894,7 +894,7 @@ describe("CopilotcliMcp", () => {
 
       // Create new CopilotcliMcp from RulesyncMcp (round-trip)
       const roundTrippedMcp = await CopilotcliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 

--- a/src/features/mcp/copilotcli-mcp.ts
+++ b/src/features/mcp/copilotcli-mcp.ts
@@ -146,19 +146,20 @@ export class CopilotcliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<CopilotcliMcp> {
     const paths = this.getSettablePaths({ global });
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      '{"mcpServers":{}}';
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new CopilotcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -168,7 +169,7 @@ export class CopilotcliMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -176,7 +177,7 @@ export class CopilotcliMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = JSON.parse(fileContent);
@@ -186,7 +187,7 @@ export class CopilotcliMcp extends ToolMcp {
     const mcpJson = { ...json, mcpServers: copilotCliMcpServers };
 
     return new CopilotcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(mcpJson, null, 2),
@@ -208,13 +209,13 @@ export class CopilotcliMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): CopilotcliMcp {
     return new CopilotcliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -234,20 +234,20 @@ describe("CursorMcp", () => {
       expect(cursorMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const cursorMcp = new CursorMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
       });
 
       expect(cursorMcp.getFilePath()).toBe("/custom/path/.cursor/mcp.json");
-      expect(cursorMcp.getBaseDir()).toBe("/custom/path");
+      expect(cursorMcp.getOutputRoot()).toBe("/custom/path");
     });
 
     it("should parse JSON content correctly", () => {
@@ -645,7 +645,7 @@ describe("CursorMcp", () => {
 
       expect(cursorMcp).toBeInstanceOf(CursorMcp);
       expect(cursorMcp.getJson()).toEqual(jsonData);
-      expect(cursorMcp.getBaseDir()).toBe(testDir);
+      expect(cursorMcp.getOutputRoot()).toBe(testDir);
       expect(cursorMcp.getRelativeDirPath()).toBe(".cursor");
       expect(cursorMcp.getRelativeFilePath()).toBe("mcp.json");
     });
@@ -723,7 +723,7 @@ describe("CursorMcp", () => {
       expect(cursorMcp.getJson()).toEqual(complexMcpData);
     });
 
-    it("should use custom baseDir when provided", async () => {
+    it("should use custom outputRoot when provided", async () => {
       const mcpJsonPath = join(testDir, ".cursor", "mcp.json");
       const jsonData = {
         mcpServers: {
@@ -737,11 +737,11 @@ describe("CursorMcp", () => {
       await ensureDir(join(testDir, ".cursor"));
       await writeFileContent(mcpJsonPath, JSON.stringify(jsonData));
 
-      const cursorMcp = await CursorMcp.fromFile({ baseDir: testDir, validate: true });
+      const cursorMcp = await CursorMcp.fromFile({ outputRoot: testDir, validate: true });
 
       expect(cursorMcp).toBeInstanceOf(CursorMcp);
       expect(cursorMcp.getJson()).toEqual(jsonData);
-      expect(cursorMcp.getBaseDir()).toBe(testDir);
+      expect(cursorMcp.getOutputRoot()).toBe(testDir);
       expect(cursorMcp.getFilePath()).toBe(join(testDir, ".cursor", "mcp.json"));
     });
 
@@ -802,7 +802,7 @@ describe("CursorMcp", () => {
       await writeFileContent(mcpJsonPath, JSON.stringify(jsonData, null, 2));
 
       const cursorMcp = await CursorMcp.fromFile({
-        baseDir: homeDir,
+        outputRoot: homeDir,
         validate: true,
         global: true,
       });
@@ -818,7 +818,7 @@ describe("CursorMcp", () => {
       const homeDir = testDir;
 
       const cursorMcp = await CursorMcp.fromFile({
-        baseDir: homeDir,
+        outputRoot: homeDir,
         validate: true,
         global: true,
       });
@@ -849,7 +849,7 @@ describe("CursorMcp", () => {
       );
 
       const cursorMcp = await CursorMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -894,7 +894,7 @@ describe("CursorMcp", () => {
       expect(cursorMcp.getJson()).toEqual({
         mcpServers: rulesyncMcpData.mcpServers,
       });
-      expect(cursorMcp.getBaseDir()).toBe(testDir);
+      expect(cursorMcp.getOutputRoot()).toBe(testDir);
       expect(cursorMcp.getRelativeDirPath()).toBe(".cursor");
       expect(cursorMcp.getRelativeFilePath()).toBe("mcp.json");
     });
@@ -959,7 +959,7 @@ describe("CursorMcp", () => {
       });
     });
 
-    it("should use custom baseDir when provided", async () => {
+    it("should use custom outputRoot when provided", async () => {
       const rulesyncMcpData = {
         mcpServers: {
           "custom-server": {
@@ -976,12 +976,12 @@ describe("CursorMcp", () => {
       });
 
       const cursorMcp = await CursorMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
 
-      expect(cursorMcp.getBaseDir()).toBe(testDir);
+      expect(cursorMcp.getOutputRoot()).toBe(testDir);
       expect(cursorMcp.getFilePath()).toBe(join(testDir, ".cursor", "mcp.json"));
     });
 
@@ -1051,7 +1051,7 @@ describe("CursorMcp", () => {
       });
 
       const cursorMcp = await CursorMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
         global: true,
@@ -1098,7 +1098,7 @@ describe("CursorMcp", () => {
       });
 
       const cursorMcp = await CursorMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1151,7 +1151,7 @@ describe("CursorMcp", () => {
       });
 
       const cursorMcp = await CursorMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1183,7 +1183,7 @@ describe("CursorMcp", () => {
       };
 
       const cursorMcp = new CursorMcp({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(cursorMcpData),
@@ -1192,7 +1192,7 @@ describe("CursorMcp", () => {
       const rulesyncMcp = cursorMcp.toRulesyncMcp();
 
       expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/path");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/path");
       expect(rulesyncMcp.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
@@ -1222,7 +1222,7 @@ describe("CursorMcp", () => {
       };
 
       const cursorMcp = new CursorMcp({
-        baseDir: "/custom",
+        outputRoot: "/custom",
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(complexData),
@@ -1230,7 +1230,7 @@ describe("CursorMcp", () => {
 
       const rulesyncMcp = cursorMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/custom");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/custom");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...complexData,
@@ -1251,14 +1251,14 @@ describe("CursorMcp", () => {
 
     it("should have correct type definitions for parameters", () => {
       const constructorParams: CursorMcpParams = {
-        baseDir: "/custom",
+        outputRoot: "/custom",
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: "{}",
         validate: false,
       };
 
-      expect(constructorParams.baseDir).toBe("/custom");
+      expect(constructorParams.outputRoot).toBe("/custom");
       expect(constructorParams.validate).toBe(false);
     });
   });
@@ -1287,20 +1287,20 @@ describe("CursorMcp", () => {
       expect(typeof cursorMcp.getFileContent()).toBe("string");
       expect(typeof cursorMcp.getRelativeDirPath()).toBe("string");
       expect(typeof cursorMcp.getRelativeFilePath()).toBe("string");
-      expect(typeof cursorMcp.getBaseDir()).toBe("string");
+      expect(typeof cursorMcp.getOutputRoot()).toBe("string");
       expect(typeof cursorMcp.getRelativePathFromCwd()).toBe("string");
     });
 
     it("should call parent constructor correctly", () => {
       const jsonData = { mcpServers: { test: { command: "node" } } };
       const cursorMcp = new CursorMcp({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
-      expect(cursorMcp.getBaseDir()).toBe("/test/base");
+      expect(cursorMcp.getOutputRoot()).toBe("/test/base");
       expect(cursorMcp.getRelativeDirPath()).toBe(".cursor");
       expect(cursorMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(cursorMcp.getFileContent()).toBe(JSON.stringify(jsonData));

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -99,12 +99,12 @@ export class CursorMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<CursorMcp> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"mcpServers":{}}';
     let json: Record<string, unknown>;
     try {
@@ -118,7 +118,7 @@ export class CursorMcp extends ToolMcp {
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new CursorMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -128,7 +128,7 @@ export class CursorMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -136,7 +136,7 @@ export class CursorMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     let json: Record<string, unknown>;
@@ -156,7 +156,7 @@ export class CursorMcp extends ToolMcp {
     const cursorConfig = { ...json, mcpServers: transformedServers };
 
     return new CursorMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(cursorConfig, null, 2),
@@ -184,13 +184,13 @@ export class CursorMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): CursorMcp {
     return new CursorMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/deepagents-mcp.test.ts
+++ b/src/features/mcp/deepagents-mcp.test.ts
@@ -68,7 +68,7 @@ describe("DeepagentsMcp", () => {
       });
       await writeFileContent(join(deepagentsDir, ".mcp.json"), mcpContent);
 
-      const mcp = await DeepagentsMcp.fromFile({ baseDir: testDir });
+      const mcp = await DeepagentsMcp.fromFile({ outputRoot: testDir });
 
       expect(mcp.getRelativeDirPath()).toBe(".deepagents");
       expect(mcp.getRelativeFilePath()).toBe(".mcp.json");
@@ -77,7 +77,7 @@ describe("DeepagentsMcp", () => {
     });
 
     it("should initialize with empty mcpServers if file does not exist", async () => {
-      const mcp = await DeepagentsMcp.fromFile({ baseDir: testDir });
+      const mcp = await DeepagentsMcp.fromFile({ outputRoot: testDir });
       const json = mcp.getJson();
       expect(json.mcpServers).toEqual({});
     });
@@ -96,13 +96,13 @@ describe("DeepagentsMcp", () => {
       await writeFileContent(join(deepagentsDir, "mcp.json"), rulesyncMcpContent);
 
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "mcp.json",
         fileContent: rulesyncMcpContent,
       });
 
-      const mcp = await DeepagentsMcp.fromRulesyncMcp({ baseDir: testDir, rulesyncMcp });
+      const mcp = await DeepagentsMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
 
       const json = mcp.getJson();
       expect(json.mcpServers).toEqual({
@@ -116,7 +116,7 @@ describe("DeepagentsMcp", () => {
   describe("toRulesyncMcp", () => {
     it("should convert deepagents mcp config to rulesync format", () => {
       const mcp = new DeepagentsMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({
@@ -138,7 +138,7 @@ describe("DeepagentsMcp", () => {
   describe("forDeletion", () => {
     it("should create a placeholder file for deletion", () => {
       const mcp = DeepagentsMcp.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: ".mcp.json",
       });

--- a/src/features/mcp/deepagents-mcp.ts
+++ b/src/features/mcp/deepagents-mcp.ts
@@ -36,19 +36,20 @@ export class DeepagentsMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<DeepagentsMcp> {
     const paths = this.getSettablePaths({ global });
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      '{"mcpServers":{}}';
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new DeepagentsMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -57,7 +58,7 @@ export class DeepagentsMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -65,7 +66,7 @@ export class DeepagentsMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = JSON.parse(fileContent);
@@ -73,7 +74,7 @@ export class DeepagentsMcp extends ToolMcp {
     const mcpJson = { ...json, mcpServers: rulesyncMcp.getMcpServers() };
 
     return new DeepagentsMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(mcpJson, null, 2),
@@ -92,13 +93,13 @@ export class DeepagentsMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): DeepagentsMcp {
     return new DeepagentsMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/factorydroid-mcp.test.ts
+++ b/src/features/mcp/factorydroid-mcp.test.ts
@@ -46,7 +46,7 @@ describe("FactorydroidMcp", () => {
   describe("constructor", () => {
     it("should create instance with valid MCP config", () => {
       const mcp = new FactorydroidMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(validMcpConfig),
@@ -59,7 +59,7 @@ describe("FactorydroidMcp", () => {
 
     it("should handle empty MCP config", () => {
       const mcp = new FactorydroidMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "mcp.json",
         fileContent: "{}",
@@ -73,7 +73,7 @@ describe("FactorydroidMcp", () => {
   describe("fromRulesyncMcp", () => {
     it("should create FactorydroidMcp from RulesyncMcp", () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "rulesync.mcp.json",
         fileContent: JSON.stringify(validMcpConfig),
@@ -81,7 +81,7 @@ describe("FactorydroidMcp", () => {
       });
 
       const factorydroidMcp = FactorydroidMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -93,7 +93,7 @@ describe("FactorydroidMcp", () => {
 
     it("should handle RulesyncMcp with empty servers", () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: "rulesync.mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -101,7 +101,7 @@ describe("FactorydroidMcp", () => {
       });
 
       const factorydroidMcp = FactorydroidMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -117,7 +117,7 @@ describe("FactorydroidMcp", () => {
       await writeFileContent(mcpFile, JSON.stringify(validMcpConfig, null, 2));
 
       const mcp = await FactorydroidMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -128,7 +128,7 @@ describe("FactorydroidMcp", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         FactorydroidMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
         }),
       ).rejects.toThrow();
@@ -138,7 +138,7 @@ describe("FactorydroidMcp", () => {
   describe("toRulesyncMcp", () => {
     it("should convert to RulesyncMcp", () => {
       const mcp = new FactorydroidMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(validMcpConfig),
@@ -158,7 +158,7 @@ describe("FactorydroidMcp", () => {
   describe("validate", () => {
     it("should return success for valid MCP config", () => {
       const mcp = new FactorydroidMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(validMcpConfig),
@@ -174,7 +174,7 @@ describe("FactorydroidMcp", () => {
   describe("forDeletion", () => {
     it("should create deletion marker", () => {
       const mcp = FactorydroidMcp.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory",
         relativeFilePath: "mcp.json",
       });

--- a/src/features/mcp/factorydroid-mcp.ts
+++ b/src/features/mcp/factorydroid-mcp.ts
@@ -34,19 +34,19 @@ export class FactorydroidMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<FactorydroidMcp> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new FactorydroidMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -55,7 +55,7 @@ export class FactorydroidMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): FactorydroidMcp {
@@ -69,7 +69,7 @@ export class FactorydroidMcp extends ToolMcp {
     const fileContent = JSON.stringify(factorydroidConfig, null, 2);
 
     return new FactorydroidMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -86,12 +86,12 @@ export class FactorydroidMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): FactorydroidMcp {
     return new FactorydroidMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/geminicli-mcp.test.ts
+++ b/src/features/mcp/geminicli-mcp.test.ts
@@ -96,13 +96,13 @@ describe("GeminiCliMcp", () => {
       expect(geminiCliMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const geminiCliMcp = new GeminiCliMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".gemini",
         relativeFilePath: "settings.json",
         fileContent: validJsonContent,
@@ -205,7 +205,7 @@ describe("GeminiCliMcp", () => {
       );
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliMcp).toBeInstanceOf(GeminiCliMcp);
@@ -215,7 +215,7 @@ describe("GeminiCliMcp", () => {
 
     it("should initialize empty mcpServers if file does not exist", async () => {
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliMcp).toBeInstanceOf(GeminiCliMcp);
@@ -233,7 +233,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliMcp.getJson()).toEqual({
@@ -244,7 +244,7 @@ describe("GeminiCliMcp", () => {
       });
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       await ensureDir(join(customDir, ".gemini"));
 
@@ -259,7 +259,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(customDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(geminiCliMcp.getFilePath()).toBe(join(customDir, ".gemini/settings.json"));
@@ -279,7 +279,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -294,7 +294,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -317,7 +317,7 @@ describe("GeminiCliMcp", () => {
       );
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -339,7 +339,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -349,7 +349,7 @@ describe("GeminiCliMcp", () => {
 
     it("should initialize global config file if it does not exist", async () => {
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -379,7 +379,7 @@ describe("GeminiCliMcp", () => {
       );
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -415,7 +415,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -425,7 +425,7 @@ describe("GeminiCliMcp", () => {
       expect(geminiCliMcp.getRelativeFilePath()).toBe("settings.json");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", async () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -438,7 +438,7 @@ describe("GeminiCliMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -447,7 +447,7 @@ describe("GeminiCliMcp", () => {
       const customDir = join(testDir, "target");
       await ensureDir(customDir);
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         rulesyncMcp,
       });
 
@@ -471,7 +471,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -490,7 +490,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: false,
       });
@@ -509,7 +509,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -532,7 +532,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -559,7 +559,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -604,7 +604,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -657,7 +657,7 @@ describe("GeminiCliMcp", () => {
       });
 
       const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -729,7 +729,7 @@ describe("GeminiCliMcp", () => {
         },
       };
       const geminiCliMcp = new GeminiCliMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".gemini",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify(jsonData),
@@ -737,7 +737,7 @@ describe("GeminiCliMcp", () => {
 
       const rulesyncMcp = geminiCliMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...jsonData,
@@ -901,7 +901,7 @@ describe("GeminiCliMcp", () => {
 
       // Step 1: Load from file
       const originalGeminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp
@@ -909,7 +909,7 @@ describe("GeminiCliMcp", () => {
 
       // Step 3: Create new GeminiCliMcp from RulesyncMcp
       const newGeminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -947,7 +947,7 @@ describe("GeminiCliMcp", () => {
 
       // Create GeminiCliMcp
       const geminiCliMcp = new GeminiCliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -979,7 +979,7 @@ describe("GeminiCliMcp", () => {
 
       // Step 1: Load from global config
       const originalGeminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -988,7 +988,7 @@ describe("GeminiCliMcp", () => {
 
       // Step 3: Create new GeminiCliMcp from RulesyncMcp in global mode
       const newGeminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1006,7 +1006,7 @@ describe("GeminiCliMcp", () => {
 
       await expect(
         GeminiCliMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -1017,7 +1017,7 @@ describe("GeminiCliMcp", () => {
 
       await expect(
         GeminiCliMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           global: true,
         }),
       ).rejects.toThrow();
@@ -1031,7 +1031,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliMcp.getJson().mcpServers).toEqual({});
@@ -1045,7 +1045,7 @@ describe("GeminiCliMcp", () => {
       await writeFileContent(join(testDir, ".gemini/settings.json"), JSON.stringify(jsonData));
 
       const geminiCliMcp = await GeminiCliMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(geminiCliMcp.getJson().mcpServers).toEqual({});
@@ -1058,7 +1058,7 @@ describe("GeminiCliMcp", () => {
 
       await expect(
         GeminiCliMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -1069,7 +1069,7 @@ describe("GeminiCliMcp", () => {
 
       await expect(
         GeminiCliMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });

--- a/src/features/mcp/geminicli-mcp.ts
+++ b/src/features/mcp/geminicli-mcp.ts
@@ -38,19 +38,20 @@ export class GeminiCliMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<GeminiCliMcp> {
     const paths = this.getSettablePaths({ global });
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      '{"mcpServers":{}}';
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? '{"mcpServers":{}}';
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new GeminiCliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -59,7 +60,7 @@ export class GeminiCliMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -67,14 +68,14 @@ export class GeminiCliMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = JSON.parse(fileContent);
     const newJson = { ...json, mcpServers: rulesyncMcp.getJson().mcpServers };
 
     return new GeminiCliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -100,13 +101,13 @@ export class GeminiCliMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): GeminiCliMcp {
     return new GeminiCliMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/junie-mcp.test.ts
+++ b/src/features/mcp/junie-mcp.test.ts
@@ -54,7 +54,7 @@ describe("JunieMcp", () => {
       const content = JSON.stringify({ mcpServers: { A: { command: "echo" } } }, null, 2);
       await writeFileContent(filePath, content);
 
-      const junie = await JunieMcp.fromFile({ baseDir: testDir, validate: true });
+      const junie = await JunieMcp.fromFile({ outputRoot: testDir, validate: true });
 
       expect(junie.getFilePath()).toBe(filePath);
       expect(junie.getFileContent()).toBe(content);
@@ -70,13 +70,13 @@ describe("JunieMcp", () => {
         2,
       );
       const rulesync = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: rulesyncContent,
       });
 
-      const junie = JunieMcp.fromRulesyncMcp({ baseDir: testDir, rulesyncMcp: rulesync });
+      const junie = JunieMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp: rulesync });
 
       expect(junie.getRelativeDirPath()).toBe(".junie/mcp");
       expect(junie.getRelativeFilePath()).toBe("mcp.json");
@@ -88,7 +88,7 @@ describe("JunieMcp", () => {
     it("maps back to a RulesyncMcp with same content", () => {
       const content = JSON.stringify({ mcpServers: { X: { command: "echo" } } }, null, 2);
       const junie = new JunieMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/mcp",
         relativeFilePath: "mcp.json",
         fileContent: content,

--- a/src/features/mcp/junie-mcp.ts
+++ b/src/features/mcp/junie-mcp.ts
@@ -32,19 +32,19 @@ export class JunieMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<JunieMcp> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
 
     return new JunieMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -53,12 +53,12 @@ export class JunieMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): JunieMcp {
     return new JunieMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent: rulesyncMcp.getFileContent(),
@@ -75,12 +75,12 @@ export class JunieMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): JunieMcp {
     return new JunieMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/kilo-mcp.test.ts
+++ b/src/features/mcp/kilo-mcp.test.ts
@@ -88,13 +88,13 @@ describe("KiloMcp", () => {
       expect(kiloMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcp: {},
       });
 
       const kiloMcp = new KiloMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".",
         relativeFilePath: "kilo.json",
         fileContent: validJsonContent,
@@ -182,7 +182,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData, null, 2));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp).toBeInstanceOf(KiloMcp);
@@ -192,7 +192,7 @@ describe("KiloMcp", () => {
 
     it("should initialize empty mcp if file does not exist", async () => {
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp).toBeInstanceOf(KiloMcp);
@@ -209,7 +209,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson()).toEqual({
@@ -220,7 +220,7 @@ describe("KiloMcp", () => {
       });
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       await ensureDir(customDir);
 
@@ -237,7 +237,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(customDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(kiloMcp.getFilePath()).toBe(join(customDir, "kilo.json"));
@@ -258,7 +258,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -272,7 +272,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -295,7 +295,7 @@ describe("KiloMcp", () => {
       await writeFileContent(globalPath, JSON.stringify(jsonData, null, 2));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -318,7 +318,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -328,7 +328,7 @@ describe("KiloMcp", () => {
 
     it("should initialize global config file if it does not exist", async () => {
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -359,7 +359,7 @@ describe("KiloMcp", () => {
       );
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -397,7 +397,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -416,7 +416,7 @@ describe("KiloMcp", () => {
       expect(kiloMcp.getRelativeFilePath()).toBe("kilo.jsonc");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", async () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -429,7 +429,7 @@ describe("KiloMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -438,7 +438,7 @@ describe("KiloMcp", () => {
       const customDir = join(testDir, "target");
       await ensureDir(customDir);
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         rulesyncMcp,
       });
 
@@ -474,7 +474,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -502,7 +502,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: false,
       });
@@ -521,7 +521,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -544,7 +544,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -580,7 +580,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -635,7 +635,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -691,7 +691,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -731,7 +731,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -767,7 +767,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -804,7 +804,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -845,7 +845,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -887,7 +887,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -922,7 +922,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -970,7 +970,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1011,7 +1011,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1047,7 +1047,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1098,7 +1098,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1122,7 +1122,7 @@ describe("KiloMcp", () => {
       });
 
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1168,7 +1168,7 @@ describe("KiloMcp", () => {
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
-    it("should convert environment to env and preserve baseDir", () => {
+    it("should convert environment to env and preserve outputRoot", () => {
       const jsonData = {
         mcp: {
           "complex-server": {
@@ -1183,7 +1183,7 @@ describe("KiloMcp", () => {
         },
       };
       const kiloMcp = new KiloMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".",
         relativeFilePath: "kilo.json",
         fileContent: JSON.stringify(jsonData),
@@ -1191,7 +1191,7 @@ describe("KiloMcp", () => {
 
       const rulesyncMcp = kiloMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         mcpServers: {
@@ -1769,7 +1769,7 @@ describe("KiloMcp", () => {
 
       // Step 1: Load from file
       const originalKiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp (now converts to standard format)
@@ -1788,7 +1788,7 @@ describe("KiloMcp", () => {
 
       // Step 3: Create new KiloMcp from RulesyncMcp
       const newKiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1839,7 +1839,7 @@ describe("KiloMcp", () => {
 
       // Create KiloMcp
       const kiloMcp = new KiloMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "kilo.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -1872,7 +1872,7 @@ describe("KiloMcp", () => {
 
       // Step 1: Load from global config
       const originalKiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -1890,7 +1890,7 @@ describe("KiloMcp", () => {
 
       // Step 3: Create new KiloMcp from RulesyncMcp in global mode
       const newKiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1928,7 +1928,7 @@ describe("KiloMcp", () => {
 
       // Step 1: Load from file
       const originalKiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp
@@ -1946,7 +1946,7 @@ describe("KiloMcp", () => {
 
       // Step 3: Convert back to Kilo format
       const newKiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1991,7 +1991,7 @@ describe("KiloMcp", () => {
 
       // Step 1: Convert to Kilo
       const kiloMcp = await KiloMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -2017,7 +2017,7 @@ describe("KiloMcp", () => {
     it("should handle missing files by returning default empty mcp", async () => {
       // When both jsonc and json are missing, should return default mcp
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson().mcp).toEqual({});
@@ -2026,7 +2026,7 @@ describe("KiloMcp", () => {
     it("should handle missing files in global mode by returning default empty mcp", async () => {
       // When global files don't exist, should return default mcp
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -2040,7 +2040,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson().mcp).toEqual({});
@@ -2053,7 +2053,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonData));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson().mcp).toEqual({});
@@ -2065,7 +2065,7 @@ describe("KiloMcp", () => {
 
       await expect(
         KiloMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -2075,7 +2075,7 @@ describe("KiloMcp", () => {
 
       await expect(
         KiloMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -2094,7 +2094,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.jsonc"), jsoncContent);
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       const exampleServer = kiloMcp.getJson().mcp?.exampleServer;
@@ -2128,7 +2128,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.jsonc"), jsoncContent);
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson().mcp?.fromJsonc).toBeDefined();
@@ -2148,7 +2148,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, "kilo.json"), JSON.stringify(jsonContent));
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(kiloMcp.getJson().mcp?.fromJson).toBeDefined();
@@ -2167,7 +2167,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, ".config", "kilo", "kilo.jsonc"), jsoncContent);
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -2200,7 +2200,7 @@ describe("KiloMcp", () => {
       await writeFileContent(join(testDir, ".config", "kilo", "kilo.jsonc"), jsoncContent);
 
       const kiloMcp = await KiloMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 

--- a/src/features/mcp/kilo-mcp.ts
+++ b/src/features/mcp/kilo-mcp.ts
@@ -220,12 +220,12 @@ export class KiloMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<KiloMcp> {
     const basePaths = this.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     let fileContent: string | null = null;
     let relativeFilePath = "kilo.jsonc";
@@ -247,7 +247,7 @@ export class KiloMcp extends ToolMcp {
     const newJson = { ...json, mcp: json.mcp ?? {} };
 
     return new KiloMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -256,13 +256,13 @@ export class KiloMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
   }: ToolMcpFromRulesyncMcpParams): Promise<KiloMcp> {
     const basePaths = this.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     let fileContent: string | null = null;
     let relativeFilePath = "kilo.jsonc";
@@ -295,7 +295,7 @@ export class KiloMcp extends ToolMcp {
     };
 
     return new KiloMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -322,13 +322,13 @@ export class KiloMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): KiloMcp {
     return new KiloMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/kiro-mcp.test.ts
+++ b/src/features/mcp/kiro-mcp.test.ts
@@ -33,7 +33,7 @@ describe("KiroMcp", () => {
   describe("fromRulesyncMcp", () => {
     it("should convert exposed servers for project mode", () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({
@@ -60,7 +60,7 @@ describe("KiroMcp", () => {
 
   describe("fromFile", () => {
     it("should initialize missing project file", async () => {
-      const kiroMcp = await KiroMcp.fromFile({ baseDir: testDir });
+      const kiroMcp = await KiroMcp.fromFile({ outputRoot: testDir });
 
       expect(kiroMcp.getFilePath()).toBe(join(testDir, ".kiro", "settings", "mcp.json"));
       expect(JSON.parse(kiroMcp.getFileContent())).toEqual({ mcpServers: {} });
@@ -70,7 +70,7 @@ describe("KiroMcp", () => {
   describe("toRulesyncMcp", () => {
     it("should convert to Rulesync format", () => {
       const kiroMcp = new KiroMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kiro", "settings"),
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({
@@ -93,7 +93,7 @@ describe("KiroMcp", () => {
   describe("forDeletion", () => {
     it("should create deletable placeholder", () => {
       const kiroMcp = KiroMcp.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kiro", "settings"),
         relativeFilePath: "obsolete.json",
       });

--- a/src/features/mcp/kiro-mcp.ts
+++ b/src/features/mcp/kiro-mcp.ts
@@ -32,16 +32,17 @@ export class KiroMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<KiroMcp> {
     const paths = this.getSettablePaths();
     const fileContent =
-      (await readFileContentOrNull(join(baseDir, paths.relativeDirPath, paths.relativeFilePath))) ??
-      '{"mcpServers":{}}';
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? '{"mcpServers":{}}';
 
     return new KiroMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -50,7 +51,7 @@ export class KiroMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): KiroMcp {
@@ -58,7 +59,7 @@ export class KiroMcp extends ToolMcp {
     const fileContent = JSON.stringify({ mcpServers: rulesyncMcp.getMcpServers() }, null, 2);
 
     return new KiroMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -77,12 +78,12 @@ export class KiroMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): KiroMcp {
     return new KiroMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/mcp-processor.test.ts
+++ b/src/features/mcp/mcp-processor.test.ts
@@ -131,14 +131,14 @@ describe("McpProcessor", () => {
     it("should create instance with valid tool target", () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
       expect(processor).toBeInstanceOf(McpProcessor);
     });
 
-    it("should create instance with default baseDir", () => {
+    it("should create instance with default outputRoot", () => {
       const processor = new McpProcessor({ logger: createMockLogger(), toolTarget: "cursor" });
 
       expect(processor).toBeInstanceOf(McpProcessor);
@@ -148,7 +148,7 @@ describe("McpProcessor", () => {
       expect(() => {
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid" as McpProcessorToolTarget,
         });
         return processor;
@@ -159,7 +159,7 @@ describe("McpProcessor", () => {
   describe("loadRulesyncFiles", () => {
     it("should load rulesync MCP files successfully", async () => {
       const mockRulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -169,7 +169,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -177,7 +177,7 @@ describe("McpProcessor", () => {
 
       expect(files).toHaveLength(1);
       expect(files[0]).toBe(mockRulesyncMcp);
-      expect(RulesyncMcp.fromFile).toHaveBeenCalledWith({ baseDir: testDir });
+      expect(RulesyncMcp.fromFile).toHaveBeenCalledWith({ outputRoot: testDir });
     });
 
     it("should return empty array when no MCP files found", async () => {
@@ -185,7 +185,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -199,7 +199,7 @@ describe("McpProcessor", () => {
     describe("claudecode", () => {
       it("should load ClaudecodeMcp files", async () => {
         const mockMcp = new ClaudecodeMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claudecode",
           relativeFilePath: "mcp.json",
           fileContent: JSON.stringify({ servers: {} }),
@@ -209,7 +209,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
         });
 
@@ -218,7 +218,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(ClaudecodeMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -226,7 +226,7 @@ describe("McpProcessor", () => {
 
       it("should load ClaudecodeMcp files for claudecode-legacy target", async () => {
         const mockMcp = new ClaudecodeMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claudecode",
           relativeFilePath: "mcp.json",
           fileContent: JSON.stringify({ servers: {} }),
@@ -236,7 +236,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode-legacy",
         });
 
@@ -245,7 +245,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(ClaudecodeMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -253,7 +253,7 @@ describe("McpProcessor", () => {
 
       it("should load ClaudecodeMcp files in global mode", async () => {
         const mockMcp = new ClaudecodeMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claude",
           relativeFilePath: ".claude.json",
           fileContent: JSON.stringify({ mcpServers: {} }),
@@ -263,7 +263,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -273,7 +273,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(ClaudecodeMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         });
@@ -283,7 +283,7 @@ describe("McpProcessor", () => {
     describe("cline", () => {
       it("should load ClineMcp files", async () => {
         const mockMcp = new ClineMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".cline",
           relativeFilePath: "mcp.json",
           fileContent: JSON.stringify({ servers: {} }),
@@ -293,7 +293,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "cline",
         });
 
@@ -302,7 +302,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(ClineMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -312,7 +312,7 @@ describe("McpProcessor", () => {
     describe("copilot", () => {
       it("should load CopilotMcp files", async () => {
         const mockMcp = new CopilotMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".github",
           relativeFilePath: "copilot-mcp.yml",
           fileContent: JSON.stringify({ servers: {} }),
@@ -322,7 +322,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "copilot",
         });
 
@@ -331,7 +331,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(CopilotMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -341,7 +341,7 @@ describe("McpProcessor", () => {
     describe("copilotcli", () => {
       it("should load CopilotcliMcp files", async () => {
         const mockMcp = new CopilotcliMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".copilot",
           relativeFilePath: "mcp-config.json",
           fileContent: JSON.stringify({ mcpServers: {} }),
@@ -351,7 +351,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "copilotcli",
         });
 
@@ -360,7 +360,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(CopilotcliMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -368,7 +368,7 @@ describe("McpProcessor", () => {
 
       it("should load CopilotcliMcp files in global mode", async () => {
         const mockMcp = new CopilotcliMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".copilot",
           relativeFilePath: "mcp-config.json",
           fileContent: JSON.stringify({ mcpServers: {} }),
@@ -378,7 +378,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "copilotcli",
           global: true,
         });
@@ -388,7 +388,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(CopilotcliMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         });
@@ -398,7 +398,7 @@ describe("McpProcessor", () => {
     describe("cursor", () => {
       it("should load CursorMcp files", async () => {
         const mockMcp = new CursorMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".cursor",
           relativeFilePath: "mcp.json",
           fileContent: JSON.stringify({ servers: {} }),
@@ -408,7 +408,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "cursor",
         });
 
@@ -417,7 +417,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(CursorMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -427,7 +427,7 @@ describe("McpProcessor", () => {
     describe("geminicli", () => {
       it("should load GeminiCliMcp files", async () => {
         const mockMcp = new GeminiCliMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".gemini",
           relativeFilePath: "settings.json",
           fileContent: JSON.stringify({ mcpServers: {} }),
@@ -437,7 +437,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "geminicli",
         });
 
@@ -446,7 +446,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(GeminiCliMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -454,7 +454,7 @@ describe("McpProcessor", () => {
 
       it("should load GeminiCliMcp files in global mode", async () => {
         const mockMcp = new GeminiCliMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".gemini",
           relativeFilePath: "settings.json",
           fileContent: JSON.stringify({ mcpServers: {} }),
@@ -464,7 +464,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "geminicli",
           global: true,
         });
@@ -474,7 +474,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(GeminiCliMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         });
@@ -492,7 +492,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "codexcli",
           global: true,
         });
@@ -502,7 +502,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(CodexcliMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         });
@@ -511,7 +511,7 @@ describe("McpProcessor", () => {
       it("should throw error when used in local mode", async () => {
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "codexcli",
           global: false,
         });
@@ -529,7 +529,7 @@ describe("McpProcessor", () => {
     describe("roo", () => {
       it("should load RooMcp files", async () => {
         const mockMcp = new RooMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".roo",
           relativeFilePath: "mcp.json",
           fileContent: JSON.stringify({ servers: {} }),
@@ -539,7 +539,7 @@ describe("McpProcessor", () => {
 
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "roo",
         });
 
@@ -548,7 +548,7 @@ describe("McpProcessor", () => {
         expect(files).toHaveLength(1);
         expect(files[0]).toBe(mockMcp);
         expect(RooMcp.fromFile).toHaveBeenCalledWith({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         });
@@ -560,7 +560,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -573,7 +573,7 @@ describe("McpProcessor", () => {
       // Create a processor with a valid toolTarget
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -590,14 +590,14 @@ describe("McpProcessor", () => {
   describe("convertRulesyncFilesToToolFiles", () => {
     it("should convert rulesync files to claudecode tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
       });
 
       const mockToolMcp = new ClaudecodeMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claudecode",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -607,7 +607,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -616,7 +616,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(ClaudecodeMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -624,14 +624,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to claudecode tool files in global mode", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       const mockToolMcp = new ClaudecodeMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: ".claude.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -641,7 +641,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -651,7 +651,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(ClaudecodeMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -659,14 +659,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to cline tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
       });
 
       const mockToolMcp = new ClineMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cline",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -676,7 +676,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cline",
       });
 
@@ -685,7 +685,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(ClineMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -693,14 +693,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to copilot tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
       });
 
       const mockToolMcp = new CopilotMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-mcp.yml",
         fileContent: JSON.stringify({ servers: {} }),
@@ -710,7 +710,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -719,7 +719,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(CopilotMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -727,14 +727,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to copilotcli tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       const mockToolMcp = new CopilotcliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -744,7 +744,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilotcli",
       });
 
@@ -753,7 +753,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(CopilotcliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -761,14 +761,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to copilotcli tool files in global mode", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       const mockToolMcp = new CopilotcliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".copilot",
         relativeFilePath: "mcp-config.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -778,7 +778,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilotcli",
         global: true,
       });
@@ -788,7 +788,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(CopilotcliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -796,14 +796,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to cursor tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
       });
 
       const mockToolMcp = new CursorMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -813,7 +813,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
       });
 
@@ -822,7 +822,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(CursorMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -830,14 +830,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to geminicli tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       const mockToolMcp = new GeminiCliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -847,7 +847,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "geminicli",
       });
 
@@ -856,7 +856,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(GeminiCliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -864,14 +864,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to geminicli tool files in global mode", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
       });
 
       const mockToolMcp = new GeminiCliMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -881,7 +881,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "geminicli",
         global: true,
       });
@@ -891,7 +891,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(GeminiCliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -899,7 +899,7 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to codexcli tool files in global mode", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -914,7 +914,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
         global: true,
       });
@@ -924,7 +924,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(CodexcliMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -932,14 +932,14 @@ describe("McpProcessor", () => {
 
     it("should convert rulesync files to roo tool files", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
       });
 
       const mockToolMcp = new RooMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -949,7 +949,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "roo",
       });
 
@@ -958,7 +958,7 @@ describe("McpProcessor", () => {
       expect(toolFiles).toHaveLength(1);
       expect(toolFiles[0]).toBe(mockToolMcp);
       expect(RooMcp.fromRulesyncMcp).toHaveBeenCalledWith({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -967,7 +967,7 @@ describe("McpProcessor", () => {
     it("should throw error when no RulesyncMcp found", async () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -978,7 +978,7 @@ describe("McpProcessor", () => {
 
     it("should throw error for unsupported tool target", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ servers: {} }),
@@ -986,7 +986,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -1000,7 +1000,7 @@ describe("McpProcessor", () => {
 
     it("should strip enabledTools and disabledTools for tools that do not support them", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -1010,7 +1010,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -1024,7 +1024,7 @@ describe("McpProcessor", () => {
 
     it("should not strip enabledTools and disabledTools for codexcli", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -1034,7 +1034,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
         global: true,
       });
@@ -1046,7 +1046,7 @@ describe("McpProcessor", () => {
 
     it("should not strip enabledTools and disabledTools for opencode", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -1057,7 +1057,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "opencode",
       });
 
@@ -1071,7 +1071,7 @@ describe("McpProcessor", () => {
     it("should return empty array when no tool files provided", async () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -1123,7 +1123,7 @@ describe("McpProcessor", () => {
     it("should return deletable files only", async () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -1133,7 +1133,7 @@ describe("McpProcessor", () => {
       expect(filesToDelete[0]?.getRelativeFilePath()).toBe("mcp.json");
       expect(vi.mocked(CopilotMcp).forDeletion).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       );
     });
@@ -1150,7 +1150,7 @@ describe("McpProcessor", () => {
       for (const target of targets) {
         const processor = new McpProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: target,
         });
 
@@ -1164,7 +1164,7 @@ describe("McpProcessor", () => {
     it("should handle errors gracefully", async () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
@@ -1189,7 +1189,7 @@ describe("McpProcessor", () => {
 
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -1203,7 +1203,7 @@ describe("McpProcessor", () => {
     it("should not filter out deletable files in local mode", async () => {
       const processor = new McpProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: false,
       });

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -316,7 +316,7 @@ export class McpProcessor extends FeatureProcessor {
   private readonly getFactory: GetFactory;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
@@ -324,7 +324,7 @@ export class McpProcessor extends FeatureProcessor {
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
@@ -332,7 +332,7 @@ export class McpProcessor extends FeatureProcessor {
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = McpProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -350,7 +350,7 @@ export class McpProcessor extends FeatureProcessor {
    */
   async loadRulesyncFiles(): Promise<RulesyncFile[]> {
     try {
-      return [await RulesyncMcp.fromFile({ baseDir: this.inputRoot })];
+      return [await RulesyncMcp.fromFile({ outputRoot: this.inputRoot })];
     } catch (error) {
       this.logger.error(
         `Failed to load a Rulesync MCP file (${RULESYNC_MCP_RELATIVE_FILE_PATH}): ${formatError(error)}`,
@@ -374,7 +374,7 @@ export class McpProcessor extends FeatureProcessor {
 
       if (forDeletion) {
         const toolMcp = factory.class.forDeletion({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.relativeDirPath,
           relativeFilePath: paths.relativeFilePath,
           global: this.global,
@@ -387,7 +387,7 @@ export class McpProcessor extends FeatureProcessor {
 
       const toolMcps = [
         await factory.class.fromFile({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           validate: true,
           global: this.global,
         }),
@@ -428,7 +428,7 @@ export class McpProcessor extends FeatureProcessor {
         const filteredRulesyncMcp = mcp.stripMcpServerFields(fieldsToStrip);
 
         return await factory.class.fromRulesyncMcp({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           rulesyncMcp: filteredRulesyncMcp,
           global: this.global,
         });

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -88,13 +88,13 @@ describe("OpencodeMcp", () => {
       expect(opencodeMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcp: {},
       });
 
       const opencodeMcp = new OpencodeMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".",
         relativeFilePath: "opencode.json",
         fileContent: validJsonContent,
@@ -182,7 +182,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData, null, 2));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp).toBeInstanceOf(OpencodeMcp);
@@ -192,7 +192,7 @@ describe("OpencodeMcp", () => {
 
     it("should initialize empty mcp if file does not exist", async () => {
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp).toBeInstanceOf(OpencodeMcp);
@@ -209,7 +209,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson()).toEqual({
@@ -220,7 +220,7 @@ describe("OpencodeMcp", () => {
       });
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       await ensureDir(customDir);
 
@@ -237,7 +237,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(customDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
       });
 
       expect(opencodeMcp.getFilePath()).toBe(join(customDir, "opencode.json"));
@@ -258,7 +258,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
@@ -272,7 +272,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
@@ -295,7 +295,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(globalPath, JSON.stringify(jsonData, null, 2));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -318,7 +318,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: false,
       });
 
@@ -328,7 +328,7 @@ describe("OpencodeMcp", () => {
 
     it("should initialize global config file if it does not exist", async () => {
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -361,7 +361,7 @@ describe("OpencodeMcp", () => {
       );
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -399,7 +399,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -418,7 +418,7 @@ describe("OpencodeMcp", () => {
       expect(opencodeMcp.getRelativeFilePath()).toBe("opencode.jsonc");
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", async () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {
           "custom-server": {
@@ -431,7 +431,7 @@ describe("OpencodeMcp", () => {
         },
       };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
@@ -440,7 +440,7 @@ describe("OpencodeMcp", () => {
       const customDir = join(testDir, "target");
       await ensureDir(customDir);
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         rulesyncMcp,
       });
 
@@ -476,7 +476,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
       });
@@ -504,7 +504,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: false,
       });
@@ -523,7 +523,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -546,7 +546,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -582,7 +582,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: false,
       });
@@ -637,7 +637,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -693,7 +693,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -733,7 +733,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -769,7 +769,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -806,7 +806,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -847,7 +847,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -889,7 +889,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -924,7 +924,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -975,7 +975,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1019,7 +1019,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1055,7 +1055,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1106,7 +1106,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1130,7 +1130,7 @@ describe("OpencodeMcp", () => {
       });
 
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1176,7 +1176,7 @@ describe("OpencodeMcp", () => {
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
-    it("should convert environment to env and preserve baseDir", () => {
+    it("should convert environment to env and preserve outputRoot", () => {
       const jsonData = {
         mcp: {
           "complex-server": {
@@ -1191,7 +1191,7 @@ describe("OpencodeMcp", () => {
         },
       };
       const opencodeMcp = new OpencodeMcp({
-        baseDir: "/test/dir",
+        outputRoot: "/test/dir",
         relativeDirPath: ".",
         relativeFilePath: "opencode.json",
         fileContent: JSON.stringify(jsonData),
@@ -1199,7 +1199,7 @@ describe("OpencodeMcp", () => {
 
       const rulesyncMcp = opencodeMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/dir");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/dir");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
         $schema: RULESYNC_MCP_SCHEMA_URL,
         mcpServers: {
@@ -1780,7 +1780,7 @@ describe("OpencodeMcp", () => {
 
       // Step 1: Load from file
       const originalOpencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp (now converts to standard format)
@@ -1799,7 +1799,7 @@ describe("OpencodeMcp", () => {
 
       // Step 3: Create new OpencodeMcp from RulesyncMcp
       const newOpencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -1850,7 +1850,7 @@ describe("OpencodeMcp", () => {
 
       // Create OpencodeMcp
       const opencodeMcp = new OpencodeMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "opencode.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -1883,7 +1883,7 @@ describe("OpencodeMcp", () => {
 
       // Step 1: Load from global config
       const originalOpencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -1901,7 +1901,7 @@ describe("OpencodeMcp", () => {
 
       // Step 3: Create new OpencodeMcp from RulesyncMcp in global mode
       const newOpencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         global: true,
       });
@@ -1944,7 +1944,7 @@ describe("OpencodeMcp", () => {
 
       // Step 1: Load from file
       const originalOpencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Step 2: Convert to RulesyncMcp
@@ -1962,7 +1962,7 @@ describe("OpencodeMcp", () => {
 
       // Step 3: Convert back to OpenCode format
       const newOpencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -2007,7 +2007,7 @@ describe("OpencodeMcp", () => {
 
       // Step 1: Convert to OpenCode
       const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -2033,7 +2033,7 @@ describe("OpencodeMcp", () => {
     it("should handle missing files by returning default empty mcp", async () => {
       // When both jsonc and json are missing, should return default mcp
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson().mcp).toEqual({});
@@ -2042,7 +2042,7 @@ describe("OpencodeMcp", () => {
     it("should handle missing files in global mode by returning default empty mcp", async () => {
       // When global files don't exist, should return default mcp
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -2056,7 +2056,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson().mcp).toEqual({});
@@ -2069,7 +2069,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonData));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson().mcp).toEqual({});
@@ -2081,7 +2081,7 @@ describe("OpencodeMcp", () => {
 
       await expect(
         OpencodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -2091,7 +2091,7 @@ describe("OpencodeMcp", () => {
 
       await expect(
         OpencodeMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
@@ -2110,7 +2110,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.jsonc"), jsoncContent);
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       const exampleServer = opencodeMcp.getJson().mcp?.exampleServer;
@@ -2144,7 +2144,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.jsonc"), jsoncContent);
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson().mcp?.fromJsonc).toBeDefined();
@@ -2164,7 +2164,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, "opencode.json"), JSON.stringify(jsonContent));
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(opencodeMcp.getJson().mcp?.fromJson).toBeDefined();
@@ -2183,7 +2183,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, ".config", "opencode", "opencode.jsonc"), jsoncContent);
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 
@@ -2216,7 +2216,7 @@ describe("OpencodeMcp", () => {
       await writeFileContent(join(testDir, ".config", "opencode", "opencode.jsonc"), jsoncContent);
 
       const opencodeMcp = await OpencodeMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         global: true,
       });
 

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -223,12 +223,12 @@ export class OpencodeMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<OpencodeMcp> {
     const basePaths = this.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     let fileContent: string | null = null;
     let relativeFilePath = "opencode.jsonc";
@@ -250,7 +250,7 @@ export class OpencodeMcp extends ToolMcp {
     const newJson = { ...json, mcp: json.mcp ?? {} };
 
     return new OpencodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -259,13 +259,13 @@ export class OpencodeMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
   }: ToolMcpFromRulesyncMcpParams): Promise<OpencodeMcp> {
     const basePaths = this.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     let fileContent: string | null = null;
     let relativeFilePath = "opencode.jsonc";
@@ -300,7 +300,7 @@ export class OpencodeMcp extends ToolMcp {
     };
 
     return new OpencodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -327,13 +327,13 @@ export class OpencodeMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): OpencodeMcp {
     return new OpencodeMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/roo-mcp.test.ts
+++ b/src/features/mcp/roo-mcp.test.ts
@@ -48,13 +48,13 @@ describe("RooMcp", () => {
       expect(rooMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const rooMcp = new RooMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".roo",
         relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
@@ -62,7 +62,7 @@ describe("RooMcp", () => {
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe("/custom/path");
+      expect(rooMcp.getOutputRoot()).toBe("/custom/path");
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(rooMcp.getFileContent()).toBe(validJsonContent);
@@ -129,12 +129,12 @@ describe("RooMcp", () => {
       await writeFileContent(mcpFilePath, JSON.stringify(mcpContent, null, 2));
 
       const rooMcp = await RooMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe(testDir);
+      expect(rooMcp.getOutputRoot()).toBe(testDir);
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rooMcp.getFileContent())).toEqual(mcpContent);
@@ -157,26 +157,26 @@ describe("RooMcp", () => {
       await writeFileContent(mcpFilePath, JSON.stringify(mcpContent, null, 2));
 
       const rooMcp = await RooMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: false,
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe(testDir);
+      expect(rooMcp.getOutputRoot()).toBe(testDir);
       expect(JSON.parse(rooMcp.getFileContent())).toEqual(mcpContent);
     });
 
     it("should throw error when file does not exist", async () => {
       await expect(
         RooMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow();
     });
 
-    it("should create instance with custom baseDir parameter", async () => {
-      const customBaseDir = join(testDir, "custom");
-      const rooDir = join(customBaseDir, ".roo");
+    it("should create instance with custom outputRoot parameter", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      const rooDir = join(customOutputRoot, ".roo");
       const mcpFilePath = join(rooDir, "mcp.json");
 
       const mcpContent = {
@@ -187,7 +187,7 @@ describe("RooMcp", () => {
       await writeFileContent(mcpFilePath, JSON.stringify(mcpContent));
 
       const rooMcp = await RooMcp.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
@@ -217,13 +217,13 @@ describe("RooMcp", () => {
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe(testDir);
+      expect(rooMcp.getOutputRoot()).toBe(testDir);
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rooMcp.getFileContent())).toEqual(mcpContent);
     });
 
-    it("should create instance from RulesyncMcp with custom baseDir", () => {
+    it("should create instance from RulesyncMcp with custom outputRoot", () => {
       const mcpContent = {
         mcpServers: {
           "custom-server": {
@@ -240,12 +240,12 @@ describe("RooMcp", () => {
       });
 
       const rooMcp = RooMcp.fromRulesyncMcp({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncMcp,
       });
 
       expect(rooMcp).toBeInstanceOf(RooMcp);
-      expect(rooMcp.getBaseDir()).toBe("/custom/base");
+      expect(rooMcp.getOutputRoot()).toBe("/custom/base");
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rooMcp.getFileContent())).toEqual(mcpContent);
@@ -413,7 +413,7 @@ describe("RooMcp", () => {
       };
 
       const rooMcp = new RooMcp({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".roo",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify(mcpContent),
@@ -422,7 +422,7 @@ describe("RooMcp", () => {
       const rulesyncMcp = rooMcp.toRulesyncMcp();
 
       expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/path");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/path");
       expect(rulesyncMcp.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
@@ -667,13 +667,13 @@ describe("RooMcp", () => {
 
     it("should have access to base directory methods", () => {
       const rooMcp = new RooMcp({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: ".roo",
         relativeFilePath: "mcp.json",
         fileContent: "{}",
       });
 
-      expect(rooMcp.getBaseDir()).toBe("/test/base");
+      expect(rooMcp.getOutputRoot()).toBe("/test/base");
       expect(rooMcp.getRelativeDirPath()).toBe(".roo");
       expect(rooMcp.getRelativeFilePath()).toBe("mcp.json");
     });

--- a/src/features/mcp/roo-mcp.ts
+++ b/src/features/mcp/roo-mcp.ts
@@ -85,18 +85,18 @@ export class RooMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolMcpFromFileParams): Promise<RooMcp> {
     const fileContent = await readFileContent(
       join(
-        baseDir,
+        outputRoot,
         this.getSettablePaths().relativeDirPath,
         this.getSettablePaths().relativeFilePath,
       ),
     );
     return new RooMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -105,7 +105,7 @@ export class RooMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): RooMcp {
@@ -114,7 +114,7 @@ export class RooMcp extends ToolMcp {
     const fileContent = JSON.stringify({ mcpServers: convertedMcpServers }, null, 2);
 
     return new RooMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
       fileContent,
@@ -134,12 +134,12 @@ export class RooMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolMcpForDeletionParams): RooMcp {
     return new RooMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/rovodev-mcp.test.ts
+++ b/src/features/mcp/rovodev-mcp.test.ts
@@ -50,7 +50,7 @@ describe("RovodevMcp", () => {
     it("should throw fromFile when global is false", async () => {
       await expect(
         RovodevMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: false,
         }),
@@ -59,7 +59,7 @@ describe("RovodevMcp", () => {
 
     it("should throw fromRulesyncMcp when global is false", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_MCP_FILE_NAME,
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -68,7 +68,7 @@ describe("RovodevMcp", () => {
 
       await expect(
         RovodevMcp.fromRulesyncMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncMcp,
           validate: true,
           global: false,
@@ -81,7 +81,7 @@ describe("RovodevMcp", () => {
     it("should throw for invalid JSON in fileContent", () => {
       expect(() => {
         new RovodevMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".rovodev",
           relativeFilePath: "mcp.json",
           fileContent: "{ not json",
@@ -94,7 +94,7 @@ describe("RovodevMcp", () => {
     it("should include path in parse error message", () => {
       expect(() => {
         new RovodevMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".rovodev",
           relativeFilePath: "mcp.json",
           fileContent: "{ not json",
@@ -112,7 +112,7 @@ describe("RovodevMcp", () => {
 
       await expect(
         RovodevMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         }),
@@ -120,7 +120,7 @@ describe("RovodevMcp", () => {
 
       await expect(
         RovodevMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: true,
           global: true,
         }),
@@ -134,7 +134,7 @@ describe("RovodevMcp", () => {
       await writeFileContent(join(testDir, ".rovodev", "mcp.json"), "{ not json");
 
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_MCP_FILE_NAME,
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -143,7 +143,7 @@ describe("RovodevMcp", () => {
 
       await expect(
         RovodevMcp.fromRulesyncMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncMcp,
           validate: true,
           global: true,
@@ -152,7 +152,7 @@ describe("RovodevMcp", () => {
 
       await expect(
         RovodevMcp.fromRulesyncMcp({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncMcp,
           validate: true,
           global: true,
@@ -164,7 +164,7 @@ describe("RovodevMcp", () => {
   describe("toRulesyncMcp", () => {
     it("should not propagate unknown top-level keys from Rovodev mcp.json", () => {
       const rovodev = new RovodevMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rovodev",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({
@@ -189,7 +189,7 @@ describe("RovodevMcp", () => {
   describe("round-trip conversion", () => {
     it("should round-trip RulesyncMcp through RovodevMcp and back", async () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_MCP_FILE_NAME,
         fileContent: JSON.stringify(validMcpConfig),
@@ -197,7 +197,7 @@ describe("RovodevMcp", () => {
       });
 
       const rovodev = await RovodevMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
         validate: true,
         global: true,
@@ -218,7 +218,7 @@ describe("RovodevMcp", () => {
       await writeFileContent(mcpPath, JSON.stringify(validMcpConfig, null, 2));
 
       const rovodev = await RovodevMcp.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
         global: true,
       });
@@ -235,7 +235,7 @@ describe("RovodevMcp", () => {
   describe("isDeletable", () => {
     it("should always return false (global-only MCP config is not treated as deletable project output)", () => {
       const globalInstance = new RovodevMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rovodev",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),
@@ -245,7 +245,7 @@ describe("RovodevMcp", () => {
       expect(globalInstance.isDeletable()).toBe(false);
 
       const nonGlobalInstance = new RovodevMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rovodev",
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({ mcpServers: {} }),

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -74,7 +74,7 @@ export class RovodevMcp extends ToolMcp {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<RovodevMcp> {
@@ -82,13 +82,13 @@ export class RovodevMcp extends ToolMcp {
       throw new Error("Rovodev MCP is global-only; use --global to sync ~/.rovodev/mcp.json");
     }
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"mcpServers":{}}';
     const json = parseRovodevMcpJson(fileContent, paths.relativeDirPath, paths.relativeFilePath);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new RovodevMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
@@ -98,7 +98,7 @@ export class RovodevMcp extends ToolMcp {
   }
 
   static async fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
     global = false,
@@ -109,7 +109,7 @@ export class RovodevMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(
-      join(baseDir, paths.relativeDirPath, paths.relativeFilePath),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = parseRovodevMcpJson(fileContent, paths.relativeDirPath, paths.relativeFilePath);
@@ -120,7 +120,7 @@ export class RovodevMcp extends ToolMcp {
     const rovodevConfig = { ...json, mcpServers };
 
     return new RovodevMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(rovodevConfig, null, 2),
@@ -143,13 +143,13 @@ export class RovodevMcp extends ToolMcp {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolMcpForDeletionParams): RovodevMcp {
     return new RovodevMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "{}",

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -53,13 +53,13 @@ describe("RulesyncMcp", () => {
       expect(rulesyncMcp.getFileContent()).toBe(validJsonContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: validJsonContent,
@@ -68,7 +68,7 @@ describe("RulesyncMcp", () => {
       expect(rulesyncMcp.getFilePath()).toBe(
         `/custom/path/${RULESYNC_RELATIVE_DIR_PATH}/.mcp.json`,
       );
-      expect(rulesyncMcp.getBaseDir()).toBe("/custom/path");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/custom/path");
     });
 
     it("should parse JSON content correctly", () => {
@@ -507,7 +507,7 @@ describe("RulesyncMcp", () => {
 
       expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
       expect(rulesyncMcp.getJson()).toEqual(jsonData);
-      expect(rulesyncMcp.getBaseDir()).toBe(testDir);
+      expect(rulesyncMcp.getOutputRoot()).toBe(testDir);
       expect(rulesyncMcp.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncMcp.getRelativeFilePath()).toBe(basename(RULESYNC_MCP_RELATIVE_FILE_PATH));
     });
@@ -715,7 +715,7 @@ describe("RulesyncMcp", () => {
 
     it("should have correct type definitions for parameters", () => {
       const constructorParams: RulesyncMcpParams = {
-        baseDir: "/custom",
+        outputRoot: "/custom",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: "{}",
@@ -726,7 +726,7 @@ describe("RulesyncMcp", () => {
         validate: false,
       };
 
-      expect(constructorParams.baseDir).toBe("/custom");
+      expect(constructorParams.outputRoot).toBe("/custom");
       expect(fromFileParams.validate).toBe(false);
     });
   });
@@ -755,20 +755,20 @@ describe("RulesyncMcp", () => {
       expect(typeof rulesyncMcp.getFileContent()).toBe("string");
       expect(typeof rulesyncMcp.getRelativeDirPath()).toBe("string");
       expect(typeof rulesyncMcp.getRelativeFilePath()).toBe("string");
-      expect(typeof rulesyncMcp.getBaseDir()).toBe("string");
+      expect(typeof rulesyncMcp.getOutputRoot()).toBe("string");
       expect(typeof rulesyncMcp.getRelativePathFromCwd()).toBe("string");
     });
 
     it("should call parent constructor correctly", () => {
       const jsonData = { mcpServers: { test: { command: "node" } } };
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/test/base",
+        outputRoot: "/test/base",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify(jsonData),
       });
 
-      expect(rulesyncMcp.getBaseDir()).toBe("/test/base");
+      expect(rulesyncMcp.getOutputRoot()).toBe("/test/base");
       expect(rulesyncMcp.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(rulesyncMcp.getRelativeFilePath()).toBe(".mcp.json");
       expect(rulesyncMcp.getFileContent()).toBe(JSON.stringify(jsonData));
@@ -917,9 +917,9 @@ describe("RulesyncMcp", () => {
       expect(rulesyncMcp.getJson()).toEqual(originalData);
     });
 
-    it("should preserve baseDir and paths in the new instance", () => {
+    it("should preserve outputRoot and paths in the new instance", () => {
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
         fileContent: JSON.stringify({
@@ -934,7 +934,7 @@ describe("RulesyncMcp", () => {
 
       const result = rulesyncMcp.stripMcpServerFields(["enabledTools"]);
 
-      expect(result.getBaseDir()).toBe("/custom/path");
+      expect(result.getOutputRoot()).toBe("/custom/path");
       expect(result.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(result.getRelativeFilePath()).toBe(".mcp.json");
     });

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -35,7 +35,7 @@ export const RulesyncMcpFileSchema = z.looseObject({
 
 export type RulesyncMcpParams = RulesyncFileParams;
 
-export type RulesyncMcpFromFileParams = Pick<RulesyncFileFromFileParams, "baseDir" | "validate">;
+export type RulesyncMcpFromFileParams = Pick<RulesyncFileFromFileParams, "outputRoot" | "validate">;
 
 export type RulesyncMcpSettablePaths = {
   recommended: {
@@ -86,23 +86,27 @@ export class RulesyncMcp extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     logger,
   }: RulesyncMcpFromFileParams & { logger?: Logger }): Promise<RulesyncMcp> {
     const paths = this.getSettablePaths();
     const recommendedPath = join(
-      baseDir,
+      outputRoot,
       paths.recommended.relativeDirPath,
       paths.recommended.relativeFilePath,
     );
-    const legacyPath = join(baseDir, paths.legacy.relativeDirPath, paths.legacy.relativeFilePath);
+    const legacyPath = join(
+      outputRoot,
+      paths.legacy.relativeDirPath,
+      paths.legacy.relativeFilePath,
+    );
 
     // Check if recommended path exists
     if (await fileExists(recommendedPath)) {
       const fileContent = await readFileContent(recommendedPath);
       return new RulesyncMcp({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.recommended.relativeDirPath,
         relativeFilePath: paths.recommended.relativeFilePath,
         fileContent,
@@ -117,7 +121,7 @@ export class RulesyncMcp extends RulesyncFile {
       );
       const fileContent = await readFileContent(legacyPath);
       return new RulesyncMcp({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.legacy.relativeDirPath,
         relativeFilePath: paths.legacy.relativeFilePath,
         fileContent,
@@ -128,7 +132,7 @@ export class RulesyncMcp extends RulesyncFile {
     // If neither exists, try to read recommended path (will throw appropriate error)
     const fileContent = await readFileContent(recommendedPath);
     return new RulesyncMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.recommended.relativeDirPath,
       relativeFilePath: paths.recommended.relativeFilePath,
       fileContent,
@@ -161,7 +165,7 @@ export class RulesyncMcp extends RulesyncFile {
     );
 
     return new RulesyncMcp({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: this.relativeDirPath,
       relativeFilePath: this.relativeFilePath,
       fileContent: JSON.stringify({ mcpServers: filteredServers }, null, 2),

--- a/src/features/mcp/tool-mcp.test.ts
+++ b/src/features/mcp/tool-mcp.test.ts
@@ -45,12 +45,12 @@ class TestToolMcp extends ToolMcp {
   }
 
   static fromRulesyncMcp({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): TestToolMcp {
     return new TestToolMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath: "test",
       relativeFilePath: "test.json",
       fileContent: rulesyncMcp.getFileContent(),
@@ -95,18 +95,18 @@ describe("ToolMcp", () => {
       expect(toolMcp.getRelativeDirPath()).toBe("test");
       expect(toolMcp.getRelativeFilePath()).toBe("test.json");
       expect(toolMcp.getFileContent()).toBe(validJsonContent);
-      // baseDir should default to process.cwd()
-      expect(toolMcp.getBaseDir()).toBe(testDir);
+      // outputRoot should default to process.cwd()
+      expect(toolMcp.getOutputRoot()).toBe(testDir);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validJsonContent = JSON.stringify({
         mcpServers: {},
       });
 
       const customPath = join(testDir, "custom", "path");
       const toolMcp = new TestToolMcp({
-        baseDir: customPath,
+        outputRoot: customPath,
         relativeDirPath: "test",
         relativeFilePath: "test.json",
         fileContent: validJsonContent,
@@ -364,13 +364,13 @@ describe("ToolMcp", () => {
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
-    it("should preserve baseDir when creating RulesyncMcp", () => {
+    it("should preserve outputRoot when creating RulesyncMcp", () => {
       const jsonData = {
         mcpServers: {},
       };
       const customDir = join(testDir, "custom", "base", "dir");
       const toolMcp = new TestToolMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         relativeDirPath: "test",
         relativeFilePath: "test.json",
         fileContent: JSON.stringify(jsonData),
@@ -378,7 +378,7 @@ describe("ToolMcp", () => {
 
       const rulesyncMcp = toolMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe(customDir);
+      expect(rulesyncMcp.getOutputRoot()).toBe(customDir);
       expect(rulesyncMcp.getFilePath()).toBe(
         join(customDir, RULESYNC_RELATIVE_DIR_PATH, "mcp.json"),
       );
@@ -432,7 +432,7 @@ describe("ToolMcp", () => {
         },
       };
       const toolMcp = new TestToolMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "custom",
         relativeFilePath: "custom.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -440,7 +440,7 @@ describe("ToolMcp", () => {
 
       const rulesyncMcp = toolMcp.toRulesyncMcp();
 
-      expect(rulesyncMcp.getBaseDir()).toBe(testDir);
+      expect(rulesyncMcp.getOutputRoot()).toBe(testDir);
       const expectedContent = {
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...complexJsonData,
@@ -453,7 +453,7 @@ describe("ToolMcp", () => {
     it("should throw error for abstract fromFile method", async () => {
       await expect(
         ToolMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow("Please implement this method in the subclass.");
     });
@@ -475,7 +475,7 @@ describe("ToolMcp", () => {
     it("should throw error for fromFile with custom parameters", async () => {
       await expect(
         ToolMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           validate: false,
         }),
       ).rejects.toThrow("Please implement this method in the subclass.");
@@ -485,7 +485,7 @@ describe("ToolMcp", () => {
       const customDir = join(testDir, "custom");
       const targetDir = join(testDir, "target");
       const rulesyncMcp = new RulesyncMcp({
-        baseDir: customDir,
+        outputRoot: customDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "mcp.json",
         fileContent: JSON.stringify({
@@ -500,7 +500,7 @@ describe("ToolMcp", () => {
 
       await expect(async () => {
         await ToolMcp.fromRulesyncMcp({
-          baseDir: targetDir,
+          outputRoot: targetDir,
           rulesyncMcp,
           validate: false,
         });
@@ -530,14 +530,14 @@ describe("ToolMcp", () => {
 
       expect(toolMcp).toBeInstanceOf(TestToolMcp);
       expect(toolMcp.getJson()).toEqual(jsonData);
-      // baseDir should default to process.cwd()
-      expect(toolMcp.getBaseDir()).toBe(testDir);
+      // outputRoot should default to process.cwd()
+      expect(toolMcp.getOutputRoot()).toBe(testDir);
     });
 
     it("should allow TestToolMcp.fromFile to throw expected error", async () => {
       await expect(
         TestToolMcp.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow("Please implement this method in the subclass.");
     });
@@ -591,7 +591,7 @@ describe("ToolMcp", () => {
 
       // Step 1: Create original ToolMcp
       const originalToolMcp = new TestToolMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "original",
         relativeFilePath: "original.json",
         fileContent: JSON.stringify(originalJsonData),
@@ -602,7 +602,7 @@ describe("ToolMcp", () => {
 
       // Step 3: Create new ToolMcp from RulesyncMcp
       const newToolMcp = TestToolMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -611,7 +611,7 @@ describe("ToolMcp", () => {
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...originalJsonData,
       });
-      expect(newToolMcp.getBaseDir()).toBe(testDir);
+      expect(newToolMcp.getOutputRoot()).toBe(testDir);
     });
 
     it("should maintain data consistency across transformations", () => {
@@ -653,7 +653,7 @@ describe("ToolMcp", () => {
 
       // Create TestToolMcp
       const toolMcp = new TestToolMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "integration",
         relativeFilePath: "integration.json",
         fileContent: JSON.stringify(complexJsonData),
@@ -662,7 +662,7 @@ describe("ToolMcp", () => {
       // Convert to RulesyncMcp and back
       const rulesyncMcp = toolMcp.toRulesyncMcp();
       const newToolMcp = TestToolMcp.fromRulesyncMcp({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncMcp,
       });
 
@@ -671,7 +671,7 @@ describe("ToolMcp", () => {
         $schema: RULESYNC_MCP_SCHEMA_URL,
         ...complexJsonData,
       });
-      expect(newToolMcp.getBaseDir()).toBe(testDir);
+      expect(newToolMcp.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle edge cases in data transformation", () => {

--- a/src/features/mcp/tool-mcp.ts
+++ b/src/features/mcp/tool-mcp.ts
@@ -16,10 +16,13 @@ export type ToolMcpFromRulesyncMcpParams = Omit<
   rulesyncMcp: RulesyncMcp;
 };
 
-export type ToolMcpFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate" | "global">;
+export type ToolMcpFromFileParams = Pick<
+  AiFileFromFileParams,
+  "outputRoot" | "validate" | "global"
+>;
 
 export type ToolMcpForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;
@@ -68,7 +71,7 @@ export abstract class ToolMcp extends ToolFile {
       ...json,
     };
     return new RulesyncMcp({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_MCP_FILE_NAME,
       fileContent: JSON.stringify(withSchema, null, 2),

--- a/src/features/permissions/claudecode-permissions.test.ts
+++ b/src/features/permissions/claudecode-permissions.test.ts
@@ -122,7 +122,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -146,7 +146,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -170,7 +170,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -192,7 +192,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -224,7 +224,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -259,7 +259,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -295,7 +295,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -332,7 +332,7 @@ describe("ClaudecodePermissions", () => {
 
       const mockLogger = createMockLogger();
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
         logger: mockLogger,
       });
@@ -372,7 +372,7 @@ describe("ClaudecodePermissions", () => {
 
       const mockLogger = createMockLogger();
       await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
         logger: mockLogger,
       });
@@ -405,7 +405,7 @@ describe("ClaudecodePermissions", () => {
 
       // Should not throw even without logger
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -423,7 +423,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -445,7 +445,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -478,7 +478,7 @@ describe("ClaudecodePermissions", () => {
       });
 
       const instance = await ClaudecodePermissions.fromRulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncPermissions,
       });
 
@@ -613,7 +613,7 @@ describe("ClaudecodePermissions", () => {
   describe("forDeletion", () => {
     it("should create minimal instance for deletion", () => {
       const instance = ClaudecodePermissions.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
       });

--- a/src/features/permissions/claudecode-permissions.ts
+++ b/src/features/permissions/claudecode-permissions.ts
@@ -97,14 +97,14 @@ export class ClaudecodePermissions extends ToolPermissions {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolPermissionsFromFileParams): Promise<ClaudecodePermissions> {
     const paths = ClaudecodePermissions.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"permissions":{}}';
     return new ClaudecodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -113,12 +113,12 @@ export class ClaudecodePermissions extends ToolPermissions {
   }
 
   static async fromRulesyncPermissions({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncPermissions,
     logger,
   }: ToolPermissionsFromRulesyncPermissionsParams): Promise<ClaudecodePermissions> {
     const paths = ClaudecodePermissions.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = await readOrInitializeFileContent(
       filePath,
       JSON.stringify({}, null, 2),
@@ -194,7 +194,7 @@ export class ClaudecodePermissions extends ToolPermissions {
     const fileContent = JSON.stringify(merged, null, 2);
 
     return new ClaudecodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -230,12 +230,12 @@ export class ClaudecodePermissions extends ToolPermissions {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolPermissionsForDeletionParams): ClaudecodePermissions {
     return new ClaudecodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ permissions: {} }, null, 2),

--- a/src/features/permissions/codexcli-permissions.test.ts
+++ b/src/features/permissions/codexcli-permissions.test.ts
@@ -25,7 +25,7 @@ describe("CodexcliPermissions", () => {
   it("should convert rulesync permissions to Codex CLI config.toml profile", async () => {
     const logger = createMockLogger();
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -38,7 +38,7 @@ describe("CodexcliPermissions", () => {
     });
 
     const codexPermissions = await CodexcliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
       logger,
     });
@@ -56,7 +56,7 @@ describe("CodexcliPermissions", () => {
 
   it("should convert Codex CLI permissions profile to rulesync format", () => {
     const codexPermissions = new CodexcliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".codex",
       relativeFilePath: "config.toml",
       fileContent: `
@@ -88,14 +88,14 @@ default_permissions = "rulesync"
     await ensureDir(codexDir);
     await writeFileContent(join(codexDir, "config.toml"), 'default_permissions = "rulesync"');
 
-    const loaded = await CodexcliPermissions.fromFile({ baseDir: testDir });
+    const loaded = await CodexcliPermissions.fromFile({ outputRoot: testDir });
     expect(loaded).toBeInstanceOf(CodexcliPermissions);
     expect(loaded.getFileContent()).toContain('default_permissions = "rulesync"');
   });
 
   it("should convert rulesync bash permissions to Codex CLI .rules file", () => {
     const rulesFile = createCodexcliBashRulesFile({
-      baseDir: testDir,
+      outputRoot: testDir,
       config: {
         permission: {
           bash: {

--- a/src/features/permissions/codexcli-permissions.ts
+++ b/src/features/permissions/codexcli-permissions.ts
@@ -40,16 +40,16 @@ export class CodexcliPermissions extends ToolPermissions {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolPermissionsFromFileParams): Promise<CodexcliPermissions> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? smolToml.stringify({});
 
     return new CodexcliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -58,14 +58,14 @@ export class CodexcliPermissions extends ToolPermissions {
   }
 
   static async fromRulesyncPermissions({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncPermissions,
     validate = true,
     logger,
     global = false,
   }: ToolPermissionsFromRulesyncPermissionsParams): Promise<CodexcliPermissions> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = (await readFileContentOrNull(filePath)) ?? smolToml.stringify({});
     const parsed = toMutableTable(smolToml.parse(existingContent));
 
@@ -80,7 +80,7 @@ export class CodexcliPermissions extends ToolPermissions {
     parsed.default_permissions = RULESYNC_PROFILE_NAME;
 
     return new CodexcliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: smolToml.stringify(parsed),
@@ -120,12 +120,12 @@ export class CodexcliPermissions extends ToolPermissions {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolPermissionsForDeletionParams): CodexcliPermissions {
     return new CodexcliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: smolToml.stringify({}),
@@ -141,14 +141,14 @@ export class CodexcliRulesFile extends ToolFile {
 }
 
 export function createCodexcliBashRulesFile({
-  baseDir = process.cwd(),
+  outputRoot = process.cwd(),
   config,
 }: {
-  baseDir?: string;
+  outputRoot?: string;
   config: PermissionsConfig;
 }): CodexcliRulesFile {
   return new CodexcliRulesFile({
-    baseDir,
+    outputRoot,
     relativeDirPath: join(".codex", "rules"),
     relativeFilePath: RULESYNC_BASH_RULES_FILE_NAME,
     fileContent: buildCodexBashRulesContent(config),

--- a/src/features/permissions/geminicli-permissions.test.ts
+++ b/src/features/permissions/geminicli-permissions.test.ts
@@ -37,7 +37,7 @@ describe("GeminicliPermissions", () => {
 
   it("should emit a Gemini CLI policy TOML at .gemini/policies/rulesync.toml", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -49,7 +49,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -82,7 +82,7 @@ describe("GeminicliPermissions", () => {
 
   it("should assign higher priority to deny rules than ask or allow rules", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -93,7 +93,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -116,7 +116,7 @@ describe("GeminicliPermissions", () => {
 
   it("should emit argsPattern for bash patterns with interior glob metacharacters", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -127,7 +127,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -139,7 +139,7 @@ describe("GeminicliPermissions", () => {
 
   it("should convert Gemini CLI policy TOML back to rulesync format", () => {
     const geminiPermissions = new GeminicliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
       fileContent: [
@@ -174,7 +174,7 @@ describe("GeminicliPermissions", () => {
 
   it("should accept legacy unanchored argsPattern encoding for backward compatibility", () => {
     const geminiPermissions = new GeminicliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
       fileContent: [
@@ -199,20 +199,20 @@ describe("GeminicliPermissions", () => {
       '[[rule]]\ntoolName = "run_shell_command"\ndecision = "allow"\ncommandPrefix = "git"\npriority = 100\n',
     );
 
-    const loaded = await GeminicliPermissions.fromFile({ baseDir: testDir });
+    const loaded = await GeminicliPermissions.fromFile({ outputRoot: testDir });
     expect(loaded).toBeInstanceOf(GeminicliPermissions);
     expect(loaded.getFileContent()).toContain('commandPrefix = "git"');
   });
 
   it("should return empty permissions when TOML file is missing", async () => {
-    const loaded = await GeminicliPermissions.fromFile({ baseDir: testDir });
+    const loaded = await GeminicliPermissions.fromFile({ outputRoot: testDir });
     const json = loaded.toRulesyncPermissions().getJson();
     expect(json.permission).toEqual({});
   });
 
   it("should throw a descriptive error on malformed TOML", () => {
     const geminiPermissions = new GeminicliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
       fileContent: "[[rule]]\ninvalid !!! :: broken",
@@ -225,7 +225,7 @@ describe("GeminicliPermissions", () => {
 
   it("should translate ? as a single-char wildcard that respects path segments", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -234,7 +234,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -246,7 +246,7 @@ describe("GeminicliPermissions", () => {
 
   it("should round-trip ** patterns back to rulesync", async () => {
     const source = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -254,11 +254,11 @@ describe("GeminicliPermissions", () => {
       }),
     });
     const emitted = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions: source,
     });
     const reloaded = new GeminicliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
       fileContent: emitted.getFileContent(),
@@ -270,7 +270,7 @@ describe("GeminicliPermissions", () => {
 
   it("should skip patterns containing a quote to avoid regex-anchor hijack", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -279,7 +279,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -290,7 +290,7 @@ describe("GeminicliPermissions", () => {
 
   it("should not allow a malicious pattern to inject a second [[rule]] block", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -303,7 +303,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -315,7 +315,7 @@ describe("GeminicliPermissions", () => {
 
   it("should not pollute Object.prototype when importing a rule with toolName __proto__", () => {
     const geminiPermissions = new GeminicliPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
       fileContent: [
@@ -346,7 +346,7 @@ describe("GeminicliPermissions", () => {
 
   it("should treat glob character classes as regex literals to prevent JSON-boundary bypass", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -360,7 +360,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -376,7 +376,7 @@ describe("GeminicliPermissions", () => {
 
   it("should skip bash match-all patterns with allow or deny decisions", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -392,7 +392,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -403,7 +403,7 @@ describe("GeminicliPermissions", () => {
 
   it("should still allow bash catch-all with ask decision", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -412,7 +412,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -425,7 +425,7 @@ describe("GeminicliPermissions", () => {
 
   it("should skip empty pattern for non-bash tools", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -434,7 +434,7 @@ describe("GeminicliPermissions", () => {
     });
 
     const geminiPermissions = await GeminicliPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -445,7 +445,7 @@ describe("GeminicliPermissions", () => {
 
   it("should be deletable because rulesync.toml is exclusively owned by rulesync", async () => {
     const geminiPermissions = GeminicliPermissions.forDeletion({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".gemini", "policies"),
       relativeFilePath: "rulesync.toml",
     });

--- a/src/features/permissions/geminicli-permissions.ts
+++ b/src/features/permissions/geminicli-permissions.ts
@@ -74,15 +74,15 @@ export class GeminicliPermissions extends ToolPermissions {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolPermissionsFromFileParams): Promise<GeminicliPermissions> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? "";
     return new GeminicliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -91,7 +91,7 @@ export class GeminicliPermissions extends ToolPermissions {
   }
 
   static fromRulesyncPermissions({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncPermissions,
     validate = true,
     global = false,
@@ -101,7 +101,7 @@ export class GeminicliPermissions extends ToolPermissions {
     const fileContent = buildGeminicliPolicyContent(rulesyncPermissions.getJson(), logger);
 
     return new GeminicliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -183,12 +183,12 @@ export class GeminicliPermissions extends ToolPermissions {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolPermissionsForDeletionParams): GeminicliPermissions {
     return new GeminicliPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/permissions/kiro-permissions.test.ts
+++ b/src/features/permissions/kiro-permissions.test.ts
@@ -23,7 +23,7 @@ describe("KiroPermissions", () => {
 
   it("should convert rulesync permissions to Kiro default agent permissions", async () => {
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -37,7 +37,7 @@ describe("KiroPermissions", () => {
     });
 
     const kiroPermissions = await KiroPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 
@@ -52,7 +52,7 @@ describe("KiroPermissions", () => {
 
   it("should convert Kiro default agent permissions to rulesync format", () => {
     const kiroPermissions = new KiroPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: join(".kiro", "agents"),
       relativeFilePath: "default.json",
       fileContent: JSON.stringify({
@@ -91,7 +91,7 @@ describe("KiroPermissions", () => {
     await ensureDir(kiroDir);
     await writeFileContent(join(kiroDir, "default.json"), JSON.stringify({ model: "x" }));
 
-    const loaded = await KiroPermissions.fromFile({ baseDir: testDir });
+    const loaded = await KiroPermissions.fromFile({ outputRoot: testDir });
     expect(loaded).toBeInstanceOf(KiroPermissions);
     expect(JSON.parse(loaded.getFileContent()).model).toBe("x");
   });
@@ -107,7 +107,7 @@ describe("KiroPermissions", () => {
     );
 
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".rulesync",
       relativeFilePath: "permissions.json",
       fileContent: JSON.stringify({
@@ -119,7 +119,7 @@ describe("KiroPermissions", () => {
     });
 
     const kiroPermissions = await KiroPermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
 

--- a/src/features/permissions/kiro-permissions.ts
+++ b/src/features/permissions/kiro-permissions.ts
@@ -36,14 +36,14 @@ export class KiroPermissions extends ToolPermissions {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: ToolPermissionsFromFileParams): Promise<KiroPermissions> {
     const paths = this.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
     return new KiroPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,
@@ -52,13 +52,13 @@ export class KiroPermissions extends ToolPermissions {
   }
 
   static async fromRulesyncPermissions({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncPermissions,
     validate = true,
     logger,
   }: ToolPermissionsFromRulesyncPermissionsParams): Promise<KiroPermissions> {
     const paths = this.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
 
     const parsedResult = KiroAgentSchema.safeParse(JSON.parse(existingContent));
@@ -72,7 +72,7 @@ export class KiroPermissions extends ToolPermissions {
     const next = buildKiroPermissionsFromRulesync({ config, logger, existing: parsedResult.data });
 
     return new KiroPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent: JSON.stringify(next, null, 2),
@@ -139,12 +139,12 @@ export class KiroPermissions extends ToolPermissions {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolPermissionsForDeletionParams): KiroPermissions {
     return new KiroPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({}, null, 2),

--- a/src/features/permissions/opencode-permissions.test.ts
+++ b/src/features/permissions/opencode-permissions.test.ts
@@ -39,7 +39,7 @@ describe("OpencodePermissions", () => {
   it("should load opencode.jsonc and initialize permission", async () => {
     await writeFileContent(join(testDir, "opencode.jsonc"), JSON.stringify({ model: "x" }));
 
-    const instance = await OpencodePermissions.fromFile({ baseDir: testDir });
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir });
     const json = instance.getJson();
 
     expect(instance.getRelativeFilePath()).toBe("opencode.jsonc");
@@ -49,7 +49,7 @@ describe("OpencodePermissions", () => {
   it("should merge rulesync permission into existing opencode config", async () => {
     await writeFileContent(join(testDir, "opencode.json"), JSON.stringify({ model: "x" }));
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
       fileContent: JSON.stringify({
@@ -60,7 +60,7 @@ describe("OpencodePermissions", () => {
     });
 
     const instance = await OpencodePermissions.fromRulesyncPermissions({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncPermissions,
     });
     const json = JSON.parse(instance.getFileContent());
@@ -77,7 +77,7 @@ describe("OpencodePermissions", () => {
       JSON.stringify({ permission: { bash: "ask" } }),
     );
 
-    const instance = await OpencodePermissions.fromFile({ baseDir: testDir, global: true });
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir, global: true });
     const rulesync = instance.toRulesyncPermissions().getJson();
 
     expect(rulesync.permission.bash).toEqual({ "*": "ask" });

--- a/src/features/permissions/opencode-permissions.ts
+++ b/src/features/permissions/opencode-permissions.ts
@@ -53,12 +53,12 @@ export class OpencodePermissions extends ToolPermissions {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolPermissionsFromFileParams): Promise<OpencodePermissions> {
     const basePaths = OpencodePermissions.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     const jsoncPath = join(jsonDir, "opencode.jsonc");
     const jsonPath = join(jsonDir, "opencode.json");
@@ -77,7 +77,7 @@ export class OpencodePermissions extends ToolPermissions {
     const nextJson = { ...parsed, permission: parsed.permission ?? {} };
 
     return new OpencodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(nextJson, null, 2),
@@ -86,12 +86,12 @@ export class OpencodePermissions extends ToolPermissions {
   }
 
   static async fromRulesyncPermissions({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncPermissions,
     global = false,
   }: ToolPermissionsFromRulesyncPermissionsParams): Promise<OpencodePermissions> {
     const basePaths = OpencodePermissions.getSettablePaths({ global });
-    const jsonDir = join(baseDir, basePaths.relativeDirPath);
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
 
     const jsoncPath = join(jsonDir, "opencode.jsonc");
     const jsonPath = join(jsonDir, "opencode.json");
@@ -113,7 +113,7 @@ export class OpencodePermissions extends ToolPermissions {
     };
 
     return new OpencodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(nextJson, null, 2),
@@ -145,12 +145,12 @@ export class OpencodePermissions extends ToolPermissions {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolPermissionsForDeletionParams): OpencodePermissions {
     return new OpencodePermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify({ permission: {} }, null, 2),

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -34,16 +34,16 @@ describe("PermissionsProcessor", () => {
   });
 
   describe("constructor", () => {
-    it("should create instance with default baseDir", () => {
+    it("should create instance with default outputRoot", () => {
       const processor = new PermissionsProcessor({ logger, toolTarget: "claudecode" });
 
       expect(processor).toBeInstanceOf(PermissionsProcessor);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -54,7 +54,7 @@ describe("PermissionsProcessor", () => {
       expect(() => {
         const _instance = new PermissionsProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid-target" as any,
         });
       }).toThrow();
@@ -64,7 +64,7 @@ describe("PermissionsProcessor", () => {
       expect(() => {
         const _instance = new PermissionsProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
         });
       }).not.toThrow();
@@ -103,7 +103,7 @@ describe("PermissionsProcessor", () => {
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -116,7 +116,7 @@ describe("PermissionsProcessor", () => {
     it("should return empty array when permissions file does not exist", async () => {
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -141,7 +141,7 @@ describe("PermissionsProcessor", () => {
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -154,7 +154,7 @@ describe("PermissionsProcessor", () => {
     it("should return non-deletable files for forDeletion", async () => {
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -176,7 +176,7 @@ describe("PermissionsProcessor", () => {
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "opencode",
       });
 
@@ -201,7 +201,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
       });
 
@@ -221,7 +221,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "geminicli",
       });
 
@@ -247,7 +247,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "kiro",
       });
 
@@ -261,7 +261,7 @@ default_permissions = "rulesync"
   describe("convertRulesyncFilesToToolFiles", () => {
     it("should convert rulesync permissions to Claude Code tool files", async () => {
       const rulesyncPermissions = new RulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
         fileContent: JSON.stringify({
@@ -274,7 +274,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -292,7 +292,7 @@ default_permissions = "rulesync"
     it("should throw when no rulesync permissions file is provided", async () => {
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -303,7 +303,7 @@ default_permissions = "rulesync"
 
     it("should generate .codex/config.toml and .codex/rules/rulesync.rules for Codex CLI", async () => {
       const rulesyncPermissions = new RulesyncPermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
         fileContent: JSON.stringify({
@@ -316,7 +316,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
       });
 
@@ -336,7 +336,7 @@ default_permissions = "rulesync"
   describe("convertToolFilesToRulesyncFiles", () => {
     it("should convert Claude Code permissions to rulesync format", async () => {
       const claudePermissions = new ClaudecodePermissions({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude",
         relativeFilePath: "settings.json",
         fileContent: JSON.stringify({
@@ -349,7 +349,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -382,7 +382,7 @@ default_permissions = "rulesync"
 
       const processor = new PermissionsProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -112,21 +112,21 @@ export class PermissionsProcessor extends FeatureProcessor {
   private readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = PermissionsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -141,7 +141,7 @@ export class PermissionsProcessor extends FeatureProcessor {
     try {
       return [
         await RulesyncPermissions.fromFile({
-          baseDir: this.inputRoot,
+          outputRoot: this.inputRoot,
           validate: true,
         }),
       ];
@@ -165,7 +165,7 @@ export class PermissionsProcessor extends FeatureProcessor {
 
       if (forDeletion) {
         const toolPermissions = factory.class.forDeletion({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.relativeDirPath,
           relativeFilePath: paths.relativeFilePath,
           global: this.global,
@@ -175,7 +175,7 @@ export class PermissionsProcessor extends FeatureProcessor {
       }
 
       const toolPermissions = await factory.class.fromFile({
-        baseDir: this.baseDir,
+        outputRoot: this.outputRoot,
         validate: true,
         global: this.global,
       });
@@ -203,7 +203,7 @@ export class PermissionsProcessor extends FeatureProcessor {
     if (!factory) throw new Error(`Unsupported tool target: ${this.toolTarget}`);
 
     const toolPermissions = await factory.class.fromRulesyncPermissions({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       rulesyncPermissions,
       logger: this.logger,
       global: this.global,
@@ -213,7 +213,7 @@ export class PermissionsProcessor extends FeatureProcessor {
     }
 
     const bashRulesFile = createCodexcliBashRulesFile({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       config: rulesyncPermissions.getJson(),
     });
     return [toolPermissions, bashRulesFile];

--- a/src/features/permissions/rulesync-permissions.test.ts
+++ b/src/features/permissions/rulesync-permissions.test.ts
@@ -50,19 +50,19 @@ describe("RulesyncPermissions", () => {
       expect(instance.getFileContent()).toBe(validContent);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const validContent = JSON.stringify({
         permission: {},
       });
 
       const instance = new RulesyncPermissions({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
         fileContent: validContent,
       });
 
-      expect(instance.getBaseDir()).toBe("/custom/path");
+      expect(instance.getOutputRoot()).toBe("/custom/path");
       expect(instance.getFilePath()).toBe(
         `/custom/path/${RULESYNC_RELATIVE_DIR_PATH}/${RULESYNC_PERMISSIONS_FILE_NAME}`,
       );
@@ -326,7 +326,7 @@ describe("RulesyncPermissions", () => {
 
       expect(instance).toBeInstanceOf(RulesyncPermissions);
       expect(instance.getJson()).toEqual(jsonData);
-      expect(instance.getBaseDir()).toBe(testDir);
+      expect(instance.getOutputRoot()).toBe(testDir);
       expect(instance.getRelativeDirPath()).toBe(RULESYNC_RELATIVE_DIR_PATH);
       expect(instance.getRelativeFilePath()).toBe(RULESYNC_PERMISSIONS_FILE_NAME);
     });

--- a/src/features/permissions/rulesync-permissions.ts
+++ b/src/features/permissions/rulesync-permissions.ts
@@ -15,7 +15,7 @@ export type RulesyncPermissionsParams = RulesyncFileParams;
 
 export type RulesyncPermissionsFromFileParams = Pick<
   RulesyncFileFromFileParams,
-  "baseDir" | "validate"
+  "outputRoot" | "validate"
 >;
 
 export type RulesyncPermissionsSettablePaths = {
@@ -54,11 +54,11 @@ export class RulesyncPermissions extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     validate = true,
   }: RulesyncPermissionsFromFileParams): Promise<RulesyncPermissions> {
     const paths = RulesyncPermissions.getSettablePaths();
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
 
     if (!(await fileExists(filePath))) {
       throw new Error(`No ${RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH} found.`);
@@ -66,7 +66,7 @@ export class RulesyncPermissions extends RulesyncFile {
 
     const fileContent = await readFileContent(filePath);
     return new RulesyncPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
       fileContent,

--- a/src/features/permissions/tool-permissions.ts
+++ b/src/features/permissions/tool-permissions.ts
@@ -23,12 +23,15 @@ export type ToolPermissionsSettablePaths = {
   relativeFilePath: string;
 };
 
-export type ToolPermissionsFromFileParams = Pick<AiFileFromFileParams, "baseDir" | "validate"> & {
+export type ToolPermissionsFromFileParams = Pick<
+  AiFileFromFileParams,
+  "outputRoot" | "validate"
+> & {
   global?: boolean;
 };
 
 export type ToolPermissionsForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;
@@ -57,7 +60,7 @@ export abstract class ToolPermissions extends ToolFile {
     fileContent: string;
   }): RulesyncPermissions {
     return new RulesyncPermissions({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
       fileContent,

--- a/src/features/rules/agentsmd-rule.test.ts
+++ b/src/features/rules/agentsmd-rule.test.ts
@@ -25,7 +25,7 @@ describe("AgentsMdRule", () => {
   describe("constructor", () => {
     it("should create an AgentsMdRule with valid parameters", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Agent\n\nThis is a test agent configuration.",
@@ -36,7 +36,7 @@ describe("AgentsMdRule", () => {
 
     it("should create an AgentsMdRule with root flag", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root Agent\n\nThis is a root agent configuration.",
@@ -48,7 +48,7 @@ describe("AgentsMdRule", () => {
 
     it("should default root to false when not specified", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Agent\n\nContent",
@@ -64,7 +64,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -79,7 +79,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -91,7 +91,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: false,
       });
@@ -105,7 +105,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), rootContent);
 
       const rootRule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -118,7 +118,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), memoryContent);
 
       const memoryRule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -129,7 +129,7 @@ describe("AgentsMdRule", () => {
   describe("fromRulesyncRule", () => {
     it("should create AgentsMdRule from RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -137,7 +137,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -146,7 +146,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle validation parameter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -154,7 +154,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: false,
       });
@@ -164,7 +164,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle subprojectPath from agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -178,7 +178,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -189,7 +189,7 @@ describe("AgentsMdRule", () => {
 
     it("should ignore subprojectPath for root rules", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -203,7 +203,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -215,7 +215,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle empty subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -229,7 +229,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -240,7 +240,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle complex nested subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "nested.md",
         frontmatter: {
@@ -254,7 +254,7 @@ describe("AgentsMdRule", () => {
       });
 
       const rule = AgentsMdRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -267,7 +267,7 @@ describe("AgentsMdRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert AgentsMdRule to RulesyncRule", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Agent\n\nAgent configuration.",
@@ -286,7 +286,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle root agent file conversion", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root Agent\n\nRoot configuration.",
@@ -308,7 +308,7 @@ describe("AgentsMdRule", () => {
   describe("validate", () => {
     it("should always return success for any content", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Agent\n\nValid content.",
@@ -322,7 +322,7 @@ describe("AgentsMdRule", () => {
 
     it("should return success for empty content", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "",
@@ -336,7 +336,7 @@ describe("AgentsMdRule", () => {
 
     it("should return success for malformed markdown", () => {
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Unclosed heading\nSome text without proper structure\n### Random heading",
@@ -351,7 +351,7 @@ describe("AgentsMdRule", () => {
     it("should return success for very long content", () => {
       const longContent = "# Long Agent\n\n" + "A".repeat(10000);
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         fileContent: longContent,
@@ -373,7 +373,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(memoriesDir, "special-char.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "special-char.md",
       });
 
@@ -388,7 +388,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(nestedDir, "nested.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested.md",
       });
 
@@ -424,7 +424,7 @@ describe("AgentsMdRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting agentsmd", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -438,7 +438,7 @@ describe("AgentsMdRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -452,7 +452,7 @@ describe("AgentsMdRule", () => {
 
     it("should return false for rules not targeting agentsmd", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -466,7 +466,7 @@ describe("AgentsMdRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -480,7 +480,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle mixed targets including agentsmd", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -494,7 +494,7 @@ describe("AgentsMdRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -513,7 +513,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(memoriesDir, "empty.md"), "");
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "empty.md",
       });
 
@@ -529,7 +529,7 @@ describe("AgentsMdRule", () => {
       await writeFileContent(join(memoriesDir, "whitespace.md"), content);
 
       const rule = await AgentsMdRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "whitespace.md",
       });
 
@@ -540,7 +540,7 @@ describe("AgentsMdRule", () => {
     it("should handle very large file content", () => {
       const largeContent = "# Large Agent\n\n" + "Content ".repeat(100000);
       const rule = new AgentsMdRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "large.md",
         fileContent: largeContent,

--- a/src/features/rules/agentsmd-rule.ts
+++ b/src/features/rules/agentsmd-rule.ts
@@ -53,17 +53,17 @@ export class AgentsMdRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AgentsMdRule> {
     // Determine if it's a root file based on path
     const isRoot = relativeFilePath === "AGENTS.md";
     const relativePath = isRoot ? "AGENTS.md" : join(".agents", "memories", relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new AgentsMdRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: isRoot
         ? this.getSettablePaths().root.relativeDirPath
         : this.getSettablePaths().nonRoot.relativeDirPath,
@@ -75,14 +75,14 @@ export class AgentsMdRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): AgentsMdRule {
     const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".";
 
     return new AgentsMdRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",
@@ -92,13 +92,13 @@ export class AgentsMdRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AgentsMdRule {
     return new AgentsMdRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,

--- a/src/features/rules/antigravity-rule.test.ts
+++ b/src/features/rules/antigravity-rule.test.ts
@@ -46,10 +46,10 @@ trigger: always_on
 This is a test rule.`);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const antigravityRule = new AntigravityRule({
         frontmatter: { trigger: "always_on" },
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".agent/rules",
         relativeFilePath: "test-rule.md",
         body: "# Custom Rule",
@@ -107,7 +107,7 @@ trigger: always_on
       await writeFileContent(join(rulesDir, "test.md"), testContent);
 
       const antigravityRule = await AntigravityRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -117,11 +117,11 @@ trigger: always_on
       expect(antigravityRule.getFilePath()).toBe(join(testDir, ".agent/rules/test.md"));
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file using testDir
       const rulesDir = join(testDir, ".agent/rules");
       await ensureDir(rulesDir);
-      const testContent = "---\ntrigger: always_on\n---\n\n# Default BaseDir Test";
+      const testContent = "---\ntrigger: always_on\n---\n\n# Default OutputRoot Test";
       const testFilePath = join(rulesDir, "default-test.md");
       await writeFileContent(testFilePath, testContent);
 
@@ -143,13 +143,13 @@ trigger: always_on
       await writeFileContent(join(rulesDir, "validation-test.md"), testContent);
 
       const antigravityRuleWithValidation = await AntigravityRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: true,
       });
 
       const antigravityRuleWithoutValidation = await AntigravityRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -161,7 +161,7 @@ trigger: always_on
     it("should throw error when file does not exist", async () => {
       await expect(
         AntigravityRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -194,7 +194,7 @@ trigger: always_on
       );
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -208,7 +208,7 @@ trigger: always_on
       });
 
       const antigravityRule = AntigravityRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -280,7 +280,7 @@ trigger: always_on
       });
 
       const antigravityRule = AntigravityRule.fromRulesyncRule({
-        baseDir: "/project",
+        outputRoot: "/project",
         rulesyncRule,
       });
 
@@ -568,7 +568,7 @@ globs: '*.ts'
       await writeFileContent(join(rulesDir, "frontmatter.md"), content);
 
       const antigravityRule = await AntigravityRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "frontmatter.md",
       });
 
@@ -610,7 +610,7 @@ globs: '*.ts'
       for (const testCase of testCases) {
         await writeFileContent(join(rulesDir, testCase.file), testCase.content);
         const rule = await AntigravityRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: testCase.file,
         });
         expect(rule.getFrontmatter()).toMatchObject(testCase.expectedFrontmatter);
@@ -624,7 +624,7 @@ globs: '*.ts'
       await writeFileContent(join(rulesDir, "no-frontmatter.md"), content);
 
       const antigravityRule = await AntigravityRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-frontmatter.md",
         validate: false, // Skip validation as it might fail without frontmatter
       });

--- a/src/features/rules/antigravity-rule.ts
+++ b/src/features/rules/antigravity-rule.ts
@@ -332,12 +332,12 @@ export class AntigravityRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AntigravityRule> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath,
     );
@@ -358,7 +358,7 @@ export class AntigravityRule extends ToolRule {
     }
 
     return new AntigravityRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       body,
@@ -377,7 +377,7 @@ export class AntigravityRule extends ToolRule {
    * - Otherwise, infers "always_on" trigger
    */
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AntigravityRule {
@@ -403,7 +403,7 @@ export class AntigravityRule extends ToolRule {
     const kebabCaseFilename = toKebabCaseFilename(rulesyncRule.getRelativeFilePath());
 
     return new AntigravityRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: kebabCaseFilename,
       frontmatter,
@@ -453,7 +453,7 @@ export class AntigravityRule extends ToolRule {
     };
 
     return new RulesyncRule({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RulesyncRule.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath: this.getRelativeFilePath(),
       frontmatter: {
@@ -488,12 +488,12 @@ export class AntigravityRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): AntigravityRule {
     return new AntigravityRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},

--- a/src/features/rules/augmentcode-legacy-rule.test.ts
+++ b/src/features/rules/augmentcode-legacy-rule.test.ts
@@ -38,9 +38,9 @@ describe("AugmentcodeLegacyRule", () => {
       );
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const augmentcodeLegacyRule = new AugmentcodeLegacyRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".augment/rules",
         relativeFilePath: "custom-rule.md",
         fileContent: "# Custom Legacy Rule",
@@ -104,7 +104,7 @@ describe("AugmentcodeLegacyRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert non-root AugmentcodeLegacyRule to RulesyncRule", () => {
       const augmentcodeLegacyRule = new AugmentcodeLegacyRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Legacy Rule\n\nThis is a test legacy rule.",
@@ -114,7 +114,7 @@ describe("AugmentcodeLegacyRule", () => {
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(".");
+      expect(rulesyncRule.getOutputRoot()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(rulesyncRule.getBody()).toBe("# Test Legacy Rule\n\nThis is a test legacy rule.");
@@ -128,7 +128,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should convert root AugmentcodeLegacyRule to RulesyncRule", () => {
       const augmentcodeLegacyRule = new AugmentcodeLegacyRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".augment-guidelines",
         fileContent: "# Root Guidelines\n\nThese are root guidelines.",
@@ -138,7 +138,7 @@ describe("AugmentcodeLegacyRule", () => {
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(".");
+      expect(rulesyncRule.getOutputRoot()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe(".augment-guidelines");
       expect(rulesyncRule.getBody()).toBe("# Root Guidelines\n\nThese are root guidelines.");
@@ -152,7 +152,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should convert AugmentcodeLegacyRule to RulesyncRule preserving metadata", () => {
       const augmentcodeLegacyRule = new AugmentcodeLegacyRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".augment/rules",
         relativeFilePath: "complex-rule.md",
         fileContent: "# Complex Legacy Rule\n\nThis is a more complex legacy rule with content.",
@@ -161,7 +161,7 @@ describe("AugmentcodeLegacyRule", () => {
 
       const rulesyncRule = augmentcodeLegacyRule.toRulesyncRule();
 
-      expect(rulesyncRule.getBaseDir()).toBe(".");
+      expect(rulesyncRule.getOutputRoot()).toBe(".");
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe("complex-rule.md");
       expect(rulesyncRule.getBody()).toBe(
@@ -196,9 +196,9 @@ describe("AugmentcodeLegacyRule", () => {
       );
     });
 
-    it("should create AugmentcodeLegacyRule from RulesyncRule with custom baseDir", () => {
+    it("should create AugmentcodeLegacyRule from RulesyncRule with custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: "/source/path",
+        outputRoot: "/source/path",
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "source-rule.md",
         frontmatter: {
@@ -211,7 +211,7 @@ describe("AugmentcodeLegacyRule", () => {
       });
 
       const augmentcodeLegacyRule = AugmentcodeLegacyRule.fromRulesyncRule({
-        baseDir: "/target/path",
+        outputRoot: "/target/path",
         rulesyncRule,
       });
 
@@ -299,7 +299,7 @@ describe("AugmentcodeLegacyRule", () => {
       );
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-rule.md",
       });
 
@@ -317,7 +317,7 @@ describe("AugmentcodeLegacyRule", () => {
       await writeFileContent(testFilePath, "# Root Guidelines\n\nThese are the root guidelines.");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: ".augment-guidelines",
       });
 
@@ -330,37 +330,39 @@ describe("AugmentcodeLegacyRule", () => {
       expect(augmentcodeLegacyRule.isRoot()).toBe(true);
     });
 
-    it("should create AugmentcodeLegacyRule from file with custom baseDir", async () => {
-      const customBaseDir = join(testDir, "custom");
-      const augmentRulesDir = join(customBaseDir, ".augment", "rules");
+    it("should create AugmentcodeLegacyRule from file with custom outputRoot", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      const augmentRulesDir = join(customOutputRoot, ".augment", "rules");
       await ensureDir(augmentRulesDir);
       const testFilePath = join(augmentRulesDir, "custom-rule.md");
       await writeFileContent(testFilePath, "# Custom Legacy Rule");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeFilePath: "custom-rule.md",
       });
 
       expect(augmentcodeLegacyRule.getFilePath()).toBe(
-        join(customBaseDir, ".augment", "rules", "custom-rule.md"),
+        join(customOutputRoot, ".augment", "rules", "custom-rule.md"),
       );
       expect(augmentcodeLegacyRule.getFileContent()).toBe("# Custom Legacy Rule");
       expect(augmentcodeLegacyRule.isRoot()).toBe(false);
     });
 
-    it("should create root AugmentcodeLegacyRule from file with custom baseDir", async () => {
-      const customBaseDir = join(testDir, "custom");
-      await ensureDir(customBaseDir);
-      const testFilePath = join(customBaseDir, ".augment-guidelines");
+    it("should create root AugmentcodeLegacyRule from file with custom outputRoot", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      await ensureDir(customOutputRoot);
+      const testFilePath = join(customOutputRoot, ".augment-guidelines");
       await writeFileContent(testFilePath, "# Custom Root Guidelines");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeFilePath: ".augment-guidelines",
       });
 
-      expect(augmentcodeLegacyRule.getFilePath()).toBe(join(customBaseDir, ".augment-guidelines"));
+      expect(augmentcodeLegacyRule.getFilePath()).toBe(
+        join(customOutputRoot, ".augment-guidelines"),
+      );
       expect(augmentcodeLegacyRule.getFileContent()).toBe("# Custom Root Guidelines");
       expect(augmentcodeLegacyRule.isRoot()).toBe(true);
     });
@@ -372,7 +374,7 @@ describe("AugmentcodeLegacyRule", () => {
       await writeFileContent(testFilePath, "# Validated Legacy Rule");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validated-rule.md",
         validate: true,
       });
@@ -388,7 +390,7 @@ describe("AugmentcodeLegacyRule", () => {
       await writeFileContent(testFilePath, "# Unvalidated Legacy Rule");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "unvalidated-rule.md",
         validate: false,
       });
@@ -407,7 +409,7 @@ describe("AugmentcodeLegacyRule", () => {
       );
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "formatted-rule.md",
       });
 
@@ -423,7 +425,7 @@ describe("AugmentcodeLegacyRule", () => {
       await writeFileContent(testFilePath, "");
 
       const augmentcodeLegacyRule = await AugmentcodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "empty-rule.md",
       });
 
@@ -433,7 +435,7 @@ describe("AugmentcodeLegacyRule", () => {
     it("should throw error when non-root file does not exist", async () => {
       await expect(
         AugmentcodeLegacyRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent-rule.md",
         }),
       ).rejects.toThrow();
@@ -442,7 +444,7 @@ describe("AugmentcodeLegacyRule", () => {
     it("should throw error when root file does not exist", async () => {
       await expect(
         AugmentcodeLegacyRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: ".augment-guidelines",
         }),
       ).rejects.toThrow();
@@ -532,7 +534,7 @@ describe("AugmentcodeLegacyRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting augmentcode-legacy", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -546,7 +548,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -560,7 +562,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should return false for rules not targeting augmentcode-legacy", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -574,7 +576,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -588,7 +590,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should handle mixed targets including augmentcode-legacy", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -602,7 +604,7 @@ describe("AugmentcodeLegacyRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -622,7 +624,7 @@ describe("AugmentcodeLegacyRule", () => {
       });
 
       // Test inherited methods
-      expect(typeof augmentcodeLegacyRule.getBaseDir).toBe("function");
+      expect(typeof augmentcodeLegacyRule.getOutputRoot).toBe("function");
       expect(typeof augmentcodeLegacyRule.getRelativeDirPath).toBe("function");
       expect(typeof augmentcodeLegacyRule.getRelativeFilePath).toBe("function");
       expect(typeof augmentcodeLegacyRule.getFileContent).toBe("function");

--- a/src/features/rules/augmentcode-legacy-rule.ts
+++ b/src/features/rules/augmentcode-legacy-rule.ts
@@ -35,7 +35,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
     };
 
     return new RulesyncRule({
-      baseDir: ".", // RulesyncRule baseDir is always the project root directory
+      outputRoot: ".", // RulesyncRule outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.getFileContent(),
       relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
@@ -62,13 +62,13 @@ export class AugmentcodeLegacyRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
     return new AugmentcodeLegacyRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,
@@ -89,7 +89,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AugmentcodeLegacyRule> {
@@ -99,10 +99,10 @@ export class AugmentcodeLegacyRule extends ToolRule {
     const relativePath = isRoot
       ? settablePaths.root.relativeFilePath
       : join(settablePaths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new AugmentcodeLegacyRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: isRoot
         ? settablePaths.root.relativeDirPath
         : settablePaths.nonRoot.relativeDirPath,
@@ -114,7 +114,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): AugmentcodeLegacyRule {
@@ -122,7 +122,7 @@ export class AugmentcodeLegacyRule extends ToolRule {
     const isRoot = relativeFilePath === settablePaths.root.relativeFilePath;
 
     return new AugmentcodeLegacyRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/augmentcode-rule.test.ts
+++ b/src/features/rules/augmentcode-rule.test.ts
@@ -36,9 +36,9 @@ describe("AugmentcodeRule", () => {
       expect(augmentcodeRule.getFileContent()).toBe("# Test Rule\n\nThis is a test augment rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const augmentcodeRule = new AugmentcodeRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".augment/rules",
         relativeFilePath: "custom-rule.md",
         fileContent: "# Custom Rule",
@@ -96,9 +96,9 @@ describe("AugmentcodeRule", () => {
       expect(augmentcodeRule.getFileContent()).toBe("# Source Rule\n\nThis is a source rule.");
     });
 
-    it("should create AugmentcodeRule from RulesyncRule with custom baseDir", () => {
+    it("should create AugmentcodeRule from RulesyncRule with custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: "/source/path",
+        outputRoot: "/source/path",
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "source-rule.md",
         frontmatter: {
@@ -111,7 +111,7 @@ describe("AugmentcodeRule", () => {
       });
 
       const augmentcodeRule = AugmentcodeRule.fromRulesyncRule({
-        baseDir: "/target/path",
+        outputRoot: "/target/path",
         rulesyncRule,
       });
 
@@ -174,7 +174,7 @@ describe("AugmentcodeRule", () => {
       );
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-rule.md",
       });
 
@@ -186,20 +186,20 @@ describe("AugmentcodeRule", () => {
       );
     });
 
-    it("should create AugmentcodeRule from file with custom baseDir", async () => {
-      const customBaseDir = join(testDir, "custom");
-      const augmentRulesDir = join(customBaseDir, ".augment", "rules");
+    it("should create AugmentcodeRule from file with custom outputRoot", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      const augmentRulesDir = join(customOutputRoot, ".augment", "rules");
       await ensureDir(augmentRulesDir);
       const testFilePath = join(augmentRulesDir, "custom-rule.md");
       await writeFileContent(testFilePath, "---\ntitle: Custom\n---\n# Custom Rule");
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeFilePath: "custom-rule.md",
       });
 
       expect(augmentcodeRule.getFilePath()).toBe(
-        join(customBaseDir, ".augment", "rules", "custom-rule.md"),
+        join(customOutputRoot, ".augment", "rules", "custom-rule.md"),
       );
       expect(augmentcodeRule.getFileContent()).toBe("# Custom Rule");
     });
@@ -211,7 +211,7 @@ describe("AugmentcodeRule", () => {
       await writeFileContent(testFilePath, "---\ntitle: Validated\n---\n# Validated Rule");
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validated-rule.md",
         validate: true,
       });
@@ -227,7 +227,7 @@ describe("AugmentcodeRule", () => {
       await writeFileContent(testFilePath, "---\ntitle: Unvalidated\n---\n# Unvalidated Rule");
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "unvalidated-rule.md",
         validate: false,
       });
@@ -243,7 +243,7 @@ describe("AugmentcodeRule", () => {
       await writeFileContent(testFilePath, "# Simple Rule\n\nNo frontmatter here.");
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-frontmatter.md",
       });
 
@@ -260,7 +260,7 @@ describe("AugmentcodeRule", () => {
       );
 
       const augmentcodeRule = await AugmentcodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "whitespace-rule.md",
       });
 
@@ -272,7 +272,7 @@ describe("AugmentcodeRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         AugmentcodeRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent-rule.md",
         }),
       ).rejects.toThrow();
@@ -282,7 +282,7 @@ describe("AugmentcodeRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert AugmentcodeRule to RulesyncRule", () => {
       const augmentcodeRule = new AugmentcodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test-rule.md",
         fileContent: "# Test Rule\n\nThis is a test rule.",
@@ -291,7 +291,7 @@ describe("AugmentcodeRule", () => {
       const rulesyncRule = augmentcodeRule.toRulesyncRule();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(testDir);
+      expect(rulesyncRule.getOutputRoot()).toBe(testDir);
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe("test-rule.md");
       expect(rulesyncRule.getBody()).toBe("# Test Rule\n\nThis is a test rule.");
@@ -299,7 +299,7 @@ describe("AugmentcodeRule", () => {
 
     it("should convert AugmentcodeRule to RulesyncRule preserving metadata", () => {
       const augmentcodeRule = new AugmentcodeRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".augment/rules",
         relativeFilePath: "complex-rule.md",
         fileContent: "# Complex Rule\n\nThis is a more complex rule with content.",
@@ -308,7 +308,7 @@ describe("AugmentcodeRule", () => {
 
       const rulesyncRule = augmentcodeRule.toRulesyncRule();
 
-      expect(rulesyncRule.getBaseDir()).toBe(testDir);
+      expect(rulesyncRule.getOutputRoot()).toBe(testDir);
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe("complex-rule.md");
       expect(rulesyncRule.getBody()).toBe(
@@ -367,7 +367,7 @@ describe("AugmentcodeRule", () => {
       });
 
       // Test inherited methods
-      expect(typeof augmentcodeRule.getBaseDir).toBe("function");
+      expect(typeof augmentcodeRule.getOutputRoot).toBe("function");
       expect(typeof augmentcodeRule.getRelativeDirPath).toBe("function");
       expect(typeof augmentcodeRule.getRelativeFilePath).toBe("function");
       expect(typeof augmentcodeRule.getFileContent).toBe("function");
@@ -400,7 +400,7 @@ describe("AugmentcodeRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting augmentcode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -414,7 +414,7 @@ describe("AugmentcodeRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -428,7 +428,7 @@ describe("AugmentcodeRule", () => {
 
     it("should return false for rules not targeting augmentcode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -442,7 +442,7 @@ describe("AugmentcodeRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -456,7 +456,7 @@ describe("AugmentcodeRule", () => {
 
     it("should handle mixed targets including augmentcode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -470,7 +470,7 @@ describe("AugmentcodeRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".augment/rules",
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/augmentcode-rule.ts
+++ b/src/features/rules/augmentcode-rule.ts
@@ -40,13 +40,13 @@ export class AugmentcodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): AugmentcodeRule {
     return new AugmentcodeRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         nonRootPath: this.getSettablePaths().nonRoot,
@@ -55,12 +55,12 @@ export class AugmentcodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<AugmentcodeRule> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath,
     );
@@ -68,7 +68,7 @@ export class AugmentcodeRule extends ToolRule {
     const { body: content } = parseFrontmatter(fileContent, filePath);
 
     return new AugmentcodeRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent: content.trim(),
@@ -81,12 +81,12 @@ export class AugmentcodeRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): AugmentcodeRule {
     return new AugmentcodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/claudecode-legacy-rule.test.ts
+++ b/src/features/rules/claudecode-legacy-rule.test.ts
@@ -40,9 +40,9 @@ describe("ClaudecodeLegacyRule", () => {
       expect(claudecodeLegacyRule.getFileContent()).toBe("# Test Memory\n\nThis is a test memory.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const claudecodeLegacyRule = new ClaudecodeLegacyRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".claude/memories",
         relativeFilePath: "custom-memory.md",
         fileContent: "# Custom Memory",
@@ -84,12 +84,12 @@ describe("ClaudecodeLegacyRule", () => {
 
   describe("fromFile", () => {
     it("should create instance from root CLAUDE.md file", async () => {
-      // Setup test file - for root, the file should be directly at baseDir/CLAUDE.md
+      // Setup test file - for root, the file should be directly at outputRoot/CLAUDE.md
       const testContent = "# Claude Code Project\n\nProject overview and instructions.";
       await writeFileContent(join(testDir, "CLAUDE.md"), testContent);
 
       const claudecodeLegacyRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
       });
 
@@ -108,7 +108,7 @@ describe("ClaudecodeLegacyRule", () => {
       await writeFileContent(join(memoriesDir, "memory-test.md"), testContent);
 
       const claudecodeLegacyRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-test.md",
       });
 
@@ -121,9 +121,9 @@ describe("ClaudecodeLegacyRule", () => {
       expect(claudecodeLegacyRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir when not provided", async () => {
-      // Setup test file in test directory - for root CLAUDE.md, it should be at baseDir/CLAUDE.md
-      const testContent = "# Default BaseDir Test";
+    it("should use default outputRoot when not provided", async () => {
+      // Setup test file in test directory - for root CLAUDE.md, it should be at outputRoot/CLAUDE.md
+      const testContent = "# Default OutputRoot Test";
       await writeFileContent(join(testDir, "CLAUDE.md"), testContent);
 
       const claudecodeLegacyRule = await ClaudecodeLegacyRule.fromFile({
@@ -138,7 +138,7 @@ describe("ClaudecodeLegacyRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         ClaudecodeLegacyRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -152,18 +152,18 @@ describe("ClaudecodeLegacyRule", () => {
       const rootContent = "# Root Project Overview";
       const memoryContent = "# Memory Rule";
 
-      // Root file goes directly in baseDir
+      // Root file goes directly in outputRoot
       await writeFileContent(join(testDir, "CLAUDE.md"), rootContent);
       // Memory file goes in .claude/memories
       await writeFileContent(join(memoriesDir, "memory.md"), memoryContent);
 
       const rootRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
       });
 
       const memoryRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -227,7 +227,7 @@ describe("ClaudecodeLegacyRule", () => {
       expect(claudecodeLegacyRule.isRoot()).toBe(false);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -241,7 +241,7 @@ describe("ClaudecodeLegacyRule", () => {
       });
 
       const claudecodeLegacyRule = ClaudecodeLegacyRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -254,7 +254,7 @@ describe("ClaudecodeLegacyRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert ClaudecodeLegacyRule to RulesyncRule for root rule", () => {
       const claudecodeLegacyRule = new ClaudecodeLegacyRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "CLAUDE.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -271,7 +271,7 @@ describe("ClaudecodeLegacyRule", () => {
 
     it("should convert ClaudecodeLegacyRule to RulesyncRule for memory rule", () => {
       const claudecodeLegacyRule = new ClaudecodeLegacyRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/memories",
         relativeFilePath: "memory-convert.md",
         fileContent: "# Memory Convert Test\n\nThis memory will be converted.",
@@ -352,7 +352,7 @@ describe("ClaudecodeLegacyRule", () => {
       await writeFileContent(join(claudeDir, "CLAUDE.md"), testContent);
 
       const claudecodeLegacyRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
         relativeDirPath: ".claude",
       });
@@ -373,7 +373,7 @@ describe("ClaudecodeLegacyRule", () => {
       await writeFileContent(join(globalDir, "CLAUDE.md"), testContent);
 
       const claudecodeLegacyRule = await ClaudecodeLegacyRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
         global: true,
       });
@@ -437,7 +437,7 @@ describe("ClaudecodeLegacyRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting claudecode-legacy", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -451,7 +451,7 @@ describe("ClaudecodeLegacyRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -465,7 +465,7 @@ describe("ClaudecodeLegacyRule", () => {
 
     it("should return false for rules not targeting claudecode-legacy", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -479,7 +479,7 @@ describe("ClaudecodeLegacyRule", () => {
 
     it("should return false for rules targeting only claudecode (not legacy)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {

--- a/src/features/rules/claudecode-legacy-rule.ts
+++ b/src/features/rules/claudecode-legacy-rule.ts
@@ -74,7 +74,7 @@ export class ClaudecodeLegacyRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -86,11 +86,11 @@ export class ClaudecodeLegacyRule extends ToolRule {
     if (isRoot) {
       const rootDirPath = overrideDirPath ?? paths.root.relativeDirPath;
       const fileContent = await readFileContent(
-        join(baseDir, rootDirPath, paths.root.relativeFilePath),
+        join(outputRoot, rootDirPath, paths.root.relativeFilePath),
       );
 
       return new ClaudecodeLegacyRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: rootDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -104,9 +104,9 @@ export class ClaudecodeLegacyRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new ClaudecodeLegacyRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -116,7 +116,7 @@ export class ClaudecodeLegacyRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -124,7 +124,7 @@ export class ClaudecodeLegacyRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new ClaudecodeLegacyRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -142,7 +142,7 @@ export class ClaudecodeLegacyRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -151,7 +151,7 @@ export class ClaudecodeLegacyRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new ClaudecodeLegacyRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/claudecode-rule.test.ts
+++ b/src/features/rules/claudecode-rule.test.ts
@@ -148,7 +148,7 @@ describe("ClaudecodeRule (Modular Rules)", () => {
       await writeFileContent(join(claudeDir, "CLAUDE.md"), testContent);
 
       const claudecodeRule = await ClaudecodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
         relativeDirPath: ".claude",
       });
@@ -165,7 +165,7 @@ describe("ClaudecodeRule (Modular Rules)", () => {
       await writeFileContent(join(testDir, "CLAUDE.md"), testContent);
 
       const claudecodeRule = await ClaudecodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
       });
 
@@ -190,7 +190,7 @@ Rules for TypeScript files.`;
       await writeFileContent(join(rulesDir, "typescript.md"), testContent);
 
       const claudecodeRule = await ClaudecodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "typescript.md",
       });
 
@@ -208,7 +208,7 @@ Rules for TypeScript files.`;
       await writeFileContent(join(rulesDir, "general.md"), testContent);
 
       const claudecodeRule = await ClaudecodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "general.md",
       });
 
@@ -219,7 +219,7 @@ Rules for TypeScript files.`;
     it("should throw error when file does not exist", async () => {
       await expect(
         ClaudecodeRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -318,7 +318,7 @@ Rules for TypeScript files.`;
   describe("toRulesyncRule", () => {
     it("should convert ClaudecodeRule to RulesyncRule for root rule", () => {
       const claudecodeRule = new ClaudecodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "CLAUDE.md",
         frontmatter: {},
@@ -338,7 +338,7 @@ Rules for TypeScript files.`;
 
     it("should convert ClaudecodeRule to RulesyncRule for non-root rule with paths", () => {
       const claudecodeRule = new ClaudecodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/rules",
         relativeFilePath: "typescript.md",
         frontmatter: { paths: ["src/**/*.ts", "tests/**/*.ts"] },
@@ -393,7 +393,7 @@ Rules for TypeScript files.`;
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting claudecode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -407,7 +407,7 @@ Rules for TypeScript files.`;
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -421,7 +421,7 @@ Rules for TypeScript files.`;
 
     it("should return false for rules not targeting claudecode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -435,7 +435,7 @@ Rules for TypeScript files.`;
 
     it("should return false for rules targeting only claudecode-legacy (not modular)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -456,7 +456,7 @@ Rules for TypeScript files.`;
       await writeFileContent(join(globalDir, "CLAUDE.md"), testContent);
 
       const claudecodeRule = await ClaudecodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "CLAUDE.md",
         global: true,
       });
@@ -499,7 +499,7 @@ Rules for TypeScript files.`;
       const originalBody = "# Roundtrip Test\n\nContent should remain the same.";
 
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -512,7 +512,7 @@ Rules for TypeScript files.`;
       });
 
       const claudecodeRule = ClaudecodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -529,7 +529,7 @@ Rules for TypeScript files.`;
       const originalPaths = ["src/**/*.ts", "tests/**/*.ts"];
 
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "typescript.md",
         frontmatter: {
@@ -541,7 +541,7 @@ Rules for TypeScript files.`;
       });
 
       const claudecodeRule = ClaudecodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 

--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -128,7 +128,7 @@ export class ClaudecodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -140,11 +140,11 @@ export class ClaudecodeRule extends ToolRule {
     if (isRoot) {
       const rootDirPath = overrideDirPath ?? paths.root.relativeDirPath;
       const fileContent = await readFileContent(
-        join(baseDir, rootDirPath, paths.root.relativeFilePath),
+        join(outputRoot, rootDirPath, paths.root.relativeFilePath),
       );
 
       return new ClaudecodeRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: rootDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         frontmatter: {},
@@ -159,7 +159,7 @@ export class ClaudecodeRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const filePath = join(baseDir, relativePath);
+    const filePath = join(outputRoot, relativePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -170,7 +170,7 @@ export class ClaudecodeRule extends ToolRule {
     }
 
     return new ClaudecodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -181,7 +181,7 @@ export class ClaudecodeRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -190,7 +190,7 @@ export class ClaudecodeRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new ClaudecodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},
@@ -201,7 +201,7 @@ export class ClaudecodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -224,7 +224,7 @@ export class ClaudecodeRule extends ToolRule {
 
     if (root) {
       return new ClaudecodeRule({
-        baseDir,
+        outputRoot,
         frontmatter: claudecodeFrontmatter,
         body,
         relativeDirPath: paths.root.relativeDirPath,
@@ -239,7 +239,7 @@ export class ClaudecodeRule extends ToolRule {
     }
 
     return new ClaudecodeRule({
-      baseDir,
+      outputRoot,
       frontmatter: claudecodeFrontmatter,
       body,
       relativeDirPath: paths.nonRoot.relativeDirPath,
@@ -270,7 +270,7 @@ export class ClaudecodeRule extends ToolRule {
     };
 
     return new RulesyncRule({
-      baseDir: this.getBaseDir(),
+      outputRoot: this.getOutputRoot(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,

--- a/src/features/rules/cline-rule.test.ts
+++ b/src/features/rules/cline-rule.test.ts
@@ -35,9 +35,9 @@ describe("ClineRule", () => {
       expect(clineRule.getFileContent()).toBe("# Test Rule\n\nThis is a test rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const clineRule = new ClineRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".clinerules",
         relativeFilePath: "custom-rule.md",
         fileContent: "# Custom Rule",
@@ -86,7 +86,7 @@ describe("ClineRule", () => {
 
     it("should preserve file path information in conversion", () => {
       const clineRule = new ClineRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".clinerules",
         relativeFilePath: "path-test.md",
         fileContent: "# Path Test",
@@ -122,7 +122,7 @@ describe("ClineRule", () => {
       expect(clineRule.getFileContent()).toContain("# Source Rule\n\nThis is from RulesyncRule.");
     });
 
-    it("should create ClineRule from RulesyncRule with custom baseDir", () => {
+    it("should create ClineRule from RulesyncRule with custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: ".",
         relativeFilePath: "custom-base-rule.md",
@@ -136,7 +136,7 @@ describe("ClineRule", () => {
       });
 
       const clineRule = ClineRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -257,7 +257,7 @@ console.log("Code example");
       await writeFileContent(join(clinerulesDir, "file-test.md"), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "file-test.md",
       });
 
@@ -268,20 +268,20 @@ console.log("Code example");
       expect(clineRule.getFilePath()).toBe(join(testDir, ".clinerules", "file-test.md"));
     });
 
-    it("should create ClineRule from file with custom baseDir", async () => {
-      const customBaseDir = join(testDir, "custom");
-      const clinerulesDir = join(customBaseDir, ".clinerules");
+    it("should create ClineRule from file with custom outputRoot", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      const clinerulesDir = join(customOutputRoot, ".clinerules");
       await ensureDir(clinerulesDir);
 
       const testFileContent = "# Custom Base File Test";
       await writeFileContent(join(clinerulesDir, "custom-base.md"), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeFilePath: "custom-base.md",
       });
 
-      expect(clineRule.getFilePath()).toBe(join(customBaseDir, ".clinerules", "custom-base.md"));
+      expect(clineRule.getFilePath()).toBe(join(customOutputRoot, ".clinerules", "custom-base.md"));
       expect(clineRule.getFileContent()).toBe(testFileContent);
     });
 
@@ -293,7 +293,7 @@ console.log("Code example");
       await writeFileContent(join(clinerulesDir, "validated-file.md"), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validated-file.md",
         validate: true,
       });
@@ -310,7 +310,7 @@ console.log("Code example");
       await writeFileContent(join(clinerulesDir, "unvalidated-file.md"), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "unvalidated-file.md",
         validate: false,
       });
@@ -334,7 +334,7 @@ This rule has YAML frontmatter.`;
       await writeFileContent(join(clinerulesDir, "frontmatter-test.md"), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "frontmatter-test.md",
       });
 
@@ -350,7 +350,7 @@ This rule has YAML frontmatter.`;
       await writeFileContent(join(testDir, ".clinerules", relativeFilePath), testFileContent);
 
       const clineRule = await ClineRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath,
       });
 
@@ -458,7 +458,7 @@ This rule has YAML frontmatter.`;
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting cline", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -472,7 +472,7 @@ This rule has YAML frontmatter.`;
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -486,7 +486,7 @@ This rule has YAML frontmatter.`;
 
     it("should return false for rules not targeting cline", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -500,7 +500,7 @@ This rule has YAML frontmatter.`;
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -514,7 +514,7 @@ This rule has YAML frontmatter.`;
 
     it("should handle mixed targets including cline", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -528,7 +528,7 @@ This rule has YAML frontmatter.`;
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/cline-rule.ts
+++ b/src/features/rules/cline-rule.ts
@@ -41,13 +41,13 @@ export class ClineRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
     return new ClineRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         nonRootPath: this.getSettablePaths().nonRoot,
@@ -67,17 +67,17 @@ export class ClineRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<ClineRule> {
     // Read file content
     const fileContent = await readFileContent(
-      join(baseDir, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
+      join(outputRoot, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
     );
 
     return new ClineRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -86,12 +86,12 @@ export class ClineRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): ClineRule {
     return new ClineRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/codexcli-rule.test.ts
+++ b/src/features/rules/codexcli-rule.test.ts
@@ -38,14 +38,14 @@ This is the main agent configuration for the project.
       await writeFileContent(filePath, agentsContent);
 
       const rule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
       expect(rule.getFileContent()).toBe(agentsContent);
       expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
       expect(rule.getRelativeDirPath()).toBe(".");
-      expect(rule.getBaseDir()).toBe(testDir);
+      expect(rule.getOutputRoot()).toBe(testDir);
     });
 
     it("should load non-root rule from .codex/memories directory", async () => {
@@ -63,14 +63,14 @@ This is a specific memory configuration.
       await writeFileContent(filePath, memoryContent);
 
       const rule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "error-handling.md",
       });
 
       expect(rule.getFileContent()).toBe(memoryContent);
       expect(rule.getRelativeFilePath()).toBe("error-handling.md");
       expect(rule.getRelativeDirPath()).toBe(".codex/memories");
-      expect(rule.getBaseDir()).toBe(testDir);
+      expect(rule.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle empty content files", async () => {
@@ -78,7 +78,7 @@ This is a specific memory configuration.
       await writeFileContent(filePath, "");
 
       const rule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -86,21 +86,21 @@ This is a specific memory configuration.
       expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
     });
 
-    it("should respect baseDir parameter", async () => {
-      const customBaseDir = join(testDir, "custom");
-      await ensureDir(customBaseDir);
+    it("should respect outputRoot parameter", async () => {
+      const customOutputRoot = join(testDir, "custom");
+      await ensureDir(customOutputRoot);
 
       const agentsContent = "Custom base directory content";
-      const filePath = join(customBaseDir, "AGENTS.md");
+      const filePath = join(customOutputRoot, "AGENTS.md");
       await writeFileContent(filePath, agentsContent);
 
       const rule = await CodexcliRule.fromFile({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeFilePath: "AGENTS.md",
       });
 
       expect(rule.getFileContent()).toBe(agentsContent);
-      expect(rule.getBaseDir()).toBe(customBaseDir);
+      expect(rule.getOutputRoot()).toBe(customOutputRoot);
     });
 
     it("should handle validation parameter", async () => {
@@ -109,13 +109,13 @@ This is a specific memory configuration.
       await writeFileContent(filePath, agentsContent);
 
       const ruleWithValidation = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: true,
       });
 
       const ruleWithoutValidation = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: false,
       });
@@ -131,7 +131,7 @@ This is a specific memory configuration.
       await writeFileContent(rootPath, rootContent);
 
       const rootRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -147,7 +147,7 @@ This is a specific memory configuration.
       await writeFileContent(nonRootPath, nonRootContent);
 
       const nonRootRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "specific.md",
       });
 
@@ -159,7 +159,7 @@ This is a specific memory configuration.
   describe("fromRulesyncRule", () => {
     it("should create root CodexcliRule from root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "root.md",
         frontmatter: { root: true, targets: ["*"], description: "Root rule", globs: [] },
@@ -168,19 +168,19 @@ This is a specific memory configuration.
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(codexcliRule.getFileContent()).toBe("Root rule body content");
       expect(codexcliRule.getRelativeFilePath()).toBe("AGENTS.md");
       expect(codexcliRule.getRelativeDirPath()).toBe(".");
-      expect(codexcliRule.getBaseDir()).toBe(testDir);
+      expect(codexcliRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should create non-root CodexcliRule from non-root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "specific.md",
         frontmatter: { root: false, targets: ["*"], description: "Non-root rule", globs: [] },
@@ -189,19 +189,19 @@ This is a specific memory configuration.
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(codexcliRule.getFileContent()).toBe("Non-root rule body content");
       expect(codexcliRule.getRelativeFilePath()).toBe("specific.md");
       expect(codexcliRule.getRelativeDirPath()).toBe(".codex/memories");
-      expect(codexcliRule.getBaseDir()).toBe(testDir);
+      expect(codexcliRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle empty body content", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "empty.md",
         frontmatter: { root: false, targets: ["*"], description: "Empty rule", globs: [] },
@@ -210,7 +210,7 @@ This is a specific memory configuration.
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -238,7 +238,7 @@ interface Example {
 More detailed instructions here.`;
 
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "complex.md",
         frontmatter: { root: true, targets: ["*"], description: "Complex rule", globs: [] },
@@ -247,7 +247,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -256,7 +256,7 @@ More detailed instructions here.`;
 
     it("should handle subprojectPath from agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -270,7 +270,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -283,7 +283,7 @@ More detailed instructions here.`;
 
     it("should ignore subprojectPath for root rules", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -297,7 +297,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -308,7 +308,7 @@ More detailed instructions here.`;
 
     it("should handle empty subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -322,7 +322,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -333,7 +333,7 @@ More detailed instructions here.`;
 
     it("should handle complex nested subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "nested.md",
         frontmatter: {
@@ -347,7 +347,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -360,7 +360,7 @@ More detailed instructions here.`;
 
     it("should handle undefined agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -371,7 +371,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -382,7 +382,7 @@ More detailed instructions here.`;
 
     it("should respect validation parameter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: { root: false, targets: ["*"], description: "Test rule", globs: [] },
@@ -391,13 +391,13 @@ More detailed instructions here.`;
       });
 
       const ruleWithValidation = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
 
       const ruleWithoutValidation = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: false,
       });
@@ -406,11 +406,11 @@ More detailed instructions here.`;
       expect(ruleWithoutValidation.getFileContent()).toBe("Test body");
     });
 
-    it("should handle custom baseDir", () => {
-      const customBaseDir = join(testDir, "custom");
+    it("should handle custom outputRoot", () => {
+      const customOutputRoot = join(testDir, "custom");
 
       const rulesyncRule = new RulesyncRule({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: { root: false, targets: ["*"], description: "Test rule", globs: [] },
@@ -419,11 +419,11 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         rulesyncRule,
       });
 
-      expect(codexcliRule.getBaseDir()).toBe(customBaseDir);
+      expect(codexcliRule.getOutputRoot()).toBe(customOutputRoot);
     });
   });
 
@@ -434,7 +434,7 @@ More detailed instructions here.`;
       await writeFileContent(filePath, agentsContent);
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -456,7 +456,7 @@ More detailed instructions here.`;
       await writeFileContent(filePath, memoryContent);
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "specific.md",
       });
 
@@ -474,7 +474,7 @@ More detailed instructions here.`;
       await writeFileContent(filePath, "");
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -501,7 +501,7 @@ More detailed instructions here.`;
         await writeFileContent(filePath, content);
 
         const rule = await CodexcliRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "AGENTS.md",
         });
 
@@ -513,7 +513,7 @@ More detailed instructions here.`;
 
     it("should return success for rule created from RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: { root: false, targets: ["*"], description: "Test rule", globs: [] },
@@ -522,7 +522,7 @@ More detailed instructions here.`;
       });
 
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -539,13 +539,13 @@ More detailed instructions here.`;
       await writeFileContent(filePath, content);
 
       const ruleFromFile = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
       // Create via fromRulesyncRule
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "AGENTS.md",
         frontmatter: { root: true, targets: ["*"], description: "", globs: [] },
@@ -554,7 +554,7 @@ More detailed instructions here.`;
       });
 
       const ruleFromRulesync = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -623,7 +623,7 @@ More detailed instructions here.`;
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -641,7 +641,7 @@ More detailed instructions here.`;
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -656,7 +656,7 @@ More detailed instructions here.`;
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const codexcliRule = await CodexcliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: false,
       });
@@ -736,7 +736,7 @@ More detailed instructions here.`;
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting codexcli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -750,7 +750,7 @@ More detailed instructions here.`;
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -764,7 +764,7 @@ More detailed instructions here.`;
 
     it("should return false for rules not targeting codexcli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -778,7 +778,7 @@ More detailed instructions here.`;
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -792,7 +792,7 @@ More detailed instructions here.`;
 
     it("should handle mixed targets including codexcli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -806,7 +806,7 @@ More detailed instructions here.`;
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -841,7 +841,7 @@ interface ApiResponse<T> {
 \`\`\``;
 
       const originalRulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "codex-rule.md",
         frontmatter: {
@@ -856,7 +856,7 @@ interface ApiResponse<T> {
 
       // Convert to CodexcliRule
       const codexcliRule = CodexcliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesyncRule,
       });
 
@@ -905,7 +905,7 @@ interface ApiResponse<T> {
 
         const fileName = file.isRoot ? file.path : file.path.split("/").pop()!;
         const rule = await CodexcliRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: fileName,
         });
 

--- a/src/features/rules/codexcli-rule.ts
+++ b/src/features/rules/codexcli-rule.ts
@@ -57,7 +57,7 @@ export class CodexcliRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -68,11 +68,11 @@ export class CodexcliRule extends ToolRule {
     if (isRoot) {
       const relativePath = paths.root.relativeFilePath;
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
+        join(outputRoot, paths.root.relativeDirPath, relativePath),
       );
 
       return new CodexcliRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -86,9 +86,9 @@ export class CodexcliRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new CodexcliRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -98,7 +98,7 @@ export class CodexcliRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -106,7 +106,7 @@ export class CodexcliRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new CodexcliRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -127,7 +127,7 @@ export class CodexcliRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -136,7 +136,7 @@ export class CodexcliRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new CodexcliRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -25,7 +25,7 @@ describe("CopilotRule", () => {
   describe("constructor", () => {
     it("should create instance with basic parameters", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter: {
@@ -45,10 +45,10 @@ describe("CopilotRule", () => {
       expect(copilotRule.getBody()).toBe("This is a test rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
-      const customBaseDir = "/custom/path";
+    it("should create instance with custom outputRoot", () => {
+      const customOutputRoot = "/custom/path";
       const copilotRule = new CopilotRule({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "custom.instructions.md",
         frontmatter: {
@@ -64,7 +64,7 @@ describe("CopilotRule", () => {
 
     it("should create root copilot rule", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {
@@ -83,7 +83,7 @@ describe("CopilotRule", () => {
     it("should validate frontmatter when validation is enabled", () => {
       expect(() => {
         const copilotRule = new CopilotRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".github/instructions",
           relativeFilePath: "test.instructions.md",
           frontmatter: {
@@ -100,7 +100,7 @@ describe("CopilotRule", () => {
     it("should throw error for invalid frontmatter when validation is enabled", () => {
       expect(() => {
         const copilotRule = new CopilotRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".github/instructions",
           relativeFilePath: "test.instructions.md",
           frontmatter: {
@@ -116,7 +116,7 @@ describe("CopilotRule", () => {
     it("should create instance without validation by default", () => {
       expect(() => {
         const copilotRule = new CopilotRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".github/instructions",
           relativeFilePath: "test.instructions.md",
           frontmatter: {
@@ -130,7 +130,7 @@ describe("CopilotRule", () => {
 
     it("should create instance with minimal frontmatter", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "minimal.instructions.md",
         frontmatter: {},
@@ -194,7 +194,7 @@ describe("CopilotRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert non-root CopilotRule to RulesyncRule", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter: {
@@ -219,7 +219,7 @@ describe("CopilotRule", () => {
 
     it("should strip .instructions.md extension when converting to RulesyncRule", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "example.instructions.md",
         frontmatter: {
@@ -236,7 +236,7 @@ describe("CopilotRule", () => {
 
     it("should convert root CopilotRule to RulesyncRule", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {
@@ -264,7 +264,7 @@ describe("CopilotRule", () => {
       // Re-importing them must not silently add globs, otherwise the
       // generate → import roundtrip would duplicate root rules.
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {},
@@ -287,7 +287,7 @@ describe("CopilotRule", () => {
       // generate -> import cycle for a root rule with no globs must yield the
       // same frontmatter shape (no globs injected).
       const original = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "overview.md",
         frontmatter: {
@@ -300,7 +300,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: original,
       });
 
@@ -318,7 +318,7 @@ describe("CopilotRule", () => {
 
     it("should include copilot-specific fields when converting", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {
@@ -339,7 +339,7 @@ describe("CopilotRule", () => {
 
     it("should handle undefined description in frontmatter", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter: {
@@ -357,7 +357,7 @@ describe("CopilotRule", () => {
   describe("fromRulesyncRule", () => {
     it("should create CopilotRule from non-root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -371,7 +371,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
@@ -388,7 +388,7 @@ describe("CopilotRule", () => {
 
     it("should create root CopilotRule from root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "root.md",
         frontmatter: {
@@ -402,7 +402,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
@@ -416,7 +416,7 @@ describe("CopilotRule", () => {
 
     it("should create root CopilotRule in global mode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "root.md",
         frontmatter: {
@@ -430,7 +430,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
         global: true,
@@ -443,7 +443,7 @@ describe("CopilotRule", () => {
 
     it("should use regular paths when global=false for root rule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "root.md",
         frontmatter: {
@@ -457,7 +457,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
         global: false,
@@ -469,7 +469,7 @@ describe("CopilotRule", () => {
 
     it("should carry copilot-specific fields from RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "root.md",
         frontmatter: {
@@ -486,7 +486,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
@@ -494,9 +494,9 @@ describe("CopilotRule", () => {
       expect(copilotRule.getFrontmatter()).toEqual({});
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -512,12 +512,12 @@ describe("CopilotRule", () => {
         rulesyncRule,
       });
 
-      expect(copilotRule.getBaseDir()).toBe(testDir);
+      expect(copilotRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle RulesyncRule without globs", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -531,7 +531,7 @@ describe("CopilotRule", () => {
       });
 
       const copilotRule = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -555,7 +555,7 @@ This is test rule content from file.`;
       await writeFileContent(filePath, fileContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.instructions.md",
         validate: true,
       });
@@ -579,7 +579,7 @@ This is test rule content from file.`;
       await writeFileContent(rootFilePath, rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "copilot-instructions.md",
         validate: true,
       });
@@ -604,7 +604,7 @@ This should be treated as a non-root rule.`;
       await writeFileContent(join(instructionsDir, "copilot-instructions.md"), fileContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "copilot-instructions.md",
         validate: true,
@@ -628,7 +628,7 @@ This should be treated as a non-root rule.`;
       await writeFileContent(join(githubDir, "copilot-instructions.md"), rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         validate: true,
@@ -649,7 +649,7 @@ This should be treated as a non-root rule.`;
       await writeFileContent(rootFilePath, rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "copilot-instructions.md",
         global: true,
       });
@@ -667,7 +667,7 @@ This should be treated as a non-root rule.`;
       await writeFileContent(join(copilotDir, "copilot-instructions.md"), rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "copilot-instructions.md",
         global: true,
       });
@@ -683,7 +683,7 @@ This should be treated as a non-root rule.`;
       await writeFileContent(join(testDir, ".github", "copilot-instructions.md"), rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "copilot-instructions.md",
         global: false,
       });
@@ -692,25 +692,25 @@ This should be treated as a non-root rule.`;
       expect(copilotRule.getRelativeFilePath()).toBe("copilot-instructions.md");
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const instructionsDir = join(testDir, ".github", "instructions");
       await ensureDir(instructionsDir);
 
       const fileContent = `---
-description: "Test with default baseDir"
+description: "Test with default outputRoot"
 ---
 
-Content with default baseDir.`;
+Content with default outputRoot.`;
 
       const filePath = join(instructionsDir, "default.instructions.md");
       await writeFileContent(filePath, fileContent);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "default.instructions.md",
       });
 
-      expect(copilotRule.getBaseDir()).toBe(testDir);
+      expect(copilotRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should throw error for invalid frontmatter with validation", async () => {
@@ -729,7 +729,7 @@ Content with invalid frontmatter.`;
 
       await expect(
         CopilotRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid.instructions.md",
           validate: true,
         }),
@@ -745,7 +745,7 @@ Content with invalid frontmatter.`;
       await writeFileContent(filePath, contentWithoutFrontmatter);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-frontmatter.instructions.md",
         validate: true,
       });
@@ -770,7 +770,7 @@ description: "Test trimming"
       await writeFileContent(filePath, contentWithWhitespace);
 
       const copilotRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "trim.instructions.md",
       });
 
@@ -781,7 +781,7 @@ description: "Test trimming"
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "valid.instructions.md",
         frontmatter: {
@@ -799,7 +799,7 @@ description: "Test trimming"
 
     it("should return success for empty frontmatter", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "empty.instructions.md",
         frontmatter: {},
@@ -814,7 +814,7 @@ description: "Test trimming"
 
     it("should return error for invalid frontmatter", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "invalid.instructions.md",
         frontmatter: {
@@ -840,7 +840,7 @@ description: "Test trimming"
       };
 
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter,
@@ -857,7 +857,7 @@ description: "Test trimming"
       const body = "This is the rule body content.";
 
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter: {
@@ -875,7 +875,7 @@ description: "Test trimming"
     it("should omit frontmatter for root rule", () => {
       const body = "This is the root rule content.";
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {
@@ -901,7 +901,7 @@ description: "Test trimming"
         applyTo: "*.js",
       };
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "test.instructions.md",
         frontmatter,
@@ -920,7 +920,7 @@ description: "Test trimming"
 
     it("should handle empty body for root rule", () => {
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github",
         relativeFilePath: "copilot-instructions.md",
         frontmatter: {
@@ -945,7 +945,7 @@ description: "Test trimming"
         applyTo: "*.ts,*.tsx,*.js,*.jsx",
       };
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "complex.instructions.md",
         frontmatter,
@@ -967,7 +967,7 @@ description: "Test trimming"
     it("should handle minimal frontmatter for non-root rule", () => {
       const body = "Minimal rule content.";
       const copilotRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "minimal.instructions.md",
         frontmatter: {},
@@ -1092,7 +1092,7 @@ description: "Test trimming"
     it("should create, convert, and validate round-trip with RulesyncRule", () => {
       // Create original CopilotRule
       const originalCopilot = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "integration.instructions.md",
         frontmatter: {
@@ -1107,7 +1107,7 @@ description: "Test trimming"
 
       // Convert back to CopilotRule
       const convertedCopilot = CopilotRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -1124,7 +1124,7 @@ description: "Test trimming"
 
       // Create rule from parameters
       const originalRule = new CopilotRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/instructions",
         relativeFilePath: "e2e.instructions.md",
         frontmatter: {
@@ -1139,7 +1139,7 @@ description: "Test trimming"
 
       // Read back from file
       const loadedRule = await CopilotRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "e2e.instructions.md",
         validate: true,
       });
@@ -1154,7 +1154,7 @@ description: "Test trimming"
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting copilot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1168,7 +1168,7 @@ description: "Test trimming"
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1182,7 +1182,7 @@ description: "Test trimming"
 
     it("should return false for rules not targeting copilot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1196,7 +1196,7 @@ description: "Test trimming"
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1210,7 +1210,7 @@ description: "Test trimming"
 
     it("should handle mixed targets including copilot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1224,7 +1224,7 @@ description: "Test trimming"
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -139,7 +139,7 @@ export class CopilotRule extends ToolRule {
     const relativeFilePath = originalFilePath.replace(/\.instructions\.md$/, ".md");
 
     return new RulesyncRule({
-      baseDir: this.getBaseDir(),
+      outputRoot: this.getOutputRoot(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
@@ -149,7 +149,7 @@ export class CopilotRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -170,7 +170,7 @@ export class CopilotRule extends ToolRule {
     if (root) {
       // Root file: .github/copilot-instructions.md (no frontmatter for root file)
       return new CopilotRule({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         frontmatter: {},
         body,
         relativeDirPath: paths.root.relativeDirPath,
@@ -190,7 +190,7 @@ export class CopilotRule extends ToolRule {
     const newFileName = `${nameWithoutExt}.instructions.md`;
 
     return new CopilotRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: copilotFrontmatter,
       body,
       relativeDirPath: paths.nonRoot.relativeDirPath,
@@ -201,7 +201,7 @@ export class CopilotRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     validate = true,
@@ -220,11 +220,11 @@ export class CopilotRule extends ToolRule {
 
     if (isRoot) {
       const relativePath = join(paths.root.relativeDirPath, paths.root.relativeFilePath);
-      const filePath = join(baseDir, relativePath);
+      const filePath = join(outputRoot, relativePath);
       const fileContent = await readFileContent(filePath);
       // Root file: no frontmatter expected
       return new CopilotRule({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         frontmatter: {},
@@ -239,7 +239,7 @@ export class CopilotRule extends ToolRule {
     }
 
     const relativePath = join(resolvedRelativeDirPath, relativeFilePath);
-    const filePath = join(baseDir, relativePath);
+    const filePath = join(outputRoot, relativePath);
     const fileContent = await readFileContent(filePath);
 
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -251,7 +251,7 @@ export class CopilotRule extends ToolRule {
     }
 
     return new CopilotRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: resolvedRelativeDirPath,
       relativeFilePath: relativeFilePath.endsWith(".instructions.md")
         ? relativeFilePath
@@ -264,7 +264,7 @@ export class CopilotRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -275,7 +275,7 @@ export class CopilotRule extends ToolRule {
       join(paths.root.relativeDirPath, paths.root.relativeFilePath);
 
     return new CopilotRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},

--- a/src/features/rules/copilotcli-rule.test.ts
+++ b/src/features/rules/copilotcli-rule.test.ts
@@ -22,7 +22,7 @@ describe("CopilotcliRule", () => {
   describe("fromRulesyncRule", () => {
     it("should pass validate to the copied Copilot rule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -33,7 +33,7 @@ describe("CopilotcliRule", () => {
 
       const invalidCopilotRule = Reflect.construct(CopilotRule, [
         {
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".github/instructions",
           relativeFilePath: "test.instructions.md",
           frontmatter: {

--- a/src/features/rules/copilotcli-rule.ts
+++ b/src/features/rules/copilotcli-rule.ts
@@ -10,7 +10,7 @@ import {
 export class CopilotcliRule extends CopilotRule {
   private static fromCopilotRule(copilotRule: CopilotRule, validate = true): CopilotcliRule {
     return new CopilotcliRule({
-      baseDir: copilotRule.getBaseDir(),
+      outputRoot: copilotRule.getOutputRoot(),
       relativeDirPath: copilotRule.getRelativeDirPath(),
       relativeFilePath: copilotRule.getRelativeFilePath(),
       frontmatter: copilotRule.getFrontmatter(),

--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -193,7 +193,7 @@ Test content`;
 
       const cursorRule = CursorRule.fromRulesyncRule({
         rulesyncRule,
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorRule.getFrontmatter()).toEqual({
@@ -262,7 +262,7 @@ Test content`;
 
       const cursorRule = CursorRule.fromRulesyncRule({
         rulesyncRule,
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(cursorRule.getFrontmatter().description).toBeUndefined();
@@ -397,7 +397,7 @@ This is the rule content
       await writeFileContent(filePath, fileContent);
 
       const rule = await CursorRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.mdc",
       });
 
@@ -417,7 +417,7 @@ This is the rule content
       await writeFileContent(filePath, content);
 
       const rule = await CursorRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "simple.mdc",
       });
 
@@ -436,7 +436,7 @@ This is the rule content
 
       await expect(
         CursorRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid.mdc",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -451,7 +451,7 @@ This is the rule content
       await writeFileContent(filePath, content);
 
       const rule = await CursorRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "invalid.mdc",
         validate: false,
       });
@@ -678,7 +678,7 @@ This is the rule content
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting cursor", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -692,7 +692,7 @@ This is the rule content
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -706,7 +706,7 @@ This is the rule content
 
     it("should return false for rules not targeting cursor", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -720,7 +720,7 @@ This is the rule content
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -734,7 +734,7 @@ This is the rule content
 
     it("should handle mixed targets including cursor", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -748,7 +748,7 @@ This is the rule content
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -829,7 +829,7 @@ This is the rule content
       // Write to disk and re-read
       await writeFileContent(filePath, rule.getFileContent());
       const reimported = await CursorRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "no-desc.mdc",
       });
 
@@ -853,7 +853,7 @@ Rule with null description`;
 
       // Should NOT throw a Zod validation error
       const rule = await CursorRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "null-desc.mdc",
       });
 

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -188,7 +188,7 @@ export class CursorRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): CursorRule {
@@ -209,7 +209,7 @@ export class CursorRule extends ToolRule {
     const newFileName = `${nameWithoutExt}.mdc`;
 
     return new CursorRule({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: cursorFrontmatter,
       body,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
@@ -219,13 +219,13 @@ export class CursorRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<CursorRule> {
     // Read file content
     const filePath = join(
-      baseDir,
+      outputRoot,
       this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath,
     );
@@ -238,12 +238,12 @@ export class CursorRule extends ToolRule {
     const result = CursorRuleFrontmatterSchema.safeParse(frontmatter);
     if (!result.success) {
       throw new Error(
-        `Invalid frontmatter in ${join(baseDir, relativeFilePath)}: ${formatError(result.error)}`,
+        `Invalid frontmatter in ${join(outputRoot, relativeFilePath)}: ${formatError(result.error)}`,
       );
     }
 
     return new CursorRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -253,12 +253,12 @@ export class CursorRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): CursorRule {
     return new CursorRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: {},

--- a/src/features/rules/deepagents-rule.test.ts
+++ b/src/features/rules/deepagents-rule.test.ts
@@ -24,7 +24,7 @@ describe("DeepagentsRule", () => {
   describe("constructor", () => {
     it("should create a DeepagentsRule with valid parameters", () => {
       const rule = new DeepagentsRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test\n\nSome content.",
@@ -35,7 +35,7 @@ describe("DeepagentsRule", () => {
 
     it("should create a DeepagentsRule with root flag", () => {
       const rule = new DeepagentsRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root Agent\n\nRoot configuration.",
@@ -47,7 +47,7 @@ describe("DeepagentsRule", () => {
 
     it("should default root to false when not specified", () => {
       const rule = new DeepagentsRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents/memories",
         relativeFilePath: "test.md",
         fileContent: "Content",
@@ -78,7 +78,7 @@ describe("DeepagentsRule", () => {
       await writeFileContent(join(deepagentsDir, "AGENTS.md"), content);
 
       const rule = await DeepagentsRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -94,7 +94,7 @@ describe("DeepagentsRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), content);
 
       const rule = await DeepagentsRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -106,14 +106,14 @@ describe("DeepagentsRule", () => {
   describe("fromRulesyncRule", () => {
     it("should create DeepagentsRule from RulesyncRule (non-root)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["deepagents"] },
         body: "# Agent Config\n\nContent.",
       });
 
-      const rule = DeepagentsRule.fromRulesyncRule({ baseDir: testDir, rulesyncRule });
+      const rule = DeepagentsRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
 
       expect(rule.getFileContent()).toBe("# Agent Config\n\nContent.");
       expect(rule.getRelativeDirPath()).toBe(".deepagents/memories");
@@ -122,14 +122,14 @@ describe("DeepagentsRule", () => {
 
     it("should create root DeepagentsRule from root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "root.md",
         frontmatter: { root: true, targets: ["deepagents"] },
         body: "# Root Content",
       });
 
-      const rule = DeepagentsRule.fromRulesyncRule({ baseDir: testDir, rulesyncRule });
+      const rule = DeepagentsRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
 
       expect(rule.getFileContent()).toBe("# Root Content");
       expect(rule.getRelativeDirPath()).toBe(".deepagents");
@@ -141,7 +141,7 @@ describe("DeepagentsRule", () => {
   describe("forDeletion", () => {
     it("should create a placeholder root rule for deletion", () => {
       const rule = DeepagentsRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents",
         relativeFilePath: "AGENTS.md",
       });
@@ -156,7 +156,7 @@ describe("DeepagentsRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true when target is deepagents", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["deepagents"] },
@@ -168,7 +168,7 @@ describe("DeepagentsRule", () => {
 
     it("should return true when target is wildcard", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["*"] },
@@ -180,7 +180,7 @@ describe("DeepagentsRule", () => {
 
     it("should return false when target is different tool", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["claudecode"] },
@@ -194,7 +194,7 @@ describe("DeepagentsRule", () => {
   describe("validate", () => {
     it("should always return success", () => {
       const rule = new DeepagentsRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".deepagents/memories",
         relativeFilePath: "test.md",
         fileContent: "Content",

--- a/src/features/rules/deepagents-rule.ts
+++ b/src/features/rules/deepagents-rule.ts
@@ -53,7 +53,7 @@ export class DeepagentsRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<DeepagentsRule> {
@@ -62,10 +62,10 @@ export class DeepagentsRule extends ToolRule {
     const relativePath = isRoot
       ? join(".deepagents", "AGENTS.md")
       : join(".deepagents", "memories", relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new DeepagentsRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: isRoot
         ? settablePaths.root.relativeDirPath
         : settablePaths.nonRoot.relativeDirPath,
@@ -77,14 +77,14 @@ export class DeepagentsRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): DeepagentsRule {
     const isRoot = relativeFilePath === "AGENTS.md" && relativeDirPath === ".deepagents";
 
     return new DeepagentsRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",
@@ -94,13 +94,13 @@ export class DeepagentsRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): DeepagentsRule {
     return new DeepagentsRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,

--- a/src/features/rules/factorydroid-rule.test.ts
+++ b/src/features/rules/factorydroid-rule.test.ts
@@ -63,7 +63,7 @@ This is a test factorydroid rule.`;
   describe("constructor", () => {
     it("should create root rule instance", () => {
       const rule = new FactorydroidRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: validRuleContent,
@@ -77,7 +77,7 @@ This is a test factorydroid rule.`;
 
     it("should create non-root rule instance", () => {
       const rule = new FactorydroidRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/rules",
         relativeFilePath: "memory-1.md",
         fileContent: validRuleContent,
@@ -93,7 +93,7 @@ This is a test factorydroid rule.`;
   describe("fromRulesyncRule", () => {
     it("should create root FactorydroidRule from RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "AGENTS.md",
         frontmatter: {
@@ -107,7 +107,7 @@ This is a test factorydroid rule.`;
       });
 
       const factorydroidRule = FactorydroidRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
@@ -119,7 +119,7 @@ This is a test factorydroid rule.`;
 
     it("should create non-root FactorydroidRule from RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "memory-1.md",
         frontmatter: {
@@ -133,7 +133,7 @@ This is a test factorydroid rule.`;
       });
 
       const factorydroidRule = FactorydroidRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         validate: true,
       });
@@ -151,7 +151,7 @@ This is a test factorydroid rule.`;
       await writeFileContent(rootFile, validRuleContent);
 
       const rule = await FactorydroidRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: true,
       });
@@ -167,7 +167,7 @@ This is a test factorydroid rule.`;
       await writeFileContent(memoryFile, validRuleContent);
 
       const rule = await FactorydroidRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-1.md",
         validate: true,
       });
@@ -180,7 +180,7 @@ This is a test factorydroid rule.`;
     it("should throw error when file does not exist", async () => {
       await expect(
         FactorydroidRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "AGENTS.md",
           validate: true,
         }),
@@ -191,7 +191,7 @@ This is a test factorydroid rule.`;
   describe("toRulesyncRule", () => {
     it("should convert to RulesyncRule", () => {
       const rule = new FactorydroidRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: validRuleContent,
@@ -210,7 +210,7 @@ This is a test factorydroid rule.`;
   describe("validate", () => {
     it("should return success for any content", () => {
       const rule = new FactorydroidRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "Any content",
@@ -271,7 +271,7 @@ This is a test factorydroid rule.`;
   describe("forDeletion", () => {
     it("should create deletion marker for root rule", () => {
       const rule = FactorydroidRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
       });
@@ -282,7 +282,7 @@ This is a test factorydroid rule.`;
 
     it("should create deletion marker for non-root rule", () => {
       const rule = FactorydroidRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/rules",
         relativeFilePath: "memory-1.md",
       });

--- a/src/features/rules/factorydroid-rule.ts
+++ b/src/features/rules/factorydroid-rule.ts
@@ -62,7 +62,7 @@ export class FactorydroidRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -72,10 +72,10 @@ export class FactorydroidRule extends ToolRule {
 
     if (isRoot) {
       const relativePath = join(paths.root.relativeDirPath, paths.root.relativeFilePath);
-      const fileContent = await readFileContent(join(baseDir, relativePath));
+      const fileContent = await readFileContent(join(outputRoot, relativePath));
 
       return new FactorydroidRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -89,9 +89,9 @@ export class FactorydroidRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new FactorydroidRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -101,7 +101,7 @@ export class FactorydroidRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -112,7 +112,7 @@ export class FactorydroidRule extends ToolRule {
       relativeDirPath === paths.root.relativeDirPath;
 
     return new FactorydroidRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",
@@ -122,7 +122,7 @@ export class FactorydroidRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -130,7 +130,7 @@ export class FactorydroidRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new FactorydroidRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,

--- a/src/features/rules/geminicli-rule.test.ts
+++ b/src/features/rules/geminicli-rule.test.ts
@@ -40,9 +40,9 @@ describe("GeminiCliRule", () => {
       expect(geminiCliRule.getFileContent()).toBe("# Test Rule\n\nThis is a test rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const geminiCliRule = new GeminiCliRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".gemini/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
@@ -94,7 +94,7 @@ describe("GeminiCliRule", () => {
       await writeFileContent(join(memoriesDir, "test.md"), testContent);
 
       const geminiCliRule = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -110,7 +110,7 @@ describe("GeminiCliRule", () => {
       await writeFileContent(join(testDir, "GEMINI.md"), testContent);
 
       const geminiCliRule = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "GEMINI.md",
       });
 
@@ -120,11 +120,11 @@ describe("GeminiCliRule", () => {
       expect(geminiCliRule.getFilePath()).toBe(join(testDir, "GEMINI.md"));
     });
 
-    it("should use default baseDir when not provided", async () => {
-      // Since process.cwd() is mocked to return testDir, default baseDir will use testDir
+    it("should use default outputRoot when not provided", async () => {
+      // Since process.cwd() is mocked to return testDir, default outputRoot will use testDir
       const memoriesDir = join(testDir, ".gemini/memories");
       await ensureDir(memoriesDir);
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       const testFilePath = join(memoriesDir, "default-test.md");
       await writeFileContent(testFilePath, testContent);
 
@@ -146,13 +146,13 @@ describe("GeminiCliRule", () => {
       await writeFileContent(join(memoriesDir, "validation-test.md"), testContent);
 
       const geminiCliRuleWithValidation = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: true,
       });
 
       const geminiCliRuleWithoutValidation = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -164,7 +164,7 @@ describe("GeminiCliRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         GeminiCliRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -222,7 +222,7 @@ describe("GeminiCliRule", () => {
       );
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -236,7 +236,7 @@ describe("GeminiCliRule", () => {
       });
 
       const geminiCliRule = GeminiCliRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -274,7 +274,7 @@ describe("GeminiCliRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert GeminiCliRule to RulesyncRule", () => {
       const geminiCliRule = new GeminiCliRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/memories",
         relativeFilePath: "convert-test.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -290,7 +290,7 @@ describe("GeminiCliRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const geminiCliRule = new GeminiCliRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".",
         relativeFilePath: "GEMINI.md",
         fileContent: "# Root Gemini Rule\n\nRoot content.",
@@ -399,7 +399,7 @@ describe("GeminiCliRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting geminicli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -413,7 +413,7 @@ describe("GeminiCliRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -427,7 +427,7 @@ describe("GeminiCliRule", () => {
 
     it("should return false for rules not targeting geminicli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -441,7 +441,7 @@ describe("GeminiCliRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -455,7 +455,7 @@ describe("GeminiCliRule", () => {
 
     it("should handle mixed targets including geminicli", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -469,7 +469,7 @@ describe("GeminiCliRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -490,7 +490,7 @@ describe("GeminiCliRule", () => {
 
       // Load from file
       const geminiCliRule = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "integration.md",
       });
 
@@ -510,7 +510,7 @@ describe("GeminiCliRule", () => {
 
       // Load from file
       const geminiCliRule = await GeminiCliRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "GEMINI.md",
       });
 
@@ -533,7 +533,7 @@ describe("GeminiCliRule", () => {
 
       // Start with rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -547,7 +547,7 @@ describe("GeminiCliRule", () => {
 
       // Convert to gemini cli rule
       const geminiCliRule = GeminiCliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -564,7 +564,7 @@ describe("GeminiCliRule", () => {
 
       // Start with root rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "root-roundtrip.md",
         frontmatter: {
@@ -578,7 +578,7 @@ describe("GeminiCliRule", () => {
 
       // Convert to gemini cli rule
       const geminiCliRule = GeminiCliRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -613,7 +613,7 @@ describe("GeminiCliRule", () => {
       // Load each file and verify
       for (const file of files) {
         const geminiCliRule = await GeminiCliRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: file.name,
         });
 
@@ -631,7 +631,7 @@ describe("GeminiCliRule", () => {
       const largeContent = "# Large Content Test\n\n" + "Lorem ipsum dolor sit amet. ".repeat(1000);
 
       const geminiCliRule = new GeminiCliRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/memories",
         relativeFilePath: "large.md",
         fileContent: largeContent,

--- a/src/features/rules/geminicli-rule.ts
+++ b/src/features/rules/geminicli-rule.ts
@@ -56,7 +56,7 @@ export class GeminiCliRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -67,11 +67,11 @@ export class GeminiCliRule extends ToolRule {
     if (isRoot) {
       const relativePath = paths.root.relativeFilePath;
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
+        join(outputRoot, paths.root.relativeDirPath, relativePath),
       );
 
       return new GeminiCliRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -85,9 +85,9 @@ export class GeminiCliRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new GeminiCliRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -97,7 +97,7 @@ export class GeminiCliRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -105,7 +105,7 @@ export class GeminiCliRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new GeminiCliRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -125,7 +125,7 @@ export class GeminiCliRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -134,7 +134,7 @@ export class GeminiCliRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new GeminiCliRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/goose-rule.test.ts
+++ b/src/features/rules/goose-rule.test.ts
@@ -81,9 +81,9 @@ describe("GooseRule", () => {
       expect(gooseRule.isRoot()).toBe(false);
     });
 
-    it("should create a GooseRule with custom baseDir", () => {
+    it("should create a GooseRule with custom outputRoot", () => {
       const params: GooseRuleParams = {
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".goose",
         relativeFilePath: "custom.md",
         fileContent: "# Custom Rule",
@@ -96,7 +96,7 @@ describe("GooseRule", () => {
 
     it("should pass all parameters to parent ToolRule", () => {
       const params: GooseRuleParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Content",
@@ -106,7 +106,7 @@ describe("GooseRule", () => {
 
       const gooseRule = new GooseRule(params);
 
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
       expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
       expect(gooseRule.getRelativeFilePath()).toBe("test.md");
       expect(gooseRule.getFileContent()).toBe("# Test Content");
@@ -120,7 +120,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(testDir, ".goosehints"), gooseContent);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: ".goosehints",
       });
 
@@ -138,7 +138,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(memoriesDir, "test-memory.md"), memoryContent);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-memory.md",
       });
 
@@ -149,7 +149,7 @@ describe("GooseRule", () => {
       expect(gooseRule.getFilePath()).toBe(join(testDir, ".goose/memories/test-memory.md"));
     });
 
-    it("should use default baseDir (process.cwd()) when not provided", async () => {
+    it("should use default outputRoot (process.cwd()) when not provided", async () => {
       const gooseContent = "# Default Test";
       await writeFileContent(join(testDir, ".goosehints"), gooseContent);
 
@@ -157,7 +157,7 @@ describe("GooseRule", () => {
         relativeFilePath: ".goosehints",
       });
 
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
       expect(gooseRule.isRoot()).toBe(true);
     });
 
@@ -166,7 +166,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(testDir, ".goosehints"), gooseContent);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: ".goosehints",
         validate: false,
       });
@@ -177,7 +177,7 @@ describe("GooseRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         GooseRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -188,7 +188,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(testDir, ".goosehints"), gooseContent);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: ".goosehints",
         global: true,
       });
@@ -213,12 +213,12 @@ describe("GooseRule", () => {
       });
 
       const gooseRule = GooseRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(gooseRule).toBeInstanceOf(GooseRule);
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
       expect(gooseRule.getRelativeDirPath()).toBe(".");
       expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
       expect(gooseRule.isRoot()).toBe(true);
@@ -237,18 +237,18 @@ describe("GooseRule", () => {
       });
 
       const gooseRule = GooseRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(gooseRule).toBeInstanceOf(GooseRule);
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
       expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
       expect(gooseRule.getRelativeFilePath()).toBe("memory.md");
       expect(gooseRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir (process.cwd()) when not provided", () => {
+    it("should use default outputRoot (process.cwd()) when not provided", () => {
       const frontmatter: RulesyncRuleFrontmatterInput = {
         description: "Default test",
         root: true,
@@ -265,7 +265,7 @@ describe("GooseRule", () => {
         rulesyncRule,
       });
 
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle validation parameter", () => {
@@ -303,7 +303,7 @@ describe("GooseRule", () => {
       });
 
       const gooseRule = GooseRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         global: true,
       });
@@ -394,7 +394,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(testDir, ".goosehints"), content);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: ".goosehints",
       });
 
@@ -409,7 +409,7 @@ describe("GooseRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), content);
 
       const gooseRule = await GooseRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -457,7 +457,7 @@ describe("GooseRule", () => {
   describe("forDeletion", () => {
     it("should create a GooseRule for deletion of root file", () => {
       const gooseRule = GooseRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: ".goosehints",
       });
@@ -469,7 +469,7 @@ describe("GooseRule", () => {
 
     it("should create a GooseRule for deletion of non-root file", () => {
       const gooseRule = GooseRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "memory.md",
       });
@@ -483,7 +483,7 @@ describe("GooseRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting goose", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -497,7 +497,7 @@ describe("GooseRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -511,7 +511,7 @@ describe("GooseRule", () => {
 
     it("should return false for rules not targeting goose", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -525,7 +525,7 @@ describe("GooseRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -539,7 +539,7 @@ describe("GooseRule", () => {
 
     it("should handle mixed targets including goose", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -553,7 +553,7 @@ describe("GooseRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -567,13 +567,13 @@ describe("GooseRule", () => {
   describe("integration with ToolRule", () => {
     it("should inherit all ToolRule functionality", () => {
       const gooseRule = new GooseRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".goose",
         relativeFilePath: "integration.md",
         fileContent: "# Integration Test",
       });
 
-      expect(gooseRule.getBaseDir()).toBe(testDir);
+      expect(gooseRule.getOutputRoot()).toBe(testDir);
       expect(gooseRule.getRelativeDirPath()).toBe(".goose");
       expect(gooseRule.getRelativeFilePath()).toBe("integration.md");
       expect(gooseRule.getFileContent()).toBe("# Integration Test");

--- a/src/features/rules/goose-rule.ts
+++ b/src/features/rules/goose-rule.ts
@@ -56,7 +56,7 @@ export class GooseRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -67,11 +67,11 @@ export class GooseRule extends ToolRule {
     if (isRoot) {
       const relativePath = paths.root.relativeFilePath;
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
+        join(outputRoot, paths.root.relativeDirPath, relativePath),
       );
 
       return new GooseRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -85,9 +85,9 @@ export class GooseRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new GooseRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -97,7 +97,7 @@ export class GooseRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -105,7 +105,7 @@ export class GooseRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new GooseRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -125,7 +125,7 @@ export class GooseRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -134,7 +134,7 @@ export class GooseRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new GooseRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/junie-rule.test.ts
+++ b/src/features/rules/junie-rule.test.ts
@@ -39,9 +39,9 @@ describe("JunieRule", () => {
       expect(junieRule.getFileContent()).toBe("# Test Guidelines\n\nThis is a test guideline.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const junieRule = new JunieRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".junie",
         relativeFilePath: "guidelines.md",
         fileContent: "# Custom Guidelines",
@@ -98,12 +98,12 @@ describe("JunieRule", () => {
 
   describe("fromFile", () => {
     it("should create instance from root guidelines file", async () => {
-      // Setup test file - root guidelines live at baseDir/.junie/guidelines.md
+      // Setup test file - root guidelines live at outputRoot/.junie/guidelines.md
       const testContent = "# Junie Guidelines\n\nGuidelines from file.";
       await writeFileContent(join(testDir, ".junie", "guidelines.md"), testContent);
 
       const junieRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "guidelines.md",
       });
 
@@ -122,7 +122,7 @@ describe("JunieRule", () => {
       await writeFileContent(join(memoriesDir, "memory-test.md"), testContent);
 
       const junieRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-test.md",
       });
 
@@ -133,9 +133,9 @@ describe("JunieRule", () => {
       expect(junieRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in mocked current directory
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       await writeFileContent(join(testDir, ".junie", "guidelines.md"), testContent);
 
       const junieRule = await JunieRule.fromFile({
@@ -152,13 +152,13 @@ describe("JunieRule", () => {
       await writeFileContent(join(testDir, ".junie", "guidelines.md"), testContent);
 
       const junieRuleWithValidation = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "guidelines.md",
         validate: true,
       });
 
       const junieRuleWithoutValidation = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "guidelines.md",
         validate: false,
       });
@@ -170,7 +170,7 @@ describe("JunieRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         JunieRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -190,12 +190,12 @@ describe("JunieRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), memoryContent);
 
       const rootRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "guidelines.md",
       });
 
       const memoryRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -257,7 +257,7 @@ describe("JunieRule", () => {
       expect(junieRule.isRoot()).toBe(false);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -271,7 +271,7 @@ describe("JunieRule", () => {
       });
 
       const junieRule = JunieRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -309,7 +309,7 @@ describe("JunieRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert JunieRule to RulesyncRule for root rule", () => {
       const junieRule = new JunieRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie",
         relativeFilePath: "guidelines.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -326,7 +326,7 @@ describe("JunieRule", () => {
 
     it("should convert JunieRule to RulesyncRule for memory rule", () => {
       const junieRule = new JunieRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/memories",
         relativeFilePath: "memory-convert.md",
         fileContent: "# Memory Convert Test\n\nThis memory will be converted.",
@@ -345,7 +345,7 @@ describe("JunieRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const junieRule = new JunieRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".junie",
         relativeFilePath: "metadata-test.md",
         fileContent: "# Metadata Test\n\nWith metadata preserved.",
@@ -423,7 +423,7 @@ describe("JunieRule", () => {
 
       // Load from file
       const junieRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "guidelines.md",
       });
 
@@ -445,7 +445,7 @@ describe("JunieRule", () => {
 
       // Load from file
       const junieRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-integration.md",
       });
 
@@ -463,7 +463,7 @@ describe("JunieRule", () => {
 
       // Start with rulesync rule (root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -477,7 +477,7 @@ describe("JunieRule", () => {
 
       // Convert to junie rule
       const junieRule = JunieRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -494,7 +494,7 @@ describe("JunieRule", () => {
 
       // Start with rulesync rule (non-root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "detail-roundtrip.md",
         frontmatter: {
@@ -508,7 +508,7 @@ describe("JunieRule", () => {
 
       // Convert to junie rule
       const junieRule = JunieRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -530,7 +530,7 @@ describe("JunieRule", () => {
       // This should work with the current implementation since fromFile
       // determines path based on the relativeFilePath parameter
       const junieRule = await JunieRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested-rule.md",
       });
 
@@ -543,7 +543,7 @@ describe("JunieRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting junie", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -557,7 +557,7 @@ describe("JunieRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -571,7 +571,7 @@ describe("JunieRule", () => {
 
     it("should return false for rules not targeting junie", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -585,7 +585,7 @@ describe("JunieRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -599,7 +599,7 @@ describe("JunieRule", () => {
 
     it("should handle mixed targets including junie", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -613,7 +613,7 @@ describe("JunieRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/junie-rule.ts
+++ b/src/features/rules/junie-rule.ts
@@ -59,7 +59,7 @@ export class JunieRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<JunieRule> {
@@ -68,10 +68,10 @@ export class JunieRule extends ToolRule {
     const relativePath = isRoot
       ? join(settablePaths.root.relativeDirPath, settablePaths.root.relativeFilePath)
       : join(settablePaths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new JunieRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: isRoot
         ? settablePaths.root.relativeDirPath
         : settablePaths.nonRoot.relativeDirPath,
@@ -83,13 +83,13 @@ export class JunieRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): JunieRule {
     return new JunieRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,
@@ -108,14 +108,14 @@ export class JunieRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): JunieRule {
     const isRoot = JunieRule.isRootRelativeFilePath(relativeFilePath);
 
     return new JunieRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/kilo-rule.test.ts
+++ b/src/features/rules/kilo-rule.test.ts
@@ -40,9 +40,9 @@ describe("KiloRule", () => {
       expect(kiloRule.getFileContent()).toBe("# Test Memory\n\nThis is a test memory.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const kiloRule = new KiloRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".kilo/rules",
         relativeFilePath: "custom-memory.md",
         fileContent: "# Custom Memory",
@@ -103,12 +103,12 @@ describe("KiloRule", () => {
 
   describe("fromFile", () => {
     it("should create instance from root AGENTS.md file", async () => {
-      // Setup test file - for root, the file should be directly at baseDir/AGENTS.md
+      // Setup test file - for root, the file should be directly at outputRoot/AGENTS.md
       const testContent = "# Kilo Project\n\nProject overview and agent instructions.";
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -127,7 +127,7 @@ describe("KiloRule", () => {
       await writeFileContent(join(memoriesDir, "memory-test.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-test.md",
       });
 
@@ -138,9 +138,9 @@ describe("KiloRule", () => {
       expect(kiloRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in test directory - process.cwd() is mocked to return testDir
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
@@ -157,13 +157,13 @@ describe("KiloRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const kiloRuleWithValidation = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: true,
       });
 
       const kiloRuleWithoutValidation = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: false,
       });
@@ -175,7 +175,7 @@ describe("KiloRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         KiloRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -189,18 +189,18 @@ describe("KiloRule", () => {
       const rootContent = "# Root Project Overview";
       const memoryContent = "# Memory Rule";
 
-      // Root file goes directly in baseDir
+      // Root file goes directly in outputRoot
       await writeFileContent(join(testDir, "AGENTS.md"), rootContent);
       // Memory file goes in .kilo/rules
       await writeFileContent(join(memoriesDir, "memory.md"), memoryContent);
 
       const rootRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
       const memoryRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -262,7 +262,7 @@ describe("KiloRule", () => {
       expect(kiloRule.isRoot()).toBe(false);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -276,7 +276,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -312,7 +312,7 @@ describe("KiloRule", () => {
 
     it("should handle subprojectPath from agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -326,7 +326,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -337,7 +337,7 @@ describe("KiloRule", () => {
 
     it("should ignore subprojectPath for root rules", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -351,7 +351,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -362,7 +362,7 @@ describe("KiloRule", () => {
 
     it("should handle empty subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -376,7 +376,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -387,7 +387,7 @@ describe("KiloRule", () => {
 
     it("should handle complex nested subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "nested.md",
         frontmatter: {
@@ -401,7 +401,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -412,7 +412,7 @@ describe("KiloRule", () => {
 
     it("should handle undefined agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -423,7 +423,7 @@ describe("KiloRule", () => {
       });
 
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -434,7 +434,7 @@ describe("KiloRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert KiloRule to RulesyncRule for root rule", () => {
       const kiloRule = new KiloRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -451,7 +451,7 @@ describe("KiloRule", () => {
 
     it("should convert KiloRule to RulesyncRule for memory rule", () => {
       const kiloRule = new KiloRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kilo/rules",
         relativeFilePath: "memory-convert.md",
         fileContent: "# Memory Convert Test\n\nThis memory will be converted.",
@@ -470,7 +470,7 @@ describe("KiloRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const kiloRule = new KiloRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Metadata Test\n\nWith metadata preserved.",
@@ -548,7 +548,7 @@ describe("KiloRule", () => {
 
       // Load from file
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -570,7 +570,7 @@ describe("KiloRule", () => {
 
       // Load from file
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-integration.md",
       });
 
@@ -588,7 +588,7 @@ describe("KiloRule", () => {
 
       // Start with rulesync rule (root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -602,7 +602,7 @@ describe("KiloRule", () => {
 
       // Convert to kilo rule
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -619,7 +619,7 @@ describe("KiloRule", () => {
 
       // Start with rulesync rule (non-root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "detail-roundtrip.md",
         frontmatter: {
@@ -633,7 +633,7 @@ describe("KiloRule", () => {
 
       // Convert to kilo rule
       const kiloRule = KiloRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -655,7 +655,7 @@ describe("KiloRule", () => {
       // This should work with the current implementation since fromFile
       // determines path based on the relativeFilePath parameter
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested-rule.md",
       });
 
@@ -776,7 +776,7 @@ describe("KiloRule", () => {
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -794,7 +794,7 @@ describe("KiloRule", () => {
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -809,7 +809,7 @@ describe("KiloRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const kiloRule = await KiloRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: false,
       });
@@ -868,7 +868,7 @@ describe("KiloRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting kilo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -882,7 +882,7 @@ describe("KiloRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -896,7 +896,7 @@ describe("KiloRule", () => {
 
     it("should return false for rules not targeting kilo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -910,7 +910,7 @@ describe("KiloRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -924,7 +924,7 @@ describe("KiloRule", () => {
 
     it("should handle mixed targets including kilo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -938,7 +938,7 @@ describe("KiloRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/kilo-rule.ts
+++ b/src/features/rules/kilo-rule.ts
@@ -53,7 +53,7 @@ export class KiloRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -64,11 +64,11 @@ export class KiloRule extends ToolRule {
     if (isRoot) {
       const relativePath = paths.root.relativeFilePath;
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
+        join(outputRoot, paths.root.relativeDirPath, relativePath),
       );
 
       return new KiloRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -82,9 +82,9 @@ export class KiloRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new KiloRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -94,7 +94,7 @@ export class KiloRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -102,7 +102,7 @@ export class KiloRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new KiloRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -122,7 +122,7 @@ export class KiloRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -131,7 +131,7 @@ export class KiloRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new KiloRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -42,9 +42,9 @@ describe("KiroRule", () => {
       );
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const kiroRule = new KiroRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".kiro/steering",
         relativeFilePath: "structure.md",
         fileContent: "# Structure Guidelines",
@@ -118,7 +118,7 @@ describe("KiroRule", () => {
       await writeFileContent(join(steeringDir, "product.md"), testContent);
 
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "product.md",
       });
 
@@ -137,7 +137,7 @@ describe("KiroRule", () => {
       await writeFileContent(join(steeringDir, "structure.md"), testContent);
 
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "structure.md",
       });
 
@@ -156,7 +156,7 @@ describe("KiroRule", () => {
       await writeFileContent(join(steeringDir, "tech.md"), testContent);
 
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "tech.md",
       });
 
@@ -167,12 +167,12 @@ describe("KiroRule", () => {
       expect(kiroRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in test directory's .kiro/steering
-      // Since process.cwd() is mocked to return testDir, the default baseDir will use testDir
+      // Since process.cwd() is mocked to return testDir, the default outputRoot will use testDir
       const steeringDir = join(testDir, ".kiro/steering");
       await ensureDir(steeringDir);
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       await writeFileContent(join(steeringDir, "product.md"), testContent);
 
       const kiroRule = await KiroRule.fromFile({
@@ -192,13 +192,13 @@ describe("KiroRule", () => {
       await writeFileContent(join(steeringDir, "product.md"), testContent);
 
       const kiroRuleWithValidation = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "product.md",
         validate: true,
       });
 
       const kiroRuleWithoutValidation = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "product.md",
         validate: false,
       });
@@ -210,7 +210,7 @@ describe("KiroRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         KiroRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -224,7 +224,7 @@ describe("KiroRule", () => {
       await writeFileContent(join(nestedDir, "nested-product.md"), testContent);
 
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested-product.md",
       });
 
@@ -285,7 +285,7 @@ describe("KiroRule", () => {
       expect(kiroRule.isRoot()).toBe(false);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -299,7 +299,7 @@ describe("KiroRule", () => {
       });
 
       const kiroRule = KiroRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -377,7 +377,7 @@ describe("KiroRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert KiroRule to RulesyncRule for root rule", () => {
       const kiroRule = new KiroRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/steering",
         relativeFilePath: "product.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -394,7 +394,7 @@ describe("KiroRule", () => {
 
     it("should convert KiroRule to RulesyncRule for steering document", () => {
       const kiroRule = new KiroRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/steering",
         relativeFilePath: "structure-convert.md",
         fileContent: "# Structure Convert Test\n\nThis structure will be converted.",
@@ -413,7 +413,7 @@ describe("KiroRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const kiroRule = new KiroRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".kiro/steering",
         relativeFilePath: "metadata-test.md",
         fileContent: "# Metadata Test\n\nWith metadata preserved.",
@@ -439,7 +439,7 @@ describe("KiroRule", () => {
 
       for (const doc of documents) {
         const kiroRule = new KiroRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".kiro/steering",
           relativeFilePath: doc.filename,
           fileContent: doc.content,
@@ -516,7 +516,7 @@ describe("KiroRule", () => {
 
       // Load from file
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "product.md",
       });
 
@@ -538,7 +538,7 @@ describe("KiroRule", () => {
 
       // Load from file
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "structure.md",
       });
 
@@ -556,7 +556,7 @@ describe("KiroRule", () => {
 
       // Start with rulesync rule (root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -570,7 +570,7 @@ describe("KiroRule", () => {
 
       // Convert to kiro rule
       const kiroRule = KiroRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -587,7 +587,7 @@ describe("KiroRule", () => {
 
       // Start with rulesync rule (non-root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "detail-roundtrip.md",
         frontmatter: {
@@ -601,7 +601,7 @@ describe("KiroRule", () => {
 
       // Convert to kiro rule
       const kiroRule = KiroRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -621,7 +621,7 @@ describe("KiroRule", () => {
       await writeFileContent(join(nestedDir, "nested-product.md"), content);
 
       const kiroRule = await KiroRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested-product.md",
       });
 
@@ -644,7 +644,7 @@ describe("KiroRule", () => {
         await writeFileContent(join(steeringDir, doc.filename), doc.content);
 
         const kiroRule = await KiroRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: doc.filename,
         });
 
@@ -660,7 +660,7 @@ describe("KiroRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting kiro", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -674,7 +674,7 @@ describe("KiroRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -688,7 +688,7 @@ describe("KiroRule", () => {
 
     it("should return false for rules not targeting kiro", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -702,7 +702,7 @@ describe("KiroRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -716,7 +716,7 @@ describe("KiroRule", () => {
 
     it("should handle mixed targets including kiro", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -730,7 +730,7 @@ describe("KiroRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -39,16 +39,16 @@ export class KiroRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<KiroRule> {
     const fileContent = await readFileContent(
-      join(baseDir, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
+      join(outputRoot, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
     );
 
     return new KiroRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -58,13 +58,13 @@ export class KiroRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): KiroRule {
     return new KiroRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         nonRootPath: this.getSettablePaths().nonRoot,
@@ -81,12 +81,12 @@ export class KiroRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): KiroRule {
     return new KiroRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/opencode-rule.test.ts
+++ b/src/features/rules/opencode-rule.test.ts
@@ -40,9 +40,9 @@ describe("OpenCodeRule", () => {
       expect(opencodeRule.getFileContent()).toBe("# Test Memory\n\nThis is a test memory.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const opencodeRule = new OpenCodeRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".opencode/memories",
         relativeFilePath: "custom-memory.md",
         fileContent: "# Custom Memory",
@@ -103,12 +103,12 @@ describe("OpenCodeRule", () => {
 
   describe("fromFile", () => {
     it("should create instance from root AGENTS.md file", async () => {
-      // Setup test file - for root, the file should be directly at baseDir/AGENTS.md
+      // Setup test file - for root, the file should be directly at outputRoot/AGENTS.md
       const testContent = "# OpenCode Project\n\nProject overview and agent instructions.";
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -127,7 +127,7 @@ describe("OpenCodeRule", () => {
       await writeFileContent(join(memoriesDir, "memory-test.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-test.md",
       });
 
@@ -138,9 +138,9 @@ describe("OpenCodeRule", () => {
       expect(opencodeRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in test directory - process.cwd() is mocked to return testDir
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
@@ -157,13 +157,13 @@ describe("OpenCodeRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const opencodeRuleWithValidation = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: true,
       });
 
       const opencodeRuleWithoutValidation = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         validate: false,
       });
@@ -175,7 +175,7 @@ describe("OpenCodeRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         OpenCodeRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -189,18 +189,18 @@ describe("OpenCodeRule", () => {
       const rootContent = "# Root Project Overview";
       const memoryContent = "# Memory Rule";
 
-      // Root file goes directly in baseDir
+      // Root file goes directly in outputRoot
       await writeFileContent(join(testDir, "AGENTS.md"), rootContent);
       // Memory file goes in .opencode/memories
       await writeFileContent(join(memoriesDir, "memory.md"), memoryContent);
 
       const rootRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
       const memoryRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -264,7 +264,7 @@ describe("OpenCodeRule", () => {
       expect(opencodeRule.isRoot()).toBe(false);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -278,7 +278,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -314,7 +314,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle subprojectPath from agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -328,7 +328,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -341,7 +341,7 @@ describe("OpenCodeRule", () => {
 
     it("should ignore subprojectPath for root rules", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -355,7 +355,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -366,7 +366,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle empty subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -380,7 +380,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -391,7 +391,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle complex nested subprojectPath", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "nested.md",
         frontmatter: {
@@ -405,7 +405,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -418,7 +418,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle undefined agentsmd field", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -429,7 +429,7 @@ describe("OpenCodeRule", () => {
       });
 
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -440,7 +440,7 @@ describe("OpenCodeRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert OpenCodeRule to RulesyncRule for root rule", () => {
       const opencodeRule = new OpenCodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -457,7 +457,7 @@ describe("OpenCodeRule", () => {
 
     it("should convert OpenCodeRule to RulesyncRule for memory rule", () => {
       const opencodeRule = new OpenCodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".opencode/memories",
         relativeFilePath: "memory-convert.md",
         fileContent: "# Memory Convert Test\n\nThis memory will be converted.",
@@ -476,7 +476,7 @@ describe("OpenCodeRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const opencodeRule = new OpenCodeRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Metadata Test\n\nWith metadata preserved.",
@@ -554,7 +554,7 @@ describe("OpenCodeRule", () => {
 
       // Load from file
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -576,7 +576,7 @@ describe("OpenCodeRule", () => {
 
       // Load from file
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory-integration.md",
       });
 
@@ -594,7 +594,7 @@ describe("OpenCodeRule", () => {
 
       // Start with rulesync rule (root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -608,7 +608,7 @@ describe("OpenCodeRule", () => {
 
       // Convert to opencode rule
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -625,7 +625,7 @@ describe("OpenCodeRule", () => {
 
       // Start with rulesync rule (non-root)
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "detail-roundtrip.md",
         frontmatter: {
@@ -639,7 +639,7 @@ describe("OpenCodeRule", () => {
 
       // Convert to opencode rule
       const opencodeRule = OpenCodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -661,7 +661,7 @@ describe("OpenCodeRule", () => {
       // This should work with the current implementation since fromFile
       // determines path based on the relativeFilePath parameter
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/nested-rule.md",
       });
 
@@ -782,7 +782,7 @@ describe("OpenCodeRule", () => {
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -800,7 +800,7 @@ describe("OpenCodeRule", () => {
       await writeFileContent(join(globalDir, "AGENTS.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -815,7 +815,7 @@ describe("OpenCodeRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), testContent);
 
       const opencodeRule = await OpenCodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: false,
       });
@@ -874,7 +874,7 @@ describe("OpenCodeRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting opencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -888,7 +888,7 @@ describe("OpenCodeRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -902,7 +902,7 @@ describe("OpenCodeRule", () => {
 
     it("should return false for rules not targeting opencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -916,7 +916,7 @@ describe("OpenCodeRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -930,7 +930,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle mixed targets including opencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -944,7 +944,7 @@ describe("OpenCodeRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/opencode-rule.ts
+++ b/src/features/rules/opencode-rule.ts
@@ -53,7 +53,7 @@ export class OpenCodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -64,11 +64,11 @@ export class OpenCodeRule extends ToolRule {
     if (isRoot) {
       const relativePath = paths.root.relativeFilePath;
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, relativePath),
+        join(outputRoot, paths.root.relativeDirPath, relativePath),
       );
 
       return new OpenCodeRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -82,9 +82,9 @@ export class OpenCodeRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new OpenCodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -94,7 +94,7 @@ export class OpenCodeRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -102,7 +102,7 @@ export class OpenCodeRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     return new OpenCodeRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -122,7 +122,7 @@ export class OpenCodeRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -131,7 +131,7 @@ export class OpenCodeRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new OpenCodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/pi-rule.test.ts
+++ b/src/features/rules/pi-rule.test.ts
@@ -68,7 +68,7 @@ describe("PiRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const rule = await PiRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
       });
 
@@ -85,7 +85,7 @@ describe("PiRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), content);
 
       const rule = await PiRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -102,7 +102,7 @@ describe("PiRule", () => {
       await writeFileContent(join(globalDir, "AGENTS.md"), content);
 
       const rule = await PiRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "AGENTS.md",
         global: true,
       });
@@ -115,7 +115,7 @@ describe("PiRule", () => {
     it("should throw when asked for non-root file in global mode", async () => {
       await expect(
         PiRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "memory.md",
           global: true,
         }),
@@ -126,7 +126,7 @@ describe("PiRule", () => {
   describe("fromRulesyncRule", () => {
     it("should produce a root rule from a root rulesync rule", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "overview.md",
         frontmatter: {
@@ -137,7 +137,7 @@ describe("PiRule", () => {
       });
 
       const rule = PiRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -149,7 +149,7 @@ describe("PiRule", () => {
 
     it("should produce a non-root rule under .agents/memories", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "memory.md",
         frontmatter: {
@@ -160,7 +160,7 @@ describe("PiRule", () => {
       });
 
       const rule = PiRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -171,7 +171,7 @@ describe("PiRule", () => {
 
     it("should throw for non-root rule in global mode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "memory.md",
         frontmatter: {
@@ -183,7 +183,7 @@ describe("PiRule", () => {
 
       expect(() =>
         PiRule.fromRulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncRule,
           global: true,
         }),
@@ -192,7 +192,7 @@ describe("PiRule", () => {
 
     it("should use global root paths when global is true", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "overview.md",
         frontmatter: {
@@ -203,7 +203,7 @@ describe("PiRule", () => {
       });
 
       const rule = PiRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         global: true,
       });
@@ -217,7 +217,7 @@ describe("PiRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert a root rule", () => {
       const rule = new PiRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "# Root\nBody.",
@@ -232,7 +232,7 @@ describe("PiRule", () => {
 
     it("should convert a non-root rule", () => {
       const rule = new PiRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "memories"),
         relativeFilePath: "memory.md",
         fileContent: "# Memory\nBody.",
@@ -249,7 +249,7 @@ describe("PiRule", () => {
   describe("validate", () => {
     it("should always succeed", () => {
       const rule = new PiRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
         fileContent: "",
@@ -265,7 +265,7 @@ describe("PiRule", () => {
   describe("forDeletion", () => {
     it("should create a root deletion stub when path matches root", () => {
       const rule = PiRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
       });
@@ -276,7 +276,7 @@ describe("PiRule", () => {
 
     it("should create a non-root deletion stub when path does not match root", () => {
       const rule = PiRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "memories"),
         relativeFilePath: "memory.md",
       });
@@ -289,7 +289,7 @@ describe("PiRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for pi target", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["pi"] },
@@ -301,7 +301,7 @@ describe("PiRule", () => {
 
     it("should return true for wildcard targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["*"] },
@@ -313,7 +313,7 @@ describe("PiRule", () => {
 
     it("should return false for non-pi targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["cursor"] },

--- a/src/features/rules/pi-rule.ts
+++ b/src/features/rules/pi-rule.ts
@@ -64,7 +64,7 @@ export class PiRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
@@ -74,11 +74,11 @@ export class PiRule extends ToolRule {
 
     if (isRoot) {
       const fileContent = await readFileContent(
-        join(baseDir, paths.root.relativeDirPath, paths.root.relativeFilePath),
+        join(outputRoot, paths.root.relativeDirPath, paths.root.relativeFilePath),
       );
 
       return new PiRule({
-        baseDir,
+        outputRoot,
         relativeDirPath: paths.root.relativeDirPath,
         relativeFilePath: paths.root.relativeFilePath,
         fileContent,
@@ -94,9 +94,9 @@ export class PiRule extends ToolRule {
     }
 
     const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new PiRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.nonRoot.relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -106,7 +106,7 @@ export class PiRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -121,7 +121,7 @@ export class PiRule extends ToolRule {
 
     return new PiRule(
       this.buildToolRuleParamsAgentsmd({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -141,7 +141,7 @@ export class PiRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
@@ -150,7 +150,7 @@ export class PiRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new PiRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/qwencode-rule.test.ts
+++ b/src/features/rules/qwencode-rule.test.ts
@@ -41,9 +41,9 @@ describe("QwencodeRule", () => {
       expect(qwencodeRule.isRoot()).toBe(false);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const qwencodeRule = new QwencodeRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
@@ -108,7 +108,7 @@ describe("QwencodeRule", () => {
       await writeFileContent(join(memoriesDir, "test.md"), testContent);
 
       const qwencodeRule = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -125,7 +125,7 @@ describe("QwencodeRule", () => {
       await writeFileContent(join(testDir, "QWEN.md"), testContent);
 
       const qwencodeRule = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "QWEN.md",
       });
 
@@ -136,11 +136,11 @@ describe("QwencodeRule", () => {
       expect(qwencodeRule.isRoot()).toBe(true);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in test directory (process.cwd() is mocked to return testDir)
       const memoriesDir = join(testDir, ".qwen/memories");
       await ensureDir(memoriesDir);
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       const testFilePath = join(memoriesDir, "default-test.md");
       await writeFileContent(testFilePath, testContent);
 
@@ -155,9 +155,9 @@ describe("QwencodeRule", () => {
       expect(qwencodeRule.getFilePath()).toBe(join(testDir, ".qwen/memories/default-test.md"));
     });
 
-    it("should handle root file detection with default baseDir", async () => {
+    it("should handle root file detection with default outputRoot", async () => {
       // Setup root test file in test directory (process.cwd() is mocked to return testDir)
-      const testContent = "# Root Default BaseDir Test";
+      const testContent = "# Root Default OutputRoot Test";
       const rootFilePath = join(testDir, "QWEN.md");
       await writeFileContent(rootFilePath, testContent);
 
@@ -179,13 +179,13 @@ describe("QwencodeRule", () => {
       await writeFileContent(join(memoriesDir, "validation-test.md"), testContent);
 
       const qwencodeRuleWithValidation = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: true,
       });
 
       const qwencodeRuleWithoutValidation = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -197,7 +197,7 @@ describe("QwencodeRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         QwencodeRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -206,7 +206,7 @@ describe("QwencodeRule", () => {
     it("should throw error when root file does not exist", async () => {
       await expect(
         QwencodeRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "QWEN.md",
         }),
       ).rejects.toThrow();
@@ -264,7 +264,7 @@ describe("QwencodeRule", () => {
       expect(qwencodeRule.isRoot()).toBe(true);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -278,7 +278,7 @@ describe("QwencodeRule", () => {
       });
 
       const qwencodeRule = QwencodeRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -337,7 +337,7 @@ describe("QwencodeRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert non-root QwencodeRule to RulesyncRule", () => {
       const qwencodeRule = new QwencodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "convert-test.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -359,7 +359,7 @@ describe("QwencodeRule", () => {
 
     it("should convert root QwencodeRule to RulesyncRule", () => {
       const qwencodeRule = new QwencodeRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "QWEN.md",
         fileContent: "# Root Convert Test\n\nThis root will be converted.",
@@ -382,7 +382,7 @@ describe("QwencodeRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const qwencodeRule = new QwencodeRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "metadata-test.md",
         fileContent: "# Metadata Test\n\nContent with metadata.",
@@ -489,7 +489,7 @@ describe("QwencodeRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting qwencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -503,7 +503,7 @@ describe("QwencodeRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -517,7 +517,7 @@ describe("QwencodeRule", () => {
 
     it("should return false for rules not targeting qwencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -531,7 +531,7 @@ describe("QwencodeRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -545,7 +545,7 @@ describe("QwencodeRule", () => {
 
     it("should handle mixed targets including qwencode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -559,7 +559,7 @@ describe("QwencodeRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".qwen/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -580,7 +580,7 @@ describe("QwencodeRule", () => {
 
       // Load from file
       const qwencodeRule = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "integration.md",
       });
 
@@ -600,7 +600,7 @@ describe("QwencodeRule", () => {
 
       // Load from file
       const qwencodeRule = await QwencodeRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "QWEN.md",
       });
 
@@ -621,7 +621,7 @@ describe("QwencodeRule", () => {
 
       // Start with rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -635,7 +635,7 @@ describe("QwencodeRule", () => {
 
       // Convert to qwencode rule
       const qwencodeRule = QwencodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -652,7 +652,7 @@ describe("QwencodeRule", () => {
 
       // Start with root rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "root-roundtrip.md",
         frontmatter: {
@@ -666,7 +666,7 @@ describe("QwencodeRule", () => {
 
       // Convert to qwencode rule
       const qwencodeRule = QwencodeRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 

--- a/src/features/rules/qwencode-rule.ts
+++ b/src/features/rules/qwencode-rule.ts
@@ -50,16 +50,16 @@ export class QwencodeRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<QwencodeRule> {
     const isRoot = relativeFilePath === "QWEN.md";
     const relativePath = isRoot ? "QWEN.md" : join(".qwen", "memories", relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new QwencodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: isRoot
         ? this.getSettablePaths().root.relativeDirPath
         : this.getSettablePaths().nonRoot.relativeDirPath,
@@ -71,10 +71,10 @@ export class QwencodeRule extends ToolRule {
   }
 
   static fromRulesyncRule(params: ToolRuleFromRulesyncRuleParams): QwencodeRule {
-    const { baseDir = process.cwd(), rulesyncRule, validate = true } = params;
+    const { outputRoot = process.cwd(), rulesyncRule, validate = true } = params;
     return new QwencodeRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,
@@ -92,14 +92,14 @@ export class QwencodeRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): QwencodeRule {
     const isRoot = relativeFilePath === "QWEN.md" && relativeDirPath === ".";
 
     return new QwencodeRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/replit-rule.test.ts
+++ b/src/features/rules/replit-rule.test.ts
@@ -43,7 +43,7 @@ describe("ReplitRule", () => {
       await writeFileContent(join(testDir, "replit.md"), replitContent);
 
       const replitRule = await ReplitRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "replit.md",
       });
 
@@ -55,7 +55,7 @@ describe("ReplitRule", () => {
     it("should throw error for non-root files", async () => {
       await expect(
         ReplitRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "other.md",
         }),
       ).rejects.toThrow("ReplitRule only supports root rules");
@@ -77,7 +77,7 @@ describe("ReplitRule", () => {
       });
 
       const replitRule = ReplitRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -96,7 +96,7 @@ describe("ReplitRule", () => {
 
       expect(() =>
         ReplitRule.fromRulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncRule,
         }),
       ).toThrow("ReplitRule only supports root rules");
@@ -137,7 +137,7 @@ describe("ReplitRule", () => {
   describe("forDeletion", () => {
     it("should create minimal instance for deletion", () => {
       const replitRule = ReplitRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "replit.md",
       });
@@ -151,7 +151,7 @@ describe("ReplitRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for root rules targeting replit", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "replit.md",
         frontmatter: { targets: ["replit"], root: true },
@@ -163,7 +163,7 @@ describe("ReplitRule", () => {
 
     it("should return true for root rules targeting all (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "replit.md",
         frontmatter: { targets: ["*"], root: true },
@@ -175,7 +175,7 @@ describe("ReplitRule", () => {
 
     it("should return false for non-root rules", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "test.md",
         frontmatter: { targets: ["replit"], root: false },

--- a/src/features/rules/replit-rule.ts
+++ b/src/features/rules/replit-rule.ts
@@ -42,7 +42,7 @@ export class ReplitRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<ReplitRule> {
@@ -55,11 +55,11 @@ export class ReplitRule extends ToolRule {
 
     const relativePath = paths.root.relativeFilePath;
     const fileContent = await readFileContent(
-      join(baseDir, paths.root.relativeDirPath, relativePath),
+      join(outputRoot, paths.root.relativeDirPath, relativePath),
     );
 
     return new ReplitRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.root.relativeDirPath,
       relativeFilePath: paths.root.relativeFilePath,
       fileContent,
@@ -69,7 +69,7 @@ export class ReplitRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ReplitRule {
@@ -83,7 +83,7 @@ export class ReplitRule extends ToolRule {
 
     return new ReplitRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: paths.root,
@@ -102,7 +102,7 @@ export class ReplitRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): ReplitRule {
@@ -110,7 +110,7 @@ export class ReplitRule extends ToolRule {
     const isRoot = relativeFilePath === paths.root.relativeFilePath;
 
     return new ReplitRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/roo-rule.test.ts
+++ b/src/features/rules/roo-rule.test.ts
@@ -40,9 +40,9 @@ describe("RooRule", () => {
       expect(rooRule.getFileContent()).toBe("# Test Rule\n\nThis is a test rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const rooRule = new RooRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".roo/rules",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
@@ -93,7 +93,7 @@ describe("RooRule", () => {
       await writeFileContent(join(rulesDir, "test.md"), testContent);
 
       const rooRule = await RooRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -103,11 +103,11 @@ describe("RooRule", () => {
       expect(rooRule.getFilePath()).toBe(join(testDir, ".roo/rules/test.md"));
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file using testDir
       const rulesDir = join(testDir, ".roo/rules");
       await ensureDir(rulesDir);
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       const testFilePath = join(rulesDir, "default-test.md");
       await writeFileContent(testFilePath, testContent);
 
@@ -129,13 +129,13 @@ describe("RooRule", () => {
       await writeFileContent(join(rulesDir, "validation-test.md"), testContent);
 
       const rooRuleWithValidation = await RooRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: true,
       });
 
       const rooRuleWithoutValidation = await RooRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -147,7 +147,7 @@ describe("RooRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         RooRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -178,7 +178,7 @@ describe("RooRule", () => {
       expect(rooRule.getFileContent()).toContain("# Test RulesyncRule\n\nContent from rulesync.");
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -192,7 +192,7 @@ describe("RooRule", () => {
       });
 
       const rooRule = RooRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -278,7 +278,7 @@ describe("RooRule", () => {
   describe("toRulesyncRule", () => {
     it("should convert RooRule to RulesyncRule", () => {
       const rooRule = new RooRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/rules",
         relativeFilePath: "convert-test.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -294,7 +294,7 @@ describe("RooRule", () => {
 
     it("should preserve metadata in conversion", () => {
       const rooRule = new RooRule({
-        baseDir: "/test/path",
+        outputRoot: "/test/path",
         relativeDirPath: ".roo/rules",
         relativeFilePath: "metadata-test.md",
         fileContent: "---\ntitle: Test Rule\n---\n# Metadata Test",
@@ -380,7 +380,7 @@ describe("RooRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting roo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -394,7 +394,7 @@ describe("RooRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -408,7 +408,7 @@ describe("RooRule", () => {
 
     it("should return false for rules not targeting roo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -422,7 +422,7 @@ describe("RooRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -436,7 +436,7 @@ describe("RooRule", () => {
 
     it("should handle mixed targets including roo", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -450,7 +450,7 @@ describe("RooRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -471,7 +471,7 @@ describe("RooRule", () => {
 
       // Load from file
       const rooRule = await RooRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "integration.md",
       });
 
@@ -489,7 +489,7 @@ describe("RooRule", () => {
 
       // Start with rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -503,7 +503,7 @@ describe("RooRule", () => {
 
       // Convert to roo rule
       const rooRule = RooRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -43,16 +43,16 @@ export class RooRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<RooRule> {
     const fileContent = await readFileContent(
-      join(baseDir, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
+      join(outputRoot, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
     );
 
     return new RooRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -62,13 +62,13 @@ export class RooRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): RooRule {
     return new RooRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         nonRootPath: this.getSettablePaths().nonRoot,
@@ -108,12 +108,12 @@ export class RooRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): RooRule {
     return new RooRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/rovodev-rule.test.ts
+++ b/src/features/rules/rovodev-rule.test.ts
@@ -57,7 +57,7 @@ describe("RovodevRule", () => {
       await writeFileContent(join(testDir, ".rovodev", "AGENTS.md"), content);
 
       const rule = await RovodevRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rovodev",
         relativeFilePath: "AGENTS.md",
       });
@@ -73,7 +73,7 @@ describe("RovodevRule", () => {
       await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const rule = await RovodevRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
       });
@@ -85,7 +85,7 @@ describe("RovodevRule", () => {
     it("should reject relativeFilePath other than AGENTS.md when not loading modular-rules", async () => {
       await expect(
         RovodevRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "other.md",
         }),
       ).rejects.toThrow(/Rovodev rules support only AGENTS\.md/);
@@ -98,7 +98,7 @@ describe("RovodevRule", () => {
       await writeFileContent(join(modularDir, "api.md"), content);
 
       const rule = await RovodevRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", ".rulesync", "modular-rules"),
         relativeFilePath: "api.md",
       });
@@ -115,7 +115,7 @@ describe("RovodevRule", () => {
 
       await expect(
         RovodevRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".rovodev", ".rulesync", "modular-rules"),
           relativeFilePath: "AGENTS.md",
         }),
@@ -128,7 +128,7 @@ describe("RovodevRule", () => {
 
       await expect(
         RovodevRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: "pkg",
           relativeFilePath: "AGENTS.md",
         }),
@@ -141,7 +141,7 @@ describe("RovodevRule", () => {
 
       await expect(
         RovodevRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: "pkg",
           relativeFilePath: "AGENTS.md",
           global: true,
@@ -154,7 +154,7 @@ describe("RovodevRule", () => {
     it("should throw when AGENTS.md is missing", async () => {
       await expect(
         RovodevRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".rovodev",
           relativeFilePath: "AGENTS.md",
         }),
@@ -178,7 +178,7 @@ describe("RovodevRule", () => {
       });
 
       const rovodevRule = RovodevRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -198,7 +198,7 @@ describe("RovodevRule", () => {
       });
 
       const rovodevRule = RovodevRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
         global: true,
       });
@@ -219,7 +219,7 @@ describe("RovodevRule", () => {
       });
 
       const rovodevRule = RovodevRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -242,7 +242,7 @@ describe("RovodevRule", () => {
 
       expect(() =>
         RovodevRule.fromRulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncRule,
           global: true,
         }),
@@ -262,7 +262,7 @@ describe("RovodevRule", () => {
 
       expect(() =>
         RovodevRule.fromRulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           rulesyncRule,
         }),
       ).toThrow(/Reserved Rovodev memory basename/);
@@ -361,7 +361,7 @@ describe("RovodevRule", () => {
   describe("round-trip", () => {
     it("fromRulesyncRule then toRulesyncRule preserves body and root", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: RULESYNC_OVERVIEW_FILE_NAME,
         frontmatter: {
@@ -373,7 +373,7 @@ describe("RovodevRule", () => {
       });
 
       const rovodev = RovodevRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
@@ -400,7 +400,7 @@ describe("RovodevRule", () => {
   describe("forDeletion", () => {
     it("should create minimal instance for deletion", () => {
       const rule = RovodevRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rovodev",
         relativeFilePath: "AGENTS.md",
       });
@@ -414,7 +414,7 @@ describe("RovodevRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true when targets include rovodev", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "overview.md",
         frontmatter: { targets: ["rovodev"], root: true },
@@ -426,7 +426,7 @@ describe("RovodevRule", () => {
 
     it("should return true when targets include *", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "overview.md",
         frontmatter: { targets: ["*"], root: true },
@@ -438,7 +438,7 @@ describe("RovodevRule", () => {
 
     it("should return true for localRoot rule with rovodev target", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "local.md",
         frontmatter: { targets: ["rovodev"], localRoot: true, root: false },
@@ -450,7 +450,7 @@ describe("RovodevRule", () => {
 
     it("should return false when targets exclude rovodev", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".",
         relativeFilePath: "overview.md",
         frontmatter: { targets: ["junie"], root: true },
@@ -462,7 +462,7 @@ describe("RovodevRule", () => {
 
     it("should return true for non-root modular rules when targets include rovodev", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
         relativeFilePath: "nested.md",
         frontmatter: { targets: ["rovodev"], root: false },

--- a/src/features/rules/rovodev-rule.ts
+++ b/src/features/rules/rovodev-rule.ts
@@ -93,7 +93,7 @@ export class RovodevRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     relativeDirPath: overrideDirPath,
     validate = true,
@@ -108,7 +108,7 @@ export class RovodevRule extends ToolRule {
       overrideDirPath === paths.nonRoot.relativeDirPath
     ) {
       return this.fromModularFile({
-        baseDir,
+        outputRoot,
         relativeFilePath,
         relativeDirPath: overrideDirPath,
         validate,
@@ -117,7 +117,7 @@ export class RovodevRule extends ToolRule {
     }
 
     return this.fromRootFile({
-      baseDir,
+      outputRoot,
       relativeFilePath,
       overrideDirPath,
       validate,
@@ -127,13 +127,13 @@ export class RovodevRule extends ToolRule {
   }
 
   private static async fromModularFile({
-    baseDir,
+    outputRoot,
     relativeFilePath,
     relativeDirPath,
     validate,
     global,
   }: {
-    baseDir: string;
+    outputRoot: string;
     relativeFilePath: string;
     relativeDirPath: string;
     validate: boolean;
@@ -144,9 +144,9 @@ export class RovodevRule extends ToolRule {
         `Reserved Rovodev memory basename under modular-rules (not a modular rule): ${join(relativeDirPath, relativeFilePath)}`,
       );
     }
-    const fileContent = await readFileContent(join(baseDir, relativeDirPath, relativeFilePath));
+    const fileContent = await readFileContent(join(outputRoot, relativeDirPath, relativeFilePath));
     return new RovodevRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -157,14 +157,14 @@ export class RovodevRule extends ToolRule {
   }
 
   private static async fromRootFile({
-    baseDir,
+    outputRoot,
     relativeFilePath,
     overrideDirPath,
     validate,
     global,
     paths,
   }: {
-    baseDir: string;
+    outputRoot: string;
     relativeFilePath: string;
     overrideDirPath: string | undefined;
     validate: boolean;
@@ -198,10 +198,10 @@ export class RovodevRule extends ToolRule {
       );
     }
 
-    const fileContent = await readFileContent(join(baseDir, relativeDirPath, relativeFilePath));
+    const fileContent = await readFileContent(join(outputRoot, relativeDirPath, relativeFilePath));
 
     return new RovodevRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent,
@@ -212,13 +212,13 @@ export class RovodevRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolRuleForDeletionParams): RovodevRule {
     return new RovodevRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? ".",
       relativeFilePath: relativeFilePath ?? "AGENTS.md",
       fileContent: "",
@@ -229,7 +229,7 @@ export class RovodevRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     global = false,
@@ -240,7 +240,7 @@ export class RovodevRule extends ToolRule {
     if (isRoot) {
       return new RovodevRule(
         this.buildToolRuleParamsDefault({
-          baseDir,
+          outputRoot,
           rulesyncRule,
           validate,
           global,
@@ -265,7 +265,7 @@ export class RovodevRule extends ToolRule {
 
     return new RovodevRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         global,
@@ -278,7 +278,7 @@ export class RovodevRule extends ToolRule {
   toRulesyncRule(): RulesyncRule {
     if (this.getRelativeFilePath() === "AGENTS.local.md") {
       return new RulesyncRule({
-        baseDir: this.getBaseDir(),
+        outputRoot: this.getOutputRoot(),
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "AGENTS.local.md",
         frontmatter: {
@@ -294,7 +294,7 @@ export class RovodevRule extends ToolRule {
 
     if (!this.isRoot()) {
       return new RulesyncRule({
-        baseDir: this.getBaseDir(),
+        outputRoot: this.getOutputRoot(),
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: this.getRelativeFilePath(),
         frontmatter: {

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -42,7 +42,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "copilot-rule.md",
           frontmatter: {
@@ -51,7 +51,7 @@ describe("RulesProcessor", () => {
           body: "Copilot specific rule",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "cursor-rule.md",
           frontmatter: {
@@ -60,7 +60,7 @@ describe("RulesProcessor", () => {
           body: "Cursor specific rule",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "all-tools-rule.md",
           frontmatter: {
@@ -83,7 +83,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "copilot-rule.md",
           frontmatter: {
@@ -92,7 +92,7 @@ describe("RulesProcessor", () => {
           body: "Copilot specific rule",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "cursor-rule.md",
           frontmatter: {
@@ -112,7 +112,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "mixed-rule.md",
           frontmatter: {
@@ -121,7 +121,7 @@ describe("RulesProcessor", () => {
           body: "Mixed targets rule",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "other-rule.md",
           frontmatter: {
@@ -142,7 +142,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "no-targets.md",
           frontmatter: {},
@@ -162,7 +162,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "empty-targets.md",
           frontmatter: {
@@ -202,7 +202,7 @@ describe("RulesProcessor", () => {
 
         const rulesyncRules = [
           new RulesyncRule({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
             relativeFilePath: "targeted-rule.md",
             frontmatter: {
@@ -211,7 +211,7 @@ describe("RulesProcessor", () => {
             body: `${toolTarget} specific rule`,
           }),
           new RulesyncRule({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
             relativeFilePath: "non-targeted-rule.md",
             frontmatter: {
@@ -235,7 +235,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root-rule.md",
           frontmatter: {
@@ -247,7 +247,7 @@ describe("RulesProcessor", () => {
           body: "# Root rule content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "feature-rule.md",
           frontmatter: {
@@ -259,7 +259,7 @@ describe("RulesProcessor", () => {
           body: "# Feature rule content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "minimal-rule.md",
           frontmatter: {
@@ -293,7 +293,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -303,7 +303,7 @@ describe("RulesProcessor", () => {
           body: "# Root",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "no-metadata.md",
           frontmatter: {
@@ -328,7 +328,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -338,7 +338,7 @@ describe("RulesProcessor", () => {
           body: "# Root",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "quoted.md",
           frontmatter: {
@@ -365,7 +365,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -391,7 +391,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -403,7 +403,7 @@ describe("RulesProcessor", () => {
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "feature.md",
           frontmatter: {
@@ -435,7 +435,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -445,7 +445,7 @@ describe("RulesProcessor", () => {
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "feature.md",
           frontmatter: {
@@ -478,7 +478,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -499,7 +499,7 @@ describe("RulesProcessor", () => {
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -509,7 +509,7 @@ describe("RulesProcessor", () => {
           body: "# Root",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "multi-glob.md",
           frontmatter: {
@@ -547,12 +547,12 @@ describe("RulesProcessor", () => {
 
       const cursorProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
       });
       const claudecodeProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -570,7 +570,11 @@ describe("RulesProcessor", () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "CLAUDE.md"), "# Project from .claude dir");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const files = await processor.loadToolFiles();
       const rootFiles = files.filter((f) => f.getRelativeFilePath() === "CLAUDE.md");
@@ -585,7 +589,11 @@ describe("RulesProcessor", () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "CLAUDE.md"), "# .claude/CLAUDE.md");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const files = await processor.loadToolFiles();
       const rootFiles = files.filter((f) => f.getRelativeFilePath() === "CLAUDE.md");
@@ -600,7 +608,7 @@ describe("RulesProcessor", () => {
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -612,7 +620,11 @@ describe("RulesProcessor", () => {
     });
 
     it("should return empty when neither ./CLAUDE.md nor .claude/CLAUDE.md exist", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const files = await processor.loadToolFiles();
       const rootFiles = files.filter((f) => f.getRelativeFilePath() === "CLAUDE.md");
@@ -629,7 +641,7 @@ describe("RulesProcessor", () => {
 
       const warnSpy = vi.spyOn(logger, "warn");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "rovodev" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "rovodev" });
       const files = await processor.loadToolFiles();
       const nonRoot = files.filter(
         (f): f is RovodevRule => f instanceof RovodevRule && !f.isRoot(),
@@ -649,7 +661,7 @@ describe("RulesProcessor", () => {
         "# Frontend Rule",
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "cursor" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "cursor" });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -670,7 +682,7 @@ describe("RulesProcessor", () => {
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -708,7 +720,7 @@ describe("RulesProcessor", () => {
       ];
 
       for (const target of targets) {
-        const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: target });
+        const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: target });
 
         const filesToDelete = await processor.loadToolFiles({
           forDeletion: true,
@@ -720,7 +732,11 @@ describe("RulesProcessor", () => {
     });
 
     it("should handle errors gracefully", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -744,7 +760,7 @@ Content that would fail parsing`;
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -762,7 +778,11 @@ Content that would fail parsing`;
       await writeFileContent(join(testDir, "CLAUDE.md"), "# Root");
       await writeFileContent(join(testDir, "CLAUDE.local.md"), "# Local");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -779,7 +799,7 @@ Content that would fail parsing`;
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
@@ -797,7 +817,7 @@ Content that would fail parsing`;
       await writeFileContent(join(testDir, ".rovodev", "AGENTS.md"), "# Root");
       await writeFileContent(join(testDir, "AGENTS.local.md"), "# Local");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "rovodev" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "rovodev" });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -812,7 +832,7 @@ Content that would fail parsing`;
       await writeFileContent(join(testDir, ".rovodev", "AGENTS.md"), "# Primary");
       await writeFileContent(join(testDir, "AGENTS.md"), "# Mirror");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "rovodev" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "rovodev" });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -828,7 +848,11 @@ Content that would fail parsing`;
       await writeFileContent(join(testDir, ".claude", "CLAUDE.md"), "# Root from .claude");
       await writeFileContent(join(testDir, ".claude", "CLAUDE.local.md"), "# Local from .claude");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const filesToDelete = await processor.loadToolFiles({
         forDeletion: true,
@@ -847,7 +871,11 @@ Content that would fail parsing`;
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "CLAUDE.md"), "# Alternative Root");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const toolFiles = await processor.loadToolFiles();
 
@@ -921,7 +949,7 @@ Content that would fail parsing`;
       it("should accept global parameter", () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -932,7 +960,7 @@ Content that would fail parsing`;
       it("should default global to false when not specified", () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
         });
 
@@ -944,7 +972,7 @@ Content that would fail parsing`;
       it("should accept global parameter in constructor", () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -957,14 +985,14 @@ Content that would fail parsing`;
       it("should convert using global paths when global=true for claudecode", async () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
 
         const rulesyncRules = [
           new RulesyncRule({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
             relativeFilePath: "root.md",
             frontmatter: {
@@ -986,14 +1014,14 @@ Content that would fail parsing`;
       it("should convert using global paths when global=true for codexcli", async () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "codexcli",
           global: true,
         });
 
         const rulesyncRules = [
           new RulesyncRule({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
             relativeFilePath: "root.md",
             frontmatter: {
@@ -1015,14 +1043,14 @@ Content that would fail parsing`;
       it("should use regular paths when global=false", async () => {
         const processor = new RulesProcessor({
           logger,
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: false,
         });
 
         const rulesyncRules = [
           new RulesyncRule({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
             relativeFilePath: "root.md",
             frontmatter: {
@@ -1072,7 +1100,11 @@ targets: ["*"]
 # Local 2`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await expect(processor.loadRulesyncFiles()).rejects.toThrow("Multiple localRoot rules found");
     });
@@ -1088,7 +1120,11 @@ targets: ["*"]
 # Local without root`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await expect(processor.loadRulesyncFiles()).rejects.toThrow(
         "localRoot: true requires a root: true rule to exist",
@@ -1116,7 +1152,7 @@ targets: ["*"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -1129,7 +1165,7 @@ targets: ["*"]
       expect(rulesyncRule.getFrontmatter().root).toBe(true);
     });
 
-    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+    it("should load rulesync files from cwd even when outputRoot is different (global mode)", async () => {
       await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
       await writeFileContent(
         join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
@@ -1140,13 +1176,13 @@ targets: ["*"]
 # Root rule`,
       );
 
-      // Use a different baseDir to simulate global mode (baseDir = homeDir)
-      const differentBaseDir = join(testDir, "fake-home");
-      await ensureDir(differentBaseDir);
+      // Use a different outputRoot to simulate global mode (outputRoot = homeDir)
+      const differentOutputRoot = join(testDir, "fake-home");
+      await ensureDir(differentOutputRoot);
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: differentBaseDir,
+        outputRoot: differentOutputRoot,
         toolTarget: "claudecode",
         global: true,
       });
@@ -1160,11 +1196,15 @@ targets: ["*"]
 
   describe("localRoot content generation", () => {
     it("should generate CLAUDE.local.md for claudecode", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1174,7 +1214,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1206,13 +1246,13 @@ targets: ["*"]
     it("should generate CLAUDE.local.md for claudecode-legacy", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode-legacy",
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1222,7 +1262,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1252,11 +1292,11 @@ targets: ["*"]
     });
 
     it("should write .rovodev/AGENTS.md and mirror ./AGENTS.md for rovodev project mode", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "rovodev" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "rovodev" });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1289,11 +1329,11 @@ targets: ["*"]
     });
 
     it("should generate AGENTS.local.md for rovodev localRoot rule", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "rovodev" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "rovodev" });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1303,7 +1343,7 @@ targets: ["*"]
           body: "# Root",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1325,11 +1365,11 @@ targets: ["*"]
     });
 
     it("should append localRoot content to root file for other tools", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "copilot" });
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "copilot" });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1339,7 +1379,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1364,14 +1404,14 @@ targets: ["*"]
     it("should skip localRoot content when includeLocalRoot is false", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         featureOptions: { includeLocalRoot: false },
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1381,7 +1421,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1403,21 +1443,21 @@ targets: ["*"]
     it("should include localRoot content when includeLocalRoot is explicitly true", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         featureOptions: { includeLocalRoot: true },
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: { root: true, targets: ["*"] },
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: { localRoot: true, targets: ["*"] },
@@ -1434,21 +1474,21 @@ targets: ["*"]
     it("should throw when includeLocalRoot is not a boolean", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         featureOptions: { includeLocalRoot: "false" as unknown as boolean },
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: { root: true, targets: ["*"] },
           body: "# Root",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: { localRoot: true, targets: ["*"] },
@@ -1464,21 +1504,21 @@ targets: ["*"]
     it("should coexist with ruleDiscoveryMode option", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         featureOptions: { includeLocalRoot: false, ruleDiscoveryMode: "explicit" },
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: { root: true, targets: ["*"] },
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: { localRoot: true, targets: ["*"] },
@@ -1494,14 +1534,14 @@ targets: ["*"]
     it("should not generate localRoot rule in global mode", async () => {
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1511,7 +1551,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1531,11 +1571,15 @@ targets: ["*"]
     });
 
     it("should filter out localRoot when target does not match", async () => {
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const rulesyncRules = [
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "root.md",
           frontmatter: {
@@ -1545,7 +1589,7 @@ targets: ["*"]
           body: "# Root content",
         }),
         new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
           relativeFilePath: "local.md",
           frontmatter: {
@@ -1580,7 +1624,7 @@ targets: ["agentsmd", "opencode"]
       // Process agentsmd first
       const agentsMdProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "agentsmd",
       });
       const agentsMdRulesyncFiles = await agentsMdProcessor.loadRulesyncFiles();
@@ -1596,7 +1640,7 @@ targets: ["agentsmd", "opencode"]
       // Process opencode second (should overwrite)
       const openCodeProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "opencode",
       });
       const openCodeRulesyncFiles = await openCodeProcessor.loadRulesyncFiles();
@@ -1628,7 +1672,7 @@ targets: ["opencode", "agentsmd"]
       // Process opencode first
       const openCodeProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "opencode",
       });
       const openCodeRulesyncFiles = await openCodeProcessor.loadRulesyncFiles();
@@ -1639,7 +1683,7 @@ targets: ["opencode", "agentsmd"]
       // Process agentsmd second (should overwrite)
       const agentsMdProcessor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "agentsmd",
       });
       const agentsMdRulesyncFiles = await agentsMdProcessor.loadRulesyncFiles();
@@ -1666,7 +1710,11 @@ targets: ["*"]
 # Feature rule`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const rulesyncFiles = await processor.loadRulesyncFiles();
       const paths = rulesyncFiles.map((file) => file.getRelativeFilePath());
@@ -1687,7 +1735,11 @@ targets: ["*"]
 
       const warnSpy = vi.spyOn(logger, "warn");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await processor.loadRulesyncFiles();
 
@@ -1709,7 +1761,11 @@ targets: ["*"]
 
       const warnSpy = vi.spyOn(logger, "warn");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await processor.loadRulesyncFiles();
 
@@ -1724,7 +1780,11 @@ targets: ["*"]
 
       const warnSpy = vi.spyOn(logger, "warn");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await processor.loadRulesyncFiles();
 
@@ -1754,7 +1814,11 @@ targets: ["opencode"]
 # OpenCode Root`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const result = await processor.loadRulesyncFiles();
       const rootRules = result.filter((r) => r instanceof RulesyncRule && r.getFrontmatter().root);
@@ -1781,7 +1845,11 @@ targets: ["claudecode"]
 # Root 2`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await expect(processor.loadRulesyncFiles()).rejects.toThrow(
         "Multiple root rulesync rules found for target 'claudecode'",
@@ -1807,7 +1875,11 @@ targets: ["claudecode"]
 # Claude Root`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await expect(processor.loadRulesyncFiles()).rejects.toThrow(
         "Multiple root rulesync rules found for target 'claudecode'",
@@ -1834,7 +1906,11 @@ targets: ["opencode"]
       );
 
       // From claudecode's perspective, only the wildcard root matches
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const result = await processor.loadRulesyncFiles();
       const rootRules = result.filter((r) => r instanceof RulesyncRule && r.getFrontmatter().root);
@@ -1863,7 +1939,7 @@ targets: ["opencode"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -1893,7 +1969,11 @@ targets: ["claudecode"]
 
       const warnSpy = vi.spyOn(logger, "warn");
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await processor.loadRulesyncFiles();
 
@@ -1930,7 +2010,11 @@ targets: ["opencode"]
       );
 
       // claudecode sees only one localRoot targeting it — no error
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       const result = await processor.loadRulesyncFiles();
       expect(result).toBeDefined();
@@ -1956,7 +2040,7 @@ targets: ["copilot"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         global: true,
       });
@@ -1991,7 +2075,7 @@ targets: ["claudecode"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -2031,7 +2115,7 @@ targets: ["claudecode"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         global: true,
       });
@@ -2067,7 +2151,7 @@ targets: ["copilot"]
 
       const processor = new RulesProcessor({
         logger,
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
         global: true,
       });
@@ -2113,7 +2197,11 @@ targets: ["claudecode"]
 # Local without matching root`,
       );
 
-      const processor = new RulesProcessor({ logger, baseDir: testDir, toolTarget: "claudecode" });
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
 
       await expect(processor.loadRulesyncFiles()).rejects.toThrow(
         "localRoot: true requires a root: true rule to exist for target 'claudecode'",

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -595,7 +595,7 @@ export class RulesProcessor extends FeatureProcessor {
   private readonly featureOptions?: FeatureOptions;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     simulateCommands = false,
@@ -608,7 +608,7 @@ export class RulesProcessor extends FeatureProcessor {
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
@@ -621,7 +621,7 @@ export class RulesProcessor extends FeatureProcessor {
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = RulesProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -656,7 +656,7 @@ export class RulesProcessor extends FeatureProcessor {
           return null;
         }
         return factory.class.fromRulesyncRule({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           rulesyncRule,
           validate: true,
           global: this.global,
@@ -685,9 +685,9 @@ export class RulesProcessor extends FeatureProcessor {
         // Use .md extension - CursorRule.fromRulesyncRule will convert to .mdc
         toolRules.push(
           factory.class.fromRulesyncRule({
-            baseDir: this.baseDir,
+            outputRoot: this.outputRoot,
             rulesyncRule: new RulesyncRule({
-              baseDir: this.baseDir,
+              outputRoot: this.outputRoot,
               relativeDirPath: nonRootPath.relativeDirPath,
               relativeFilePath: "additional-conventions.md",
               frontmatter: {
@@ -735,7 +735,7 @@ export class RulesProcessor extends FeatureProcessor {
       ) {
         toolRules.push(
           new RovodevRule({
-            baseDir: this.baseDir,
+            outputRoot: this.outputRoot,
             relativeDirPath: ".",
             relativeFilePath: "AGENTS.md",
             fileContent: newContent,
@@ -797,7 +797,7 @@ export class RulesProcessor extends FeatureProcessor {
       const paths = ClaudecodeRule.getSettablePaths({ global: this.global });
       toolRules.push(
         new ClaudecodeRule({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.root.relativeDirPath,
           relativeFilePath: "CLAUDE.local.md",
           frontmatter: {},
@@ -813,7 +813,7 @@ export class RulesProcessor extends FeatureProcessor {
       });
       toolRules.push(
         new ClaudecodeLegacyRule({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: paths.root.relativeDirPath,
           relativeFilePath: "CLAUDE.local.md",
           fileContent: localRootBody,
@@ -824,7 +824,7 @@ export class RulesProcessor extends FeatureProcessor {
     } else if (this.toolTarget === "rovodev") {
       toolRules.push(
         new RovodevRule({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: ".",
           relativeFilePath: "AGENTS.local.md",
           fileContent: localRootBody,
@@ -920,18 +920,18 @@ export class RulesProcessor extends FeatureProcessor {
    * Load and parse rulesync rule files from .rulesync/rules/ directory
    */
   async loadRulesyncFiles(): Promise<RulesyncFile[]> {
-    const rulesyncBaseDir = join(this.inputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH);
-    const files = await findFilesByGlobs(join(rulesyncBaseDir, "**", "*.md"));
+    const rulesyncOutputRoot = join(this.inputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH);
+    const files = await findFilesByGlobs(join(rulesyncOutputRoot, "**", "*.md"));
     this.logger.debug(`Found ${files.length} rulesync files`);
     const rulesyncRules = await Promise.all(
       files.map((file) => {
-        const relativeFilePath = relative(rulesyncBaseDir, file);
+        const relativeFilePath = relative(rulesyncOutputRoot, file);
         checkPathTraversal({
           relativePath: relativeFilePath,
-          intendedRootDir: rulesyncBaseDir,
+          intendedRootDir: rulesyncOutputRoot,
         });
         return RulesyncRule.fromFile({
-          baseDir: this.inputRoot,
+          outputRoot: this.inputRoot,
           relativeFilePath,
         });
       }),
@@ -1024,7 +1024,7 @@ export class RulesProcessor extends FeatureProcessor {
       });
 
       const resolveRelativeDirPath = (filePath: string): string => {
-        const dirName = dirname(relative(this.baseDir, filePath));
+        const dirName = dirname(relative(this.outputRoot, filePath));
         return dirName === "" ? "." : dirName;
       };
 
@@ -1032,30 +1032,30 @@ export class RulesProcessor extends FeatureProcessor {
        * Build deletion rules from discovered file paths: resolve dir, check traversal, create forDeletion, filter isDeletable.
        *
        * Two modes:
-       * - Root mode (no opts): `relativeFilePath` = `basename(filePath)`, traversal checks `relativeDirPath` against `this.baseDir`.
-       * - Non-root mode (with `baseDirOverride` + `relativeDirPathOverride`): `relativeFilePath` = `relative(baseDirOverride, filePath)`,
-       *   traversal checks `relativeFilePath` against `baseDirOverride`.
+       * - Root mode (no opts): `relativeFilePath` = `basename(filePath)`, traversal checks `relativeDirPath` against `this.outputRoot`.
+       * - Non-root mode (with `outputRootOverride` + `relativeDirPathOverride`): `relativeFilePath` = `relative(outputRootOverride, filePath)`,
+       *   traversal checks `relativeFilePath` against `outputRootOverride`.
        */
       const buildDeletionRulesFromPaths = (
         filePaths: string[],
-        opts?: { baseDirOverride: string; relativeDirPathOverride: string },
+        opts?: { outputRootOverride: string; relativeDirPathOverride: string },
       ): ToolRule[] => {
         const isNonRoot = opts !== undefined;
-        const effectiveBaseDir = isNonRoot ? opts.baseDirOverride : this.baseDir;
+        const effectiveOutputRoot = isNonRoot ? opts.outputRootOverride : this.outputRoot;
         return filePaths
           .map((filePath) => {
             const relativeDirPath = isNonRoot
               ? opts.relativeDirPathOverride
               : resolveRelativeDirPath(filePath);
             const relativeFilePath = isNonRoot
-              ? relative(effectiveBaseDir, filePath)
+              ? relative(effectiveOutputRoot, filePath)
               : basename(filePath);
             checkPathTraversal({
               relativePath: isNonRoot ? relativeFilePath : relativeDirPath,
-              intendedRootDir: effectiveBaseDir,
+              intendedRootDir: effectiveOutputRoot,
             });
             return factory.class.forDeletion({
-              baseDir: this.baseDir,
+              outputRoot: this.outputRoot,
               relativeDirPath,
               relativeFilePath,
               global: this.global,
@@ -1086,12 +1086,12 @@ export class RulesProcessor extends FeatureProcessor {
 
         const uniqueRootFilePaths = await findFilesWithFallback(
           join(
-            this.baseDir,
+            this.outputRoot,
             settablePaths.root.relativeDirPath ?? ".",
             settablePaths.root.relativeFilePath,
           ),
           settablePaths.alternativeRoots,
-          (alt) => join(this.baseDir, alt.relativeDirPath, alt.relativeFilePath),
+          (alt) => join(this.outputRoot, alt.relativeDirPath, alt.relativeFilePath),
         );
 
         if (forDeletion) {
@@ -1103,10 +1103,10 @@ export class RulesProcessor extends FeatureProcessor {
             const relativeDirPath = resolveRelativeDirPath(filePath);
             checkPathTraversal({
               relativePath: relativeDirPath,
-              intendedRootDir: this.baseDir,
+              intendedRootDir: this.outputRoot,
             });
             return factory.class.fromFile({
-              baseDir: this.baseDir,
+              outputRoot: this.outputRoot,
               relativeFilePath: basename(filePath),
               relativeDirPath,
               global: this.global,
@@ -1127,7 +1127,7 @@ export class RulesProcessor extends FeatureProcessor {
             return [];
           }
           const uniqueLocalRootFilePaths = await findFilesByGlobs(
-            join(this.baseDir, "AGENTS.local.md"),
+            join(this.outputRoot, "AGENTS.local.md"),
           );
           return buildDeletionRulesFromPaths(uniqueLocalRootFilePaths);
         }
@@ -1141,9 +1141,9 @@ export class RulesProcessor extends FeatureProcessor {
         }
 
         const uniqueLocalRootFilePaths = await findFilesWithFallback(
-          join(this.baseDir, settablePaths.root.relativeDirPath ?? ".", "CLAUDE.local.md"),
+          join(this.outputRoot, settablePaths.root.relativeDirPath ?? ".", "CLAUDE.local.md"),
           settablePaths.alternativeRoots,
-          (alt) => join(this.baseDir, alt.relativeDirPath, "CLAUDE.local.md"),
+          (alt) => join(this.outputRoot, alt.relativeDirPath, "CLAUDE.local.md"),
         );
 
         return buildDeletionRulesFromPaths(uniqueLocalRootFilePaths);
@@ -1156,11 +1156,11 @@ export class RulesProcessor extends FeatureProcessor {
         if (!forDeletion || this.toolTarget !== "rovodev" || this.global) {
           return [];
         }
-        const primaryPaths = await findFilesByGlobs(join(this.baseDir, ".rovodev", "AGENTS.md"));
+        const primaryPaths = await findFilesByGlobs(join(this.outputRoot, ".rovodev", "AGENTS.md"));
         if (primaryPaths.length === 0) {
           return [];
         }
-        const mirrorPaths = await findFilesByGlobs(join(this.baseDir, "AGENTS.md"));
+        const mirrorPaths = await findFilesByGlobs(join(this.outputRoot, "AGENTS.md"));
         return buildDeletionRulesFromPaths(mirrorPaths);
       })();
 
@@ -1169,14 +1169,14 @@ export class RulesProcessor extends FeatureProcessor {
           return [];
         }
 
-        const nonRootBaseDir = join(this.baseDir, settablePaths.nonRoot.relativeDirPath);
+        const nonRootOutputRoot = join(this.outputRoot, settablePaths.nonRoot.relativeDirPath);
         const nonRootFilePaths = await findFilesByGlobs(
-          join(nonRootBaseDir, "**", `*.${factory.meta.extension}`),
+          join(nonRootOutputRoot, "**", `*.${factory.meta.extension}`),
         );
 
         if (forDeletion) {
           return buildDeletionRulesFromPaths(nonRootFilePaths, {
-            baseDirOverride: nonRootBaseDir,
+            outputRootOverride: nonRootOutputRoot,
             relativeDirPathOverride: settablePaths.nonRoot.relativeDirPath,
           });
         }
@@ -1185,7 +1185,7 @@ export class RulesProcessor extends FeatureProcessor {
         const nonRootPathsForImport =
           this.toolTarget === "rovodev"
             ? nonRootFilePaths.filter((filePath) => {
-                const relativeFilePath = relative(nonRootBaseDir, filePath);
+                const relativeFilePath = relative(nonRootOutputRoot, filePath);
                 const ok = RovodevRule.isAllowedModularRulesRelativePath(relativeFilePath);
                 if (!ok) {
                   this.logger.warn(
@@ -1198,13 +1198,13 @@ export class RulesProcessor extends FeatureProcessor {
 
         return await Promise.all(
           nonRootPathsForImport.map((filePath) => {
-            const relativeFilePath = relative(nonRootBaseDir, filePath);
+            const relativeFilePath = relative(nonRootOutputRoot, filePath);
             checkPathTraversal({
               relativePath: relativeFilePath,
-              intendedRootDir: nonRootBaseDir,
+              intendedRootDir: nonRootOutputRoot,
             });
             return factory.class.fromFile({
-              baseDir: this.baseDir,
+              outputRoot: this.outputRoot,
               relativeDirPath: modularRootRelative,
               relativeFilePath,
               global: this.global,

--- a/src/features/rules/rulesync-rule.test.ts
+++ b/src/features/rules/rulesync-rule.test.ts
@@ -35,7 +35,7 @@ describe("RulesyncRule", () => {
       };
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter,
@@ -54,7 +54,7 @@ describe("RulesyncRule", () => {
 
       expect(() => {
         const rule = new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: "rules",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter,
@@ -72,7 +72,7 @@ describe("RulesyncRule", () => {
 
       expect(() => {
         const rule = new RulesyncRule({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: "rules",
           relativeFilePath: "test.md",
           frontmatter: invalidFrontmatter,
@@ -87,7 +87,7 @@ describe("RulesyncRule", () => {
       const frontmatter: RulesyncRuleFrontmatterInput = {};
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter,
@@ -107,7 +107,7 @@ describe("RulesyncRule", () => {
       };
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "local-root.md",
         frontmatter,
@@ -131,7 +131,7 @@ describe("RulesyncRule", () => {
       };
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "cursor-rule.md",
         frontmatter,
@@ -156,7 +156,7 @@ describe("RulesyncRule", () => {
       };
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter,
@@ -172,7 +172,7 @@ describe("RulesyncRule", () => {
       const body = "This is the rule content\nwith multiple lines";
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -193,7 +193,7 @@ describe("RulesyncRule", () => {
       };
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter,
@@ -213,7 +213,7 @@ describe("RulesyncRule", () => {
       } as any;
 
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: invalidFrontmatter,
@@ -229,7 +229,7 @@ describe("RulesyncRule", () => {
     it("should return success when frontmatter is undefined", () => {
       // Create a rule with undefined frontmatter by bypassing the constructor
       const rule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "rules",
         relativeFilePath: "test.md",
         frontmatter: {} as any,
@@ -875,7 +875,7 @@ export interface ExampleInterface {
 
       // Test that the rule can be recreated with constructor
       const recreatedRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "integration-test.md",
         frontmatter: rule.getFrontmatter(),

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -143,12 +143,12 @@ export class RulesyncRule extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: RulesyncFileFromFileParams): Promise<RulesyncRule> {
     const filePath = join(
-      baseDir,
+      outputRoot,
       this.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath,
     );
@@ -171,7 +171,7 @@ export class RulesyncRule extends RulesyncFile {
     };
 
     return new RulesyncRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().recommended.relativeDirPath,
       relativeFilePath,
       frontmatter: validatedFrontmatter,

--- a/src/features/rules/takt-rule.test.ts
+++ b/src/features/rules/takt-rule.test.ts
@@ -45,14 +45,14 @@ describe("TaktRule", () => {
   describe("fromRulesyncRule", () => {
     it("emits a plain Markdown body under policies/", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "style.md",
         frontmatter: { targets: ["*"] },
         body: "# Style policy",
       });
 
-      const rule = TaktRule.fromRulesyncRule({ baseDir: testDir, rulesyncRule });
+      const rule = TaktRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
 
       expect(rule.getRelativeDirPath()).toBe(join(".takt", "facets", "policies"));
       expect(rule.getRelativeFilePath()).toBe("style.md");
@@ -61,7 +61,7 @@ describe("TaktRule", () => {
 
     it("renames the emitted stem with takt.name", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "long-source-name.md",
         frontmatter: {
@@ -71,14 +71,14 @@ describe("TaktRule", () => {
         body: "# Body",
       });
 
-      const rule = TaktRule.fromRulesyncRule({ baseDir: testDir, rulesyncRule });
+      const rule = TaktRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
       expect(rule.getRelativeDirPath()).toBe(join(".takt", "facets", "policies"));
       expect(rule.getRelativeFilePath()).toBe("short.md");
     });
 
     it("throws on an unsafe takt.name value", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
         relativeFilePath: "src.md",
         frontmatter: {
@@ -87,7 +87,7 @@ describe("TaktRule", () => {
         },
         body: "x",
       });
-      expect(() => TaktRule.fromRulesyncRule({ baseDir: testDir, rulesyncRule })).toThrow(
+      expect(() => TaktRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule })).toThrow(
         /Invalid takt\.name/,
       );
     });
@@ -99,7 +99,7 @@ describe("TaktRule", () => {
       await ensureDir(facetDir);
       await writeFileContent(join(facetDir, "x.md"), "Hello body\n");
 
-      const rule = await TaktRule.fromFile({ baseDir: testDir, relativeFilePath: "x.md" });
+      const rule = await TaktRule.fromFile({ outputRoot: testDir, relativeFilePath: "x.md" });
       expect(rule.getFileContent()).toBe("Hello body");
     });
   });
@@ -107,7 +107,7 @@ describe("TaktRule", () => {
   describe("forDeletion", () => {
     it("constructs a deletable instance without reading the file", () => {
       const rule = TaktRule.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "policies"),
         relativeFilePath: "x.md",
       });
@@ -118,7 +118,7 @@ describe("TaktRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("returns true when targets includes takt", () => {
       const r = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "t.md",
         frontmatter: { targets: ["takt"] },
@@ -129,7 +129,7 @@ describe("TaktRule", () => {
 
     it("returns true on wildcard targets", () => {
       const r = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "t.md",
         frontmatter: { targets: ["*"] },
@@ -140,7 +140,7 @@ describe("TaktRule", () => {
 
     it("returns false when targets excludes takt", () => {
       const r = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "t.md",
         frontmatter: { targets: ["claudecode"] },

--- a/src/features/rules/takt-rule.ts
+++ b/src/features/rules/takt-rule.ts
@@ -78,20 +78,20 @@ export class TaktRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     relativeDirPath: overrideDirPath,
   }: ToolRuleFromFileParams): Promise<TaktRule> {
     const dirPath = overrideDirPath ?? join(".takt", "facets", DEFAULT_TAKT_RULE_DIR);
-    const filePath = join(baseDir, dirPath, relativeFilePath);
+    const filePath = join(outputRoot, dirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     // Strip frontmatter when present (TAKT files are plain Markdown by spec, but
     // tolerate stray frontmatter on import for forward-compat).
     const { body } = parseFrontmatter(fileContent, filePath);
 
     return new TaktRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: dirPath,
       relativeFilePath,
       body: body.trim(),
@@ -101,12 +101,12 @@ export class TaktRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): TaktRule {
     return new TaktRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: "",
@@ -116,7 +116,7 @@ export class TaktRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): TaktRule {
@@ -133,7 +133,7 @@ export class TaktRule extends ToolRule {
     const relativeDirPath = join(".takt", "facets", DEFAULT_TAKT_RULE_DIR);
 
     return new TaktRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: rulesyncRule.getBody(),

--- a/src/features/rules/tool-rule.test.ts
+++ b/src/features/rules/tool-rule.test.ts
@@ -21,12 +21,12 @@ import {
 // Create a concrete implementation of ToolRule for testing
 class TestToolRule extends ToolRule {
   static async fromFile(params: ToolRuleFromFileParams): Promise<TestToolRule> {
-    const { baseDir = process.cwd(), relativeFilePath, validate = true } = params;
-    const filePath = join(baseDir, ".test/rules", relativeFilePath);
+    const { outputRoot = process.cwd(), relativeFilePath, validate = true } = params;
+    const filePath = join(outputRoot, ".test/rules", relativeFilePath);
     const fileContent = await readFileContent(filePath);
 
     return new TestToolRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: ".test/rules",
       relativeFilePath,
       fileContent,
@@ -130,9 +130,9 @@ describe("ToolRule", () => {
       expect(toolRule.getGlobs()).toEqual(["src/**/*"]);
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const toolRule = new TestToolRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".test/rules",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
@@ -190,7 +190,7 @@ describe("ToolRule", () => {
     it("should throw error when not implemented in base class", async () => {
       await expect(
         ToolRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test.md",
         }),
       ).rejects.toThrow("Please implement this method in the subclass.");
@@ -204,7 +204,7 @@ describe("ToolRule", () => {
       await writeFileContent(join(rulesDir, "test.md"), testContent);
 
       const toolRule = await TestToolRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test.md",
       });
 
@@ -215,11 +215,11 @@ describe("ToolRule", () => {
       expect(toolRule.getFilePath()).toBe(join(testDir, ".test/rules/test.md"));
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       // Setup test file in test directory (process.cwd() is mocked to return testDir)
       const rulesDir = join(testDir, ".test/rules");
       await ensureDir(rulesDir);
-      const testContent = "# Default BaseDir Test";
+      const testContent = "# Default OutputRoot Test";
       const testFilePath = join(rulesDir, "default-test.md");
       await writeFileContent(testFilePath, testContent);
 
@@ -240,13 +240,13 @@ describe("ToolRule", () => {
       await writeFileContent(join(rulesDir, "validation-test.md"), testContent);
 
       const toolRuleWithValidation = await TestToolRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: true,
       });
 
       const toolRuleWithoutValidation = await TestToolRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "validation-test.md",
         validate: false,
       });
@@ -258,7 +258,7 @@ describe("ToolRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         TestToolRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -355,7 +355,7 @@ describe("ToolRule", () => {
       expect(toolRule.getGlobs()).toBeUndefined();
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-base.md",
@@ -369,7 +369,7 @@ describe("ToolRule", () => {
       });
 
       const toolRule = TestToolRule.fromRulesyncRule({
-        baseDir: "/custom/base",
+        outputRoot: "/custom/base",
         rulesyncRule,
       });
 
@@ -565,7 +565,7 @@ describe("ToolRule", () => {
       expect(params.globs).toEqual([]);
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom.md",
@@ -582,11 +582,11 @@ describe("ToolRule", () => {
       });
 
       const params = (TestToolRule as any).buildToolRuleParamsAgentsmd({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         rulesyncRule,
       });
 
-      expect(params.baseDir).toBe("/custom/path");
+      expect(params.outputRoot).toBe("/custom/path");
       expect(params.relativeDirPath).toBe("subdir");
     });
 
@@ -713,7 +713,7 @@ describe("ToolRule", () => {
       expect(params.globs).toBeUndefined();
     });
 
-    it("should use custom baseDir", () => {
+    it("should use custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom.md",
@@ -727,12 +727,12 @@ describe("ToolRule", () => {
       });
 
       const params = (TestToolRule as any).buildToolRuleParamsDefault({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         rulesyncRule,
         nonRootPath: { relativeDirPath: ".agents/memories" },
       });
 
-      expect(params.baseDir).toBe("/custom/path");
+      expect(params.outputRoot).toBe("/custom/path");
     });
 
     it("should use custom validation setting", () => {
@@ -839,7 +839,7 @@ describe("ToolRule", () => {
   describe("abstract toRulesyncRule method", () => {
     it("should be implemented in concrete subclass", () => {
       const toolRule = new TestToolRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/rules",
         relativeFilePath: "convert-test.md",
         fileContent: "# Convert Test\n\nThis will be converted.",
@@ -857,7 +857,7 @@ describe("ToolRule", () => {
   describe("toRulesyncRuleDefault", () => {
     it("should create RulesyncRule with default frontmatter for non-root rule", () => {
       const toolRule = new TestToolRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/rules",
         relativeFilePath: "non-root.md",
         fileContent: "# Non-Root Rule",
@@ -867,7 +867,7 @@ describe("ToolRule", () => {
       const rulesyncRule = (toolRule as any).toRulesyncRuleDefault();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(testDir);
+      expect(rulesyncRule.getOutputRoot()).toBe(testDir);
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe("non-root.md");
       expect(rulesyncRule.getBody()).toBe("# Non-Root Rule");
@@ -881,7 +881,7 @@ describe("ToolRule", () => {
 
     it("should create RulesyncRule with description and globs", () => {
       const toolRule = new TestToolRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/rules",
         relativeFilePath: "with-metadata.md",
         fileContent: "# Rule with metadata",
@@ -899,7 +899,7 @@ describe("ToolRule", () => {
 
     it("should create RulesyncRule with default frontmatter for root rule", () => {
       const toolRule = new TestToolRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/rules",
         relativeFilePath: "root.md",
         fileContent: "# Root Rule",
@@ -909,7 +909,7 @@ describe("ToolRule", () => {
       const rulesyncRule = (toolRule as any).toRulesyncRuleDefault();
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
-      expect(rulesyncRule.getBaseDir()).toBe(testDir);
+      expect(rulesyncRule.getOutputRoot()).toBe(testDir);
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(rulesyncRule.getRelativeFilePath()).toBe(RULESYNC_OVERVIEW_FILE_NAME);
       expect(rulesyncRule.getBody()).toBe("# Root Rule");
@@ -932,7 +932,7 @@ describe("ToolRule", () => {
 
       // Load from file
       const toolRule = await TestToolRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "integration.md",
       });
 
@@ -950,7 +950,7 @@ describe("ToolRule", () => {
 
       // Start with rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -964,7 +964,7 @@ describe("ToolRule", () => {
 
       // Convert to tool rule
       const toolRule = TestToolRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -981,7 +981,7 @@ describe("ToolRule", () => {
 
       // Start with root rulesync rule
       const originalRulesync = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "root-roundtrip.md",
         frontmatter: {
@@ -995,7 +995,7 @@ describe("ToolRule", () => {
 
       // Convert to tool rule
       const toolRule = TestToolRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule: originalRulesync,
       });
 
@@ -1013,7 +1013,7 @@ describe("ToolRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting claudecode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1027,7 +1027,7 @@ describe("ToolRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1041,7 +1041,7 @@ describe("ToolRule", () => {
 
     it("should return false for rules not targeting claudecode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1055,7 +1055,7 @@ describe("ToolRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1069,7 +1069,7 @@ describe("ToolRule", () => {
 
     it("should handle mixed targets including claudecode", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -1083,7 +1083,7 @@ describe("ToolRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -26,7 +26,7 @@ export type ToolRuleFromRulesyncRuleParams = Omit<
 export type ToolRuleFromFileParams = AiFileFromFileParams;
 
 export type ToolRuleForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;
@@ -108,7 +108,7 @@ export abstract class ToolRule extends ToolFile {
   }
 
   protected static buildToolRuleParamsDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     rootPath = { relativeDirPath: ".", relativeFilePath: "AGENTS.md" },
@@ -119,7 +119,7 @@ export abstract class ToolRule extends ToolFile {
 
     if (isRoot) {
       return {
-        baseDir,
+        outputRoot,
         relativeDirPath: rootPath.relativeDirPath,
         relativeFilePath: rootPath.relativeFilePath,
         fileContent,
@@ -135,7 +135,7 @@ export abstract class ToolRule extends ToolFile {
     }
 
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath: nonRootPath.relativeDirPath,
       relativeFilePath: rulesyncRule.getRelativeFilePath(),
       fileContent,
@@ -147,14 +147,14 @@ export abstract class ToolRule extends ToolFile {
   }
 
   protected static buildToolRuleParamsAgentsmd({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
     rootPath = { relativeDirPath: ".", relativeFilePath: "AGENTS.md" },
     nonRootPath = { relativeDirPath: join(".agents", "memories") },
   }: BuildToolRuleParamsParams): BuildToolRuleParamsResult {
     const params = this.buildToolRuleParamsDefault({
-      baseDir,
+      outputRoot,
       rulesyncRule,
       validate,
       rootPath,
@@ -174,7 +174,7 @@ export abstract class ToolRule extends ToolFile {
 
   protected toRulesyncRuleDefault(): RulesyncRule {
     return new RulesyncRule({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
       relativeFilePath: this.isRoot() ? RULESYNC_OVERVIEW_FILE_NAME : this.getRelativeFilePath(),
       frontmatter: {

--- a/src/features/rules/warp-rule.test.ts
+++ b/src/features/rules/warp-rule.test.ts
@@ -81,9 +81,9 @@ describe("WarpRule", () => {
       expect(warpRule.isRoot()).toBe(false);
     });
 
-    it("should create a WarpRule with custom baseDir", () => {
+    it("should create a WarpRule with custom outputRoot", () => {
       const params: WarpRuleParams = {
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".warp",
         relativeFilePath: "custom.md",
         fileContent: "# Custom Rule",
@@ -96,7 +96,7 @@ describe("WarpRule", () => {
 
     it("should pass all parameters to parent ToolRule", () => {
       const params: WarpRuleParams = {
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         fileContent: "# Test Content",
@@ -106,7 +106,7 @@ describe("WarpRule", () => {
 
       const warpRule = new WarpRule(params);
 
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.getRelativeDirPath()).toBe(".warp/memories");
       expect(warpRule.getRelativeFilePath()).toBe("test.md");
       expect(warpRule.getFileContent()).toBe("# Test Content");
@@ -120,7 +120,7 @@ describe("WarpRule", () => {
       await writeFileContent(join(testDir, "WARP.md"), warpContent);
 
       const warpRule = await WarpRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "WARP.md",
       });
 
@@ -138,7 +138,7 @@ describe("WarpRule", () => {
       await writeFileContent(join(memoriesDir, "test-memory.md"), memoryContent);
 
       const warpRule = await WarpRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-memory.md",
       });
 
@@ -149,7 +149,7 @@ describe("WarpRule", () => {
       expect(warpRule.getFilePath()).toBe(join(testDir, ".warp/test-memory.md"));
     });
 
-    it("should use default baseDir (process.cwd()) when not provided", async () => {
+    it("should use default outputRoot (process.cwd()) when not provided", async () => {
       const warpContent = "# Default Test";
       await writeFileContent(join(testDir, "WARP.md"), warpContent);
 
@@ -157,7 +157,7 @@ describe("WarpRule", () => {
         relativeFilePath: "WARP.md",
       });
 
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.isRoot()).toBe(true);
     });
 
@@ -166,7 +166,7 @@ describe("WarpRule", () => {
       await writeFileContent(join(testDir, "WARP.md"), warpContent);
 
       const warpRule = await WarpRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "WARP.md",
         validate: false,
       });
@@ -177,7 +177,7 @@ describe("WarpRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         WarpRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "nonexistent.md",
         }),
       ).rejects.toThrow();
@@ -199,12 +199,12 @@ describe("WarpRule", () => {
       });
 
       const warpRule = WarpRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(warpRule).toBeInstanceOf(WarpRule);
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.getRelativeDirPath()).toBe(".");
       expect(warpRule.getRelativeFilePath()).toBe("WARP.md");
       expect(warpRule.isRoot()).toBe(true);
@@ -223,18 +223,18 @@ describe("WarpRule", () => {
       });
 
       const warpRule = WarpRule.fromRulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncRule,
       });
 
       expect(warpRule).toBeInstanceOf(WarpRule);
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.getRelativeDirPath()).toBe(".warp/memories");
       expect(warpRule.getRelativeFilePath()).toBe("memory.md");
       expect(warpRule.isRoot()).toBe(false);
     });
 
-    it("should use default baseDir (process.cwd()) when not provided", () => {
+    it("should use default outputRoot (process.cwd()) when not provided", () => {
       const frontmatter: RulesyncRuleFrontmatterInput = {
         description: "Default test",
         root: true,
@@ -251,7 +251,7 @@ describe("WarpRule", () => {
         rulesyncRule,
       });
 
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
     });
 
     it("should handle validation parameter", () => {
@@ -357,7 +357,7 @@ describe("WarpRule", () => {
       await writeFileContent(join(testDir, "WARP.md"), content);
 
       const warpRule = await WarpRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "WARP.md",
       });
 
@@ -372,7 +372,7 @@ describe("WarpRule", () => {
       await writeFileContent(join(memoriesDir, "memory.md"), content);
 
       const warpRule = await WarpRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "memory.md",
       });
 
@@ -409,7 +409,7 @@ describe("WarpRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting warp", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -423,7 +423,7 @@ describe("WarpRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -437,7 +437,7 @@ describe("WarpRule", () => {
 
     it("should return false for rules not targeting warp", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -451,7 +451,7 @@ describe("WarpRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -465,7 +465,7 @@ describe("WarpRule", () => {
 
     it("should handle mixed targets including warp", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -479,7 +479,7 @@ describe("WarpRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp/memories",
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -493,14 +493,14 @@ describe("WarpRule", () => {
   describe("integration with ToolRule", () => {
     it("should inherit all ToolRule functionality", () => {
       const warpRule = new WarpRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".warp",
         relativeFilePath: "integration.md",
         fileContent: "# Integration Test",
       });
 
       // Test inherited methods
-      expect(warpRule.getBaseDir()).toBe(testDir);
+      expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.getRelativeDirPath()).toBe(".warp");
       expect(warpRule.getRelativeFilePath()).toBe("integration.md");
       expect(warpRule.getFileContent()).toBe("# Integration Test");

--- a/src/features/rules/warp-rule.ts
+++ b/src/features/rules/warp-rule.ts
@@ -53,7 +53,7 @@ export class WarpRule extends ToolRule {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<WarpRule> {
@@ -61,10 +61,10 @@ export class WarpRule extends ToolRule {
     const relativePath = isRoot
       ? this.getSettablePaths().root.relativeFilePath
       : join(this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(baseDir, relativePath));
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
 
     return new WarpRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: isRoot ? this.getSettablePaths().root.relativeDirPath : ".warp",
       relativeFilePath: isRoot ? this.getSettablePaths().root.relativeFilePath : relativeFilePath,
       fileContent,
@@ -74,13 +74,13 @@ export class WarpRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): WarpRule {
     return new WarpRule(
       this.buildToolRuleParamsDefault({
-        baseDir,
+        outputRoot,
         rulesyncRule,
         validate,
         rootPath: this.getSettablePaths().root,
@@ -98,14 +98,14 @@ export class WarpRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): WarpRule {
     const isRoot = relativeFilePath === this.getSettablePaths().root.relativeFilePath;
 
     return new WarpRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/rules/windsurf-rule.test.ts
+++ b/src/features/rules/windsurf-rule.test.ts
@@ -36,9 +36,9 @@ describe("WindsurfRule", () => {
       expect(windsurfRule.getFileContent()).toBe("# Test Rule\n\nThis is a test rule.");
     });
 
-    it("should create instance with custom baseDir", () => {
+    it("should create instance with custom outputRoot", () => {
       const windsurfRule = new WindsurfRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         relativeDirPath: ".windsurf/rules",
         relativeFilePath: "test-rule.md",
         fileContent: "# Custom Rule",
@@ -87,7 +87,7 @@ describe("WindsurfRule", () => {
       await writeFileContent(filePath, ruleContent);
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-rule.md",
       });
 
@@ -104,7 +104,7 @@ describe("WindsurfRule", () => {
       await writeFileContent(filePath, ruleContent);
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "another-rule.md",
         validate: false,
       });
@@ -112,13 +112,13 @@ describe("WindsurfRule", () => {
       expect(windsurfRule.getFileContent()).toBe(ruleContent);
     });
 
-    it("should create instance from file with custom baseDir", async () => {
+    it("should create instance from file with custom outputRoot", async () => {
       const customDir = join(testDir, "custom");
       const ruleContent = "# Custom Base Dir Rule";
       await writeFileContent(join(customDir, ".windsurf", "rules", "custom-rule.md"), ruleContent);
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: customDir,
+        outputRoot: customDir,
         relativeFilePath: "custom-rule.md",
       });
 
@@ -131,7 +131,7 @@ describe("WindsurfRule", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         WindsurfRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent.md",
         }),
       ).rejects.toThrow();
@@ -145,7 +145,7 @@ describe("WindsurfRule", () => {
       );
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "nested/deep/nested-rule.md",
       });
 
@@ -175,9 +175,9 @@ describe("WindsurfRule", () => {
       );
     });
 
-    it("should create instance from RulesyncRule with custom baseDir", () => {
+    it("should create instance from RulesyncRule with custom outputRoot", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: "/existing/path",
+        outputRoot: "/existing/path",
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "custom-rule.md",
         frontmatter: { description: "Custom Rule" },
@@ -185,7 +185,7 @@ describe("WindsurfRule", () => {
       });
 
       const windsurfRule = WindsurfRule.fromRulesyncRule({
-        baseDir: "/custom/path",
+        outputRoot: "/custom/path",
         rulesyncRule,
       }) as WindsurfRule;
 
@@ -407,7 +407,7 @@ describe("WindsurfRule", () => {
     it("should handle file read errors in fromFile", async () => {
       await expect(
         WindsurfRule.fromFile({
-          baseDir: "/non-existent-directory",
+          outputRoot: "/non-existent-directory",
           relativeFilePath: "non-existent.md",
         }),
       ).rejects.toThrow();
@@ -417,7 +417,7 @@ describe("WindsurfRule", () => {
       // Try to read from a non-existent file in a valid directory
       await expect(
         WindsurfRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "restricted/non-existent.md",
         }),
       ).rejects.toThrow();
@@ -444,7 +444,7 @@ describe("WindsurfRule", () => {
   describe("isTargetedByRulesyncRule", () => {
     it("should return true for rules targeting windsurf", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -458,7 +458,7 @@ describe("WindsurfRule", () => {
 
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -472,7 +472,7 @@ describe("WindsurfRule", () => {
 
     it("should return false for rules not targeting windsurf", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -486,7 +486,7 @@ describe("WindsurfRule", () => {
 
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -500,7 +500,7 @@ describe("WindsurfRule", () => {
 
     it("should handle mixed targets including windsurf", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -514,7 +514,7 @@ describe("WindsurfRule", () => {
 
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {},
@@ -535,7 +535,7 @@ describe("WindsurfRule", () => {
         await writeFileContent(join(testDir, ".windsurf", "rules", fileName), content);
 
         const windsurfRule = await WindsurfRule.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: fileName,
         });
 
@@ -549,7 +549,7 @@ describe("WindsurfRule", () => {
       await writeFileContent(join(testDir, ".windsurf", "rules", "unicode.md"), unicodeContent);
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "unicode.md",
       });
 
@@ -562,7 +562,7 @@ describe("WindsurfRule", () => {
       await writeFileContent(join(testDir, ".windsurf", "rules", "large.md"), largeContent);
 
       const windsurfRule = await WindsurfRule.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "large.md",
       });
 

--- a/src/features/rules/windsurf-rule.ts
+++ b/src/features/rules/windsurf-rule.ts
@@ -40,16 +40,16 @@ export class WindsurfRule extends ToolRule {
     };
   }
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<WindsurfRule> {
     const fileContent = await readFileContent(
-      join(baseDir, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
+      join(outputRoot, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
     );
 
     return new WindsurfRule({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
@@ -58,12 +58,12 @@ export class WindsurfRule extends ToolRule {
   }
 
   static fromRulesyncRule({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): ToolRule {
     const toolRuleParams = this.buildToolRuleParamsDefault({
-      baseDir,
+      outputRoot,
       rulesyncRule,
       validate,
       nonRootPath: this.getSettablePaths().nonRoot,
@@ -90,12 +90,12 @@ export class WindsurfRule extends ToolRule {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolRuleForDeletionParams): WindsurfRule {
     return new WindsurfRule({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: "",

--- a/src/features/skills/agentsmd-skill.test.ts
+++ b/src/features/skills/agentsmd-skill.test.ts
@@ -41,7 +41,7 @@ describe("AgentsmdSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new AgentsmdSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -74,7 +74,7 @@ This is the body of the agentsmd skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await AgentsmdSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -92,7 +92,7 @@ This is the body of the agentsmd skill.`;
 
       await expect(
         AgentsmdSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -102,7 +102,7 @@ This is the body of the agentsmd skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -130,7 +130,7 @@ This is the body of the agentsmd skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -147,7 +147,7 @@ This is the body of the agentsmd skill.`;
 
     it("should return true when targets includes 'agentsmd'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "agentsmd-skill",
         frontmatter: {
@@ -164,7 +164,7 @@ This is the body of the agentsmd skill.`;
 
     it("should return false when targets does not include 'agentsmd'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -183,7 +183,7 @@ This is the body of the agentsmd skill.`;
   describe("toRulesyncSkill", () => {
     it("should throw error because AgentsmdSkill is simulated", () => {
       const skill = new AgentsmdSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {

--- a/src/features/skills/agentsskills-skill.test.ts
+++ b/src/features/skills/agentsskills-skill.test.ts
@@ -41,7 +41,7 @@ describe("AgentsSkillsSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new AgentsSkillsSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -74,7 +74,7 @@ This is the body of the agent skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await AgentsSkillsSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -92,7 +92,7 @@ This is the body of the agent skill.`;
 
       await expect(
         AgentsSkillsSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -102,7 +102,7 @@ This is the body of the agent skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -130,7 +130,7 @@ This is the body of the agent skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -147,7 +147,7 @@ This is the body of the agent skill.`;
 
     it("should return true when targets includes 'agentsskills'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "agentsskills-skill",
         frontmatter: {
@@ -164,7 +164,7 @@ This is the body of the agent skill.`;
 
     it("should return false when targets does not include 'agentsskills'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -183,7 +183,7 @@ This is the body of the agent skill.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const skill = new AgentsSkillsSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -218,14 +218,14 @@ This is the body of the agent skill.`;
       expect(skill.getGlobal()).toBe(false);
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const skill = AgentsSkillsSkill.forDeletion({
         dirName: "cleanup",
         relativeDirPath: join(".agents", "skills"),
       });
 
       expect(skill).toBeInstanceOf(AgentsSkillsSkill);
-      expect(skill.getBaseDir()).toBe(testDir);
+      expect(skill.getOutputRoot()).toBe(testDir);
     });
 
     it("should create instance with empty frontmatter for deletion", () => {

--- a/src/features/skills/agentsskills-skill.ts
+++ b/src/features/skills/agentsskills-skill.ts
@@ -23,7 +23,7 @@ export const AgentsSkillsSkillFrontmatterSchema = z.looseObject({
 export type AgentsSkillsSkillFrontmatter = z.infer<typeof AgentsSkillsSkillFrontmatterSchema>;
 
 export type AgentsSkillsSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: AgentsSkillsSkillFrontmatter;
@@ -40,7 +40,7 @@ export type AgentsSkillsSkillParams = {
  */
 export class AgentsSkillsSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".agents", "skills"),
     dirName,
     frontmatter,
@@ -50,7 +50,7 @@ export class AgentsSkillsSkill extends ToolSkill {
     global = false,
   }: AgentsSkillsSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -118,7 +118,7 @@ export class AgentsSkillsSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -130,7 +130,7 @@ export class AgentsSkillsSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -144,7 +144,7 @@ export class AgentsSkillsSkill extends ToolSkill {
     };
 
     return new AgentsSkillsSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: agentsSkillsFrontmatter,
@@ -168,14 +168,14 @@ export class AgentsSkillsSkill extends ToolSkill {
 
     const result = AgentsSkillsSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new AgentsSkillsSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -187,14 +187,14 @@ export class AgentsSkillsSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): AgentsSkillsSkill {
     const settablePaths = AgentsSkillsSkill.getSettablePaths({ global });
     return new AgentsSkillsSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/antigravity-skill.test.ts
+++ b/src/features/skills/antigravity-skill.test.ts
@@ -43,7 +43,7 @@ describe("AntigravitySkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content in project mode", () => {
       const skill = new AntigravitySkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agent", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -65,7 +65,7 @@ describe("AntigravitySkill", () => {
 
     it("should create instance with valid content in global mode", () => {
       const skill = new AntigravitySkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "antigravity", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -89,7 +89,7 @@ describe("AntigravitySkill", () => {
       expect(
         () =>
           new AntigravitySkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".agent", "skills"),
             dirName: "test-skill",
             frontmatter: {
@@ -117,7 +117,7 @@ This is the body of the antigravity skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await AntigravitySkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: false,
       });
@@ -142,7 +142,7 @@ This is the body of the antigravity skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await AntigravitySkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: true,
       });
@@ -161,7 +161,7 @@ This is the body of the antigravity skill.`;
 
       await expect(
         AntigravitySkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
           global: false,
         }),
@@ -180,7 +180,7 @@ Missing description field.`;
 
       await expect(
         AntigravitySkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "invalid-skill",
           global: false,
         }),
@@ -191,7 +191,7 @@ Missing description field.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill in project mode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -218,7 +218,7 @@ Missing description field.`;
 
     it("should create instance from RulesyncSkill in global mode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -247,7 +247,7 @@ Missing description field.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -264,7 +264,7 @@ Missing description field.`;
 
     it("should return true when targets includes 'antigravity'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "antigravity-skill",
         frontmatter: {
@@ -281,7 +281,7 @@ Missing description field.`;
 
     it("should return false when targets does not include 'antigravity'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -300,7 +300,7 @@ Missing description field.`;
   describe("toRulesyncSkill", () => {
     it("should convert to a RulesyncSkill in project mode", () => {
       const skill = new AntigravitySkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agent", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -324,7 +324,7 @@ Missing description field.`;
 
     it("should convert to a RulesyncSkill in global mode", () => {
       const skill = new AntigravitySkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "antigravity", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -350,7 +350,7 @@ Missing description field.`;
   describe("forDeletion", () => {
     it("should create instance for deletion in project mode", () => {
       const skill = AntigravitySkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agent", "skills"),
         dirName: "skill-to-delete",
         global: false,
@@ -362,7 +362,7 @@ Missing description field.`;
 
     it("should create instance for deletion in global mode", () => {
       const skill = AntigravitySkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "antigravity", "skills"),
         dirName: "skill-to-delete",
         global: true,
@@ -376,7 +376,7 @@ Missing description field.`;
   describe("validate", () => {
     it("should return success for valid skill", () => {
       const skill = new AntigravitySkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agent", "skills"),
         dirName: "valid-skill",
         frontmatter: {

--- a/src/features/skills/antigravity-skill.ts
+++ b/src/features/skills/antigravity-skill.ts
@@ -23,7 +23,7 @@ export const AntigravitySkillFrontmatterSchema = z.looseObject({
 export type AntigravitySkillFrontmatter = z.infer<typeof AntigravitySkillFrontmatterSchema>;
 
 export type AntigravitySkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: AntigravitySkillFrontmatter;
@@ -40,7 +40,7 @@ export type AntigravitySkillParams = {
  */
 export class AntigravitySkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".agent", "skills"),
     dirName,
     frontmatter,
@@ -50,7 +50,7 @@ export class AntigravitySkill extends ToolSkill {
     global = false,
   }: AntigravitySkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -126,7 +126,7 @@ export class AntigravitySkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -138,7 +138,7 @@ export class AntigravitySkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -153,7 +153,7 @@ export class AntigravitySkill extends ToolSkill {
     const settablePaths = AntigravitySkill.getSettablePaths({ global });
 
     return new AntigravitySkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: antigravityFrontmatter,
@@ -177,14 +177,14 @@ export class AntigravitySkill extends ToolSkill {
 
     const result = AntigravitySkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new AntigravitySkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -196,13 +196,13 @@ export class AntigravitySkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): AntigravitySkill {
     return new AntigravitySkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -104,7 +104,7 @@ describe("ClaudecodeSkill", () => {
       };
 
       const skill = new ClaudecodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         frontmatter,
         body: "Test body",
@@ -120,7 +120,7 @@ describe("ClaudecodeSkill", () => {
       };
 
       const skill = new ClaudecodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join("custom", "skills"),
         dirName: "test-skill",
         frontmatter,
@@ -492,7 +492,7 @@ describe("ClaudecodeSkill", () => {
       };
 
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         frontmatter: rulesyncFrontmatter,
         body: "Test body",
@@ -607,7 +607,7 @@ This is the skill body.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -633,7 +633,7 @@ This skill has tool restrictions.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "restricted-skill",
       });
 
@@ -655,7 +655,7 @@ This skill uses a specific model.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "model-skill",
       });
 
@@ -681,7 +681,7 @@ Main skill content.`;
       );
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "multi-file-skill",
       });
 
@@ -697,7 +697,7 @@ Main skill content.`;
 
       await expect(
         ClaudecodeSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "missing-skill",
         }),
       ).rejects.toThrow("SKILL.md not found");
@@ -718,7 +718,7 @@ Invalid frontmatter.`;
 
       await expect(
         ClaudecodeSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "invalid-skill",
         }),
       ).rejects.toThrow("Invalid frontmatter");
@@ -739,7 +739,7 @@ Custom path content.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: customPath,
         dirName: "custom-skill",
       });
@@ -761,7 +761,7 @@ Global skill content.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
 
       const skill = await ClaudecodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "global-skill",
         global: true,
       });

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -26,7 +26,7 @@ export const ClaudecodeSkillFrontmatterSchema = z.looseObject({
 export type ClaudecodeSkillFrontmatter = z.infer<typeof ClaudecodeSkillFrontmatterSchema>;
 
 export type ClaudecodeSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: ClaudecodeSkillFrontmatter;
@@ -43,7 +43,7 @@ export type ClaudecodeSkillParams = {
  */
 export class ClaudecodeSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".claude", "skills"),
     dirName,
     frontmatter,
@@ -53,7 +53,7 @@ export class ClaudecodeSkill extends ToolSkill {
     global = false,
   }: ClaudecodeSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -79,7 +79,7 @@ export class ClaudecodeSkill extends ToolSkill {
     global?: boolean;
   } = {}): ToolSkillSettablePaths {
     // Claude Code skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.claude/skills/
     // - Global mode: {getHomeDirectory()}/.claude/skills/
     return {
@@ -133,7 +133,7 @@ export class ClaudecodeSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -145,7 +145,7 @@ export class ClaudecodeSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -169,7 +169,7 @@ export class ClaudecodeSkill extends ToolSkill {
     const settablePaths = ClaudecodeSkill.getSettablePaths({ global });
 
     return new ClaudecodeSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: claudecodeFrontmatter,
@@ -193,14 +193,14 @@ export class ClaudecodeSkill extends ToolSkill {
 
     const result = ClaudecodeSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new ClaudecodeSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -212,13 +212,13 @@ export class ClaudecodeSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): ClaudecodeSkill {
     return new ClaudecodeSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/cline-skill.test.ts
+++ b/src/features/skills/cline-skill.test.ts
@@ -44,7 +44,7 @@ describe("ClineSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new ClineSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cline", "skills"),
         dirName: "pdf-processing",
         frontmatter: {
@@ -67,7 +67,7 @@ describe("ClineSkill", () => {
       expect(
         () =>
           new ClineSkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".cline", "skills"),
             dirName: "pdf-processing",
             frontmatter: { name: "pdf", description: "desc" },
@@ -91,7 +91,7 @@ Follow PDF extraction steps.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await ClineSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "pdf-processing",
       });
 
@@ -115,7 +115,7 @@ Follow PDF extraction steps.`;
 
       await expect(
         ClineSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "pdf-processing",
         }),
       ).rejects.toThrow(/must match directory name/);
@@ -125,7 +125,7 @@ Follow PDF extraction steps.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "pdf-processing",
         frontmatter: {
@@ -149,7 +149,7 @@ Follow PDF extraction steps.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const clineSkill = new ClineSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cline", "skills"),
         dirName: "pdf-processing",
         frontmatter: { name: "pdf-processing", description: "Handle PDFs" },
@@ -171,7 +171,7 @@ Follow PDF extraction steps.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "universal",
         frontmatter: { name: "universal", description: "Universal", targets: ["*"] },
@@ -184,7 +184,7 @@ Follow PDF extraction steps.`;
 
     it("should return true when targets includes 'cline'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "cline-specific",
         frontmatter: { name: "cline-specific", description: "Cline", targets: ["cline"] },
@@ -197,7 +197,7 @@ Follow PDF extraction steps.`;
 
     it("should return false when cline is not targeted", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "other-tool",
         frontmatter: { name: "other-tool", description: "Other", targets: ["copilot"] },

--- a/src/features/skills/cline-skill.ts
+++ b/src/features/skills/cline-skill.ts
@@ -23,7 +23,7 @@ export const ClineSkillFrontmatterSchema = z.looseObject({
 export type ClineSkillFrontmatter = z.infer<typeof ClineSkillFrontmatterSchema>;
 
 export type ClineSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: ClineSkillFrontmatter;
@@ -39,7 +39,7 @@ export type ClineSkillParams = {
  */
 export class ClineSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".cline", "skills"),
     dirName,
     frontmatter,
@@ -49,7 +49,7 @@ export class ClineSkill extends ToolSkill {
     global = false,
   }: ClineSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -71,7 +71,7 @@ export class ClineSkill extends ToolSkill {
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolSkillSettablePaths {
     // Cline Code skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.cline/skills/
     // - Global mode: {getHomeDirectory()}/.cline/skills/
     return {
@@ -127,7 +127,7 @@ export class ClineSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -139,7 +139,7 @@ export class ClineSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -153,7 +153,7 @@ export class ClineSkill extends ToolSkill {
     };
 
     return new ClineSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: clineFrontmatter.name,
       frontmatter: clineFrontmatter,
@@ -177,7 +177,7 @@ export class ClineSkill extends ToolSkill {
 
     const result = ClineSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
@@ -185,7 +185,7 @@ export class ClineSkill extends ToolSkill {
 
     if (result.data.name !== loaded.dirName) {
       const skillFilePath = join(
-        loaded.baseDir,
+        loaded.outputRoot,
         loaded.relativeDirPath,
         loaded.dirName,
         SKILL_FILE_NAME,
@@ -196,7 +196,7 @@ export class ClineSkill extends ToolSkill {
     }
 
     return new ClineSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -208,13 +208,13 @@ export class ClineSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): ClineSkill {
     return new ClineSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/codexcli-skill.test.ts
+++ b/src/features/skills/codexcli-skill.test.ts
@@ -40,7 +40,7 @@ describe("CodexCliSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content in global mode", () => {
       const skill = new CodexCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".codex", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -62,7 +62,7 @@ describe("CodexCliSkill", () => {
 
     it("should create instance with valid content in project mode", () => {
       const skill = new CodexCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".codex", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -84,7 +84,7 @@ describe("CodexCliSkill", () => {
 
     it("should create instance with metadata.short-description", () => {
       const skill = new CodexCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".codex", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -123,7 +123,7 @@ This is the body of the codex cli skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await CodexCliSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: true,
       });
@@ -148,7 +148,7 @@ This is the body of the codex cli skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await CodexCliSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: false,
       });
@@ -175,7 +175,7 @@ This is the body of the codex cli skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await CodexCliSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: false,
       });
@@ -196,7 +196,7 @@ This is the body of the codex cli skill.`;
 
       await expect(
         CodexCliSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
           global: true,
         }),
@@ -207,7 +207,7 @@ This is the body of the codex cli skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill in global mode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -234,7 +234,7 @@ This is the body of the codex cli skill.`;
 
     it("should create instance from RulesyncSkill in project mode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -261,7 +261,7 @@ This is the body of the codex cli skill.`;
 
     it("should convert codexcli.short-description to metadata.short-description", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -295,7 +295,7 @@ This is the body of the codex cli skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -312,7 +312,7 @@ This is the body of the codex cli skill.`;
 
     it("should return true when targets includes 'codexcli'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "codexcli-skill",
         frontmatter: {
@@ -329,7 +329,7 @@ This is the body of the codex cli skill.`;
 
     it("should return false when targets does not include 'codexcli'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -348,7 +348,7 @@ This is the body of the codex cli skill.`;
   describe("toRulesyncSkill", () => {
     it("should convert to a RulesyncSkill", () => {
       const skill = new CodexCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".codex", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -372,7 +372,7 @@ This is the body of the codex cli skill.`;
 
     it("should convert metadata.short-description to codexcli.short-description", () => {
       const skill = new CodexCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".codex", "skills"),
         dirName: "test-skill",
         frontmatter: {

--- a/src/features/skills/codexcli-skill.ts
+++ b/src/features/skills/codexcli-skill.ts
@@ -28,7 +28,7 @@ export const CodexCliSkillFrontmatterSchema = z.looseObject({
 export type CodexCliSkillFrontmatter = z.infer<typeof CodexCliSkillFrontmatterSchema>;
 
 export type CodexCliSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: CodexCliSkillFrontmatter;
@@ -45,7 +45,7 @@ export type CodexCliSkillParams = {
  */
 export class CodexCliSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".codex", "skills"),
     dirName,
     frontmatter,
@@ -55,7 +55,7 @@ export class CodexCliSkill extends ToolSkill {
     global = false,
   }: CodexCliSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -79,7 +79,7 @@ export class CodexCliSkill extends ToolSkill {
     global: _global = false,
   }: { global?: boolean } = {}): ToolSkillSettablePaths {
     // Codex CLI skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.codex/skills/
     // - Global mode: {$CODEX_HOME}/skills/ (typically ~/.codex/skills/)
     return {
@@ -131,7 +131,7 @@ export class CodexCliSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -143,7 +143,7 @@ export class CodexCliSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -162,7 +162,7 @@ export class CodexCliSkill extends ToolSkill {
     };
 
     return new CodexCliSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: codexFrontmatter,
@@ -186,14 +186,14 @@ export class CodexCliSkill extends ToolSkill {
 
     const result = CodexCliSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new CodexCliSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -205,13 +205,13 @@ export class CodexCliSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): CodexCliSkill {
     return new CodexCliSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/copilot-skill.test.ts
+++ b/src/features/skills/copilot-skill.test.ts
@@ -126,7 +126,7 @@ license: Apache-2.0
 Skill content goes here.`,
       );
 
-      const skill = await CopilotSkill.fromDir({ baseDir: testDir, dirName: "webapp-testing" });
+      const skill = await CopilotSkill.fromDir({ outputRoot: testDir, dirName: "webapp-testing" });
 
       expect(skill).toBeInstanceOf(CopilotSkill);
       expect(skill.getFrontmatter()).toEqual({
@@ -176,7 +176,7 @@ Skill content goes here.`,
 
     it("should convert from RulesyncSkill and preserve license", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "webapp-testing",
         frontmatter: {
@@ -202,7 +202,7 @@ Skill content goes here.`,
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets include '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-skill",
         frontmatter: { name: "all-skill", description: "All targets", targets: ["*"] },
@@ -214,7 +214,7 @@ Skill content goes here.`,
 
     it("should return true when targets include copilot", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "copilot-skill",
         frontmatter: { name: "copilot-skill", description: "Only copilot", targets: ["copilot"] },
@@ -226,7 +226,7 @@ Skill content goes here.`,
 
     it("should return false when copilot is not targeted", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "cursor-skill",
         frontmatter: { name: "cursor-skill", description: "Cursor only", targets: ["cursor"] },

--- a/src/features/skills/copilot-skill.ts
+++ b/src/features/skills/copilot-skill.ts
@@ -24,7 +24,7 @@ export const CopilotSkillFrontmatterSchema = z.looseObject({
 export type CopilotSkillFrontmatter = z.infer<typeof CopilotSkillFrontmatterSchema>;
 
 export type CopilotSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: CopilotSkillFrontmatter;
@@ -40,7 +40,7 @@ export type CopilotSkillParams = {
  */
 export class CopilotSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".github", "skills"),
     dirName,
     frontmatter,
@@ -50,7 +50,7 @@ export class CopilotSkill extends ToolSkill {
     global = false,
   }: CopilotSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -123,7 +123,7 @@ export class CopilotSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -135,7 +135,7 @@ export class CopilotSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -150,7 +150,7 @@ export class CopilotSkill extends ToolSkill {
     };
 
     return new CopilotSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: copilotFrontmatter,
@@ -174,14 +174,14 @@ export class CopilotSkill extends ToolSkill {
 
     const result = CopilotSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new CopilotSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -193,14 +193,14 @@ export class CopilotSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): CopilotSkill {
     const settablePaths = CopilotSkill.getSettablePaths({ global });
     return new CopilotSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/cursor-skill.test.ts
+++ b/src/features/skills/cursor-skill.test.ts
@@ -40,7 +40,7 @@ describe("CursorSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new CursorSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cursor", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -73,7 +73,7 @@ This is the body of the cursor skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await CursorSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -91,7 +91,7 @@ This is the body of the cursor skill.`;
 
       await expect(
         CursorSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -101,7 +101,7 @@ This is the body of the cursor skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -129,7 +129,7 @@ This is the body of the cursor skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -146,7 +146,7 @@ This is the body of the cursor skill.`;
 
     it("should return true when targets includes 'cursor'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "cursor-skill",
         frontmatter: {
@@ -163,7 +163,7 @@ This is the body of the cursor skill.`;
 
     it("should return false when targets does not include 'cursor'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -182,7 +182,7 @@ This is the body of the cursor skill.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const skill = new CursorSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".cursor", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -217,14 +217,14 @@ This is the body of the cursor skill.`;
       expect(skill.getGlobal()).toBe(false);
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const skill = CursorSkill.forDeletion({
         dirName: "cleanup",
         relativeDirPath: join(".cursor", "skills"),
       });
 
       expect(skill).toBeInstanceOf(CursorSkill);
-      expect(skill.getBaseDir()).toBe(testDir);
+      expect(skill.getOutputRoot()).toBe(testDir);
     });
 
     it("should create instance with empty frontmatter for deletion", () => {

--- a/src/features/skills/cursor-skill.ts
+++ b/src/features/skills/cursor-skill.ts
@@ -23,7 +23,7 @@ export const CursorSkillFrontmatterSchema = z.looseObject({
 export type CursorSkillFrontmatter = z.infer<typeof CursorSkillFrontmatterSchema>;
 
 export type CursorSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: CursorSkillFrontmatter;
@@ -39,7 +39,7 @@ export type CursorSkillParams = {
  */
 export class CursorSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".cursor", "skills"),
     dirName,
     frontmatter,
@@ -49,7 +49,7 @@ export class CursorSkill extends ToolSkill {
     global = false,
   }: CursorSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -71,7 +71,7 @@ export class CursorSkill extends ToolSkill {
 
   static getSettablePaths(_options?: { global?: boolean }): ToolSkillSettablePaths {
     // Cursor skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.cursor/skills/
     // - Global mode: {getHomeDirectory()}/.cursor/skills/
     return {
@@ -118,7 +118,7 @@ export class CursorSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -130,7 +130,7 @@ export class CursorSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -144,7 +144,7 @@ export class CursorSkill extends ToolSkill {
     };
 
     return new CursorSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: cursorFrontmatter,
@@ -168,14 +168,14 @@ export class CursorSkill extends ToolSkill {
 
     const result = CursorSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new CursorSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -187,14 +187,14 @@ export class CursorSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): CursorSkill {
     const settablePaths = CursorSkill.getSettablePaths({ global });
     return new CursorSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/deepagents-skill.test.ts
+++ b/src/features/skills/deepagents-skill.test.ts
@@ -37,7 +37,7 @@ describe("DeepagentsSkill", () => {
   describe("constructor", () => {
     it("should create with valid frontmatter", () => {
       const skill = new DeepagentsSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "my-skill",
         frontmatter: { name: "My Skill", description: "Does something useful." },
         body: "## Instructions\n\nDo the thing.",
@@ -50,7 +50,7 @@ describe("DeepagentsSkill", () => {
 
     it("should create with allowed-tools", () => {
       const skill = new DeepagentsSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "tool-skill",
         frontmatter: {
           name: "Tool Skill",
@@ -67,7 +67,7 @@ describe("DeepagentsSkill", () => {
       expect(
         () =>
           new DeepagentsSkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             dirName: "bad-skill",
             frontmatter: { name: "", description: "" },
             body: "",
@@ -92,7 +92,7 @@ Do the thing.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await DeepagentsSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "my-skill",
       });
 
@@ -104,14 +104,14 @@ Do the thing.`;
   describe("fromRulesyncSkill", () => {
     it("should map name and description from rulesync skill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "my-skill",
         frontmatter: { name: "My Skill", description: "Does something.", targets: ["*"] },
         body: "Instructions here.",
       });
 
-      const skill = DeepagentsSkill.fromRulesyncSkill({ baseDir: testDir, rulesyncSkill });
+      const skill = DeepagentsSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
 
       expect(skill.getFrontmatter().name).toBe("My Skill");
       expect(skill.getFrontmatter().description).toBe("Does something.");
@@ -121,14 +121,14 @@ Do the thing.`;
 
     it("should omit allowed-tools when deepagents frontmatter is absent", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "my-skill",
         frontmatter: { name: "My Skill", description: "Does something.", targets: ["*"] },
         body: "Instructions here.",
       });
 
-      const skill = DeepagentsSkill.fromRulesyncSkill({ baseDir: testDir, rulesyncSkill });
+      const skill = DeepagentsSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
 
       expect(skill.getFrontmatter()).not.toHaveProperty("allowed-tools");
     });
@@ -137,7 +137,7 @@ Do the thing.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true for deepagents target", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "my-skill",
         frontmatter: { name: "Skill", description: "Desc.", targets: ["deepagents"] },
@@ -149,7 +149,7 @@ Do the thing.`;
 
     it("should return true for wildcard target", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "my-skill",
         frontmatter: { name: "Skill", description: "Desc.", targets: ["*"] },
@@ -161,7 +161,7 @@ Do the thing.`;
 
     it("should return false for different tool target", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "my-skill",
         frontmatter: { name: "Skill", description: "Desc.", targets: ["claudecode"] },
@@ -175,7 +175,7 @@ Do the thing.`;
   describe("toRulesyncSkill", () => {
     it("should convert to rulesync skill with targets wildcard", () => {
       const skill = new DeepagentsSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "my-skill",
         frontmatter: { name: "My Skill", description: "Does something." },
         body: "Instructions.",
@@ -192,7 +192,7 @@ Do the thing.`;
   describe("forDeletion", () => {
     it("should create a deletable placeholder skill", () => {
       const skill = DeepagentsSkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "skills"),
         dirName: "my-skill",
       });

--- a/src/features/skills/deepagents-skill.ts
+++ b/src/features/skills/deepagents-skill.ts
@@ -24,7 +24,7 @@ export const DeepagentsSkillFrontmatterSchema = z.looseObject({
 export type DeepagentsSkillFrontmatter = z.infer<typeof DeepagentsSkillFrontmatterSchema>;
 
 export type DeepagentsSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: DeepagentsSkillFrontmatter;
@@ -36,7 +36,7 @@ export type DeepagentsSkillParams = {
 
 export class DeepagentsSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".deepagents", "skills"),
     dirName,
     frontmatter,
@@ -46,7 +46,7 @@ export class DeepagentsSkill extends ToolSkill {
     global = false,
   }: DeepagentsSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -114,7 +114,7 @@ export class DeepagentsSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -126,7 +126,7 @@ export class DeepagentsSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -143,7 +143,7 @@ export class DeepagentsSkill extends ToolSkill {
     };
 
     return new DeepagentsSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: deepagentsFrontmatter,
@@ -167,14 +167,14 @@ export class DeepagentsSkill extends ToolSkill {
 
     const result = DeepagentsSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new DeepagentsSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -186,14 +186,14 @@ export class DeepagentsSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): DeepagentsSkill {
     const settablePaths = DeepagentsSkill.getSettablePaths({ global });
     return new DeepagentsSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/factorydroid-skill.test.ts
+++ b/src/features/skills/factorydroid-skill.test.ts
@@ -43,7 +43,7 @@ This is a test factorydroid skill content.`;
   describe("fromRulesyncSkill", () => {
     it("should create FactorydroidSkill from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -74,7 +74,7 @@ This is a test factorydroid skill content.`;
       await writeFileContent(skillFile, validSkillContent);
 
       const skill = await FactorydroidSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         global: false,
       });
@@ -90,7 +90,7 @@ This is a test factorydroid skill content.`;
 
       await expect(
         FactorydroidSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "test-skill",
           global: false,
         }),
@@ -151,7 +151,7 @@ This is a test factorydroid skill content.`;
   describe("forDeletion", () => {
     it("should create deletion marker", () => {
       const skill = FactorydroidSkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/skills",
         dirName: "to-delete",
       });

--- a/src/features/skills/geminicli-skill.test.ts
+++ b/src/features/skills/geminicli-skill.test.ts
@@ -40,7 +40,7 @@ describe("GeminiCliSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new GeminiCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -73,7 +73,7 @@ This is the body of the gemini cli skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await GeminiCliSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -91,7 +91,7 @@ This is the body of the gemini cli skill.`;
 
       await expect(
         GeminiCliSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -109,7 +109,7 @@ Body content`;
 
       await expect(
         GeminiCliSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "bad-frontmatter",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -127,7 +127,7 @@ Global body content`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await GeminiCliSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "global-skill",
         global: true,
       });
@@ -141,7 +141,7 @@ Global body content`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -169,7 +169,7 @@ Global body content`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -186,7 +186,7 @@ Global body content`;
 
     it("should return true when targets includes 'geminicli'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "geminicli-skill",
         frontmatter: {
@@ -203,7 +203,7 @@ Global body content`;
 
     it("should return false when targets does not include 'geminicli'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -222,7 +222,7 @@ Global body content`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill with correct frontmatter", () => {
       const skill = new GeminiCliSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".gemini", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -262,7 +262,7 @@ Global body content`;
 
     it("should convert from RulesyncSkill in global mode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "global-skill",
         frontmatter: {

--- a/src/features/skills/geminicli-skill.ts
+++ b/src/features/skills/geminicli-skill.ts
@@ -23,7 +23,7 @@ export const GeminiCliSkillFrontmatterSchema = z.looseObject({
 export type GeminiCliSkillFrontmatter = z.infer<typeof GeminiCliSkillFrontmatterSchema>;
 
 export type GeminiCliSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: GeminiCliSkillFrontmatter;
@@ -42,7 +42,7 @@ export type GeminiCliSkillParams = {
  */
 export class GeminiCliSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = GeminiCliSkill.getSettablePaths().relativeDirPath,
     dirName,
     frontmatter,
@@ -52,7 +52,7 @@ export class GeminiCliSkill extends ToolSkill {
     global = false,
   }: GeminiCliSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -78,7 +78,7 @@ export class GeminiCliSkill extends ToolSkill {
     global?: boolean;
   } = {}): ToolSkillSettablePaths {
     // Gemini CLI skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.gemini/skills/
     // - Global mode: {getHomeDirectory()}/.gemini/skills/
     return {
@@ -124,7 +124,7 @@ export class GeminiCliSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -136,7 +136,7 @@ export class GeminiCliSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -150,7 +150,7 @@ export class GeminiCliSkill extends ToolSkill {
     };
 
     return new GeminiCliSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: geminiCliFrontmatter,
@@ -174,14 +174,14 @@ export class GeminiCliSkill extends ToolSkill {
 
     const result = GeminiCliSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new GeminiCliSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -193,14 +193,14 @@ export class GeminiCliSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): GeminiCliSkill {
     const settablePaths = GeminiCliSkill.getSettablePaths({ global });
     return new GeminiCliSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/junie-skill.test.ts
+++ b/src/features/skills/junie-skill.test.ts
@@ -41,7 +41,7 @@ describe("JunieSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new JunieSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".junie", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -64,7 +64,7 @@ describe("JunieSkill", () => {
       expect(
         () =>
           new JunieSkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".junie", "skills"),
             dirName: "test-skill",
             frontmatter: {
@@ -91,7 +91,7 @@ This is the body of the junie skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await JunieSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -116,7 +116,7 @@ This is the body of the junie skill.`;
 
       await expect(
         JunieSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "test-skill",
         }),
       ).rejects.toThrow(
@@ -130,7 +130,7 @@ This is the body of the junie skill.`;
 
       await expect(
         JunieSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -140,7 +140,7 @@ This is the body of the junie skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "some-other-name",
         frontmatter: {
@@ -169,7 +169,7 @@ This is the body of the junie skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -186,7 +186,7 @@ This is the body of the junie skill.`;
 
     it("should return true when targets includes 'junie'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "junie-skill",
         frontmatter: {
@@ -203,7 +203,7 @@ This is the body of the junie skill.`;
 
     it("should return false when targets does not include 'junie'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -222,7 +222,7 @@ This is the body of the junie skill.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const skill = new JunieSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".junie", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -257,14 +257,14 @@ This is the body of the junie skill.`;
       expect(skill.getGlobal()).toBe(false);
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const skill = JunieSkill.forDeletion({
         dirName: "cleanup",
         relativeDirPath: join(".junie", "skills"),
       });
 
       expect(skill).toBeInstanceOf(JunieSkill);
-      expect(skill.getBaseDir()).toBe(testDir);
+      expect(skill.getOutputRoot()).toBe(testDir);
     });
 
     it("should create instance with empty frontmatter for deletion", () => {

--- a/src/features/skills/junie-skill.ts
+++ b/src/features/skills/junie-skill.ts
@@ -23,7 +23,7 @@ export const JunieSkillFrontmatterSchema = z.looseObject({
 export type JunieSkillFrontmatter = z.infer<typeof JunieSkillFrontmatterSchema>;
 
 export type JunieSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: JunieSkillFrontmatter;
@@ -39,7 +39,7 @@ export type JunieSkillParams = {
  */
 export class JunieSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".junie", "skills"),
     dirName,
     frontmatter,
@@ -49,7 +49,7 @@ export class JunieSkill extends ToolSkill {
     global = false,
   }: JunieSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -126,7 +126,7 @@ export class JunieSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -151,7 +151,7 @@ export class JunieSkill extends ToolSkill {
     };
 
     return new JunieSkill({
-      baseDir: rulesyncSkill.getBaseDir(),
+      outputRoot: rulesyncSkill.getOutputRoot(),
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: junieFrontmatter.name,
       frontmatter: junieFrontmatter,
@@ -175,7 +175,7 @@ export class JunieSkill extends ToolSkill {
 
     const result = JunieSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
@@ -183,7 +183,7 @@ export class JunieSkill extends ToolSkill {
 
     if (result.data.name !== loaded.dirName) {
       const skillFilePath = join(
-        loaded.baseDir,
+        loaded.outputRoot,
         loaded.relativeDirPath,
         loaded.dirName,
         SKILL_FILE_NAME,
@@ -194,7 +194,7 @@ export class JunieSkill extends ToolSkill {
     }
 
     return new JunieSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -206,14 +206,14 @@ export class JunieSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): JunieSkill {
     const settablePaths = JunieSkill.getSettablePaths({ global });
     return new JunieSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/kilo-skill.test.ts
+++ b/src/features/skills/kilo-skill.test.ts
@@ -28,7 +28,7 @@ describe("KiloSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new KiloSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -50,7 +50,7 @@ describe("KiloSkill", () => {
 
     it("should create instance without validation when validate is false", () => {
       const skill = new KiloSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kilo", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -67,7 +67,7 @@ describe("KiloSkill", () => {
     it("should throw error for invalid frontmatter when validation is enabled", () => {
       expect(() => {
         new KiloSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".kilo", "skills"),
           dirName: "test-skill",
           frontmatter: {
@@ -96,7 +96,7 @@ describe("KiloSkill", () => {
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill and keep allowed-tools", () => {
       const skill = new KiloSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         frontmatter: {
           name: "Test Skill",
@@ -119,7 +119,7 @@ describe("KiloSkill", () => {
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill with project paths", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -145,7 +145,7 @@ describe("KiloSkill", () => {
 
     it("should create instance from RulesyncSkill and respect global paths", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -187,7 +187,7 @@ It can be multiline.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await KiloSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -204,7 +204,7 @@ It can be multiline.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets include kilo", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -221,7 +221,7 @@ It can be multiline.`;
 
     it("should return true when targets include wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -238,7 +238,7 @@ It can be multiline.`;
 
     it("should return false when targets do not include kilo or wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {

--- a/src/features/skills/kilo-skill.ts
+++ b/src/features/skills/kilo-skill.ts
@@ -24,7 +24,7 @@ export const KiloSkillFrontmatterSchema = z.looseObject({
 export type KiloSkillFrontmatter = z.infer<typeof KiloSkillFrontmatterSchema>;
 
 export type KiloSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: KiloSkillFrontmatter;
@@ -36,7 +36,7 @@ export type KiloSkillParams = {
 
 export class KiloSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".kilo", "skills"),
     dirName,
     frontmatter,
@@ -46,7 +46,7 @@ export class KiloSkill extends ToolSkill {
     global = false,
   }: KiloSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -115,7 +115,7 @@ export class KiloSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -127,7 +127,7 @@ export class KiloSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -143,7 +143,7 @@ export class KiloSkill extends ToolSkill {
     const settablePaths = KiloSkill.getSettablePaths({ global });
 
     return new KiloSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: kiloFrontmatter,
@@ -167,14 +167,14 @@ export class KiloSkill extends ToolSkill {
 
     const result = KiloSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new KiloSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -186,13 +186,13 @@ export class KiloSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): KiloSkill {
     return new KiloSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/kiro-skill.test.ts
+++ b/src/features/skills/kiro-skill.test.ts
@@ -65,7 +65,7 @@ describe("KiroSkill", () => {
   describe("fromRulesyncSkill", () => {
     it("should convert RulesyncSkill to KiroSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -89,7 +89,7 @@ describe("KiroSkill", () => {
   describe("toRulesyncSkill", () => {
     it("should convert KiroSkill to RulesyncSkill", () => {
       const kiroSkill = new KiroSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         frontmatter: {
           name: "test-skill",
@@ -112,7 +112,7 @@ describe("KiroSkill", () => {
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes kiro", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "kiro-skill",
         frontmatter: {
@@ -128,7 +128,7 @@ describe("KiroSkill", () => {
 
     it("should return true when targets includes wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-skill",
         frontmatter: {
@@ -144,7 +144,7 @@ describe("KiroSkill", () => {
 
     it("should return false when targets does not include kiro", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "other-skill",
         frontmatter: {
@@ -174,7 +174,7 @@ This is the skill body content.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await KiroSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -199,7 +199,7 @@ Missing description`;
 
       await expect(
         KiroSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "invalid-skill",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -220,7 +220,7 @@ This is the skill body content.`;
 
       await expect(
         KiroSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "test-skill",
         }),
       ).rejects.toThrow(/Frontmatter name \(wrong-name\) must match directory name \(test-skill\)/);
@@ -230,7 +230,7 @@ This is the skill body content.`;
   describe("forDeletion", () => {
     it("should create minimal instance for deletion", () => {
       const skill = KiroSkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".kiro", "skills"),
         dirName: "to-delete",
       });

--- a/src/features/skills/kiro-skill.ts
+++ b/src/features/skills/kiro-skill.ts
@@ -23,7 +23,7 @@ const KiroSkillFrontmatterSchema = z.looseObject({
 type KiroSkillFrontmatter = z.infer<typeof KiroSkillFrontmatterSchema>;
 
 type KiroSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: KiroSkillFrontmatter;
@@ -39,7 +39,7 @@ type KiroSkillParams = {
  */
 export class KiroSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".kiro", "skills"),
     dirName,
     frontmatter,
@@ -49,7 +49,7 @@ export class KiroSkill extends ToolSkill {
     global = false,
   }: KiroSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -126,7 +126,7 @@ export class KiroSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -138,7 +138,7 @@ export class KiroSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -152,7 +152,7 @@ export class KiroSkill extends ToolSkill {
     };
 
     return new KiroSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: kiroFrontmatter,
@@ -176,7 +176,7 @@ export class KiroSkill extends ToolSkill {
 
     const result = KiroSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
@@ -184,7 +184,7 @@ export class KiroSkill extends ToolSkill {
 
     if (result.data.name !== loaded.dirName) {
       const skillFilePath = join(
-        loaded.baseDir,
+        loaded.outputRoot,
         loaded.relativeDirPath,
         loaded.dirName,
         SKILL_FILE_NAME,
@@ -195,7 +195,7 @@ export class KiroSkill extends ToolSkill {
     }
 
     return new KiroSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -207,14 +207,14 @@ export class KiroSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): KiroSkill {
     const settablePaths = KiroSkill.getSettablePaths({ global });
     return new KiroSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/opencode-skill.test.ts
+++ b/src/features/skills/opencode-skill.test.ts
@@ -32,7 +32,7 @@ describe("OpenCodeSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new OpenCodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "skill"),
         dirName: "test-skill",
         frontmatter: {
@@ -54,7 +54,7 @@ describe("OpenCodeSkill", () => {
 
     it("should create instance without validation when validate is false", () => {
       const skill = new OpenCodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".opencode", "skill"),
         dirName: "test-skill",
         frontmatter: {
@@ -71,7 +71,7 @@ describe("OpenCodeSkill", () => {
     it("should throw error for invalid frontmatter when validation is enabled", () => {
       expect(() => {
         new OpenCodeSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".opencode", "skill"),
           dirName: "test-skill",
           frontmatter: {
@@ -100,7 +100,7 @@ describe("OpenCodeSkill", () => {
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill and keep allowed-tools", () => {
       const skill = new OpenCodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
         frontmatter: {
           name: "Test Skill",
@@ -123,7 +123,7 @@ describe("OpenCodeSkill", () => {
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill with project paths", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -149,7 +149,7 @@ describe("OpenCodeSkill", () => {
 
     it("should create instance from RulesyncSkill and respect global paths", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -191,7 +191,7 @@ It can be multiline.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await OpenCodeSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -208,7 +208,7 @@ It can be multiline.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets include opencode", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -225,7 +225,7 @@ It can be multiline.`;
 
     it("should return true when targets include wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -242,7 +242,7 @@ It can be multiline.`;
 
     it("should return false when targets do not include opencode or wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {

--- a/src/features/skills/opencode-skill.ts
+++ b/src/features/skills/opencode-skill.ts
@@ -24,7 +24,7 @@ export const OpenCodeSkillFrontmatterSchema = z.looseObject({
 export type OpenCodeSkillFrontmatter = z.infer<typeof OpenCodeSkillFrontmatterSchema>;
 
 export type OpenCodeSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: OpenCodeSkillFrontmatter;
@@ -36,7 +36,7 @@ export type OpenCodeSkillParams = {
 
 export class OpenCodeSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".opencode", "skill"),
     dirName,
     frontmatter,
@@ -46,7 +46,7 @@ export class OpenCodeSkill extends ToolSkill {
     global = false,
   }: OpenCodeSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -115,7 +115,7 @@ export class OpenCodeSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -127,7 +127,7 @@ export class OpenCodeSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -143,7 +143,7 @@ export class OpenCodeSkill extends ToolSkill {
     const settablePaths = OpenCodeSkill.getSettablePaths({ global });
 
     return new OpenCodeSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: opencodeFrontmatter,
@@ -167,14 +167,14 @@ export class OpenCodeSkill extends ToolSkill {
 
     const result = OpenCodeSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new OpenCodeSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -186,13 +186,13 @@ export class OpenCodeSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): OpenCodeSkill {
     return new OpenCodeSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/pi-skill.test.ts
+++ b/src/features/skills/pi-skill.test.ts
@@ -38,7 +38,7 @@ describe("PiSkill", () => {
   describe("constructor", () => {
     it("should create a PiSkill with valid frontmatter", () => {
       const skill = new PiSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "skills"),
         dirName: "test-skill",
         frontmatter: { name: "Test Skill", description: "Desc" },
@@ -56,7 +56,7 @@ describe("PiSkill", () => {
     it("should throw on invalid frontmatter when validating", () => {
       expect(() => {
         new PiSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".pi", "skills"),
           dirName: "bad",
           frontmatter: { name: 123 as any, description: "Desc" },
@@ -82,7 +82,7 @@ Body content`,
       );
 
       const skill = await PiSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "demo",
       });
 
@@ -108,7 +108,7 @@ Body content`,
       );
 
       const skill = await PiSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "demo",
         global: true,
       });
@@ -135,7 +135,7 @@ Body content`,
       await writeFileBuffer(join(skillDir, "ref.md"), Buffer.from("# Reference\nAuxiliary file."));
 
       const skill = await PiSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "demo",
       });
 
@@ -148,7 +148,7 @@ Body content`,
       expect(rulesyncSkill.getOtherFiles()).toEqual(otherFiles);
 
       const restored = PiSkill.fromRulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSkill,
       });
       expect(restored.getOtherFiles()).toEqual(otherFiles);
@@ -169,7 +169,7 @@ Body`,
 
       await expect(
         PiSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "bad",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -179,7 +179,7 @@ Body`,
   describe("fromRulesyncSkill", () => {
     it("should create a PiSkill from a RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "demo",
         frontmatter: {
@@ -192,7 +192,7 @@ Body`,
       });
 
       const skill = PiSkill.fromRulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSkill,
       });
 
@@ -206,7 +206,7 @@ Body`,
 
     it("should emit to the global path when global is true", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "demo",
         frontmatter: {
@@ -219,7 +219,7 @@ Body`,
       });
 
       const skill = PiSkill.fromRulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSkill,
         global: true,
       });
@@ -231,7 +231,7 @@ Body`,
   describe("toRulesyncSkill", () => {
     it("should convert a PiSkill to a RulesyncSkill with wildcard targets", () => {
       const skill = new PiSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "skills"),
         dirName: "demo",
         frontmatter: { name: "demo", description: "Demo" },
@@ -251,7 +251,7 @@ Body`,
   describe("validate", () => {
     it("should succeed for valid frontmatter", () => {
       const skill = new PiSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".pi", "skills"),
         dirName: "demo",
         frontmatter: { name: "demo", description: "Demo" },
@@ -280,7 +280,7 @@ Body`,
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true for wildcard", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "demo",
         frontmatter: { name: "demo", description: "Demo", targets: ["*"] },
@@ -293,7 +293,7 @@ Body`,
 
     it("should return true for pi target", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "demo",
         frontmatter: { name: "demo", description: "Demo", targets: ["pi"] },
@@ -306,7 +306,7 @@ Body`,
 
     it("should return false for unrelated targets", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "demo",
         frontmatter: { name: "demo", description: "Demo", targets: ["cursor"] },

--- a/src/features/skills/pi-skill.ts
+++ b/src/features/skills/pi-skill.ts
@@ -30,7 +30,7 @@ export const PiSkillFrontmatterSchema = z.looseObject({
 export type PiSkillFrontmatter = z.infer<typeof PiSkillFrontmatterSchema>;
 
 export type PiSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: PiSkillFrontmatter;
@@ -48,7 +48,7 @@ export type PiSkillParams = {
  */
 export class PiSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     frontmatter,
@@ -60,7 +60,7 @@ export class PiSkill extends ToolSkill {
     const resolvedDirPath = relativeDirPath ?? PiSkill.getSettablePaths({ global }).relativeDirPath;
 
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath: resolvedDirPath,
       dirName,
       mainFile: {
@@ -129,7 +129,7 @@ export class PiSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -141,7 +141,7 @@ export class PiSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -155,7 +155,7 @@ export class PiSkill extends ToolSkill {
     };
 
     return new PiSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: piFrontmatter,
@@ -179,14 +179,14 @@ export class PiSkill extends ToolSkill {
 
     const result = PiSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new PiSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -198,14 +198,14 @@ export class PiSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): PiSkill {
     const settablePaths = PiSkill.getSettablePaths({ global });
     return new PiSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/replit-skill.test.ts
+++ b/src/features/skills/replit-skill.test.ts
@@ -41,7 +41,7 @@ describe("ReplitSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new ReplitSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -74,7 +74,7 @@ This is the body of the replit skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await ReplitSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -92,7 +92,7 @@ This is the body of the replit skill.`;
 
       await expect(
         ReplitSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -102,7 +102,7 @@ This is the body of the replit skill.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -130,7 +130,7 @@ This is the body of the replit skill.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -147,7 +147,7 @@ This is the body of the replit skill.`;
 
     it("should return true when targets includes 'replit'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "replit-skill",
         frontmatter: {
@@ -164,7 +164,7 @@ This is the body of the replit skill.`;
 
     it("should return false when targets does not include 'replit'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -183,7 +183,7 @@ This is the body of the replit skill.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const skill = new ReplitSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".agents", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -218,14 +218,14 @@ This is the body of the replit skill.`;
       expect(skill.getGlobal()).toBe(false);
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const skill = ReplitSkill.forDeletion({
         dirName: "cleanup",
         relativeDirPath: join(".agents", "skills"),
       });
 
       expect(skill).toBeInstanceOf(ReplitSkill);
-      expect(skill.getBaseDir()).toBe(testDir);
+      expect(skill.getOutputRoot()).toBe(testDir);
     });
 
     it("should create instance with empty frontmatter for deletion", () => {

--- a/src/features/skills/replit-skill.ts
+++ b/src/features/skills/replit-skill.ts
@@ -23,7 +23,7 @@ export const ReplitSkillFrontmatterSchema = z.looseObject({
 export type ReplitSkillFrontmatter = z.infer<typeof ReplitSkillFrontmatterSchema>;
 
 export type ReplitSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: ReplitSkillFrontmatter;
@@ -40,7 +40,7 @@ export type ReplitSkillParams = {
  */
 export class ReplitSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".agents", "skills"),
     dirName,
     frontmatter,
@@ -50,7 +50,7 @@ export class ReplitSkill extends ToolSkill {
     global = false,
   }: ReplitSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -118,7 +118,7 @@ export class ReplitSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -130,7 +130,7 @@ export class ReplitSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -144,7 +144,7 @@ export class ReplitSkill extends ToolSkill {
     };
 
     return new ReplitSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: replitFrontmatter,
@@ -168,14 +168,14 @@ export class ReplitSkill extends ToolSkill {
 
     const result = ReplitSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new ReplitSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -187,14 +187,14 @@ export class ReplitSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): ReplitSkill {
     const settablePaths = ReplitSkill.getSettablePaths({ global });
     return new ReplitSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/roo-skill.test.ts
+++ b/src/features/skills/roo-skill.test.ts
@@ -44,7 +44,7 @@ describe("RooSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new RooSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".roo", "skills"),
         dirName: "pdf-processing",
         frontmatter: {
@@ -67,7 +67,7 @@ describe("RooSkill", () => {
       expect(
         () =>
           new RooSkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".roo", "skills"),
             dirName: "pdf-processing",
             frontmatter: { name: "pdf", description: "desc" },
@@ -91,7 +91,7 @@ Follow PDF extraction steps.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await RooSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "pdf-processing",
       });
 
@@ -115,7 +115,7 @@ Follow PDF extraction steps.`;
 
       await expect(
         RooSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "pdf-processing",
         }),
       ).rejects.toThrow(/must match directory name/);
@@ -125,7 +125,7 @@ Follow PDF extraction steps.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "pdf-processing",
         frontmatter: {
@@ -149,7 +149,7 @@ Follow PDF extraction steps.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const rooSkill = new RooSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".roo", "skills"),
         dirName: "pdf-processing",
         frontmatter: { name: "pdf-processing", description: "Handle PDFs" },
@@ -171,7 +171,7 @@ Follow PDF extraction steps.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "universal",
         frontmatter: { name: "universal", description: "Universal", targets: ["*"] },
@@ -184,7 +184,7 @@ Follow PDF extraction steps.`;
 
     it("should return true when targets includes 'roo'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "roo-specific",
         frontmatter: { name: "roo-specific", description: "Roo", targets: ["roo"] },
@@ -197,7 +197,7 @@ Follow PDF extraction steps.`;
 
     it("should return false when roo is not targeted", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "other-tool",
         frontmatter: { name: "other-tool", description: "Other", targets: ["copilot"] },

--- a/src/features/skills/roo-skill.ts
+++ b/src/features/skills/roo-skill.ts
@@ -23,7 +23,7 @@ export const RooSkillFrontmatterSchema = z.looseObject({
 export type RooSkillFrontmatter = z.infer<typeof RooSkillFrontmatterSchema>;
 
 export type RooSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: RooSkillFrontmatter;
@@ -39,7 +39,7 @@ export type RooSkillParams = {
  */
 export class RooSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".roo", "skills"),
     dirName,
     frontmatter,
@@ -49,7 +49,7 @@ export class RooSkill extends ToolSkill {
     global = false,
   }: RooSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -75,7 +75,7 @@ export class RooSkill extends ToolSkill {
     global?: boolean;
   } = {}): ToolSkillSettablePaths {
     // Roo Code skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.roo/skills/
     // - Global mode: {getHomeDirectory()}/.roo/skills/
     return {
@@ -131,7 +131,7 @@ export class RooSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -143,7 +143,7 @@ export class RooSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -157,7 +157,7 @@ export class RooSkill extends ToolSkill {
     };
 
     return new RooSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rooFrontmatter.name,
       frontmatter: rooFrontmatter,
@@ -181,7 +181,7 @@ export class RooSkill extends ToolSkill {
 
     const result = RooSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
@@ -189,7 +189,7 @@ export class RooSkill extends ToolSkill {
 
     if (result.data.name !== loaded.dirName) {
       const skillFilePath = join(
-        loaded.baseDir,
+        loaded.outputRoot,
         loaded.relativeDirPath,
         loaded.dirName,
         SKILL_FILE_NAME,
@@ -200,7 +200,7 @@ export class RooSkill extends ToolSkill {
     }
 
     return new RooSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -212,13 +212,13 @@ export class RooSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): RooSkill {
     return new RooSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/rovodev-skill.test.ts
+++ b/src/features/skills/rovodev-skill.test.ts
@@ -43,7 +43,7 @@ describe("RovodevSkill", () => {
       });
     });
 
-    it("should return the same roots for global mode (under home baseDir)", () => {
+    it("should return the same roots for global mode (under home outputRoot)", () => {
       expect(RovodevSkill.getSettablePaths({ global: true })).toEqual({
         relativeDirPath: rovodevSkillsRel(),
         alternativeSkillRoots: [agentsSkillsRel()],
@@ -54,7 +54,7 @@ describe("RovodevSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid frontmatter", () => {
       const skill = new RovodevSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: rovodevSkillsRel(),
         dirName: "my-skill",
         frontmatter: {
@@ -77,7 +77,7 @@ describe("RovodevSkill", () => {
     it("should throw when validation fails for invalid frontmatter", () => {
       expect(() => {
         new RovodevSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "bad",
           frontmatter: {
             name: "ok",
@@ -92,7 +92,7 @@ describe("RovodevSkill", () => {
     it("should throw when frontmatter name does not match directory name", () => {
       expect(() => {
         new RovodevSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "my-skill",
           frontmatter: {
             name: "wrong-name",
@@ -106,7 +106,7 @@ describe("RovodevSkill", () => {
 
     it("should not throw when validate is false with invalid shape", () => {
       const skill = new RovodevSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "lenient",
         frontmatter: {
           name: "n",
@@ -130,7 +130,7 @@ describe("RovodevSkill", () => {
       );
 
       const skill = await RovodevSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "disk-skill",
       });
 
@@ -152,7 +152,7 @@ describe("RovodevSkill", () => {
       );
 
       const skill = await RovodevSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: agentsSkillsRel(),
         dirName: "agents-skill",
       });
@@ -170,7 +170,7 @@ describe("RovodevSkill", () => {
       );
 
       const skill = await RovodevSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "global-skill",
         global: true,
       });
@@ -184,7 +184,7 @@ describe("RovodevSkill", () => {
 
       await expect(
         RovodevSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -204,7 +204,7 @@ body`,
 
       await expect(
         RovodevSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "bad-fm",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -220,7 +220,7 @@ body`,
 
       await expect(
         RovodevSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "mismatch-dir",
         }),
       ).rejects.toThrow(/must match directory name/);
@@ -230,7 +230,7 @@ body`,
   describe("fromRulesyncSkill", () => {
     it("should build RovodevSkill from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "synced",
         frontmatter: {
@@ -243,7 +243,7 @@ body`,
       });
 
       const rovodev = RovodevSkill.fromRulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSkill,
         validate: true,
         global: false,
@@ -263,7 +263,7 @@ body`,
   describe("toRulesyncSkill", () => {
     it('should convert to RulesyncSkill with targets ["*"]', () => {
       const skill = new RovodevSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "export-me",
         frontmatter: {
           name: "export-me",
@@ -290,7 +290,7 @@ body`,
   describe("round-trip", () => {
     it("fromRulesyncSkill then toRulesyncSkill preserves name, description, body, dirName", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "rt",
         frontmatter: {
@@ -303,7 +303,7 @@ body`,
       });
 
       const rovodev = RovodevSkill.fromRulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSkill,
         validate: true,
       });
@@ -321,7 +321,7 @@ body`,
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true for wildcard and rovodev targets", () => {
       const forStar = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "a",
         frontmatter: { name: "A", description: "D", targets: ["*"] },
@@ -329,7 +329,7 @@ body`,
         validate: true,
       });
       const forRovodev = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "b",
         frontmatter: { name: "B", description: "D", targets: ["rovodev"] },
@@ -337,7 +337,7 @@ body`,
         validate: true,
       });
       const forJunie = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "c",
         frontmatter: { name: "C", description: "D", targets: ["junie"] },
@@ -354,7 +354,7 @@ body`,
   describe("forDeletion", () => {
     it("should create minimal instance for deletion", () => {
       const skill = RovodevSkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: rovodevSkillsRel(),
         dirName: "gone",
       });
@@ -367,7 +367,7 @@ body`,
   describe("validate", () => {
     it("should return failure when frontmatter name does not match directory name", () => {
       const skill = new RovodevSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "ok-dir",
         frontmatter: { name: "other", description: "d" },
         body: "",
@@ -381,7 +381,7 @@ body`,
 
     it("should return failure when frontmatter does not match schema", () => {
       const skill = new RovodevSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "bad",
         frontmatter: {
           name: "n",

--- a/src/features/skills/rovodev-skill.ts
+++ b/src/features/skills/rovodev-skill.ts
@@ -23,7 +23,7 @@ export const RovodevSkillFrontmatterSchema = z.looseObject({
 export type RovodevSkillFrontmatter = z.infer<typeof RovodevSkillFrontmatterSchema>;
 
 export type RovodevSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: RovodevSkillFrontmatter;
@@ -45,7 +45,7 @@ export type RovodevSkillParams = {
  */
 export class RovodevSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = join(".rovodev", "skills"),
     dirName,
     frontmatter,
@@ -55,7 +55,7 @@ export class RovodevSkill extends ToolSkill {
     global = false,
   }: RovodevSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -130,7 +130,7 @@ export class RovodevSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -142,7 +142,7 @@ export class RovodevSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -156,7 +156,7 @@ export class RovodevSkill extends ToolSkill {
     };
 
     return new RovodevSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rovodevFrontmatter.name,
       frontmatter: rovodevFrontmatter,
@@ -180,7 +180,7 @@ export class RovodevSkill extends ToolSkill {
 
     const result = RovodevSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
@@ -188,7 +188,7 @@ export class RovodevSkill extends ToolSkill {
 
     if (result.data.name !== loaded.dirName) {
       const skillFilePath = join(
-        loaded.baseDir,
+        loaded.outputRoot,
         loaded.relativeDirPath,
         loaded.dirName,
         SKILL_FILE_NAME,
@@ -199,7 +199,7 @@ export class RovodevSkill extends ToolSkill {
     }
 
     return new RovodevSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -211,14 +211,14 @@ export class RovodevSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): RovodevSkill {
     const settablePaths = RovodevSkill.getSettablePaths({ global });
     return new RovodevSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -100,7 +100,7 @@ export type RulesyncSkillFrontmatter = z.infer<typeof RulesyncSkillFrontmatterSc
 export type SkillFile = AiDirFile;
 
 export type RulesyncSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: RulesyncSkillFrontmatterInput;
@@ -115,7 +115,7 @@ export type RulesyncSkillSettablePaths = {
 };
 
 export type RulesyncSkillFromDirParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   global?: boolean;
@@ -127,7 +127,7 @@ export type RulesyncSkillFromDirParams = {
  */
 export class RulesyncSkill extends AiDir {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = RULESYNC_SKILLS_RELATIVE_DIR_PATH,
     dirName,
     frontmatter,
@@ -137,7 +137,7 @@ export class RulesyncSkill extends AiDir {
     global = false,
   }: RulesyncSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -159,7 +159,7 @@ export class RulesyncSkill extends AiDir {
 
   static getSettablePaths(): RulesyncSkillSettablePaths {
     // Rulesync skills use the same relative path for both project and global modes
-    // The actual location differs based on baseDir:
+    // The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.rulesync/skills/
     // - Global mode: {getHomeDirectory()}/.rulesync/skills/
     return {
@@ -194,12 +194,12 @@ export class RulesyncSkill extends AiDir {
   }
 
   static async fromDir({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = RULESYNC_SKILLS_RELATIVE_DIR_PATH,
     dirName,
     global = false,
   }: RulesyncSkillFromDirParams): Promise<RulesyncSkill> {
-    const skillDirPath = join(baseDir, relativeDirPath, dirName);
+    const skillDirPath = join(outputRoot, relativeDirPath, dirName);
     const skillFilePath = join(skillDirPath, SKILL_FILE_NAME);
 
     if (!(await fileExists(skillFilePath))) {
@@ -214,14 +214,14 @@ export class RulesyncSkill extends AiDir {
       throw new Error(`Invalid frontmatter in ${skillFilePath}: ${formatError(result.error)}`);
     }
     const otherFiles = await this.collectOtherFiles(
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       SKILL_FILE_NAME,
     );
 
     return new RulesyncSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: result.data,

--- a/src/features/skills/simulated-skill.test.ts
+++ b/src/features/skills/simulated-skill.test.ts
@@ -63,7 +63,7 @@ describe("SimulatedSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -86,7 +86,7 @@ describe("SimulatedSkill", () => {
 
     it("should create instance with empty name and description", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -106,7 +106,7 @@ describe("SimulatedSkill", () => {
 
     it("should create instance without validation when validate is false", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -123,7 +123,7 @@ describe("SimulatedSkill", () => {
     it("should throw error for invalid frontmatter when validation is enabled", () => {
       expect(() => {
         new TestSimulatedSkill({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".test/skills",
           dirName: "test-skill",
           frontmatter: {
@@ -140,7 +140,7 @@ describe("SimulatedSkill", () => {
   describe("toRulesyncSkill", () => {
     it("should throw error because SimulatedSkill is simulated", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -171,7 +171,7 @@ It can be multiline.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await TestSimulatedSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -198,7 +198,7 @@ Body content`;
 
       await expect(
         TestSimulatedSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "invalid-skill",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -210,7 +210,7 @@ Body content`;
 
       await expect(
         TestSimulatedSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -220,7 +220,7 @@ Body content`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -246,7 +246,7 @@ Body content`;
 
     it("should ignore claudecode-specific options from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-skill",
         frontmatter: {
@@ -276,7 +276,7 @@ Body content`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -293,7 +293,7 @@ Body content`;
 
     it("should return true when targets includes the specific tool", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "copilot-skill",
         frontmatter: {
@@ -310,7 +310,7 @@ Body content`;
 
     it("should return false when targets does not include the specific tool", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -328,7 +328,7 @@ Body content`;
 
     it("should return true when targets is not specified (defaults to '*')", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "default-targets-skill",
         frontmatter: {
@@ -347,7 +347,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {
@@ -365,7 +365,7 @@ Body content`;
 
     it("should return error for invalid frontmatter", () => {
       const skill = new TestSimulatedSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/skills",
         dirName: "test-skill",
         frontmatter: {

--- a/src/features/skills/simulated-skill.ts
+++ b/src/features/skills/simulated-skill.ts
@@ -25,7 +25,7 @@ export const SimulatedSkillFrontmatterSchema = z.looseObject({
 export type SimulatedSkillFrontmatter = z.infer<typeof SimulatedSkillFrontmatterSchema>;
 
 export type SimulatedSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   dirName: string;
   frontmatter: SimulatedSkillFrontmatter;
@@ -50,7 +50,7 @@ export abstract class SimulatedSkill extends ToolSkill {
   private readonly body: string;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     frontmatter,
@@ -59,7 +59,7 @@ export abstract class SimulatedSkill extends ToolSkill {
     validate = true,
   }: SimulatedSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -115,7 +115,7 @@ export abstract class SimulatedSkill extends ToolSkill {
   }
 
   protected static fromRulesyncSkillDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
   }: ToolSkillFromRulesyncSkillParams): SimulatedSkillParams {
@@ -128,7 +128,7 @@ export abstract class SimulatedSkill extends ToolSkill {
     };
 
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: simulatedFrontmatter,
@@ -139,13 +139,13 @@ export abstract class SimulatedSkill extends ToolSkill {
   }
 
   protected static async fromDirDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
   }: ToolSkillFromDirParams): Promise<SimulatedSkillParams> {
     const settablePaths = this.getSettablePaths();
     const actualRelativeDirPath = relativeDirPath ?? settablePaths.relativeDirPath;
-    const skillDirPath = join(baseDir, actualRelativeDirPath, dirName);
+    const skillDirPath = join(outputRoot, actualRelativeDirPath, dirName);
     const skillFilePath = join(skillDirPath, SKILL_FILE_NAME);
 
     if (!(await fileExists(skillFilePath))) {
@@ -161,14 +161,14 @@ export abstract class SimulatedSkill extends ToolSkill {
     }
 
     const otherFiles = await this.collectOtherFiles(
-      baseDir,
+      outputRoot,
       actualRelativeDirPath,
       dirName,
       SKILL_FILE_NAME,
     );
 
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath: actualRelativeDirPath,
       dirName,
       frontmatter: result.data,
@@ -184,12 +184,12 @@ export abstract class SimulatedSkill extends ToolSkill {
    * even when skill files have old/incompatible formats.
    */
   protected static forDeletionDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
   }: ToolSkillForDeletionParams): SimulatedSkillParams {
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -36,14 +36,14 @@ describe("SkillsProcessor", () => {
     it("should create instance with valid tool target", () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
       expect(processor).toBeInstanceOf(SkillsProcessor);
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
         toolTarget: "claudecode",
@@ -56,7 +56,7 @@ describe("SkillsProcessor", () => {
       expect(() => {
         const _processor = new SkillsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid" as SkillsProcessorToolTarget,
         });
       }).toThrow("Invalid tool target for SkillsProcessor");
@@ -65,7 +65,7 @@ describe("SkillsProcessor", () => {
     it("should accept global parameter", () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
@@ -76,7 +76,7 @@ describe("SkillsProcessor", () => {
     it("should default global to false", () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -90,14 +90,14 @@ describe("SkillsProcessor", () => {
     beforeEach(() => {
       processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
 
     it("should convert rulesync skills to claudecode skills", async () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -119,7 +119,7 @@ describe("SkillsProcessor", () => {
 
     it("should filter out non-RulesyncSkill instances", async () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -143,7 +143,7 @@ describe("SkillsProcessor", () => {
     it("should filter out skills not targeted for the tool", async () => {
       // Create a skill without claudecode in targets (by not having claudecode frontmatter)
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "non-targeted-skill",
         frontmatter: {
@@ -155,7 +155,7 @@ describe("SkillsProcessor", () => {
       });
 
       const targetedSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "targeted-skill",
         frontmatter: {
@@ -186,13 +186,13 @@ describe("SkillsProcessor", () => {
     it("should pass global parameter to ClaudecodeSkill.fromRulesyncSkill", async () => {
       const globalProcessor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
 
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "global-skill",
         frontmatter: {
@@ -212,7 +212,7 @@ describe("SkillsProcessor", () => {
     it("should throw error for unsupported tool target", async () => {
       // Create processor with mock tool target (bypassing constructor validation)
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);
-      processorWithMockTarget.baseDir = testDir;
+      processorWithMockTarget.outputRoot = testDir;
       processorWithMockTarget.toolTarget = "unsupported";
       processorWithMockTarget.global = false;
       processorWithMockTarget.getFactory = (target: any) => {
@@ -220,7 +220,7 @@ describe("SkillsProcessor", () => {
       };
 
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test",
         frontmatter: { name: "test", description: "test" },
@@ -240,14 +240,14 @@ describe("SkillsProcessor", () => {
     beforeEach(() => {
       processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
 
     it("should convert tool skills to rulesync skills", async () => {
       const claudecodeSkill = new ClaudecodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -268,7 +268,7 @@ describe("SkillsProcessor", () => {
 
     it("should filter out non-ToolSkill instances", async () => {
       const claudecodeSkill = new ClaudecodeSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".claude", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -311,7 +311,7 @@ describe("SkillsProcessor", () => {
     beforeEach(() => {
       processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
@@ -407,7 +407,7 @@ Invalid content`;
       await expect(processor.loadRulesyncDirs()).rejects.toThrow("SKILL.md not found in");
     });
 
-    it("should load rulesync dirs from cwd even when baseDir is different (global mode)", async () => {
+    it("should load rulesync dirs from cwd even when outputRoot is different (global mode)", async () => {
       const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
       await ensureDir(skillsDir);
 
@@ -422,13 +422,13 @@ This is skill content`;
 
       await writeFileContent(join(skill1Dir, "SKILL.md"), skillContent);
 
-      // Use a different baseDir to simulate global mode (baseDir = homeDir)
-      const differentBaseDir = join(testDir, "fake-home");
-      await ensureDir(differentBaseDir);
+      // Use a different outputRoot to simulate global mode (outputRoot = homeDir)
+      const differentOutputRoot = join(testDir, "fake-home");
+      await ensureDir(differentOutputRoot);
 
       const globalProcessor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: differentBaseDir,
+        outputRoot: differentOutputRoot,
         toolTarget: "claudecode",
         global: true,
       });
@@ -446,7 +446,7 @@ This is skill content`;
     it("should delegate to loadClaudecodeSkills for claudecode target", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -457,7 +457,7 @@ This is skill content`;
     it("should throw error for unsupported tool target", async () => {
       // Create processor with mock tool target
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);
-      processorWithMockTarget.baseDir = testDir;
+      processorWithMockTarget.outputRoot = testDir;
       processorWithMockTarget.toolTarget = "unsupported";
       processorWithMockTarget.getFactory = (target: any) => {
         throw new Error(`Unsupported tool target: ${target}`);
@@ -471,7 +471,7 @@ This is skill content`;
     it("should load rovodev skills from .agents/skills when .rovodev/skills is absent", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "rovodev",
       });
       const skillDir = join(testDir, ".agents", "skills", "imported-skill");
@@ -497,7 +497,7 @@ Skill body`,
     it("should prefer .rovodev/skills over .agents/skills for the same skill name", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "rovodev",
       });
       const writeSkill = async (base: string, body: string) => {
@@ -530,7 +530,7 @@ ${body}`,
     beforeEach(() => {
       processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
@@ -618,7 +618,7 @@ Second content`;
       it("should use global paths when global=true", async () => {
         const globalProcessor = new SkillsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -648,7 +648,7 @@ Global skill content`;
       it("should return empty array when global skills directory does not exist", async () => {
         const globalProcessor = new SkillsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -663,7 +663,7 @@ Global skill content`;
     it("should return the same dirs as loadToolDirs", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -691,7 +691,7 @@ Test skill content`;
     it("should succeed even when SKILL.md has broken frontmatter", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -723,7 +723,7 @@ Content that would fail parsing`;
     it("should return empty array when no dirs exist", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -734,7 +734,7 @@ Content that would fail parsing`;
     it("should list rovodev skills in both .rovodev/skills and .agents/skills for deletion", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "rovodev",
       });
       const rovoDir = join(testDir, ".rovodev", "skills", "a-skill");
@@ -918,7 +918,7 @@ Content that would fail parsing`;
     it("should extend DirFeatureProcessor", () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -936,14 +936,14 @@ Content that would fail parsing`;
     beforeEach(() => {
       processor = new SkillsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
 
     it("should write skill file with frontmatter that can be read back", async () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -970,7 +970,7 @@ Content that would fail parsing`;
 
     it("should write skill file with allowed-tools frontmatter", async () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "tool-skill",
         frontmatter: {

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -299,7 +299,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
   private readonly getFactory: GetFactory;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
@@ -307,7 +307,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
@@ -315,7 +315,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, avoidBlockScalars: toolTarget === "cursor", logger });
+    super({ outputRoot, inputRoot, dryRun, avoidBlockScalars: toolTarget === "cursor", logger });
     const result = SkillsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -340,7 +340,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
           return null;
         }
         return factory.class.fromRulesyncSkill({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           rulesyncSkill: rulesyncSkill,
           global: this.global,
         });
@@ -378,7 +378,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
 
     const localSkills = await Promise.all(
       localDirNames.map((dirName) =>
-        RulesyncSkill.fromDir({ baseDir: this.inputRoot, dirName, global: this.global }),
+        RulesyncSkill.fromDir({ outputRoot: this.inputRoot, dirName, global: this.global }),
       ),
     );
 
@@ -405,7 +405,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       curatedSkills = await Promise.all(
         nonConflicting.map((dirName) =>
           RulesyncSkill.fromDir({
-            baseDir: this.inputRoot,
+            outputRoot: this.inputRoot,
             relativeDirPath: curatedRelativeDirPath,
             dirName,
             global: this.global,
@@ -434,7 +434,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const loadEntries: Array<{ root: string; dirName: string }> = [];
 
     for (const root of roots) {
-      const skillsDirPath = join(this.baseDir, root);
+      const skillsDirPath = join(this.outputRoot, root);
       if (!(await directoryExists(skillsDirPath))) {
         continue;
       }
@@ -452,7 +452,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const toolSkills = await Promise.all(
       loadEntries.map(({ root, dirName }) =>
         factory.class.fromDir({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: root,
           dirName,
           global: this.global,
@@ -473,7 +473,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
 
     const toolSkills: AiDir[] = [];
     for (const root of roots) {
-      const skillsDirPath = join(this.baseDir, root);
+      const skillsDirPath = join(this.outputRoot, root);
       if (!(await directoryExists(skillsDirPath))) {
         continue;
       }
@@ -481,7 +481,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       for (const dirPath of dirPaths) {
         const dirName = basename(dirPath);
         const toolSkill = factory.class.forDeletion({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: root,
           dirName,
           global: this.global,

--- a/src/features/skills/skills-utils.ts
+++ b/src/features/skills/skills-utils.ts
@@ -9,8 +9,8 @@ import { directoryExists, findFilesByGlobs } from "../../utils/file.js";
 /**
  * Returns the set of local skill directory names (excluding `.curated`).
  */
-export async function getLocalSkillDirNames(baseDir: string): Promise<Set<string>> {
-  const skillsDir = join(baseDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+export async function getLocalSkillDirNames(outputRoot: string): Promise<Set<string>> {
+  const skillsDir = join(outputRoot, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
   const names = new Set<string>();
 
   if (!(await directoryExists(skillsDir))) {

--- a/src/features/skills/takt-skill.test.ts
+++ b/src/features/skills/takt-skill.test.ts
@@ -32,7 +32,7 @@ describe("TaktSkill", () => {
   describe("fromRulesyncSkill", () => {
     it("emits a single flat .md file under knowledge/", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "runbook",
         frontmatter: {
           name: "runbook",
@@ -42,7 +42,7 @@ describe("TaktSkill", () => {
         body: "Runbook body",
       });
 
-      const skill = TaktSkill.fromRulesyncSkill({ baseDir: testDir, rulesyncSkill });
+      const skill = TaktSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
       expect(skill.getRelativeDirPath()).toBe(join(".takt", "facets", "knowledge"));
       expect(skill.getFileName()).toBe("runbook.md");
       expect(skill.getBody()).toBe("Runbook body");
@@ -53,7 +53,7 @@ describe("TaktSkill", () => {
 
     it("renames the stem with takt.name", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "long-source",
         frontmatter: {
           name: "long-source",
@@ -64,14 +64,14 @@ describe("TaktSkill", () => {
         body: "body",
       });
 
-      const skill = TaktSkill.fromRulesyncSkill({ baseDir: testDir, rulesyncSkill });
+      const skill = TaktSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
       expect(skill.getFileName()).toBe("short.md");
       expect(skill.getRelativeDirPath()).toBe(join(".takt", "facets", "knowledge"));
     });
 
     it("throws on an unsafe takt.name value", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "src",
         frontmatter: {
           name: "src",
@@ -81,7 +81,7 @@ describe("TaktSkill", () => {
         },
         body: "x",
       });
-      expect(() => TaktSkill.fromRulesyncSkill({ baseDir: testDir, rulesyncSkill })).toThrow(
+      expect(() => TaktSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill })).toThrow(
         /Invalid takt\.name/,
       );
     });
@@ -94,7 +94,7 @@ describe("TaktSkill", () => {
       [["claudecode"], false],
     ] as const)("targets=%j → %s", (targets, expected) => {
       const r = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "x",
         frontmatter: { name: "x", description: "x", targets: [...targets] },
         body: "y",
@@ -104,9 +104,9 @@ describe("TaktSkill", () => {
   });
 
   describe("getDirPath path-traversal guard", () => {
-    it("throws when relativeDirPath escapes baseDir", () => {
+    it("throws when relativeDirPath escapes outputRoot", () => {
       const skill = new TaktSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join("..", "escape"),
         dirName: "x",
         fileName: "x.md",
@@ -119,14 +119,14 @@ describe("TaktSkill", () => {
 
   describe("fromDir / toRulesyncSkill (unsupported)", () => {
     it("fromDir throws because reverse import is unsupported", async () => {
-      await expect(TaktSkill.fromDir({ baseDir: testDir, dirName: "x" })).rejects.toThrow(
+      await expect(TaktSkill.fromDir({ outputRoot: testDir, dirName: "x" })).rejects.toThrow(
         /not supported/,
       );
     });
 
     it("toRulesyncSkill throws because reverse import is unsupported", () => {
       const skill = new TaktSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "knowledge"),
         dirName: "x",
         fileName: "x.md",
@@ -139,7 +139,7 @@ describe("TaktSkill", () => {
   describe("forDeletion", () => {
     it("constructs an empty instance for deletion", () => {
       const skill = TaktSkill.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "knowledge"),
         dirName: "x",
       });

--- a/src/features/skills/takt-skill.ts
+++ b/src/features/skills/takt-skill.ts
@@ -21,7 +21,7 @@ import {
 export const DEFAULT_TAKT_SKILL_DIR = "knowledge";
 
 export type TaktSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   dirName: string;
   /** File name (with `.md` extension) to emit under `relativeDirPath`. */
@@ -52,7 +52,7 @@ export class TaktSkill extends ToolSkill {
   private readonly fileName: string;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     fileName,
@@ -62,7 +62,7 @@ export class TaktSkill extends ToolSkill {
     global = false,
   }: TaktSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -95,19 +95,19 @@ export class TaktSkill extends ToolSkill {
    * not a nested directory keyed by `dirName`. Drop `dirName` from the path.
    *
    * Preserves the same path-traversal guard as `AiDir.getDirPath` so a
-   * malicious `relativeDirPath` cannot escape `baseDir`.
+   * malicious `relativeDirPath` cannot escape `outputRoot`.
    */
   override getDirPath(): string {
-    const fullPath = join(this.baseDir, this.relativeDirPath);
+    const fullPath = join(this.outputRoot, this.relativeDirPath);
 
     const resolvedFull = resolve(fullPath);
-    const resolvedBase = resolve(this.baseDir);
+    const resolvedBase = resolve(this.outputRoot);
     const rel = relative(resolvedBase, resolvedFull);
 
     if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error(
-        `Path traversal detected: Final path escapes baseDir. ` +
-          `baseDir="${this.baseDir}", relativeDirPath="${this.relativeDirPath}"`,
+        `Path traversal detected: Final path escapes outputRoot. ` +
+          `outputRoot="${this.outputRoot}", relativeDirPath="${this.relativeDirPath}"`,
       );
     }
 
@@ -142,7 +142,7 @@ export class TaktSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -159,7 +159,7 @@ export class TaktSkill extends ToolSkill {
     const relativeDirPath = join(".takt", "facets", DEFAULT_TAKT_SKILL_DIR);
 
     return new TaktSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName: stem,
       fileName,
@@ -192,13 +192,13 @@ export class TaktSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): TaktSkill {
     return new TaktSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       fileName: `${dirName}.md`,

--- a/src/features/skills/tool-skill.ts
+++ b/src/features/skills/tool-skill.ts
@@ -7,7 +7,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncSkill, SkillFile } from "./rulesync-skill.js";
 
 export type ToolSkillFromRulesyncSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   rulesyncSkill: RulesyncSkill;
   validate?: boolean;
   global?: boolean;
@@ -26,14 +26,14 @@ export function toolSkillSearchRoots(paths: ToolSkillSettablePaths): string[] {
 }
 
 export type ToolSkillFromDirParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   global?: boolean;
 };
 
 export type ToolSkillForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   dirName: string;
   global?: boolean;
@@ -44,7 +44,7 @@ export type ToolSkillForDeletionParams = {
  * Used by loadSkillDirContent to return parsed file data.
  */
 export type LoadedSkillDirContent = {
-  baseDir: string;
+  outputRoot: string;
   relativeDirPath: string;
   dirName: string;
   frontmatter: Record<string, unknown>;
@@ -164,7 +164,7 @@ export abstract class ToolSkill extends AiDir {
    * @returns Parsed skill directory content
    */
   protected static async loadSkillDirContent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
@@ -174,7 +174,7 @@ export abstract class ToolSkill extends AiDir {
   }): Promise<LoadedSkillDirContent> {
     const settablePaths = getSettablePaths({ global });
     const actualRelativeDirPath = relativeDirPath ?? settablePaths.relativeDirPath;
-    const skillDirPath = join(baseDir, actualRelativeDirPath, dirName);
+    const skillDirPath = join(outputRoot, actualRelativeDirPath, dirName);
     const skillFilePath = join(skillDirPath, SKILL_FILE_NAME);
 
     if (!(await fileExists(skillFilePath))) {
@@ -185,14 +185,14 @@ export abstract class ToolSkill extends AiDir {
     const { frontmatter, body: content } = parseFrontmatter(fileContent, skillFilePath);
 
     const otherFiles = await this.collectOtherFiles(
-      baseDir,
+      outputRoot,
       actualRelativeDirPath,
       dirName,
       SKILL_FILE_NAME,
     );
 
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath: actualRelativeDirPath,
       dirName,
       frontmatter,

--- a/src/features/skills/windsurf-skill.test.ts
+++ b/src/features/skills/windsurf-skill.test.ts
@@ -40,7 +40,7 @@ describe("WindsurfSkill", () => {
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const skill = new WindsurfSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".windsurf", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -63,7 +63,7 @@ describe("WindsurfSkill", () => {
       expect(
         () =>
           new WindsurfSkill({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: join(".windsurf", "skills"),
             dirName: "invalid-skill",
             frontmatter: {
@@ -90,7 +90,7 @@ This is the body of the windsurf skill.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await WindsurfSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "test-skill",
       });
 
@@ -108,7 +108,7 @@ This is the body of the windsurf skill.`;
 
       await expect(
         WindsurfSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "empty-skill",
         }),
       ).rejects.toThrow(/SKILL\.md not found/);
@@ -126,7 +126,7 @@ Missing description field.`;
 
       await expect(
         WindsurfSkill.fromDir({
-          baseDir: testDir,
+          outputRoot: testDir,
           dirName: "bad-fm",
         }),
       ).rejects.toThrow(/Invalid frontmatter/);
@@ -144,7 +144,7 @@ Global skill body content.`;
       await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
 
       const skill = await WindsurfSkill.fromDir({
-        baseDir: testDir,
+        outputRoot: testDir,
         dirName: "global-skill",
         global: true,
       });
@@ -162,7 +162,7 @@ Global skill body content.`;
   describe("fromRulesyncSkill", () => {
     it("should create instance from RulesyncSkill", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -188,7 +188,7 @@ Global skill body content.`;
 
     it("should use global path when global is true", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "test-skill",
         frontmatter: {
@@ -212,7 +212,7 @@ Global skill body content.`;
   describe("isTargetedByRulesyncSkill", () => {
     it("should return true when targets includes '*'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "all-targets-skill",
         frontmatter: {
@@ -229,7 +229,7 @@ Global skill body content.`;
 
     it("should return true when targets includes 'windsurf'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "windsurf-skill",
         frontmatter: {
@@ -246,7 +246,7 @@ Global skill body content.`;
 
     it("should return false when targets does not include 'windsurf'", () => {
       const rulesyncSkill = new RulesyncSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
         dirName: "claudecode-only-skill",
         frontmatter: {
@@ -265,7 +265,7 @@ Global skill body content.`;
   describe("toRulesyncSkill", () => {
     it("should convert to RulesyncSkill", () => {
       const skill = new WindsurfSkill({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".windsurf", "skills"),
         dirName: "test-skill",
         frontmatter: {
@@ -300,14 +300,14 @@ Global skill body content.`;
       expect(skill.getGlobal()).toBe(false);
     });
 
-    it("should use process.cwd() as default baseDir", () => {
+    it("should use process.cwd() as default outputRoot", () => {
       const skill = WindsurfSkill.forDeletion({
         dirName: "cleanup",
         relativeDirPath: join(".windsurf", "skills"),
       });
 
       expect(skill).toBeInstanceOf(WindsurfSkill);
-      expect(skill.getBaseDir()).toBe(testDir);
+      expect(skill.getOutputRoot()).toBe(testDir);
     });
 
     it("should create instance with empty frontmatter for deletion", () => {

--- a/src/features/skills/windsurf-skill.ts
+++ b/src/features/skills/windsurf-skill.ts
@@ -23,7 +23,7 @@ export const WindsurfSkillFrontmatterSchema = z.looseObject({
 export type WindsurfSkillFrontmatter = z.infer<typeof WindsurfSkillFrontmatterSchema>;
 
 export type WindsurfSkillParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath?: string;
   dirName: string;
   frontmatter: WindsurfSkillFrontmatter;
@@ -40,7 +40,7 @@ export type WindsurfSkillParams = {
  */
 export class WindsurfSkill extends ToolSkill {
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath = WindsurfSkill.getSettablePaths().relativeDirPath,
     dirName,
     frontmatter,
@@ -50,7 +50,7 @@ export class WindsurfSkill extends ToolSkill {
     global = false,
   }: WindsurfSkillParams) {
     super({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       dirName,
       mainFile: {
@@ -123,7 +123,7 @@ export class WindsurfSkill extends ToolSkill {
     };
 
     return new RulesyncSkill({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -135,7 +135,7 @@ export class WindsurfSkill extends ToolSkill {
   }
 
   static fromRulesyncSkill({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSkill,
     validate = true,
     global = false,
@@ -149,7 +149,7 @@ export class WindsurfSkill extends ToolSkill {
     };
 
     return new WindsurfSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: settablePaths.relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: windsurfFrontmatter,
@@ -173,14 +173,14 @@ export class WindsurfSkill extends ToolSkill {
 
     const result = WindsurfSkillFrontmatterSchema.safeParse(loaded.frontmatter);
     if (!result.success) {
-      const skillDirPath = join(loaded.baseDir, loaded.relativeDirPath, loaded.dirName);
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
       throw new Error(
         `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
       );
     }
 
     return new WindsurfSkill({
-      baseDir: loaded.baseDir,
+      outputRoot: loaded.outputRoot,
       relativeDirPath: loaded.relativeDirPath,
       dirName: loaded.dirName,
       frontmatter: result.data,
@@ -192,14 +192,14 @@ export class WindsurfSkill extends ToolSkill {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     global = false,
   }: ToolSkillForDeletionParams): WindsurfSkill {
     const settablePaths = WindsurfSkill.getSettablePaths({ global });
     return new WindsurfSkill({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/agentsmd-subagent.test.ts
+++ b/src/features/subagents/agentsmd-subagent.test.ts
@@ -53,7 +53,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -76,7 +76,7 @@ Body content`;
 
     it("should create instance with empty name and description", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -96,7 +96,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -114,7 +114,7 @@ Body content`;
       expect(
         () =>
           new AgentsmdSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".agents/subagents",
             relativeFilePath: "invalid-agent.md",
             frontmatter: {
@@ -130,7 +130,7 @@ Body content`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -148,7 +148,7 @@ Body content`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with name and description", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -170,7 +170,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should throw error as it is a simulated file", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -190,7 +190,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create AgentsmdSubagent from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -203,7 +203,7 @@ Body content`;
       });
 
       const agentsmdSubagent = AgentsmdSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         rulesyncSubagent,
         validate: true,
@@ -221,7 +221,7 @@ Body content`;
 
     it("should handle RulesyncSubagent with different file extensions", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-agent.txt",
         frontmatter: {
@@ -234,7 +234,7 @@ Body content`;
       });
 
       const agentsmdSubagent = AgentsmdSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         rulesyncSubagent,
         validate: true,
@@ -245,7 +245,7 @@ Body content`;
 
     it("should handle empty name and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -258,7 +258,7 @@ Body content`;
       });
 
       const agentsmdSubagent = AgentsmdSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         rulesyncSubagent,
         validate: true,
@@ -279,7 +279,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await AgentsmdSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-agent.md",
         validate: true,
       });
@@ -302,7 +302,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await AgentsmdSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-agent.md",
         validate: true,
       });
@@ -313,7 +313,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         AgentsmdSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-agent.md",
           validate: true,
         }),
@@ -328,7 +328,7 @@ Body content`;
 
       await expect(
         AgentsmdSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -343,7 +343,7 @@ Body content`;
 
       await expect(
         AgentsmdSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-frontmatter.md",
           validate: true,
         }),
@@ -354,7 +354,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "valid-agent.md",
         frontmatter: {
@@ -372,7 +372,7 @@ Body content`;
 
     it("should handle frontmatter with additional properties", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "agent-with-extras.md",
         frontmatter: {
@@ -394,7 +394,7 @@ Body content`;
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "empty-body.md",
         frontmatter: {
@@ -417,7 +417,7 @@ Body content`;
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "special-char.md",
         frontmatter: {
@@ -438,7 +438,7 @@ Body content`;
       const longContent = "A".repeat(10000);
 
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "long-content.md",
         frontmatter: {
@@ -455,7 +455,7 @@ Body content`;
 
     it("should handle multi-line name and description", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "multiline-fields.md",
         frontmatter: {
@@ -476,7 +476,7 @@ Body content`;
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "windows-lines.md",
         frontmatter: {
@@ -561,7 +561,7 @@ Body content`;
   describe("integration with base classes", () => {
     it("should properly inherit from SimulatedSubagent", () => {
       const subagent = new AgentsmdSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -578,10 +578,10 @@ Body content`;
       expect(subagent.getRelativeFilePath()).toBe("test.md");
     });
 
-    it("should handle baseDir correctly", () => {
-      const customBaseDir = "/custom/base/dir";
+    it("should handle outputRoot correctly", () => {
+      const customOutputRoot = "/custom/base/dir";
       const subagent = new AgentsmdSubagent({
-        baseDir: customBaseDir,
+        outputRoot: customOutputRoot,
         relativeDirPath: ".agents/subagents",
         relativeFilePath: "test.md",
         frontmatter: {

--- a/src/features/subagents/claudecode-subagent.test.ts
+++ b/src/features/subagents/claudecode-subagent.test.ts
@@ -124,7 +124,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -146,7 +146,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -168,7 +168,7 @@ describe("ClaudecodeSubagent", () => {
       expect(() => {
         // oxlint-disable-next-line eslint/no-new
         new ClaudecodeSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claude/agents",
           relativeFilePath: "test-agent.md",
           frontmatter: invalidFrontmatter,
@@ -189,7 +189,7 @@ describe("ClaudecodeSubagent", () => {
       expect(() => {
         // oxlint-disable-next-line eslint/no-new
         new ClaudecodeSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".claude/agents",
           relativeFilePath: "test-agent.md",
           frontmatter: invalidFrontmatter,
@@ -210,7 +210,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -231,7 +231,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "This is the agent body content";
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -252,7 +252,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -268,7 +268,7 @@ describe("ClaudecodeSubagent", () => {
     it("should return success when frontmatter is not set", () => {
       // Create subagent without validation
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: undefined as any,
@@ -290,7 +290,7 @@ describe("ClaudecodeSubagent", () => {
       } as any;
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: invalidFrontmatter,
@@ -314,7 +314,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Agent body content";
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -346,7 +346,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Agent body content";
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -363,14 +363,14 @@ describe("ClaudecodeSubagent", () => {
       expect(rulesyncFrontmatter.claudecode?.model).toBe("opus");
     });
 
-    it("should preserve relativeFilePath and use project root as baseDir", () => {
+    it("should preserve relativeFilePath and use project root as outputRoot", () => {
       const frontmatter: ClaudecodeSubagentFrontmatter = {
         name: "test-agent",
         description: "A test agent",
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "custom/test-agent.md",
         frontmatter,
@@ -380,8 +380,8 @@ describe("ClaudecodeSubagent", () => {
 
       const rulesyncSubagent = subagent.toRulesyncSubagent();
 
-      // RulesyncSubagent baseDir is always the project root directory
-      expect(rulesyncSubagent.getBaseDir()).toBe(".");
+      // RulesyncSubagent outputRoot is always the project root directory
+      expect(rulesyncSubagent.getOutputRoot()).toBe(".");
       expect(rulesyncSubagent.getRelativeFilePath()).toBe("custom/test-agent.md");
     });
   });
@@ -403,7 +403,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Agent body content";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -411,7 +411,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
         validate: true,
@@ -442,7 +442,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -450,7 +450,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
         validate: true,
@@ -474,7 +474,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Agent body content";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -482,7 +482,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
         validate: true,
@@ -492,7 +492,7 @@ describe("ClaudecodeSubagent", () => {
       expect(frontmatter.model).toBe("haiku");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncFrontmatter: RulesyncSubagentFrontmatter = {
         targets: ["claudecode"],
         name: "test-agent",
@@ -500,7 +500,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -513,7 +513,7 @@ describe("ClaudecodeSubagent", () => {
         validate: true,
       });
 
-      expect(claudecodeSubagent.getBaseDir()).toBe(testDir);
+      expect(claudecodeSubagent.getOutputRoot()).toBe(testDir);
     });
 
     it("should use global paths when global is true", () => {
@@ -525,7 +525,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Global agent content";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "global-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -533,7 +533,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
         validate: true,
@@ -554,7 +554,7 @@ describe("ClaudecodeSubagent", () => {
 
       const body = "Local agent content";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "local-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -562,7 +562,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
         validate: true,
@@ -659,7 +659,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -667,7 +667,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
       }) as ClaudecodeSubagent;
@@ -694,7 +694,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -716,7 +716,7 @@ describe("ClaudecodeSubagent", () => {
 
     it("round-trip should preserve all fields", () => {
       const original = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "roundtrip.md",
         frontmatter: {
@@ -733,7 +733,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecode = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent: original,
       }) as ClaudecodeSubagent;
@@ -753,7 +753,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const subagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -776,7 +776,7 @@ describe("ClaudecodeSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "empty-test.md",
         frontmatter: rulesyncFrontmatter,
@@ -784,7 +784,7 @@ describe("ClaudecodeSubagent", () => {
       });
 
       const claudecodeSubagent = ClaudecodeSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         rulesyncSubagent,
       }) as ClaudecodeSubagent;
@@ -816,7 +816,7 @@ describe("ClaudecodeSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await ClaudecodeSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "file-test-agent.md",
         validate: true,
       });
@@ -826,10 +826,10 @@ describe("ClaudecodeSubagent", () => {
       expect(subagent.getBody()).toBe(body);
       expect(subagent.getRelativeFilePath()).toBe("file-test-agent.md");
       expect(subagent.getRelativeDirPath()).toBe(".claude/agents");
-      expect(subagent.getBaseDir()).toBe(testDir);
+      expect(subagent.getOutputRoot()).toBe(testDir);
     });
 
-    it("should use default baseDir when not provided", async () => {
+    it("should use default outputRoot when not provided", async () => {
       const frontmatter: ClaudecodeSubagentFrontmatter = {
         name: "default-base-agent",
         description: "An agent with default base dir",
@@ -849,7 +849,7 @@ describe("ClaudecodeSubagent", () => {
         validate: true,
       });
 
-      expect(subagent.getBaseDir()).toBe(testDir);
+      expect(subagent.getOutputRoot()).toBe(testDir);
     });
 
     it("should throw error for file with invalid frontmatter", async () => {
@@ -869,7 +869,7 @@ describe("ClaudecodeSubagent", () => {
 
       await expect(
         ClaudecodeSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -891,7 +891,7 @@ describe("ClaudecodeSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await ClaudecodeSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "incomplete-agent.md",
         validate: true,
       });
@@ -916,7 +916,7 @@ describe("ClaudecodeSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await ClaudecodeSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "trim-test-agent.md",
         validate: true,
       });
@@ -939,7 +939,7 @@ describe("ClaudecodeSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await ClaudecodeSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global-test-agent.md",
         validate: true,
         global: true,

--- a/src/features/subagents/claudecode-subagent.ts
+++ b/src/features/subagents/claudecode-subagent.ts
@@ -88,7 +88,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -98,7 +98,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -133,7 +133,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new ClaudecodeSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: claudecodeFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -170,13 +170,13 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<ClaudecodeSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     // Read file content
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
@@ -188,7 +188,7 @@ export class ClaudecodeSubagent extends ToolSubagent {
     }
 
     return new ClaudecodeSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: relativeFilePath,
       frontmatter: result.data,
@@ -199,12 +199,12 @@ export class ClaudecodeSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): ClaudecodeSubagent {
     return new ClaudecodeSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/codexcli-subagent.test.ts
+++ b/src/features/subagents/codexcli-subagent.test.ts
@@ -80,7 +80,7 @@ describe("CodexCliSubagent", () => {
     it("should create instance with valid TOML body", () => {
       const body = 'name = "Test Agent"\ndescription = "Test description"';
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "test-agent.toml",
         body,
@@ -95,7 +95,7 @@ describe("CodexCliSubagent", () => {
     it("should throw error for invalid TOML body when validate is true", () => {
       expect(() => {
         new CodexCliSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".codex/agents",
           relativeFilePath: "invalid.toml",
           body: "not valid toml {{{}",
@@ -108,7 +108,7 @@ describe("CodexCliSubagent", () => {
     it("should throw error for invalid TOML body when validate is default (true)", () => {
       expect(() => {
         new CodexCliSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".codex/agents",
           relativeFilePath: "invalid.toml",
           body: "not valid toml {{{}",
@@ -120,7 +120,7 @@ describe("CodexCliSubagent", () => {
     it("should throw error for missing required name field when validate is true", () => {
       expect(() => {
         new CodexCliSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".codex/agents",
           relativeFilePath: "missing-name.toml",
           body: 'description = "no name"',
@@ -132,7 +132,7 @@ describe("CodexCliSubagent", () => {
 
     it("should create instance with invalid TOML body when validate is false", () => {
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "invalid.toml",
         body: "not valid toml",
@@ -146,7 +146,7 @@ describe("CodexCliSubagent", () => {
 
     it("should create instance without validation when validate is false", () => {
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "test.toml",
         body: "",
@@ -168,7 +168,7 @@ describe("CodexCliSubagent", () => {
       ].join("\n");
 
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "reviewer.toml",
         body: toml,
@@ -193,7 +193,7 @@ describe("CodexCliSubagent", () => {
 
     it("should throw descriptive error for invalid TOML body", () => {
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "broken.toml",
         body: "not valid toml {{{}",
@@ -209,7 +209,7 @@ describe("CodexCliSubagent", () => {
       const toml = ['name = "simple"', 'description = "Simple agent"'].join("\n");
 
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "simple.toml",
         body: toml,
@@ -231,7 +231,7 @@ describe("CodexCliSubagent", () => {
   describe("fromRulesyncSubagent", () => {
     it("should create CodexCliSubagent from RulesyncSubagent with frontmatter", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "reviewer.md",
         frontmatter: {
@@ -248,7 +248,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSubagent,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       }) as CodexCliSubagent;
@@ -268,7 +268,7 @@ describe("CodexCliSubagent", () => {
 
     it("should not allow codexcli section to override name or description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "override.md",
         frontmatter: {
@@ -286,7 +286,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSubagent,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       }) as CodexCliSubagent;
@@ -300,7 +300,7 @@ describe("CodexCliSubagent", () => {
 
     it("should handle empty body and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "minimal.md",
         frontmatter: {
@@ -313,7 +313,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSubagent,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       }) as CodexCliSubagent;
@@ -327,7 +327,7 @@ describe("CodexCliSubagent", () => {
 
     it("should use same relative path when global is true", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "global-agent.md",
         frontmatter: {
@@ -340,7 +340,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -354,7 +354,7 @@ describe("CodexCliSubagent", () => {
 
     it("should use same relative path when global is false", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "local-agent.md",
         frontmatter: {
@@ -367,7 +367,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -393,7 +393,7 @@ describe("CodexCliSubagent", () => {
       await writeFileContent(filePath, tomlContent);
 
       const subagent = await CodexCliSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "planner.toml",
       });
 
@@ -404,7 +404,7 @@ describe("CodexCliSubagent", () => {
     it("should throw error when file does not exist", async () => {
       await expect(
         CodexCliSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent.toml",
           validate: true,
         }),
@@ -419,7 +419,7 @@ describe("CodexCliSubagent", () => {
 
       await expect(
         CodexCliSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid.toml",
           validate: true,
         }),
@@ -437,7 +437,7 @@ describe("CodexCliSubagent", () => {
       await writeFileContent(join(agentsDir, "global-test-agent.toml"), tomlContent);
 
       const subagent = await CodexCliSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global-test-agent.toml",
         validate: true,
         global: true,
@@ -453,7 +453,7 @@ describe("CodexCliSubagent", () => {
     it("should return success for valid TOML body", () => {
       const body = 'name = "test"';
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "test.toml",
         body,
@@ -468,7 +468,7 @@ describe("CodexCliSubagent", () => {
 
     it("should fail validation for invalid TOML", () => {
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "invalid.toml",
         body: "not valid toml {{{}",
@@ -520,7 +520,7 @@ describe("CodexCliSubagent", () => {
   describe("forDeletion", () => {
     it("should create deletable placeholder", () => {
       const subagent = CodexCliSubagent.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "obsolete.toml",
       });
@@ -546,7 +546,7 @@ describe("CodexCliSubagent", () => {
 
       // TOML file → CodexCliSubagent → RulesyncSubagent
       const codexcliSubagent = await CodexCliSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-agent.toml",
       });
 
@@ -567,7 +567,7 @@ describe("CodexCliSubagent", () => {
 
     it("should preserve fields through full round-trip (RulesyncSubagent → CodexCli → RulesyncSubagent)", () => {
       const originalRulesync = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "round-trip.md",
         frontmatter: {
@@ -586,7 +586,7 @@ describe("CodexCliSubagent", () => {
 
       // RulesyncSubagent → CodexCliSubagent
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         rulesyncSubagent: originalRulesync,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       }) as CodexCliSubagent;
@@ -612,7 +612,7 @@ describe("CodexCliSubagent", () => {
     it("should handle empty body content", () => {
       const body = 'name = "empty"';
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "empty.toml",
         body,
@@ -634,7 +634,7 @@ describe("CodexCliSubagent", () => {
       ].join("\n");
 
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "multi.toml",
         body: toml,
@@ -649,7 +649,7 @@ describe("CodexCliSubagent", () => {
 
     it("should preserve multiline body when generating developer_instructions", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "multiline.md",
         frontmatter: {
@@ -661,7 +661,7 @@ describe("CodexCliSubagent", () => {
       });
 
       const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
       }) as CodexCliSubagent;
@@ -680,7 +680,7 @@ describe("CodexCliSubagent", () => {
       ].join("\n");
 
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "special.toml",
         body: toml,
@@ -696,7 +696,7 @@ describe("CodexCliSubagent", () => {
     it("should be assignable to ToolSubagent type", () => {
       const body = 'name = "test"';
       const subagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "test.toml",
         body,

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -110,7 +110,7 @@ export class CodexCliSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: developer_instructions ?? "",
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -120,7 +120,7 @@ export class CodexCliSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -146,7 +146,7 @@ export class CodexCliSubagent extends ToolSubagent {
     const relativeFilePath = rulesyncSubagent.getRelativeFilePath().replace(/\.md$/, ".toml");
 
     return new CodexCliSubagent({
-      baseDir,
+      outputRoot,
       body,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
@@ -177,17 +177,17 @@ export class CodexCliSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<CodexCliSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
 
     const subagent = new CodexCliSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       body: fileContent.trim(),
@@ -209,12 +209,12 @@ export class CodexCliSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): CodexCliSubagent {
     return new CodexCliSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: "",

--- a/src/features/subagents/copilot-subagent.test.ts
+++ b/src/features/subagents/copilot-subagent.test.ts
@@ -44,7 +44,7 @@ Plan tasks`;
   describe("fromRulesyncSubagent", () => {
     it("merges user tools with required agent/runSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner.agent.md",
         frontmatter: {
@@ -61,7 +61,7 @@ Plan tasks`;
       });
 
       const subagent = CopilotSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -75,7 +75,7 @@ Plan tasks`;
 
     it("adds required tool when user tools are missing", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner.md",
         frontmatter: {
@@ -89,7 +89,7 @@ Plan tasks`;
       });
 
       const subagent = CopilotSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -101,7 +101,7 @@ Plan tasks`;
 
     it("keeps .agent.md path as-is", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner.agent.md",
         frontmatter: {
@@ -114,7 +114,7 @@ Plan tasks`;
       });
 
       const subagent = CopilotSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -125,7 +125,7 @@ Plan tasks`;
 
     it("keeps non-.md extensions unchanged", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner.txt",
         frontmatter: {
@@ -138,7 +138,7 @@ Plan tasks`;
       });
 
       const subagent = CopilotSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -149,7 +149,7 @@ Plan tasks`;
 
     it("keeps extension-less paths unchanged", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner",
         frontmatter: {
@@ -162,7 +162,7 @@ Plan tasks`;
       });
 
       const subagent = CopilotSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
@@ -175,7 +175,7 @@ Plan tasks`;
   describe("toRulesyncSubagent", () => {
     it("creates rulesync file with copilot section", () => {
       const subagent = new CopilotSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/agents",
         relativeFilePath: "planner.agent.md",
         frontmatter: {
@@ -202,7 +202,7 @@ Plan tasks`;
 
     it("keeps non-.agent.md paths unchanged", () => {
       const subagent = new CopilotSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/agents",
         relativeFilePath: "planner",
         frontmatter: {
@@ -227,7 +227,7 @@ Plan tasks`;
       await writeFileContent(join(agentsDir, "planner.agent.md"), validContent);
 
       const subagent = await CopilotSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "planner.agent.md",
       });
 
@@ -243,7 +243,7 @@ Plan tasks`;
   describe("validate", () => {
     it("validates required fields", () => {
       const subagent = new CopilotSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/agents",
         relativeFilePath: "planner.agent.md",
         frontmatter: {
@@ -262,7 +262,7 @@ Plan tasks`;
       expect(
         () =>
           new CopilotSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".github/agents",
             relativeFilePath: "invalid.agent.md",
             frontmatter: { description: "missing name" } as any,

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -114,7 +114,7 @@ export class CopilotSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".", // RulesyncCommand baseDir is always the project root directory
+      outputRoot: ".", // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -124,7 +124,7 @@ export class CopilotSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -150,7 +150,7 @@ export class CopilotSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new CopilotSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: copilotFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -187,13 +187,13 @@ export class CopilotSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<CopilotSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -203,7 +203,7 @@ export class CopilotSubagent extends ToolSubagent {
     }
 
     return new CopilotSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: relativeFilePath,
       frontmatter: result.data,
@@ -215,12 +215,12 @@ export class CopilotSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): CopilotSubagent {
     return new CopilotSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/cursor-subagent.test.ts
+++ b/src/features/subagents/cursor-subagent.test.ts
@@ -70,7 +70,7 @@ Body content`;
       };
       const body = "This is the body of the cursor agent.\nIt can be multiline.";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -96,7 +96,7 @@ Body content`;
       };
       const body = "This is a cursor agent without name or description.";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -119,7 +119,7 @@ Body content`;
       };
       const body = "Test body";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -139,7 +139,7 @@ Body content`;
       expect(
         () =>
           new CursorSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".cursor/agents",
             relativeFilePath: "invalid-agent.md",
             frontmatter,
@@ -159,7 +159,7 @@ Body content`;
       };
       const body = "This is the body content.\nWith multiple lines.";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -180,7 +180,7 @@ Body content`;
       };
       const body = "Test body";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -200,7 +200,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should convert CursorSubagent to RulesyncSubagent", () => {
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -223,7 +223,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create CursorSubagent from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -236,7 +236,7 @@ Body content`;
       });
 
       const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         rulesyncSubagent,
         validate: true,
@@ -254,7 +254,7 @@ Body content`;
 
     it("should handle RulesyncSubagent with different file extensions", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-agent.txt",
         frontmatter: {
@@ -267,7 +267,7 @@ Body content`;
       });
 
       const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         rulesyncSubagent,
         validate: true,
@@ -278,7 +278,7 @@ Body content`;
 
     it("should handle empty name and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -291,7 +291,7 @@ Body content`;
       });
 
       const cursorSubagent = CursorSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         rulesyncSubagent,
         validate: true,
@@ -312,7 +312,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await CursorSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-agent.md",
         validate: true,
       });
@@ -335,7 +335,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await CursorSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-agent.md",
         validate: true,
       });
@@ -346,7 +346,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         CursorSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-agent.md",
           validate: true,
         }),
@@ -361,7 +361,7 @@ Body content`;
 
       await expect(
         CursorSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -376,7 +376,7 @@ Body content`;
 
       await expect(
         CursorSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-frontmatter.md",
           validate: true,
         }),
@@ -392,7 +392,7 @@ Body content`;
       };
       const body = "Valid body";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "valid-agent.md",
         frontmatter,
@@ -415,7 +415,7 @@ Body content`;
       } as any;
       const body = "Body content";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "agent-with-extras.md",
         frontmatter,
@@ -477,7 +477,7 @@ Body content`;
       };
       const body = "";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "empty-body.md",
         frontmatter,
@@ -500,7 +500,7 @@ Body content`;
       };
       const body = "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "special-char.md",
         frontmatter,
@@ -522,7 +522,7 @@ Body content`;
       };
       const body = "A".repeat(10000);
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "long-content.md",
         frontmatter,
@@ -542,7 +542,7 @@ Body content`;
       };
       const body = "Test body";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "multiline-fields.md",
         frontmatter,
@@ -564,7 +564,7 @@ Body content`;
       };
       const body = "Line 1\r\nLine 2\r\nLine 3";
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "windows-lines.md",
         frontmatter,
@@ -580,7 +580,7 @@ Body content`;
   describe("inheritance", () => {
     it("should inherit from ToolSubagent", () => {
       const subagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -602,7 +602,7 @@ Body content`;
   describe("isTargetedByRulesyncSubagent", () => {
     it("should return true when targets includes cursor", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -619,7 +619,7 @@ Body content`;
 
     it("should return true when targets includes asterisk", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -636,7 +636,7 @@ Body content`;
 
     it("should return false when targets array is empty", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -653,7 +653,7 @@ Body content`;
 
     it("should return false when targets does not include cursor", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -670,7 +670,7 @@ Body content`;
 
     it("should return true when targets includes cursor among other targets", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -77,7 +77,7 @@ export class CursorSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".", // RulesyncSubagent baseDir is always the project root directory
+      outputRoot: ".", // RulesyncSubagent outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -87,7 +87,7 @@ export class CursorSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -106,7 +106,7 @@ export class CursorSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new CursorSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: cursorFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -143,13 +143,13 @@ export class CursorSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<CursorSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -159,7 +159,7 @@ export class CursorSubagent extends ToolSubagent {
     }
 
     return new CursorSubagent({
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: relativeFilePath,
       frontmatter: result.data,
@@ -171,12 +171,12 @@ export class CursorSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): CursorSubagent {
     return new CursorSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/deepagents-subagent.test.ts
+++ b/src/features/subagents/deepagents-subagent.test.ts
@@ -31,7 +31,7 @@ describe("DeepagentsSubagent", () => {
   describe("constructor", () => {
     it("should create with name and description", () => {
       const subagent = new DeepagentsSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         relativeFilePath: "my-agent.md",
         frontmatter: { name: "My Agent", description: "Does useful things." },
@@ -45,7 +45,7 @@ describe("DeepagentsSubagent", () => {
 
     it("should create with optional model field", () => {
       const subagent = new DeepagentsSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         relativeFilePath: "my-agent.md",
         frontmatter: { name: "Agent", description: "Desc.", model: "claude-sonnet-4-6" },
@@ -71,7 +71,7 @@ You are a test agent.`;
       await writeFileContent(join(agentsDir, "test-agent.md"), content);
 
       const subagent = await DeepagentsSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-agent.md",
       });
 
@@ -84,7 +84,7 @@ You are a test agent.`;
   describe("fromRulesyncSubagent", () => {
     it("should map name and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "my-agent.md",
         frontmatter: { name: "My Agent", description: "Does things.", targets: ["deepagents"] },
@@ -92,7 +92,7 @@ You are a test agent.`;
       });
 
       const subagent = DeepagentsSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         rulesyncSubagent,
       }) as DeepagentsSubagent;
@@ -103,7 +103,7 @@ You are a test agent.`;
 
     it("should pull model from deepagents tool-specific section", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "my-agent.md",
         frontmatter: {
@@ -116,7 +116,7 @@ You are a test agent.`;
       });
 
       const subagent = DeepagentsSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         rulesyncSubagent,
       }) as DeepagentsSubagent;
@@ -128,7 +128,7 @@ You are a test agent.`;
   describe("toRulesyncSubagent", () => {
     it("should convert back to rulesync subagent preserving name and body", () => {
       const subagent = new DeepagentsSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         relativeFilePath: "my-agent.md",
         frontmatter: { name: "My Agent", description: "Does things.", model: "claude-sonnet-4-6" },
@@ -146,7 +146,7 @@ You are a test agent.`;
 
     it("should store model in deepagents tool-specific section", () => {
       const subagent = new DeepagentsSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".deepagents", "agents"),
         relativeFilePath: "my-agent.md",
         frontmatter: { name: "Agent", description: "Desc.", model: "claude-haiku-4-5-20251001" },
@@ -166,7 +166,7 @@ You are a test agent.`;
   describe("isTargetedByRulesyncSubagent", () => {
     it("should return true for deepagents target", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "agent.md",
         frontmatter: { name: "Agent", targets: ["deepagents"] },
@@ -178,7 +178,7 @@ You are a test agent.`;
 
     it("should return true for wildcard target", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "agent.md",
         frontmatter: { name: "Agent", targets: ["*"] },
@@ -190,7 +190,7 @@ You are a test agent.`;
 
     it("should return false for different tool", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".rulesync/subagents",
         relativeFilePath: "agent.md",
         frontmatter: { name: "Agent", targets: ["claudecode"] },

--- a/src/features/subagents/deepagents-subagent.ts
+++ b/src/features/subagents/deepagents-subagent.ts
@@ -77,7 +77,7 @@ export class DeepagentsSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: this.getBaseDir(),
+      outputRoot: this.getOutputRoot(),
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -87,7 +87,7 @@ export class DeepagentsSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -118,7 +118,7 @@ export class DeepagentsSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new DeepagentsSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: deepagentsFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -154,13 +154,13 @@ export class DeepagentsSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<DeepagentsSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -170,7 +170,7 @@ export class DeepagentsSubagent extends ToolSubagent {
     }
 
     return new DeepagentsSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -181,12 +181,12 @@ export class DeepagentsSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): DeepagentsSubagent {
     return new DeepagentsSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/factorydroid-subagent.test.ts
+++ b/src/features/subagents/factorydroid-subagent.test.ts
@@ -53,7 +53,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const subagent = new FactorydroidSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         relativeFilePath: "test-droid.md",
         frontmatter: {
@@ -78,7 +78,7 @@ Body content`;
       expect(
         () =>
           new FactorydroidSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".factory/droids",
             relativeFilePath: "invalid-droid.md",
             frontmatter: {
@@ -94,7 +94,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should throw error as it is a simulated file", () => {
       const subagent = new FactorydroidSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         relativeFilePath: "test-droid.md",
         frontmatter: {
@@ -114,7 +114,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create FactorydroidSubagent from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-droid.md",
         frontmatter: {
@@ -127,7 +127,7 @@ Body content`;
       });
 
       const factorydroidSubagent = FactorydroidSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         rulesyncSubagent,
         validate: true,
@@ -152,7 +152,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await FactorydroidSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-droid.md",
         validate: true,
       });
@@ -171,7 +171,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         FactorydroidSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-droid.md",
           validate: true,
         }),
@@ -186,7 +186,7 @@ Body content`;
 
       await expect(
         FactorydroidSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-droid.md",
           validate: true,
         }),
@@ -197,7 +197,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new FactorydroidSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         relativeFilePath: "valid-droid.md",
         frontmatter: {
@@ -255,7 +255,7 @@ Body content`;
   describe("forDeletion", () => {
     it("should create deletion marker", () => {
       const subagent = FactorydroidSubagent.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         relativeFilePath: "to-delete.md",
       });
@@ -268,7 +268,7 @@ Body content`;
   describe("integration with base classes", () => {
     it("should be assignable to ToolSubagent type", () => {
       const subagent = new FactorydroidSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".factory/droids",
         relativeFilePath: "test.md",
         frontmatter: {

--- a/src/features/subagents/geminicli-subagent.test.ts
+++ b/src/features/subagents/geminicli-subagent.test.ts
@@ -54,7 +54,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -77,7 +77,7 @@ Body content`;
 
     it("should create instance with empty name and description", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -97,7 +97,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -115,7 +115,7 @@ Body content`;
       expect(
         () =>
           new GeminiCliSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".gemini/agents",
             relativeFilePath: "invalid-agent.md",
             frontmatter: {
@@ -131,7 +131,7 @@ Body content`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -149,7 +149,7 @@ Body content`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with name and description", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -171,7 +171,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should convert to RulesyncSubagent", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -193,7 +193,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create GeminiCliSubagent from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -206,7 +206,7 @@ Body content`;
       });
 
       const geminiCliSubagent = GeminiCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         rulesyncSubagent,
         validate: true,
@@ -224,7 +224,7 @@ Body content`;
 
     it("should handle RulesyncSubagent with different file extensions", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-agent.txt",
         frontmatter: {
@@ -237,7 +237,7 @@ Body content`;
       });
 
       const geminiCliSubagent = GeminiCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         rulesyncSubagent,
         validate: true,
@@ -248,7 +248,7 @@ Body content`;
 
     it("should handle empty name and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -261,7 +261,7 @@ Body content`;
       });
 
       const geminiCliSubagent = GeminiCliSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         rulesyncSubagent,
         validate: true,
@@ -282,7 +282,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await GeminiCliSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-agent.md",
         validate: true,
       });
@@ -305,7 +305,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await GeminiCliSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-agent.md",
         validate: true,
       });
@@ -316,7 +316,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         GeminiCliSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-agent.md",
           validate: true,
         }),
@@ -331,7 +331,7 @@ Body content`;
 
       await expect(
         GeminiCliSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -346,7 +346,7 @@ Body content`;
 
       await expect(
         GeminiCliSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-frontmatter.md",
           validate: true,
         }),
@@ -357,7 +357,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "valid-agent.md",
         frontmatter: {
@@ -375,7 +375,7 @@ Body content`;
 
     it("should handle frontmatter with additional properties", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "agent-with-extras.md",
         frontmatter: {
@@ -395,7 +395,7 @@ Body content`;
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "empty-body.md",
         frontmatter: {
@@ -418,7 +418,7 @@ Body content`;
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "special-char.md",
         frontmatter: {
@@ -439,7 +439,7 @@ Body content`;
       const longContent = "A".repeat(10000);
 
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "long-content.md",
         frontmatter: {
@@ -456,7 +456,7 @@ Body content`;
 
     it("should handle multi-line name and description", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "multiline-fields.md",
         frontmatter: {
@@ -477,7 +477,7 @@ Body content`;
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "windows-lines.md",
         frontmatter: {
@@ -495,7 +495,7 @@ Body content`;
   describe("inheritance", () => {
     it("should be an instance of ToolSubagent", () => {
       const subagent = new GeminiCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".gemini/agents",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -514,7 +514,7 @@ Body content`;
   describe("isTargetedByRulesyncSubagent", () => {
     it("should return true when targets includes geminicli", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -531,7 +531,7 @@ Body content`;
 
     it("should return true when targets includes asterisk", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -548,7 +548,7 @@ Body content`;
 
     it("should return false when targets array is empty", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -565,7 +565,7 @@ Body content`;
 
     it("should return false when targets does not include geminicli", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -582,7 +582,7 @@ Body content`;
 
     it("should return true when targets includes geminicli among other targets", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {

--- a/src/features/subagents/geminicli-subagent.ts
+++ b/src/features/subagents/geminicli-subagent.ts
@@ -78,7 +78,7 @@ export class GeminiCliSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -88,7 +88,7 @@ export class GeminiCliSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -109,7 +109,7 @@ export class GeminiCliSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new GeminiCliSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: geminicliSubagentFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -146,13 +146,13 @@ export class GeminiCliSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<GeminiCliSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -162,7 +162,7 @@ export class GeminiCliSubagent extends ToolSubagent {
     }
 
     return new GeminiCliSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -174,12 +174,12 @@ export class GeminiCliSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): GeminiCliSubagent {
     return new GeminiCliSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/junie-subagent.test.ts
+++ b/src/features/subagents/junie-subagent.test.ts
@@ -79,7 +79,7 @@ describe("JunieSubagent", () => {
       };
 
       const subagent = new JunieSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -99,7 +99,7 @@ describe("JunieSubagent", () => {
       expect(() => {
         // oxlint-disable-next-line eslint/no-new
         new JunieSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".junie/agents",
           relativeFilePath: "test-agent.md",
           frontmatter: invalidFrontmatter,
@@ -116,7 +116,7 @@ describe("JunieSubagent", () => {
       expect(() => {
         // oxlint-disable-next-line eslint/no-new
         new JunieSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".junie/agents",
           relativeFilePath: "test-agent.md",
           frontmatter: invalidFrontmatter,
@@ -137,7 +137,7 @@ describe("JunieSubagent", () => {
 
       const body = "Agent body content";
       const subagent = new JunieSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".junie/agents",
         relativeFilePath: "test-agent.md",
         frontmatter,
@@ -170,7 +170,7 @@ describe("JunieSubagent", () => {
 
       const body = "Agent body content";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -178,7 +178,7 @@ describe("JunieSubagent", () => {
       });
 
       const junieSubagent = JunieSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: JunieSubagent.getSettablePaths().relativeDirPath,
         rulesyncSubagent,
         validate: true,
@@ -206,7 +206,7 @@ describe("JunieSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -214,7 +214,7 @@ describe("JunieSubagent", () => {
       });
 
       const junieSubagent = JunieSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".junie", "agents"),
         rulesyncSubagent,
         validate: true,
@@ -226,7 +226,7 @@ describe("JunieSubagent", () => {
       expect((junieFrontmatter as any).extraField).toBe("value");
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const rulesyncFrontmatter: RulesyncSubagentFrontmatter = {
         targets: ["junie"],
         name: "test-agent",
@@ -234,7 +234,7 @@ describe("JunieSubagent", () => {
       };
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -246,7 +246,7 @@ describe("JunieSubagent", () => {
         relativeDirPath: JunieSubagent.getSettablePaths().relativeDirPath,
       });
 
-      expect(junieSubagent.getBaseDir()).toBe(testDir);
+      expect(junieSubagent.getOutputRoot()).toBe(testDir);
     });
   });
 
@@ -301,7 +301,7 @@ describe("JunieSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await JunieSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "file-test-agent.md",
         validate: true,
       });
@@ -311,7 +311,7 @@ describe("JunieSubagent", () => {
       expect(subagent.getBody()).toBe(body);
       expect(subagent.getRelativeFilePath()).toBe("file-test-agent.md");
       expect(subagent.getRelativeDirPath()).toBe(join(".junie", "agents"));
-      expect(subagent.getBaseDir()).toBe(testDir);
+      expect(subagent.getOutputRoot()).toBe(testDir);
     });
 
     it("should throw error for file with missing description", async () => {
@@ -325,7 +325,7 @@ describe("JunieSubagent", () => {
 
       await expect(
         JunieSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid.md",
           validate: true,
         }),
@@ -347,7 +347,7 @@ describe("JunieSubagent", () => {
       await writeFileContent(filePath, fileContent);
 
       const subagent = await JunieSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "trim-agent.md",
         validate: true,
       });

--- a/src/features/subagents/junie-subagent.ts
+++ b/src/features/subagents/junie-subagent.ts
@@ -82,7 +82,7 @@ export class JunieSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -92,7 +92,7 @@ export class JunieSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -123,7 +123,7 @@ export class JunieSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new JunieSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: junieFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -159,13 +159,13 @@ export class JunieSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<JunieSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -175,7 +175,7 @@ export class JunieSubagent extends ToolSubagent {
     }
 
     return new JunieSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -186,12 +186,12 @@ export class JunieSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): JunieSubagent {
     return new JunieSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/kilo-subagent.test.ts
+++ b/src/features/subagents/kilo-subagent.test.ts
@@ -36,7 +36,7 @@ describe("KiloSubagent", () => {
 
   it("should create a RulesyncSubagent with kilo section and subagent mode", () => {
     const subagent = new KiloSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".kilo/agent",
       relativeFilePath: "review.md",
       frontmatter: {
@@ -64,7 +64,7 @@ describe("KiloSubagent", () => {
 
   it("should build Kilo subagent from Rulesync subagent and preserve mode", () => {
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "docs-writer.md",
       frontmatter: {
@@ -83,7 +83,7 @@ describe("KiloSubagent", () => {
     const toolSubagent = KiloSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as KiloSubagent;
 
@@ -99,7 +99,7 @@ describe("KiloSubagent", () => {
 
   it("should build Kilo subagent with default mode when not specified", () => {
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "docs-writer.md",
       frontmatter: {
@@ -117,7 +117,7 @@ describe("KiloSubagent", () => {
     const toolSubagent = KiloSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as KiloSubagent;
 
@@ -134,7 +134,7 @@ describe("KiloSubagent", () => {
   it("should preserve primary mode for Kilo subagent", () => {
     // Regression test for: kilo.mode was hardcoded to 'subagent' instead of being preserved
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "primary-agent.md",
       frontmatter: {
@@ -157,7 +157,7 @@ describe("KiloSubagent", () => {
     const toolSubagent = KiloSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as KiloSubagent;
 

--- a/src/features/subagents/kilo-subagent.ts
+++ b/src/features/subagents/kilo-subagent.ts
@@ -39,7 +39,7 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -59,7 +59,7 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new KiloSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: kiloFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -78,13 +78,13 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<KiloSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -94,7 +94,7 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
     }
 
     return new KiloSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -106,12 +106,12 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): KiloSubagent {
     return new KiloSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "", mode: "subagent" },

--- a/src/features/subagents/kiro-subagent.test.ts
+++ b/src/features/subagents/kiro-subagent.test.ts
@@ -38,7 +38,7 @@ describe("KiroSubagent", () => {
     it("should create instance with valid JSON body", () => {
       const json = { name: "test" };
       const subagent = new KiroSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/agents",
         relativeFilePath: "test.json",
         body: JSON.stringify(json),
@@ -53,7 +53,7 @@ describe("KiroSubagent", () => {
     it("should throw error for invalid JSON body when validate is true", () => {
       expect(() => {
         new KiroSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".kiro/agents",
           relativeFilePath: "invalid.json",
           body: "not json",
@@ -66,7 +66,7 @@ describe("KiroSubagent", () => {
     it("should throw error for invalid JSON body when validate is default (true)", () => {
       expect(() => {
         new KiroSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".kiro/agents",
           relativeFilePath: "invalid.json",
           body: "not json",
@@ -78,7 +78,7 @@ describe("KiroSubagent", () => {
     it("should throw error for missing required name field when validate is true", () => {
       expect(() => {
         new KiroSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".kiro/agents",
           relativeFilePath: "missing-name.json",
           body: JSON.stringify({ description: "no name" }),
@@ -90,7 +90,7 @@ describe("KiroSubagent", () => {
 
     it("should create instance with invalid JSON body when validate is false", () => {
       const subagent = new KiroSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".kiro/agents",
         relativeFilePath: "invalid.json",
         body: "not json",
@@ -112,7 +112,7 @@ describe("KiroSubagent", () => {
       tools: ["read", "write"],
     };
     const subagent = new KiroSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".kiro/agents",
       relativeFilePath: "review.json",
       body: JSON.stringify(json),
@@ -138,7 +138,7 @@ describe("KiroSubagent", () => {
 
   it("should create KiroSubagent from RulesyncSubagent with frontmatter", () => {
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "reviewer.md",
       frontmatter: {
@@ -155,7 +155,7 @@ describe("KiroSubagent", () => {
     });
 
     const kiroSubagent = KiroSubagent.fromRulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       rulesyncSubagent,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as KiroSubagent;
@@ -176,7 +176,7 @@ describe("KiroSubagent", () => {
   it("should validate JSON successfully", () => {
     const json = { name: "test", prompt: "Test prompt" };
     const subagent = new KiroSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".kiro/agents",
       relativeFilePath: "test.json",
       body: JSON.stringify(json),
@@ -189,7 +189,7 @@ describe("KiroSubagent", () => {
 
   it("should fail validation for invalid JSON", () => {
     const subagent = new KiroSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".kiro/agents",
       relativeFilePath: "invalid.json",
       body: "not json",
@@ -214,7 +214,7 @@ describe("KiroSubagent", () => {
     await writeFileContent(filePath, JSON.stringify(json, null, 2));
 
     const subagent = await KiroSubagent.fromFile({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeFilePath: "planner.json",
     });
 
@@ -230,7 +230,7 @@ describe("KiroSubagent", () => {
 
     await expect(
       KiroSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "invalid.json",
         validate: true,
       }),
@@ -239,7 +239,7 @@ describe("KiroSubagent", () => {
 
   it("should identify targeted rulesync subagents", () => {
     const targeted = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "agent.md",
       frontmatter: { targets: ["kiro"], name: "agent", description: "" },
@@ -248,7 +248,7 @@ describe("KiroSubagent", () => {
     });
 
     const notTargeted = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "other.md",
       frontmatter: { targets: ["cursor"], name: "other", description: "" },
@@ -262,7 +262,7 @@ describe("KiroSubagent", () => {
 
   it("should create deletable placeholder", () => {
     const subagent = KiroSubagent.forDeletion({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".kiro/agents",
       relativeFilePath: "obsolete.json",
     });
@@ -285,7 +285,7 @@ describe("KiroSubagent", () => {
     await writeFileContent(filePath, JSON.stringify(json, null, 2));
 
     const kiroSubagent = await KiroSubagent.fromFile({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeFilePath: "test-agent.json",
     });
 

--- a/src/features/subagents/kiro-subagent.ts
+++ b/src/features/subagents/kiro-subagent.ts
@@ -100,7 +100,7 @@ export class KiroSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: prompt ?? "",
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -110,7 +110,7 @@ export class KiroSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -136,7 +136,7 @@ export class KiroSubagent extends ToolSubagent {
     const relativeFilePath = rulesyncSubagent.getRelativeFilePath().replace(/\.md$/, ".json");
 
     return new KiroSubagent({
-      baseDir,
+      outputRoot,
       body,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
@@ -167,17 +167,17 @@ export class KiroSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<KiroSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
 
     const subagent = new KiroSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       body: fileContent.trim(),
@@ -199,12 +199,12 @@ export class KiroSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): KiroSubagent {
     return new KiroSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: "",

--- a/src/features/subagents/opencode-style-subagent.ts
+++ b/src/features/subagents/opencode-style-subagent.ts
@@ -66,7 +66,7 @@ export abstract class OpenCodeStyleSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".", // RulesyncSubagent baseDir is always the project root directory
+      outputRoot: ".", // RulesyncSubagent outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,

--- a/src/features/subagents/opencode-subagent.test.ts
+++ b/src/features/subagents/opencode-subagent.test.ts
@@ -36,7 +36,7 @@ describe("OpenCodeSubagent", () => {
 
   it("should create a RulesyncSubagent with opencode section and subagent mode", () => {
     const subagent = new OpenCodeSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: ".opencode/agent",
       relativeFilePath: "review.md",
       frontmatter: {
@@ -64,7 +64,7 @@ describe("OpenCodeSubagent", () => {
 
   it("should build OpenCode subagent from Rulesync subagent and preserve mode", () => {
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "docs-writer.md",
       frontmatter: {
@@ -83,7 +83,7 @@ describe("OpenCodeSubagent", () => {
     const toolSubagent = OpenCodeSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as OpenCodeSubagent;
 
@@ -99,7 +99,7 @@ describe("OpenCodeSubagent", () => {
 
   it("should build OpenCode subagent with default mode when not specified", () => {
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "docs-writer.md",
       frontmatter: {
@@ -117,7 +117,7 @@ describe("OpenCodeSubagent", () => {
     const toolSubagent = OpenCodeSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as OpenCodeSubagent;
 
@@ -134,7 +134,7 @@ describe("OpenCodeSubagent", () => {
   it("should preserve primary mode for OpenCode subagent", () => {
     // Regression test for: opencode.mode was hardcoded to 'subagent' instead of being preserved
     const rulesyncSubagent = new RulesyncSubagent({
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "primary-agent.md",
       frontmatter: {
@@ -157,7 +157,7 @@ describe("OpenCodeSubagent", () => {
     const toolSubagent = OpenCodeSubagent.fromRulesyncSubagent({
       rulesyncSubagent,
       global: true,
-      baseDir: testDir,
+      outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
     }) as OpenCodeSubagent;
 

--- a/src/features/subagents/opencode-subagent.ts
+++ b/src/features/subagents/opencode-subagent.ts
@@ -39,7 +39,7 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -59,7 +59,7 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new OpenCodeSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: opencodeFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -78,13 +78,13 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<OpenCodeSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -94,7 +94,7 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
     }
 
     return new OpenCodeSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -106,12 +106,12 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): OpenCodeSubagent {
     return new OpenCodeSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { description: "", mode: "subagent" },

--- a/src/features/subagents/roo-subagent.test.ts
+++ b/src/features/subagents/roo-subagent.test.ts
@@ -56,7 +56,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid markdown content", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -77,7 +77,7 @@ Body content`;
 
     it("should create instance with empty name and description", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -97,7 +97,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -115,7 +115,7 @@ Body content`;
       expect(
         () =>
           new RooSubagent({
-            baseDir: testDir,
+            outputRoot: testDir,
             relativeDirPath: ".roo/subagents",
             relativeFilePath: "invalid-agent.md",
             frontmatter: {
@@ -131,7 +131,7 @@ Body content`;
   describe("getBody", () => {
     it("should return the body content", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -149,7 +149,7 @@ Body content`;
   describe("getFrontmatter", () => {
     it("should return frontmatter with name and description", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -171,7 +171,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should throw error as it is a simulated file", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -191,7 +191,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create RooSubagent from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -204,7 +204,7 @@ Body content`;
       });
 
       const rooSubagent = RooSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         rulesyncSubagent,
         validate: true,
@@ -222,7 +222,7 @@ Body content`;
 
     it("should handle RulesyncSubagent with different file extensions", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex-agent.txt",
         frontmatter: {
@@ -235,7 +235,7 @@ Body content`;
       });
 
       const rooSubagent = RooSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         rulesyncSubagent,
         validate: true,
@@ -246,7 +246,7 @@ Body content`;
 
     it("should handle empty name and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -259,7 +259,7 @@ Body content`;
       });
 
       const rooSubagent = RooSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         rulesyncSubagent,
         validate: true,
@@ -280,7 +280,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await RooSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-file-agent.md",
         validate: true,
       });
@@ -301,7 +301,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await RooSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "subdir/nested-agent.md",
         validate: true,
       });
@@ -312,7 +312,7 @@ Body content`;
     it("should throw error when file does not exist", async () => {
       await expect(
         RooSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "non-existent-agent.md",
           validate: true,
         }),
@@ -327,7 +327,7 @@ Body content`;
 
       await expect(
         RooSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -342,7 +342,7 @@ Body content`;
 
       await expect(
         RooSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-frontmatter.md",
           validate: true,
         }),
@@ -353,7 +353,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "valid-agent.md",
         frontmatter: {
@@ -371,7 +371,7 @@ Body content`;
 
     it("should handle frontmatter with additional properties", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "agent-with-extras.md",
         frontmatter: {
@@ -432,7 +432,7 @@ Body content`;
   describe("edge cases", () => {
     it("should handle empty body content", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "empty-body.md",
         frontmatter: {
@@ -455,7 +455,7 @@ Body content`;
         "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
 
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "special-char.md",
         frontmatter: {
@@ -476,7 +476,7 @@ Body content`;
       const longContent = "A".repeat(10000);
 
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "long-content.md",
         frontmatter: {
@@ -493,7 +493,7 @@ Body content`;
 
     it("should handle multi-line name and description", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "multiline-fields.md",
         frontmatter: {
@@ -514,7 +514,7 @@ Body content`;
       const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
 
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "windows-lines.md",
         frontmatter: {
@@ -532,7 +532,7 @@ Body content`;
   describe("inheritance", () => {
     it("should inherit from SimulatedSubagent", () => {
       const subagent = new RooSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".roo/subagents",
         relativeFilePath: "test.md",
         frontmatter: {
@@ -554,7 +554,7 @@ Body content`;
   describe("isTargetedByRulesyncSubagent", () => {
     it("should return true when targets includes roo", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -571,7 +571,7 @@ Body content`;
 
     it("should return true when targets includes asterisk", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -588,7 +588,7 @@ Body content`;
 
     it("should return false when targets array is empty", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -605,7 +605,7 @@ Body content`;
 
     it("should return false when targets does not include roo", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -622,7 +622,7 @@ Body content`;
 
     it("should return true when targets includes roo among other targets", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {

--- a/src/features/subagents/rovodev-subagent.test.ts
+++ b/src/features/subagents/rovodev-subagent.test.ts
@@ -61,7 +61,7 @@ oops`;
       const canonical = stringifyFrontmatter(body, frontmatter);
 
       const subagent = new RovodevSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         relativeFilePath: "a.md",
         frontmatter,
@@ -78,7 +78,7 @@ oops`;
   describe("toRulesyncSubagent", () => {
     it("should map name, description, and extra keys into rulesync rovodev section", () => {
       const subagent = new RovodevSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         relativeFilePath: "planner.md",
         frontmatter: {
@@ -127,7 +127,7 @@ oops`;
       };
       const body = "Synced body.\nSecond line.";
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "sync-agent.md",
         frontmatter: rulesyncFrontmatter,
@@ -136,7 +136,7 @@ oops`;
       });
 
       const rovodev = RovodevSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         rulesyncSubagent,
         validate: true,
@@ -161,7 +161,7 @@ oops`;
 
     it("should merge rovodev-only fields from the rovodev section", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "x.md",
         frontmatter: {
@@ -178,7 +178,7 @@ oops`;
       });
 
       const rovodev = RovodevSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         rulesyncSubagent,
         validate: true,
@@ -199,7 +199,7 @@ oops`;
       await writeFileContent(filePath, validMarkdown);
 
       const subagent = await RovodevSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "disk.md",
         validate: true,
         global: false,
@@ -220,7 +220,7 @@ oops`;
       await writeFileContent(filePath, validMarkdown);
 
       const subagent = await RovodevSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "global-agent.md",
         validate: true,
         global: true,
@@ -236,7 +236,7 @@ oops`;
       await writeFileContent(filePath, validMarkdown);
 
       const subagent = await RovodevSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "team/nested.md",
         validate: true,
       });
@@ -250,7 +250,7 @@ oops`;
 
       await expect(
         RovodevSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "bad.md",
           validate: true,
         }),
@@ -260,7 +260,7 @@ oops`;
     it("should throw when file is missing", async () => {
       await expect(
         RovodevSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "missing.md",
           validate: true,
         }),
@@ -271,7 +271,7 @@ oops`;
   describe("round-trip", () => {
     it("fromRulesyncSubagent then toRulesyncSubagent preserves semantic content", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "rt.md",
         frontmatter: {
@@ -285,7 +285,7 @@ oops`;
       });
 
       const rovodev = RovodevSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         rulesyncSubagent,
         validate: true,
@@ -329,7 +329,7 @@ oops`;
   describe("forDeletion", () => {
     it("should create a minimal instance for deletion", () => {
       const subagent = RovodevSubagent.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         relativeFilePath: "gone.md",
         global: false,
@@ -344,7 +344,7 @@ oops`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new RovodevSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".rovodev", "subagents"),
         relativeFilePath: "v.md",
         frontmatter: { name: "V", description: "ok" },

--- a/src/features/subagents/rovodev-subagent.ts
+++ b/src/features/subagents/rovodev-subagent.ts
@@ -87,7 +87,7 @@ export class RovodevSubagent extends ToolSubagent {
     };
 
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -97,7 +97,7 @@ export class RovodevSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -116,7 +116,7 @@ export class RovodevSubagent extends ToolSubagent {
     const paths = this.getSettablePaths({ global });
 
     return new RovodevSubagent({
-      baseDir,
+      outputRoot,
       frontmatter: rovodevFrontmatter,
       body,
       relativeDirPath: paths.relativeDirPath,
@@ -148,13 +148,13 @@ export class RovodevSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<RovodevSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -164,7 +164,7 @@ export class RovodevSubagent extends ToolSubagent {
     }
 
     return new RovodevSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       frontmatter: result.data,
@@ -176,14 +176,14 @@ export class RovodevSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     global = false,
   }: ToolSubagentForDeletionParams): RovodevSubagent {
     const paths = this.getSettablePaths({ global });
     return new RovodevSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: relativeDirPath ?? paths.relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/rulesync-subagent.test.ts
+++ b/src/features/subagents/rulesync-subagent.test.ts
@@ -121,7 +121,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter,
@@ -144,7 +144,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "claude.md",
         frontmatter,
@@ -163,7 +163,7 @@ describe("RulesyncSubagent", () => {
 
       expect(() => {
         const _instance = new RulesyncSubagent({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
           relativeFilePath: "no-desc.md",
           frontmatter: frontmatterWithoutDescription as any,
@@ -181,7 +181,7 @@ describe("RulesyncSubagent", () => {
 
       expect(() => {
         const _instance = new RulesyncSubagent({
-          baseDir: ".",
+          outputRoot: ".",
           relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
           relativeFilePath: "skip-validation.md",
           frontmatter: invalidFrontmatter as any,
@@ -193,7 +193,7 @@ describe("RulesyncSubagent", () => {
 
     it("should inherit all AiFile functionality", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: "/test",
+        outputRoot: "/test",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "inherit.md",
         frontmatter: {
@@ -204,7 +204,7 @@ describe("RulesyncSubagent", () => {
         body: "Inherited body",
       });
 
-      expect(subagent.getBaseDir()).toBe("/test");
+      expect(subagent.getOutputRoot()).toBe("/test");
       expect(subagent.getRelativeDirPath()).toBe(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
       expect(subagent.getRelativeFilePath()).toBe("inherit.md");
       // fileContent is now auto-generated from frontmatter and body
@@ -233,7 +233,7 @@ describe("RulesyncSubagent", () => {
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "multi.md",
         frontmatter,
@@ -252,7 +252,7 @@ describe("RulesyncSubagent", () => {
       const body = "This is the subagent body content with instructions.";
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "body-test.md",
         frontmatter: {
@@ -268,7 +268,7 @@ describe("RulesyncSubagent", () => {
 
     it("should handle empty body", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "empty-body.md",
         frontmatter: {
@@ -286,7 +286,7 @@ describe("RulesyncSubagent", () => {
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "valid.md",
         frontmatter: {
@@ -305,7 +305,7 @@ describe("RulesyncSubagent", () => {
 
     it("should return success for frontmatter without description (description is optional)", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "no-desc-validate.md",
         frontmatter: {
@@ -492,7 +492,7 @@ description: Testing whitespace handling
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "poly.md",
         frontmatter,
@@ -519,7 +519,7 @@ description: Testing whitespace handling
 
     it("should maintain type safety", () => {
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "typed.md",
         frontmatter: {
@@ -588,7 +588,7 @@ description: File with empty body
       };
 
       const subagent = new RulesyncSubagent({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "complex.md",
         frontmatter,

--- a/src/features/subagents/rulesync-subagent.ts
+++ b/src/features/subagents/rulesync-subagent.ts
@@ -107,11 +107,11 @@ export class RulesyncSubagent extends RulesyncFile {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
   }: RulesyncSubagentFromFileParams): Promise<RulesyncSubagent> {
     // Read file content
-    const filePath = join(baseDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, relativeFilePath);
+    const filePath = join(outputRoot, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -124,7 +124,7 @@ export class RulesyncSubagent extends RulesyncFile {
     const filename = basename(relativeFilePath);
 
     return new RulesyncSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: filename,
       frontmatter: result.data,

--- a/src/features/subagents/simulated-subagent.test.ts
+++ b/src/features/subagents/simulated-subagent.test.ts
@@ -67,7 +67,7 @@ Body content`;
   describe("constructor", () => {
     it("should create instance with valid content", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -90,7 +90,7 @@ Body content`;
 
     it("should create instance with empty name and description", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -110,7 +110,7 @@ Body content`;
 
     it("should create instance without validation when validate is false", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -127,7 +127,7 @@ Body content`;
     it("should throw error for invalid frontmatter when validation is enabled", () => {
       expect(() => {
         new TestSimulatedSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".test/agents",
           relativeFilePath: "test-agent.md",
           frontmatter: {
@@ -144,7 +144,7 @@ Body content`;
   describe("toRulesyncSubagent", () => {
     it("should throw error because SimulatedSubagent is simulated", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -167,7 +167,7 @@ Body content`;
       await writeFileContent(filePath, validMarkdownContent);
 
       const subagent = await TestSimulatedSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "test-agent.md",
         validate: true,
       });
@@ -188,7 +188,7 @@ Body content`;
 
       await expect(
         TestSimulatedSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "invalid-agent.md",
           validate: true,
         }),
@@ -201,7 +201,7 @@ Body content`;
 
       await expect(
         TestSimulatedSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "no-frontmatter.md",
           validate: true,
         }),
@@ -212,7 +212,7 @@ Body content`;
   describe("fromRulesyncSubagent", () => {
     it("should create instance from RulesyncSubagent", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -225,7 +225,7 @@ Body content`;
       });
 
       const simulatedSubagent = TestSimulatedSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         rulesyncSubagent,
         validate: true,
@@ -243,7 +243,7 @@ Body content`;
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -261,7 +261,7 @@ Body content`;
 
     it("should return error for invalid frontmatter", () => {
       const subagent = new TestSimulatedSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test/agents",
         relativeFilePath: "test-agent.md",
         frontmatter: {

--- a/src/features/subagents/simulated-subagent.ts
+++ b/src/features/subagents/simulated-subagent.ts
@@ -62,7 +62,7 @@ export abstract class SimulatedSubagent extends ToolSubagent {
   }
 
   protected static fromRulesyncSubagentDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
   }: ToolSubagentFromRulesyncSubagentParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
@@ -76,7 +76,7 @@ export abstract class SimulatedSubagent extends ToolSubagent {
     const body = rulesyncSubagent.getBody();
 
     return {
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       frontmatter: simulatedFrontmatter,
       body,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
@@ -104,11 +104,11 @@ export abstract class SimulatedSubagent extends ToolSubagent {
   }
 
   protected static async fromFileDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
   }: ToolSubagentFromFileParams): Promise<ConstructorParameters<typeof SimulatedSubagent>[0]> {
-    const filePath = join(baseDir, this.getSettablePaths().relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, this.getSettablePaths().relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -118,7 +118,7 @@ export abstract class SimulatedSubagent extends ToolSubagent {
     }
 
     return {
-      baseDir: baseDir,
+      outputRoot: outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: basename(relativeFilePath),
       frontmatter: result.data,
@@ -128,12 +128,12 @@ export abstract class SimulatedSubagent extends ToolSubagent {
   }
 
   protected static forDeletionDefault({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): ConstructorParameters<typeof SimulatedSubagent>[0] {
     return {
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       frontmatter: { name: "", description: "" },

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -47,14 +47,14 @@ describe("SubagentsProcessor", () => {
     it("should create instance with valid tool target", () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
       expect(processor).toBeInstanceOf(SubagentsProcessor);
     });
 
-    it("should use default baseDir when not provided", () => {
+    it("should use default outputRoot when not provided", () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
         toolTarget: "claudecode",
@@ -67,7 +67,7 @@ describe("SubagentsProcessor", () => {
       expect(() => {
         const _processor = new SubagentsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "invalid" as SubagentsProcessorToolTarget,
         });
       }).toThrow();
@@ -78,7 +78,7 @@ describe("SubagentsProcessor", () => {
         expect(() => {
           const _processor = new SubagentsProcessor({
             logger: createMockLogger(),
-            baseDir: testDir,
+            outputRoot: testDir,
             toolTarget,
           });
         }).not.toThrow();
@@ -92,14 +92,14 @@ describe("SubagentsProcessor", () => {
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
 
     it("should filter and convert RulesyncSubagent instances for claudecode", async () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -130,13 +130,13 @@ describe("SubagentsProcessor", () => {
     it("should convert with global flag when processor is in global mode", async () => {
       const globalProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         global: true,
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "global-test-agent.md",
         frontmatter: {
@@ -175,13 +175,13 @@ describe("SubagentsProcessor", () => {
     it("should throw error for unsupported tool target", async () => {
       const unsupportedProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         getFactory: createMockGetFactoryThatThrowsUnsupported,
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: { name: "test", description: "test", targets: ["*"] },
@@ -197,12 +197,12 @@ describe("SubagentsProcessor", () => {
     it("should convert RulesyncSubagent to CopilotSubagent for copilot target", async () => {
       const copilotProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -223,12 +223,12 @@ describe("SubagentsProcessor", () => {
     it("should convert RulesyncSubagent to CursorSubagent for cursor target", async () => {
       const cursorProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -249,12 +249,12 @@ describe("SubagentsProcessor", () => {
     it("should convert RulesyncSubagent to CodexCliSubagent for codexcli target", async () => {
       const codexcliProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test-agent.md",
         frontmatter: {
@@ -275,12 +275,12 @@ describe("SubagentsProcessor", () => {
     it("should convert RulesyncSubagent to OpenCodeSubagent for opencode target", async () => {
       const opencodeProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "opencode",
       });
 
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "opencode-agent.md",
         frontmatter: {
@@ -306,14 +306,14 @@ describe("SubagentsProcessor", () => {
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
 
     it("should filter and convert ToolSubagent instances", async () => {
       const claudecodeSubagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "test-agent.md",
         fileContent: `---
@@ -361,7 +361,7 @@ Test agent content`,
 
     it("should skip simulated subagents when converting to rulesync", async () => {
       const claudecodeSubagent = new ClaudecodeSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".claude/agents",
         relativeFilePath: "claude-agent.md",
         fileContent: `---
@@ -378,7 +378,7 @@ Claude content`,
       });
 
       const copilotSubagent = new CopilotSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".github/agents",
         relativeFilePath: "copilot-agent.md",
         frontmatter: {
@@ -392,7 +392,7 @@ Claude content`,
       });
 
       const cursorSubagent = new CursorSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".cursor/agents",
         relativeFilePath: "cursor-agent.md",
         frontmatter: {
@@ -405,7 +405,7 @@ Claude content`,
       });
 
       const codexCliSubagent = new CodexCliSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".codex/agents",
         relativeFilePath: "codex-agent.toml",
         body: 'name = "codex-agent"\ndescription = "CodexCli agent"',
@@ -429,7 +429,7 @@ Claude content`,
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
@@ -532,7 +532,7 @@ Invalid content`;
       expect(validRulesyncSubagent.getFrontmatter().name).toBe("valid-agent");
     });
 
-    it("should load rulesync files from cwd even when baseDir is different (global mode)", async () => {
+    it("should load rulesync files from cwd even when outputRoot is different (global mode)", async () => {
       const subagentsDir = join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
       await ensureDir(subagentsDir);
 
@@ -545,13 +545,13 @@ Global agent content`;
 
       await writeFileContent(join(subagentsDir, "global-agent.md"), validSubagentContent);
 
-      // Use a different baseDir to simulate global mode (baseDir = homeDir)
-      const differentBaseDir = join(testDir, "fake-home");
-      await ensureDir(differentBaseDir);
+      // Use a different outputRoot to simulate global mode (outputRoot = homeDir)
+      const differentOutputRoot = join(testDir, "fake-home");
+      await ensureDir(differentOutputRoot);
 
       const globalProcessor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: differentBaseDir,
+        outputRoot: differentOutputRoot,
         toolTarget: "claudecode",
         global: true,
       });
@@ -569,7 +569,7 @@ Global agent content`;
     it("should delegate to loadClaudecodeSubagents for claudecode target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -579,7 +579,7 @@ Global agent content`;
     it("should delegate to loadCopilotSubagents for copilot target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -589,7 +589,7 @@ Global agent content`;
     it("should delegate to loadCursorSubagents for cursor target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -599,7 +599,7 @@ Global agent content`;
     it("should delegate to loadCodexCliSubagents for codexcli target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
       });
       const toolFiles = await processor.loadToolFiles();
@@ -609,7 +609,7 @@ Global agent content`;
     it("should throw error for unsupported tool target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
         getFactory: createMockGetFactoryThatThrowsUnsupported,
       });
@@ -626,7 +626,7 @@ Global agent content`;
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "copilot",
       });
     });
@@ -661,7 +661,7 @@ Copilot agent content`;
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "cursor",
       });
     });
@@ -696,7 +696,7 @@ Cursor agent content`;
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "codexcli",
       });
     });
@@ -727,7 +727,7 @@ Cursor agent content`;
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
@@ -797,7 +797,7 @@ Second content`;
       it("should use global paths when global=true", async () => {
         const globalProcessor = new SubagentsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -826,7 +826,7 @@ Global agent content`;
       it("should return empty array when global agents directory does not exist", async () => {
         const globalProcessor = new SubagentsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -838,7 +838,7 @@ Global agent content`;
       it("should load multiple global subagent files", async () => {
         const globalProcessor = new SubagentsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: "claudecode",
           global: true,
         });
@@ -1009,12 +1009,12 @@ Second global content`;
     it("should extend FeatureProcessor", () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
       expect(processor).toBeInstanceOf(SubagentsProcessor);
-      // Should have inherited baseDir property and other FeatureProcessor functionality
+      // Should have inherited outputRoot property and other FeatureProcessor functionality
       expect(typeof processor.convertRulesyncFilesToToolFiles).toBe("function");
       expect(typeof processor.convertToolFilesToRulesyncFiles).toBe("function");
       expect(typeof processor.loadRulesyncFiles).toBe("function");
@@ -1028,7 +1028,7 @@ Second global content`;
     beforeEach(() => {
       processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
     });
@@ -1083,7 +1083,7 @@ Valid content`,
     it("should return files with correct paths for deletion", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -1119,7 +1119,7 @@ Test agent content`;
       for (const target of targets) {
         const processor = new SubagentsProcessor({
           logger: createMockLogger(),
-          baseDir: testDir,
+          outputRoot: testDir,
           toolTarget: target,
         });
 
@@ -1133,7 +1133,7 @@ Test agent content`;
     it("should return empty array when no files exist", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -1144,7 +1144,7 @@ Test agent content`;
     it("should handle multiple files correctly", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 
@@ -1175,7 +1175,7 @@ Second agent`;
     it("should succeed even when file has broken frontmatter", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         toolTarget: "claudecode",
       });
 

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -242,7 +242,7 @@ export class SubagentsProcessor extends FeatureProcessor {
   private readonly getFactory: GetFactory;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     toolTarget,
     global = false,
@@ -250,7 +250,7 @@ export class SubagentsProcessor extends FeatureProcessor {
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     toolTarget: ToolTarget;
     global?: boolean;
@@ -258,7 +258,7 @@ export class SubagentsProcessor extends FeatureProcessor {
     dryRun?: boolean;
     logger: Logger;
   }) {
-    super({ baseDir, inputRoot, dryRun, logger });
+    super({ outputRoot, inputRoot, dryRun, logger });
     const result = SubagentsProcessorToolTargetSchema.safeParse(toolTarget);
     if (!result.success) {
       throw new Error(
@@ -283,7 +283,7 @@ export class SubagentsProcessor extends FeatureProcessor {
           return null;
         }
         return factory.class.fromRulesyncSubagent({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
           rulesyncSubagent: rulesyncSubagent,
           global: this.global,
@@ -349,7 +349,7 @@ export class SubagentsProcessor extends FeatureProcessor {
 
       try {
         const rulesyncSubagent = await RulesyncSubagent.fromFile({
-          baseDir: this.inputRoot,
+          outputRoot: this.inputRoot,
           relativeFilePath: mdFile,
           validate: true,
         });
@@ -384,14 +384,14 @@ export class SubagentsProcessor extends FeatureProcessor {
     const paths = factory.class.getSettablePaths({ global: this.global });
 
     const subagentFilePaths = await findFilesByGlobs(
-      join(this.baseDir, paths.relativeDirPath, factory.meta.filePattern),
+      join(this.outputRoot, paths.relativeDirPath, factory.meta.filePattern),
     );
 
     if (forDeletion) {
       const toolSubagents = subagentFilePaths
         .map((path) =>
           factory.class.forDeletion({
-            baseDir: this.baseDir,
+            outputRoot: this.outputRoot,
             relativeDirPath: paths.relativeDirPath,
             relativeFilePath: basename(path),
             global: this.global,
@@ -408,7 +408,7 @@ export class SubagentsProcessor extends FeatureProcessor {
     const toolSubagents = await Promise.all(
       subagentFilePaths.map((path) =>
         factory.class.fromFile({
-          baseDir: this.baseDir,
+          outputRoot: this.outputRoot,
           relativeFilePath: basename(path),
           global: this.global,
         }),

--- a/src/features/subagents/takt-subagent.test.ts
+++ b/src/features/subagents/takt-subagent.test.ts
@@ -33,7 +33,7 @@ describe("TaktSubagent", () => {
   describe("fromRulesyncSubagent", () => {
     it("emits a plain Markdown body under personas/", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "planner.md",
         frontmatter: {
@@ -45,7 +45,7 @@ describe("TaktSubagent", () => {
       });
 
       const sub = TaktSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "personas"),
         rulesyncSubagent,
       });
@@ -56,7 +56,7 @@ describe("TaktSubagent", () => {
 
     it("renames the stem with takt.name", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "long.md",
         frontmatter: {
@@ -68,7 +68,7 @@ describe("TaktSubagent", () => {
       });
 
       const sub = TaktSubagent.fromRulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "personas"),
         rulesyncSubagent,
       });
@@ -78,7 +78,7 @@ describe("TaktSubagent", () => {
 
     it("throws on an unsafe takt.name value", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "src.md",
         frontmatter: {
@@ -90,7 +90,7 @@ describe("TaktSubagent", () => {
       });
       expect(() =>
         TaktSubagent.fromRulesyncSubagent({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: join(".takt", "facets", "personas"),
           rulesyncSubagent,
         }),
@@ -104,7 +104,7 @@ describe("TaktSubagent", () => {
       await ensureDir(dir);
       await writeFileContent(join(dir, "p.md"), "body\n");
 
-      const sub = await TaktSubagent.fromFile({ baseDir: testDir, relativeFilePath: "p.md" });
+      const sub = await TaktSubagent.fromFile({ outputRoot: testDir, relativeFilePath: "p.md" });
       expect(sub.getBody()).toBe("body");
     });
   });
@@ -112,7 +112,7 @@ describe("TaktSubagent", () => {
   describe("forDeletion", () => {
     it("constructs a deletable empty instance", () => {
       const sub = TaktSubagent.forDeletion({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: join(".takt", "facets", "personas"),
         relativeFilePath: "p.md",
       });
@@ -127,7 +127,7 @@ describe("TaktSubagent", () => {
       [["claudecode"], false],
     ] as const)("targets=%j → %s", (targets, expected) => {
       const r = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "x.md",
         frontmatter: { targets: [...targets], name: "x" },

--- a/src/features/subagents/takt-subagent.ts
+++ b/src/features/subagents/takt-subagent.ts
@@ -55,7 +55,7 @@ export class TaktSubagent extends ToolSubagent {
       name: stem,
     };
     return new RulesyncSubagent({
-      baseDir: ".",
+      outputRoot: ".",
       frontmatter: rulesyncFrontmatter,
       body: this.body,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -65,7 +65,7 @@ export class TaktSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     rulesyncSubagent,
     validate = true,
     global = false,
@@ -84,7 +84,7 @@ export class TaktSubagent extends ToolSubagent {
     const body = rulesyncSubagent.getBody();
 
     return new TaktSubagent({
-      baseDir,
+      outputRoot,
       body,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
@@ -105,18 +105,18 @@ export class TaktSubagent extends ToolSubagent {
   }
 
   static async fromFile({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<TaktSubagent> {
     const paths = this.getSettablePaths({ global });
-    const filePath = join(baseDir, paths.relativeDirPath, relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { body } = parseFrontmatter(fileContent, filePath);
 
     return new TaktSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath,
       body: body.trim(),
@@ -126,12 +126,12 @@ export class TaktSubagent extends ToolSubagent {
   }
 
   static forDeletion({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
   }: ToolSubagentForDeletionParams): TaktSubagent {
     return new TaktSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       body: "",

--- a/src/features/subagents/tool-subagent.test.ts
+++ b/src/features/subagents/tool-subagent.test.ts
@@ -13,9 +13,9 @@ import {
 // Test implementation of ToolSubagent for testing abstract class behavior
 class TestToolSubagent extends ToolSubagent {
   static async fromFile(_params: ToolSubagentFromFileParams): Promise<TestToolSubagent> {
-    const { baseDir = process.cwd(), relativeFilePath } = _params;
+    const { outputRoot = process.cwd(), relativeFilePath } = _params;
     return new TestToolSubagent({
-      baseDir,
+      outputRoot,
       relativeDirPath: ".test",
       relativeFilePath,
       fileContent: "test tool subagent content",
@@ -23,12 +23,12 @@ class TestToolSubagent extends ToolSubagent {
   }
 
   static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): TestToolSubagent {
-    const { rulesyncSubagent, baseDir = process.cwd(), ...rest } = params;
+    const { rulesyncSubagent, outputRoot = process.cwd(), ...rest } = params;
     const frontmatter = rulesyncSubagent.getFrontmatter();
     const body = rulesyncSubagent.getBody();
 
     return new TestToolSubagent({
-      baseDir,
+      outputRoot,
       ...rest,
       relativeDirPath: ".test",
       relativeFilePath: "test-tool.md",
@@ -51,7 +51,7 @@ class TestToolSubagent extends ToolSubagent {
 
   toRulesyncSubagent(): RulesyncSubagent {
     return new RulesyncSubagent({
-      baseDir: this.baseDir,
+      outputRoot: this.outputRoot,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: "converted.md",
       frontmatter: {
@@ -82,7 +82,7 @@ describe("ToolSubagent", () => {
   describe("abstract class characteristics", () => {
     it("should be abstract (cannot be instantiated directly)", () => {
       const toolSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -95,7 +95,7 @@ describe("ToolSubagent", () => {
     it("should throw error when calling fromFile on base class", async () => {
       await expect(
         ToolSubagent.fromFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeFilePath: "test.md",
         }),
       ).rejects.toThrow("Please implement this method in the subclass.");
@@ -103,7 +103,7 @@ describe("ToolSubagent", () => {
 
     it("should throw error when calling fromRulesyncSubagent on base class", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -118,7 +118,7 @@ describe("ToolSubagent", () => {
       expect(() => {
         ToolSubagent.fromRulesyncSubagent({
           rulesyncSubagent,
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath: ".test",
         });
       }).toThrow("Please implement this method in the subclass.");
@@ -128,7 +128,7 @@ describe("ToolSubagent", () => {
   describe("inheritance from ToolFile", () => {
     it("should inherit all ToolFile and AiFile functionality", () => {
       const toolSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "test.md",
         fileContent: "test content",
@@ -145,7 +145,7 @@ describe("ToolSubagent", () => {
 
     it("should support validation", () => {
       const validToolSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "valid.md",
         fileContent: "valid content",
@@ -160,7 +160,7 @@ describe("ToolSubagent", () => {
   describe("concrete implementation functionality", () => {
     it("should work with fromFile static method", async () => {
       const toolSubagent = await TestToolSubagent.fromFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeFilePath: "config.md",
       });
 
@@ -173,7 +173,7 @@ describe("ToolSubagent", () => {
 
     it("should work with fromRulesyncSubagent static method", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "source.md",
         frontmatter: {
@@ -187,7 +187,7 @@ describe("ToolSubagent", () => {
 
       const toolSubagent = TestToolSubagent.fromRulesyncSubagent({
         rulesyncSubagent,
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
       });
 
@@ -202,7 +202,7 @@ describe("ToolSubagent", () => {
 
     it("should convert back to RulesyncSubagent", () => {
       const toolSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "convert.md",
         fileContent: "content to convert",
@@ -221,7 +221,7 @@ describe("ToolSubagent", () => {
   describe("polymorphism", () => {
     it("should support polymorphic usage", () => {
       const toolSubagent: ToolSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "poly.md",
         fileContent: "polymorphic content",
@@ -238,7 +238,7 @@ describe("ToolSubagent", () => {
 
     it("should maintain type safety through inheritance", () => {
       const testSubagent = new TestToolSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         relativeFilePath: "typed.md",
         fileContent: "typed content",
@@ -261,18 +261,18 @@ describe("ToolSubagent", () => {
     it("should have correct ToolSubagentFromFileParams type", () => {
       const params: ToolSubagentFromFileParams = {
         relativeFilePath: "test.md",
-        baseDir: testDir,
+        outputRoot: testDir,
         validate: true,
       };
 
       expect(params.relativeFilePath).toBe("test.md");
-      expect(params.baseDir).toBe(testDir);
+      expect(params.outputRoot).toBe(testDir);
       expect(params.validate).toBe(true);
     });
 
     it("should have correct ToolSubagentFromRulesyncSubagentParams type", () => {
       const rulesyncSubagent = new RulesyncSubagent({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         relativeFilePath: "test.md",
         frontmatter: {
@@ -286,13 +286,13 @@ describe("ToolSubagent", () => {
 
       const params: ToolSubagentFromRulesyncSubagentParams = {
         rulesyncSubagent,
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".test",
         validate: true,
       };
 
       expect(params.rulesyncSubagent).toBe(rulesyncSubagent);
-      expect(params.baseDir).toBe(testDir);
+      expect(params.outputRoot).toBe(testDir);
       expect(params.validate).toBe(true);
     });
   });

--- a/src/features/subagents/tool-subagent.ts
+++ b/src/features/subagents/tool-subagent.ts
@@ -20,7 +20,7 @@ export type ToolSubagentFromFileParams = AiFileFromFileParams & {
 };
 
 export type ToolSubagentForDeletionParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   global?: boolean;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -148,7 +148,7 @@ describe("generate", () => {
 
     // Single check, scoped to the input root, not per outputRoot.
     expect(checkRulesyncDirExists).toHaveBeenCalledTimes(1);
-    expect(checkRulesyncDirExists).toHaveBeenCalledWith({ outputRoot: inputRootMock });
+    expect(checkRulesyncDirExists).toHaveBeenCalledWith({ inputRoot: inputRootMock });
   });
 
   it("should forward inputRoot to ConfigResolver.resolve", async () => {
@@ -156,6 +156,18 @@ describe("generate", () => {
 
     expect(ConfigResolver.resolve).toHaveBeenCalledWith(
       expect.objectContaining({ inputRoot: "./central-rules" }),
+    );
+  });
+
+  it("should accept the deprecated `baseDirs` alias and forward it to the resolver", async () => {
+    // The deprecated `baseDirs` alias is declared on `GenerateOptions` so TS
+    // callers can pass it without a compile error. The resolver itself is
+    // responsible for emitting the one-shot deprecation warning and mapping
+    // the value to `outputRoots`; here we only assert the value is forwarded.
+    await generate({ baseDirs: ["/legacy-a", "/legacy-b"] });
+
+    expect(ConfigResolver.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({ baseDirs: ["/legacy-a", "/legacy-b"] }),
     );
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,7 +34,7 @@ vi.mock("./utils/logger.js", async (importOriginal) => {
 });
 
 const mockConfig = {
-  getBaseDirs: () => ["/project"],
+  getOutputRoots: () => ["/project"],
   getInputRoot: () => process.cwd(),
 } as unknown as Config;
 
@@ -137,18 +137,18 @@ describe("generate", () => {
     expect(result).toEqual(mockGenerateResult);
   });
 
-  it("should probe checkRulesyncDirExists against config.getInputRoot() rather than each baseDir", async () => {
+  it("should probe checkRulesyncDirExists against config.getInputRoot() rather than each outputRoot", async () => {
     const inputRootMock = "/some/input-root";
     vi.mocked(ConfigResolver.resolve).mockResolvedValue({
-      getBaseDirs: () => ["/project-a", "/project-b"],
+      getOutputRoots: () => ["/project-a", "/project-b"],
       getInputRoot: () => inputRootMock,
     } as unknown as Config as never);
 
     await generate();
 
-    // Single check, scoped to the input root, not per baseDir.
+    // Single check, scoped to the input root, not per outputRoot.
     expect(checkRulesyncDirExists).toHaveBeenCalledTimes(1);
-    expect(checkRulesyncDirExists).toHaveBeenCalledWith({ baseDir: inputRootMock });
+    expect(checkRulesyncDirExists).toHaveBeenCalledWith({ outputRoot: inputRootMock });
   });
 
   it("should forward inputRoot to ConfigResolver.resolve", async () => {
@@ -162,7 +162,7 @@ describe("generate", () => {
   it("should mention the input root path in the not-found error", async () => {
     const inputRootMock = "/some/input-root";
     vi.mocked(ConfigResolver.resolve).mockResolvedValue({
-      getBaseDirs: () => ["/project"],
+      getOutputRoots: () => ["/project"],
       getInputRoot: () => inputRootMock,
     } as unknown as Config as never);
     vi.mocked(checkRulesyncDirExists).mockResolvedValue(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,11 @@ type BaseOptions = {
 export type GenerateOptions = BaseOptions & {
   targets?: ToolTarget[];
   features?: Feature[];
-  baseDirs?: string[];
+  outputRoots?: string[];
   /**
    * Directory containing the `.rulesync/` source files. Defaults to the
    * current working directory at config-construction time. When set, output
-   * is still written to each `baseDirs` entry; only the input source root
+   * is still written to each `outputRoots` entry; only the input source root
    * is redirected. Mirrors the CLI's `--input-root` option.
    */
   inputRoot?: string;
@@ -67,10 +67,10 @@ export async function generate(options: GenerateOptions = {}): Promise<GenerateR
   });
 
   // The pre-flight check probes the input source root rather than each
-  // output `baseDir`. This matches the CLI's behavior and the way features
+  // output `outputRoot`. This matches the CLI's behavior and the way features
   // load `.rulesync/**` content (always relative to `config.getInputRoot()`).
   const inputRoot = config.getInputRoot();
-  if (!(await checkRulesyncDirExists({ baseDir: inputRoot }))) {
+  if (!(await checkRulesyncDirExists({ outputRoot: inputRoot }))) {
     throw new Error(`.rulesync directory not found in '${inputRoot}'. Run 'rulesync init' first.`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,13 @@ export type GenerateOptions = BaseOptions & {
   features?: Feature[];
   outputRoots?: string[];
   /**
+   * @deprecated Use `outputRoots` instead. Accepted as a backward-compatible
+   * alias for the programmatic API; emits a one-shot deprecation warning when
+   * provided. When both `outputRoots` and `baseDirs` are supplied,
+   * `outputRoots` wins. Will be removed in a future major release.
+   */
+  baseDirs?: string[];
+  /**
    * Directory containing the `.rulesync/` source files. Defaults to the
    * current working directory at config-construction time. When set, output
    * is still written to each `outputRoots` entry; only the input source root
@@ -67,10 +74,10 @@ export async function generate(options: GenerateOptions = {}): Promise<GenerateR
   });
 
   // The pre-flight check probes the input source root rather than each
-  // output `outputRoot`. This matches the CLI's behavior and the way features
+  // output root. This matches the CLI's behavior and the way features
   // load `.rulesync/**` content (always relative to `config.getInputRoot()`).
   const inputRoot = config.getInputRoot();
-  if (!(await checkRulesyncDirExists({ outputRoot: inputRoot }))) {
+  if (!(await checkRulesyncDirExists({ inputRoot }))) {
     throw new Error(`.rulesync directory not found in '${inputRoot}'. Run 'rulesync init' first.`);
   }
 

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -69,7 +69,7 @@ describe("installApm", () => {
   it("warns and returns early when there are no dependencies", async () => {
     await writeManifest("name: my-project\nversion: 1.0.0\n");
 
-    const result = await installApm({ baseDir: testDir, logger });
+    const result = await installApm({ outputRoot: testDir, logger });
 
     expect(result).toEqual({
       dependenciesProcessed: 0,
@@ -129,7 +129,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    const result = await installApm({ baseDir: testDir, logger });
+    const result = await installApm({ outputRoot: testDir, logger });
 
     expect(result.dependenciesProcessed).toBe(1);
     expect(result.deployedFileCount).toBe(2);
@@ -174,7 +174,7 @@ describe("installApm", () => {
       throw err;
     });
 
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     expect(mockClientInstance.getDefaultBranch).toHaveBeenCalledWith("acme", "security");
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith("acme", "security", "trunk");
@@ -190,12 +190,12 @@ describe("installApm", () => {
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     // First pass: populate the lockfile.
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
 
     // Second pass: lockfile should short-circuit ref resolution.
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
 
     const lock = await readApmLock(testDir);
@@ -211,10 +211,10 @@ describe("installApm", () => {
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
 
-    await installApm({ baseDir: testDir, logger, options: { update: true } });
+    await installApm({ outputRoot: testDir, logger, options: { update: true } });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(2);
 
     const lock = await readApmLock(testDir);
@@ -231,7 +231,7 @@ describe("installApm", () => {
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/rulesync-apm.lock.yaml is missing/);
   });
 
@@ -244,7 +244,7 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     await writeManifest(
       `dependencies:
@@ -254,7 +254,7 @@ describe("installApm", () => {
 `,
     );
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/missing entries for/);
   });
 
@@ -266,10 +266,10 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     const before = await readFileContent(getApmLockPath(testDir));
-    await installApm({ baseDir: testDir, logger, options: { frozen: true } });
+    await installApm({ outputRoot: testDir, logger, options: { frozen: true } });
     const after = await readFileContent(getApmLockPath(testDir));
     expect(after).toBe(before);
   });
@@ -282,7 +282,7 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     await writeManifest(
       `dependencies:
@@ -291,7 +291,7 @@ describe("installApm", () => {
 `,
     );
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/manifest ref does not match/);
   });
 
@@ -320,13 +320,13 @@ describe("installApm", () => {
     );
     mockClientInstance.getFileContent.mockResolvedValue("original content");
 
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     // Simulate tampered upstream: same SHA, different bytes on next install.
     mockClientInstance.getFileContent.mockResolvedValue("tampered content");
 
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/content_hash mismatch/);
   });
 
@@ -343,7 +343,7 @@ describe("installApm", () => {
     mockClientInstance.resolveRefToSha.mockImplementation(async (_owner: string, repo: string) =>
       repo === "first" ? VALID_SHA : SECOND_SHA,
     );
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     const lockBefore = await readApmLock(testDir);
     expect(lockBefore?.dependencies.map((d) => d.repo_url)).toEqual([
       "https://github.com/acme/first",
@@ -362,7 +362,7 @@ describe("installApm", () => {
     });
 
     const result = await installApm({
-      baseDir: testDir,
+      outputRoot: testDir,
       logger,
       options: { update: true },
     });
@@ -384,13 +384,13 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     const lockBefore = await readApmLock(testDir);
 
     mockClientInstance.resolveRefToSha.mockRejectedValue(new Error("network error"));
 
     const result = await installApm({
-      baseDir: testDir,
+      outputRoot: testDir,
       logger,
       options: { update: true },
     });
@@ -437,7 +437,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
     expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
     expect(await fileExists(join(testDir, ".github/instructions/b.instructions.md"))).toBe(true);
 
@@ -458,7 +458,7 @@ describe("installApm", () => {
       },
     );
 
-    await installApm({ baseDir: testDir, logger, options: { update: true } });
+    await installApm({ outputRoot: testDir, logger, options: { update: true } });
 
     expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
     // B must be removed both from disk and from the lockfile.
@@ -492,7 +492,7 @@ describe("installApm", () => {
       },
     );
     mockClientInstance.getFileContent.mockResolvedValue("original content");
-    await installApm({ baseDir: testDir, logger });
+    await installApm({ outputRoot: testDir, logger });
 
     const deployedPath = join(testDir, ".github/instructions/a.instructions.md");
     const before = await readFileContent(deployedPath);
@@ -502,7 +502,7 @@ describe("installApm", () => {
     mockClientInstance.getFileContent.mockResolvedValue("tampered content");
 
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/content_hash mismatch/);
 
     // The on-disk file must still contain the original bytes, not the
@@ -539,7 +539,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    const result = await installApm({ baseDir: testDir, logger });
+    const result = await installApm({ outputRoot: testDir, logger });
     expect(result.deployedFileCount).toBe(1);
     const deployed = await readFileContent(join(testDir, ".github/instructions/s.instructions.md"));
     expect(deployed).toBe("content of packages/security/.apm/instructions/s.instructions.md");
@@ -547,7 +547,7 @@ describe("installApm", () => {
     expect(lock?.dependencies[0]?.virtual_path).toBe("packages/security");
   });
 
-  it("refuses to remove stale files whose recorded path escapes baseDir", async () => {
+  it("refuses to remove stale files whose recorded path escapes outputRoot", async () => {
     // Hand-craft a lockfile whose deployed_files contains attacker-controlled
     // paths. `deployed_files` is only schema-validated as a string array, so
     // a hostile repo could plant this and trigger arbitrary `removeFile` on
@@ -557,7 +557,7 @@ describe("installApm", () => {
     // We cannot safely write a file *outside* testDir from a test (the
     // testing guidelines forbid polluting anything outside the project
     // test directory), so we prove the defense by asserting (a) the guard
-    // warns for each offending entry and (b) legitimate in-baseDir cleanup
+    // warns for each offending entry and (b) legitimate in-outputRoot cleanup
     // still proceeds as a control.
     const absoluteOutside = "/tmp/rulesync-apm-test-absolute-target.md";
     const lockYaml = `lockfile_version: "1"
@@ -576,7 +576,7 @@ dependencies:
 `;
     await writeFileContent(getApmLockPath(testDir), lockYaml);
 
-    // Plant the "clean" stale file that lives inside baseDir so we can
+    // Plant the "clean" stale file that lives inside outputRoot so we can
     // verify the normal cleanup path still works even when the guard skips
     // its neighbors.
     await writeFileContent(
@@ -594,9 +594,9 @@ dependencies:
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     const localLogger = createMockLogger();
-    await installApm({ baseDir: testDir, logger: localLogger, options: { update: true } });
+    await installApm({ outputRoot: testDir, logger: localLogger, options: { update: true } });
 
-    // Legit in-baseDir stale file is still removed (control: cleanup works).
+    // Legit in-outputRoot stale file is still removed (control: cleanup works).
     expect(await fileExists(join(testDir, ".github/instructions/old.instructions.md"))).toBe(false);
     // Warn logs were emitted for the two refused entries.
     const warnMessages = localLogger.warn.mock.calls.map((args) => String(args[0]));
@@ -637,7 +637,7 @@ dependencies:
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
-    await installApm({ baseDir: testDir, logger, options: { update: true } });
+    await installApm({ outputRoot: testDir, logger, options: { update: true } });
 
     const after = await readApmLock(testDir);
     expect(after?.mcp_servers).toEqual(["security-scanner", "code-reviewer"]);
@@ -697,7 +697,7 @@ dependencies:
     mockClientInstance.getFileContent.mockResolvedValue("arbitrary content");
 
     await expect(
-      installApm({ baseDir: testDir, logger, options: { frozen: true } }),
+      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
     ).resolves.toBeDefined();
   });
 
@@ -729,9 +729,9 @@ dependencies:
     );
     mockClientInstance.getFileContent.mockResolvedValue("evil");
 
-    const result = await installApm({ baseDir: testDir, logger });
+    const result = await installApm({ outputRoot: testDir, logger });
     expect(result.deployedFileCount).toBe(0);
-    // The escape payload must not appear anywhere under baseDir.
+    // The escape payload must not appear anywhere under outputRoot.
     expect(await fileExists(join(testDir, "escape.md"))).toBe(false);
     expect(await fileExists(join(testDir, ".github/instructions/escape.md"))).toBe(false);
   });

--- a/src/lib/apm/apm-install.test.ts
+++ b/src/lib/apm/apm-install.test.ts
@@ -69,7 +69,7 @@ describe("installApm", () => {
   it("warns and returns early when there are no dependencies", async () => {
     await writeManifest("name: my-project\nversion: 1.0.0\n");
 
-    const result = await installApm({ outputRoot: testDir, logger });
+    const result = await installApm({ projectRoot: testDir, logger });
 
     expect(result).toEqual({
       dependenciesProcessed: 0,
@@ -129,7 +129,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    const result = await installApm({ outputRoot: testDir, logger });
+    const result = await installApm({ projectRoot: testDir, logger });
 
     expect(result.dependenciesProcessed).toBe(1);
     expect(result.deployedFileCount).toBe(2);
@@ -174,7 +174,7 @@ describe("installApm", () => {
       throw err;
     });
 
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     expect(mockClientInstance.getDefaultBranch).toHaveBeenCalledWith("acme", "security");
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith("acme", "security", "trunk");
@@ -190,12 +190,12 @@ describe("installApm", () => {
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     // First pass: populate the lockfile.
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
 
     // Second pass: lockfile should short-circuit ref resolution.
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(1);
 
     const lock = await readApmLock(testDir);
@@ -211,10 +211,10 @@ describe("installApm", () => {
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
 
-    await installApm({ outputRoot: testDir, logger, options: { update: true } });
+    await installApm({ projectRoot: testDir, logger, options: { update: true } });
     expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledTimes(2);
 
     const lock = await readApmLock(testDir);
@@ -231,7 +231,7 @@ describe("installApm", () => {
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/rulesync-apm.lock.yaml is missing/);
   });
 
@@ -244,7 +244,7 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     await writeManifest(
       `dependencies:
@@ -254,7 +254,7 @@ describe("installApm", () => {
 `,
     );
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/missing entries for/);
   });
 
@@ -266,10 +266,10 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     const before = await readFileContent(getApmLockPath(testDir));
-    await installApm({ outputRoot: testDir, logger, options: { frozen: true } });
+    await installApm({ projectRoot: testDir, logger, options: { frozen: true } });
     const after = await readFileContent(getApmLockPath(testDir));
     expect(after).toBe(before);
   });
@@ -282,7 +282,7 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     await writeManifest(
       `dependencies:
@@ -291,7 +291,7 @@ describe("installApm", () => {
 `,
     );
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/manifest ref does not match/);
   });
 
@@ -320,13 +320,13 @@ describe("installApm", () => {
     );
     mockClientInstance.getFileContent.mockResolvedValue("original content");
 
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     // Simulate tampered upstream: same SHA, different bytes on next install.
     mockClientInstance.getFileContent.mockResolvedValue("tampered content");
 
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/content_hash mismatch/);
   });
 
@@ -343,7 +343,7 @@ describe("installApm", () => {
     mockClientInstance.resolveRefToSha.mockImplementation(async (_owner: string, repo: string) =>
       repo === "first" ? VALID_SHA : SECOND_SHA,
     );
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     const lockBefore = await readApmLock(testDir);
     expect(lockBefore?.dependencies.map((d) => d.repo_url)).toEqual([
       "https://github.com/acme/first",
@@ -362,7 +362,7 @@ describe("installApm", () => {
     });
 
     const result = await installApm({
-      outputRoot: testDir,
+      projectRoot: testDir,
       logger,
       options: { update: true },
     });
@@ -384,13 +384,13 @@ describe("installApm", () => {
 `,
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     const lockBefore = await readApmLock(testDir);
 
     mockClientInstance.resolveRefToSha.mockRejectedValue(new Error("network error"));
 
     const result = await installApm({
-      outputRoot: testDir,
+      projectRoot: testDir,
       logger,
       options: { update: true },
     });
@@ -437,7 +437,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
     expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
     expect(await fileExists(join(testDir, ".github/instructions/b.instructions.md"))).toBe(true);
 
@@ -458,7 +458,7 @@ describe("installApm", () => {
       },
     );
 
-    await installApm({ outputRoot: testDir, logger, options: { update: true } });
+    await installApm({ projectRoot: testDir, logger, options: { update: true } });
 
     expect(await fileExists(join(testDir, ".github/instructions/a.instructions.md"))).toBe(true);
     // B must be removed both from disk and from the lockfile.
@@ -492,7 +492,7 @@ describe("installApm", () => {
       },
     );
     mockClientInstance.getFileContent.mockResolvedValue("original content");
-    await installApm({ outputRoot: testDir, logger });
+    await installApm({ projectRoot: testDir, logger });
 
     const deployedPath = join(testDir, ".github/instructions/a.instructions.md");
     const before = await readFileContent(deployedPath);
@@ -502,7 +502,7 @@ describe("installApm", () => {
     mockClientInstance.getFileContent.mockResolvedValue("tampered content");
 
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).rejects.toThrow(/content_hash mismatch/);
 
     // The on-disk file must still contain the original bytes, not the
@@ -539,7 +539,7 @@ describe("installApm", () => {
       async (_owner: string, _repo: string, path: string) => `content of ${path}`,
     );
 
-    const result = await installApm({ outputRoot: testDir, logger });
+    const result = await installApm({ projectRoot: testDir, logger });
     expect(result.deployedFileCount).toBe(1);
     const deployed = await readFileContent(join(testDir, ".github/instructions/s.instructions.md"));
     expect(deployed).toBe("content of packages/security/.apm/instructions/s.instructions.md");
@@ -547,7 +547,7 @@ describe("installApm", () => {
     expect(lock?.dependencies[0]?.virtual_path).toBe("packages/security");
   });
 
-  it("refuses to remove stale files whose recorded path escapes outputRoot", async () => {
+  it("refuses to remove stale files whose recorded path escapes projectRoot", async () => {
     // Hand-craft a lockfile whose deployed_files contains attacker-controlled
     // paths. `deployed_files` is only schema-validated as a string array, so
     // a hostile repo could plant this and trigger arbitrary `removeFile` on
@@ -557,7 +557,7 @@ describe("installApm", () => {
     // We cannot safely write a file *outside* testDir from a test (the
     // testing guidelines forbid polluting anything outside the project
     // test directory), so we prove the defense by asserting (a) the guard
-    // warns for each offending entry and (b) legitimate in-outputRoot cleanup
+    // warns for each offending entry and (b) legitimate in-projectRoot cleanup
     // still proceeds as a control.
     const absoluteOutside = "/tmp/rulesync-apm-test-absolute-target.md";
     const lockYaml = `lockfile_version: "1"
@@ -576,7 +576,7 @@ dependencies:
 `;
     await writeFileContent(getApmLockPath(testDir), lockYaml);
 
-    // Plant the "clean" stale file that lives inside outputRoot so we can
+    // Plant the "clean" stale file that lives inside projectRoot so we can
     // verify the normal cleanup path still works even when the guard skips
     // its neighbors.
     await writeFileContent(
@@ -594,9 +594,9 @@ dependencies:
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
     const localLogger = createMockLogger();
-    await installApm({ outputRoot: testDir, logger: localLogger, options: { update: true } });
+    await installApm({ projectRoot: testDir, logger: localLogger, options: { update: true } });
 
-    // Legit in-outputRoot stale file is still removed (control: cleanup works).
+    // Legit in-projectRoot stale file is still removed (control: cleanup works).
     expect(await fileExists(join(testDir, ".github/instructions/old.instructions.md"))).toBe(false);
     // Warn logs were emitted for the two refused entries.
     const warnMessages = localLogger.warn.mock.calls.map((args) => String(args[0]));
@@ -637,7 +637,7 @@ dependencies:
     );
     mockClientInstance.listDirectory.mockResolvedValue([]);
 
-    await installApm({ outputRoot: testDir, logger, options: { update: true } });
+    await installApm({ projectRoot: testDir, logger, options: { update: true } });
 
     const after = await readApmLock(testDir);
     expect(after?.mcp_servers).toEqual(["security-scanner", "code-reviewer"]);
@@ -697,7 +697,7 @@ dependencies:
     mockClientInstance.getFileContent.mockResolvedValue("arbitrary content");
 
     await expect(
-      installApm({ outputRoot: testDir, logger, options: { frozen: true } }),
+      installApm({ projectRoot: testDir, logger, options: { frozen: true } }),
     ).resolves.toBeDefined();
   });
 
@@ -729,9 +729,9 @@ dependencies:
     );
     mockClientInstance.getFileContent.mockResolvedValue("evil");
 
-    const result = await installApm({ outputRoot: testDir, logger });
+    const result = await installApm({ projectRoot: testDir, logger });
     expect(result.deployedFileCount).toBe(0);
-    // The escape payload must not appear anywhere under outputRoot.
+    // The escape payload must not appear anywhere under projectRoot.
     expect(await fileExists(join(testDir, "escape.md"))).toBe(false);
     expect(await fileExists(join(testDir, ".github/instructions/escape.md"))).toBe(false);
   });

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -65,19 +65,19 @@ export type ApmInstallResult = {
  * currently understands (Instructions and Skills), and updates `rulesync-apm.lock.yaml`.
  */
 export async function installApm(params: {
-  baseDir: string;
+  outputRoot: string;
   options?: ApmInstallOptions;
   logger: Logger;
 }): Promise<ApmInstallResult> {
-  const { baseDir, options = {}, logger } = params;
+  const { outputRoot, options = {}, logger } = params;
 
-  const manifest = await readApmManifest(baseDir);
+  const manifest = await readApmManifest(outputRoot);
   if (manifest.dependencies.length === 0) {
     logger.warn("apm.yml has no dependencies.apm entries. Nothing to install.");
     return { dependenciesProcessed: 0, deployedFileCount: 0, failedDependencyCount: 0 };
   }
 
-  const existingLock = await readApmLock(baseDir);
+  const existingLock = await readApmLock(outputRoot);
   if (options.frozen) {
     if (!existingLock) {
       throw new Error(
@@ -143,7 +143,7 @@ export async function installApm(params: {
       dep,
       client,
       semaphore,
-      baseDir,
+      outputRoot,
       existingLock,
       frozen,
       update: options.update ?? false,
@@ -223,12 +223,12 @@ export async function installApm(params: {
         continue;
       }
       try {
-        checkPathTraversal({ relativePath, intendedRootDir: baseDir });
+        checkPathTraversal({ relativePath, intendedRootDir: outputRoot });
       } catch {
-        logger.warn(`Refusing to remove stale apm file outside baseDir: "${relativePath}".`);
+        logger.warn(`Refusing to remove stale apm file outside outputRoot: "${relativePath}".`);
         continue;
       }
-      const absolute = join(baseDir, relativePath);
+      const absolute = join(outputRoot, relativePath);
       // `removeFile` is best-effort and swallows ENOENT, so missing files are
       // a no-op. This keeps a corrupted partial-install from blowing up here.
       await removeFile(absolute);
@@ -242,7 +242,7 @@ export async function installApm(params: {
   // runs with mixed results still record the successful pins.
   if (!frozen) {
     newLock.generated_at = new Date().toISOString();
-    await writeApmLock({ baseDir, lock: newLock });
+    await writeApmLock({ outputRoot, lock: newLock });
     if (failedCount === 0) {
       logger.debug("rulesync-apm.lock.yaml updated.");
     } else {
@@ -263,13 +263,13 @@ async function installDependency(params: {
   dep: ApmDependency;
   client: GitHubClient;
   semaphore: Semaphore;
-  baseDir: string;
+  outputRoot: string;
   existingLock: ApmLock | null;
   frozen: boolean;
   update: boolean;
   logger: Logger;
 }): Promise<{ lockEntry: ApmLockDependency; deployedFiles: string[] }> {
-  const { dep, client, semaphore, baseDir, existingLock, frozen, update, logger } = params;
+  const { dep, client, semaphore, outputRoot, existingLock, frozen, update, logger } = params;
   const repoUrl = canonicalRepoUrl(dep);
   const locked = existingLock ? findApmLockDependency(existingLock, repoUrl) : undefined;
 
@@ -322,7 +322,7 @@ async function installDependency(params: {
       const deployRelative = toPosixPath(join(primitive.deployDir, relativeToBase));
       checkPathTraversal({
         relativePath: deployRelative,
-        intendedRootDir: baseDir,
+        intendedRootDir: outputRoot,
       });
       const content = await withSemaphore(semaphore, () =>
         client.getFileContent(dep.owner, dep.repo, file.path, resolvedSha),
@@ -338,7 +338,7 @@ async function installDependency(params: {
       }
       deployed.push({ path: deployRelative, content });
       if (!frozen) {
-        await writeFileContent(join(baseDir, deployRelative), content);
+        await writeFileContent(join(outputRoot, deployRelative), content);
       }
     }
   }
@@ -376,7 +376,7 @@ async function installDependency(params: {
   // Under --frozen we deferred all writes until after the hash check passed.
   if (frozen) {
     for (const { path: deployRelative, content } of deployed) {
-      await writeFileContent(join(baseDir, deployRelative), content);
+      await writeFileContent(join(outputRoot, deployRelative), content);
     }
   }
 

--- a/src/lib/apm/apm-install.ts
+++ b/src/lib/apm/apm-install.ts
@@ -65,19 +65,19 @@ export type ApmInstallResult = {
  * currently understands (Instructions and Skills), and updates `rulesync-apm.lock.yaml`.
  */
 export async function installApm(params: {
-  outputRoot: string;
+  projectRoot: string;
   options?: ApmInstallOptions;
   logger: Logger;
 }): Promise<ApmInstallResult> {
-  const { outputRoot, options = {}, logger } = params;
+  const { projectRoot, options = {}, logger } = params;
 
-  const manifest = await readApmManifest(outputRoot);
+  const manifest = await readApmManifest(projectRoot);
   if (manifest.dependencies.length === 0) {
     logger.warn("apm.yml has no dependencies.apm entries. Nothing to install.");
     return { dependenciesProcessed: 0, deployedFileCount: 0, failedDependencyCount: 0 };
   }
 
-  const existingLock = await readApmLock(outputRoot);
+  const existingLock = await readApmLock(projectRoot);
   if (options.frozen) {
     if (!existingLock) {
       throw new Error(
@@ -143,7 +143,7 @@ export async function installApm(params: {
       dep,
       client,
       semaphore,
-      outputRoot,
+      projectRoot,
       existingLock,
       frozen,
       update: options.update ?? false,
@@ -223,12 +223,12 @@ export async function installApm(params: {
         continue;
       }
       try {
-        checkPathTraversal({ relativePath, intendedRootDir: outputRoot });
+        checkPathTraversal({ relativePath, intendedRootDir: projectRoot });
       } catch {
-        logger.warn(`Refusing to remove stale apm file outside outputRoot: "${relativePath}".`);
+        logger.warn(`Refusing to remove stale apm file outside projectRoot: "${relativePath}".`);
         continue;
       }
-      const absolute = join(outputRoot, relativePath);
+      const absolute = join(projectRoot, relativePath);
       // `removeFile` is best-effort and swallows ENOENT, so missing files are
       // a no-op. This keeps a corrupted partial-install from blowing up here.
       await removeFile(absolute);
@@ -242,7 +242,7 @@ export async function installApm(params: {
   // runs with mixed results still record the successful pins.
   if (!frozen) {
     newLock.generated_at = new Date().toISOString();
-    await writeApmLock({ outputRoot, lock: newLock });
+    await writeApmLock({ projectRoot, lock: newLock });
     if (failedCount === 0) {
       logger.debug("rulesync-apm.lock.yaml updated.");
     } else {
@@ -263,13 +263,13 @@ async function installDependency(params: {
   dep: ApmDependency;
   client: GitHubClient;
   semaphore: Semaphore;
-  outputRoot: string;
+  projectRoot: string;
   existingLock: ApmLock | null;
   frozen: boolean;
   update: boolean;
   logger: Logger;
 }): Promise<{ lockEntry: ApmLockDependency; deployedFiles: string[] }> {
-  const { dep, client, semaphore, outputRoot, existingLock, frozen, update, logger } = params;
+  const { dep, client, semaphore, projectRoot, existingLock, frozen, update, logger } = params;
   const repoUrl = canonicalRepoUrl(dep);
   const locked = existingLock ? findApmLockDependency(existingLock, repoUrl) : undefined;
 
@@ -322,7 +322,7 @@ async function installDependency(params: {
       const deployRelative = toPosixPath(join(primitive.deployDir, relativeToBase));
       checkPathTraversal({
         relativePath: deployRelative,
-        intendedRootDir: outputRoot,
+        intendedRootDir: projectRoot,
       });
       const content = await withSemaphore(semaphore, () =>
         client.getFileContent(dep.owner, dep.repo, file.path, resolvedSha),
@@ -338,7 +338,7 @@ async function installDependency(params: {
       }
       deployed.push({ path: deployRelative, content });
       if (!frozen) {
-        await writeFileContent(join(outputRoot, deployRelative), content);
+        await writeFileContent(join(projectRoot, deployRelative), content);
       }
     }
   }
@@ -376,7 +376,7 @@ async function installDependency(params: {
   // Under --frozen we deferred all writes until after the hash check passed.
   if (frozen) {
     for (const { path: deployRelative, content } of deployed) {
-      await writeFileContent(join(outputRoot, deployRelative), content);
+      await writeFileContent(join(projectRoot, deployRelative), content);
     }
   }
 

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -220,7 +220,7 @@ dependencies: []
         package_type: "apm_package",
         deployed_files: [".github/instructions/a.instructions.md"],
       });
-      await writeApmLock({ baseDir: testDir, lock });
+      await writeApmLock({ outputRoot: testDir, lock });
       const written = await readFileContent(getApmLockPath(testDir));
       expect(written).toContain("lockfile_version:");
       const readBack = await readApmLock(testDir);

--- a/src/lib/apm/apm-lock.test.ts
+++ b/src/lib/apm/apm-lock.test.ts
@@ -220,7 +220,7 @@ dependencies: []
         package_type: "apm_package",
         deployed_files: [".github/instructions/a.instructions.md"],
       });
-      await writeApmLock({ outputRoot: testDir, lock });
+      await writeApmLock({ projectRoot: testDir, lock });
       const written = await readFileContent(getApmLockPath(testDir));
       expect(written).toContain("lockfile_version:");
       const readBack = await readApmLock(testDir);

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -66,12 +66,12 @@ export const ApmLockSchema = z.looseObject({
 });
 export type ApmLock = z.infer<typeof ApmLockSchema>;
 
-export function getApmLockPath(outputRoot: string): string {
-  return join(outputRoot, APM_LOCKFILE_FILE_NAME);
+export function getApmLockPath(projectRoot: string): string {
+  return join(projectRoot, APM_LOCKFILE_FILE_NAME);
 }
 
-export async function apmLockExists(outputRoot: string): Promise<boolean> {
-  return fileExists(getApmLockPath(outputRoot));
+export async function apmLockExists(projectRoot: string): Promise<boolean> {
+  return fileExists(getApmLockPath(projectRoot));
 }
 
 /**
@@ -129,8 +129,8 @@ export function parseApmLock(content: string): ApmLock | null {
   return parsed.data;
 }
 
-export async function readApmLock(outputRoot: string): Promise<ApmLock | null> {
-  const path = getApmLockPath(outputRoot);
+export async function readApmLock(projectRoot: string): Promise<ApmLock | null> {
+  const path = getApmLockPath(projectRoot);
   if (!(await fileExists(path))) {
     return null;
   }
@@ -138,8 +138,8 @@ export async function readApmLock(outputRoot: string): Promise<ApmLock | null> {
   return parseApmLock(content);
 }
 
-export async function writeApmLock(params: { outputRoot: string; lock: ApmLock }): Promise<void> {
-  const path = getApmLockPath(params.outputRoot);
+export async function writeApmLock(params: { projectRoot: string; lock: ApmLock }): Promise<void> {
+  const path = getApmLockPath(params.projectRoot);
   const content = serializeApmLock(params.lock);
   await writeFileContent(path, content);
 }

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -66,12 +66,12 @@ export const ApmLockSchema = z.looseObject({
 });
 export type ApmLock = z.infer<typeof ApmLockSchema>;
 
-export function getApmLockPath(baseDir: string): string {
-  return join(baseDir, APM_LOCKFILE_FILE_NAME);
+export function getApmLockPath(outputRoot: string): string {
+  return join(outputRoot, APM_LOCKFILE_FILE_NAME);
 }
 
-export async function apmLockExists(baseDir: string): Promise<boolean> {
-  return fileExists(getApmLockPath(baseDir));
+export async function apmLockExists(outputRoot: string): Promise<boolean> {
+  return fileExists(getApmLockPath(outputRoot));
 }
 
 /**
@@ -129,8 +129,8 @@ export function parseApmLock(content: string): ApmLock | null {
   return parsed.data;
 }
 
-export async function readApmLock(baseDir: string): Promise<ApmLock | null> {
-  const path = getApmLockPath(baseDir);
+export async function readApmLock(outputRoot: string): Promise<ApmLock | null> {
+  const path = getApmLockPath(outputRoot);
   if (!(await fileExists(path))) {
     return null;
   }
@@ -138,8 +138,8 @@ export async function readApmLock(baseDir: string): Promise<ApmLock | null> {
   return parseApmLock(content);
 }
 
-export async function writeApmLock(params: { baseDir: string; lock: ApmLock }): Promise<void> {
-  const path = getApmLockPath(params.baseDir);
+export async function writeApmLock(params: { outputRoot: string; lock: ApmLock }): Promise<void> {
+  const path = getApmLockPath(params.outputRoot);
   const content = serializeApmLock(params.lock);
   await writeFileContent(path, content);
 }

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -64,15 +64,15 @@ export type ApmManifest = {
 /**
  * Return the absolute path to the project's `apm.yml`.
  */
-export function getApmManifestPath(baseDir: string): string {
-  return join(baseDir, APM_MANIFEST_FILE_NAME);
+export function getApmManifestPath(outputRoot: string): string {
+  return join(outputRoot, APM_MANIFEST_FILE_NAME);
 }
 
 /**
  * True if `apm.yml` exists at the given base directory.
  */
-export async function apmManifestExists(baseDir: string): Promise<boolean> {
-  return fileExists(getApmManifestPath(baseDir));
+export async function apmManifestExists(outputRoot: string): Promise<boolean> {
+  return fileExists(getApmManifestPath(outputRoot));
 }
 
 /**
@@ -103,8 +103,8 @@ export function parseApmManifest(content: string): ApmManifest {
 /**
  * Read and parse `apm.yml` from disk.
  */
-export async function readApmManifest(baseDir: string): Promise<ApmManifest> {
-  const path = getApmManifestPath(baseDir);
+export async function readApmManifest(outputRoot: string): Promise<ApmManifest> {
+  const path = getApmManifestPath(outputRoot);
   const content = await readFileContent(path);
   return parseApmManifest(content);
 }
@@ -114,10 +114,10 @@ export async function readApmManifest(baseDir: string): Promise<ApmManifest> {
  * command itself does not mutate the manifest.
  */
 export async function writeApmManifest(params: {
-  baseDir: string;
+  outputRoot: string;
   manifest: { name?: string; version?: string; dependencies?: unknown[] };
 }): Promise<void> {
-  const path = getApmManifestPath(params.baseDir);
+  const path = getApmManifestPath(params.outputRoot);
   const content = dump(params.manifest, { lineWidth: -1 });
   await writeFileContent(path, content);
 }

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -64,15 +64,15 @@ export type ApmManifest = {
 /**
  * Return the absolute path to the project's `apm.yml`.
  */
-export function getApmManifestPath(outputRoot: string): string {
-  return join(outputRoot, APM_MANIFEST_FILE_NAME);
+export function getApmManifestPath(projectRoot: string): string {
+  return join(projectRoot, APM_MANIFEST_FILE_NAME);
 }
 
 /**
  * True if `apm.yml` exists at the given base directory.
  */
-export async function apmManifestExists(outputRoot: string): Promise<boolean> {
-  return fileExists(getApmManifestPath(outputRoot));
+export async function apmManifestExists(projectRoot: string): Promise<boolean> {
+  return fileExists(getApmManifestPath(projectRoot));
 }
 
 /**
@@ -103,8 +103,8 @@ export function parseApmManifest(content: string): ApmManifest {
 /**
  * Read and parse `apm.yml` from disk.
  */
-export async function readApmManifest(outputRoot: string): Promise<ApmManifest> {
-  const path = getApmManifestPath(outputRoot);
+export async function readApmManifest(projectRoot: string): Promise<ApmManifest> {
+  const path = getApmManifestPath(projectRoot);
   const content = await readFileContent(path);
   return parseApmManifest(content);
 }
@@ -114,10 +114,10 @@ export async function readApmManifest(outputRoot: string): Promise<ApmManifest> 
  * command itself does not mutate the manifest.
  */
 export async function writeApmManifest(params: {
-  outputRoot: string;
+  projectRoot: string;
   manifest: { name?: string; version?: string; dependencies?: unknown[] };
 }): Promise<void> {
-  const path = getApmManifestPath(params.outputRoot);
+  const path = getApmManifestPath(params.projectRoot);
   const content = dump(params.manifest, { lineWidth: -1 });
   await writeFileContent(path, content);
 }

--- a/src/lib/convert.test.ts
+++ b/src/lib/convert.test.ts
@@ -26,7 +26,7 @@ describe("convertFromTool", () => {
   let mockConfig: {
     getVerbose: ReturnType<typeof vi.fn>;
     getSilent: ReturnType<typeof vi.fn>;
-    getBaseDirs: ReturnType<typeof vi.fn>;
+    getOutputRoots: ReturnType<typeof vi.fn>;
     getFeatures: ReturnType<typeof vi.fn>;
     getFeatureOptions: ReturnType<typeof vi.fn>;
     getGlobal: ReturnType<typeof vi.fn>;
@@ -38,7 +38,7 @@ describe("convertFromTool", () => {
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
       getSilent: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getFeatures: vi.fn().mockReturnValue(["rules"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
       getGlobal: vi.fn().mockReturnValue(false),
@@ -380,10 +380,10 @@ describe("convertFromTool", () => {
     });
   });
 
-  describe("baseDir handling", () => {
-    it("should fall back to '.' when baseDirs is empty", async () => {
+  describe("outputRoot handling", () => {
+    it("should fall back to '.' when outputRoots is empty", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue([]);
+      mockConfig.getOutputRoots.mockReturnValue([]);
 
       await convertFromTool({
         logger,
@@ -392,7 +392,7 @@ describe("convertFromTool", () => {
         toTools: ["claudecode"],
       });
 
-      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ baseDir: "." }));
+      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ outputRoot: "." }));
     });
   });
 

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -158,14 +158,14 @@ async function runFeatureConvert<TProcessor, TSourceItem, TRulesyncItem>(
   return totalCount;
 }
 
-function getBaseDir(config: Config): string {
-  return config.getBaseDirs()[0] ?? ".";
+function getOutputRoot(config: Config): string {
+  return config.getOutputRoots()[0] ?? ".";
 }
 
 function buildRulesStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = RulesProcessor.getToolTargets({ global });
 
   return {
@@ -173,7 +173,7 @@ function buildRulesStrategy(ctx: ConvertContext) {
     itemLabel: "rule file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new RulesProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new RulesProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),
@@ -191,7 +191,7 @@ function buildIgnoreStrategy(ctx: ConvertContext) {
     logger.debug("Skipping ignore conversion (not supported in global mode)");
     return null;
   }
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = IgnoreProcessor.getToolTargets();
 
   return {
@@ -200,7 +200,7 @@ function buildIgnoreStrategy(ctx: ConvertContext) {
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
       new IgnoreProcessor({
-        baseDir,
+        outputRoot,
         toolTarget,
         dryRun,
         logger,
@@ -220,7 +220,7 @@ function buildIgnoreStrategy(ctx: ConvertContext) {
 function buildMcpStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = McpProcessor.getToolTargets({ global });
 
   return {
@@ -228,7 +228,7 @@ function buildMcpStrategy(ctx: ConvertContext) {
     itemLabel: "MCP file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new McpProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new McpProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),
@@ -243,7 +243,7 @@ function buildMcpStrategy(ctx: ConvertContext) {
 function buildCommandsStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = CommandsProcessor.getToolTargets({ global, includeSimulated: false });
 
   return {
@@ -251,7 +251,7 @@ function buildCommandsStrategy(ctx: ConvertContext) {
     itemLabel: "command file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new CommandsProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new CommandsProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),
@@ -266,7 +266,7 @@ function buildCommandsStrategy(ctx: ConvertContext) {
 function buildSubagentsStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = SubagentsProcessor.getToolTargets({ global, includeSimulated: false });
 
   return {
@@ -274,7 +274,7 @@ function buildSubagentsStrategy(ctx: ConvertContext) {
     itemLabel: "subagent file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new SubagentsProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new SubagentsProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),
@@ -289,7 +289,7 @@ function buildSubagentsStrategy(ctx: ConvertContext) {
 function buildSkillsStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = SkillsProcessor.getToolTargets({ global });
 
   return {
@@ -297,7 +297,7 @@ function buildSkillsStrategy(ctx: ConvertContext) {
     itemLabel: "skill(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new SkillsProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new SkillsProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolDirs(),
     toRulesync: (p, dirs) => p.convertToolDirsToRulesyncDirs(dirs),
     fromRulesync: (p, dirs) => p.convertRulesyncDirsToToolDirs(dirs),
@@ -312,7 +312,7 @@ function buildSkillsStrategy(ctx: ConvertContext) {
 function buildHooksStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = HooksProcessor.getToolTargets({ global });
   const importableTargets = HooksProcessor.getToolTargets({ global, importOnly: true });
 
@@ -322,7 +322,7 @@ function buildHooksStrategy(ctx: ConvertContext) {
     allTargets,
     importableTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new HooksProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new HooksProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),
@@ -337,7 +337,7 @@ function buildHooksStrategy(ctx: ConvertContext) {
 function buildPermissionsStrategy(ctx: ConvertContext) {
   const { config, logger } = ctx;
   const global = config.getGlobal();
-  const baseDir = getBaseDir(config);
+  const outputRoot = getOutputRoot(config);
   const allTargets = PermissionsProcessor.getToolTargets({ global });
   const importableTargets = PermissionsProcessor.getToolTargets({ global, importOnly: true });
 
@@ -347,7 +347,7 @@ function buildPermissionsStrategy(ctx: ConvertContext) {
     allTargets,
     importableTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new PermissionsProcessor({ baseDir, toolTarget, global, dryRun, logger }),
+      new PermissionsProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -305,7 +305,7 @@ describe("fetchFiles", () => {
 
   it("should throw error for GitLab provider", async () => {
     await expect(
-      fetchFiles({ logger, source: "gitlab:owner/repo", baseDir: testDir }),
+      fetchFiles({ logger, source: "gitlab:owner/repo", outputRoot: testDir }),
     ).rejects.toThrow("GitLab is not yet supported");
   });
 
@@ -387,7 +387,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo",
       options: { features: ["rules", "skills", "mcp"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.source).toBe("owner/repo");
@@ -448,7 +448,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo",
       options: { features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.files).toHaveLength(1);
@@ -495,7 +495,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo",
       options: { conflict: "skip", features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.created).toBe(1);
@@ -540,7 +540,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo",
       options: { conflict: "overwrite", features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.overwritten).toBe(1);
@@ -578,7 +578,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo",
       options: { output: "custom-output", features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Verify file was written to custom directory
@@ -604,7 +604,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo@main",
       options: { ref: "develop", features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(mockClientInstance.listDirectory).toHaveBeenCalledWith(
@@ -643,7 +643,7 @@ describe("fetchFiles", () => {
       logger,
       source: "owner/repo:packages/shared",
       options: { features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.created).toBe(1);
@@ -696,7 +696,7 @@ describe("fetchFiles", () => {
       logger,
       source,
       options: { features: ["rules", "mcp"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.created).toBeGreaterThanOrEqual(1);
@@ -738,7 +738,7 @@ describe("fetchFiles", () => {
         logger,
         source: "owner/repo",
         options: { features: ["rules"] },
-        baseDir: testDir,
+        outputRoot: testDir,
       }),
     ).rejects.toThrow("Path traversal detected");
   });
@@ -748,7 +748,7 @@ describe("fetchFiles", () => {
       fetchFiles({
         logger,
         source: "owner/repo",
-        baseDir: testDir,
+        outputRoot: testDir,
         options: {
           output: "../../outside",
         },
@@ -783,7 +783,7 @@ describe("fetchFiles", () => {
         logger,
         source: "owner/repo",
         options: { features: ["rules"] },
-        baseDir: testDir,
+        outputRoot: testDir,
       }),
     ).rejects.toThrow("exceeds maximum size limit");
   });
@@ -808,7 +808,7 @@ describe("fetchFiles", () => {
         logger,
         source: "owner/repo",
         options: { features: ["rules"] },
-        baseDir: testDir,
+        outputRoot: testDir,
       }),
     ).rejects.toThrow(/Maximum recursion depth.*exceeded/);
   });
@@ -872,7 +872,7 @@ describe("fetchFiles", () => {
         logger,
         source: "owner/repo",
         options: { features: ["rules"] },
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       // Wait for all 3 getFileContent calls to be made
@@ -939,7 +939,7 @@ describe("fetchFiles", () => {
           logger,
           source: "owner/repo",
           options: { features: ["rules"] },
-          baseDir: testDir,
+          outputRoot: testDir,
         }),
       ).rejects.toThrow("API rate limit exceeded");
     });
@@ -1007,7 +1007,7 @@ describe("fetchFiles", () => {
         logger,
         source: "owner/repo",
         options: { features: ["rules"] },
-        baseDir: testDir,
+        outputRoot: testDir,
       });
 
       expect(result.files).toHaveLength(2);
@@ -1069,7 +1069,7 @@ describe("fetchFiles with target option", () => {
       logger,
       source: "owner/repo",
       options: { features: ["rules"], target: "rulesync" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.source).toBe("owner/repo");
@@ -1110,7 +1110,7 @@ describe("fetchFiles with target option", () => {
       logger,
       source: "owner/repo",
       options: { features: ["rules"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.created).toBe(1);
@@ -1159,7 +1159,7 @@ Follow these guidelines for TypeScript development.
       logger,
       source: "owner/repo",
       options: { features: ["rules"], target: "claudecode" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.source).toBe("owner/repo");
@@ -1182,7 +1182,7 @@ Follow these guidelines for TypeScript development.
       logger,
       source: "owner/repo",
       options: { features: ["skills"], target: "claudecode" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Should return empty summary without errors
@@ -1219,7 +1219,7 @@ Follow these guidelines for TypeScript development.
       logger,
       source: "owner/repo",
       options: { features: ["rules"], target: "claudecode" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Verify no temp directories remain
@@ -1269,7 +1269,7 @@ Review the current changes and provide feedback.
       logger,
       source: "owner/repo",
       options: { features: ["commands"], target: "claudecode" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.source).toBe("owner/repo");
@@ -1327,7 +1327,7 @@ Review the current changes and provide feedback.
       logger,
       source: "owner/repo",
       options: { features: ["rules", "commands"], target: "claudecode" },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(summary.source).toBe("owner/repo");
@@ -1391,7 +1391,7 @@ Review the current changes and provide feedback.
       logger,
       source: "owner/repo",
       options: { features: ["ignore", "mcp", "hooks"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Verify all files were fetched
@@ -1454,7 +1454,7 @@ Review the current changes and provide feedback.
       logger,
       source: "owner/repo",
       options: { features: ["mcp"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Second fetch from subdir
@@ -1462,7 +1462,7 @@ Review the current changes and provide feedback.
       logger,
       source: "owner/repo:subdir",
       options: { features: ["ignore"] },
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Verify separate API calls were made for different base paths

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -154,38 +154,39 @@ async function convertFetchedFilesToRulesync(params: {
       feature: "rules",
       getTargets: () => RulesProcessor.getToolTargets({ global: false }),
       createProcessor: () =>
-        new RulesProcessor({ baseDir: tempDir, toolTarget: target, global: false, logger }),
+        new RulesProcessor({ outputRoot: tempDir, toolTarget: target, global: false, logger }),
     },
     {
       feature: "commands",
       getTargets: () =>
         CommandsProcessor.getToolTargets({ global: false, includeSimulated: false }),
       createProcessor: () =>
-        new CommandsProcessor({ baseDir: tempDir, toolTarget: target, global: false, logger }),
+        new CommandsProcessor({ outputRoot: tempDir, toolTarget: target, global: false, logger }),
     },
     {
       feature: "subagents",
       getTargets: () =>
         SubagentsProcessor.getToolTargets({ global: false, includeSimulated: false }),
       createProcessor: () =>
-        new SubagentsProcessor({ baseDir: tempDir, toolTarget: target, global: false, logger }),
+        new SubagentsProcessor({ outputRoot: tempDir, toolTarget: target, global: false, logger }),
     },
     {
       feature: "ignore",
       getTargets: () => IgnoreProcessor.getToolTargets(),
-      createProcessor: () => new IgnoreProcessor({ baseDir: tempDir, toolTarget: target, logger }),
+      createProcessor: () =>
+        new IgnoreProcessor({ outputRoot: tempDir, toolTarget: target, logger }),
     },
     {
       feature: "mcp",
       getTargets: () => McpProcessor.getToolTargets({ global: false }),
       createProcessor: () =>
-        new McpProcessor({ baseDir: tempDir, toolTarget: target, global: false, logger }),
+        new McpProcessor({ outputRoot: tempDir, toolTarget: target, global: false, logger }),
     },
     {
       feature: "hooks",
       getTargets: () => HooksProcessor.getToolTargets({ global: false }),
       createProcessor: () =>
-        new HooksProcessor({ baseDir: tempDir, toolTarget: target, global: false, logger }),
+        new HooksProcessor({ outputRoot: tempDir, toolTarget: target, global: false, logger }),
     },
   ];
 
@@ -257,7 +258,7 @@ function isNotFoundError(error: unknown): boolean {
 export type FetchParams = {
   source: string;
   options?: FetchOptions;
-  baseDir?: string;
+  outputRoot?: string;
   logger: Logger;
 };
 
@@ -270,7 +271,7 @@ export type FetchParams = {
  * converted to rulesync format, and written to the output directory.
  */
 export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
-  const { source, options = {}, baseDir = process.cwd(), logger } = params;
+  const { source, options = {}, outputRoot = process.cwd(), logger } = params;
 
   // Parse source
   const parsed = parseSource(source);
@@ -294,7 +295,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
   // Validate output directory to prevent path traversal attacks
   checkPathTraversal({
     relativePath: outputDir,
-    intendedRootDir: baseDir,
+    intendedRootDir: outputRoot,
   });
 
   // Initialize GitHub client
@@ -325,7 +326,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
       enabledFeatures,
       target,
       outputDir,
-      baseDir,
+      outputRoot,
       conflictStrategy,
       logger,
     });
@@ -359,7 +360,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
   }
 
   // Process files in parallel with concurrency control
-  const outputBasePath = join(baseDir, outputDir);
+  const outputBasePath = join(outputRoot, outputDir);
 
   // Validate paths and check file sizes first (synchronous checks)
   for (const { relativePath, size } of filesToFetch) {
@@ -524,7 +525,7 @@ async function fetchAndConvertToolFiles(params: {
   enabledFeatures: Feature[];
   target: ToolTarget;
   outputDir: string;
-  baseDir: string;
+  outputRoot: string;
   conflictStrategy: ConflictStrategy;
   logger: Logger;
 }): Promise<FetchSummary> {
@@ -536,7 +537,7 @@ async function fetchAndConvertToolFiles(params: {
     enabledFeatures,
     target,
     outputDir,
-    baseDir,
+    outputRoot,
     conflictStrategy: _conflictStrategy,
     logger,
   } = params;
@@ -603,7 +604,7 @@ async function fetchAndConvertToolFiles(params: {
     );
 
     // Convert fetched files to rulesync format
-    const outputBasePath = join(baseDir, outputDir);
+    const outputBasePath = join(outputRoot, outputDir);
     const { converted, convertedPaths } = await convertFetchedFilesToRulesync({
       tempDir,
       outputDir: outputBasePath,

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -45,7 +45,7 @@ describe("checkRulesyncDirExists", () => {
   it("should return true when .rulesync directory exists", async () => {
     vi.mocked(fileExists).mockResolvedValue(true);
 
-    const result = await checkRulesyncDirExists({ outputRoot: "/project" });
+    const result = await checkRulesyncDirExists({ inputRoot: "/project" });
 
     expect(result).toBe(true);
     expect(fileExists).toHaveBeenCalledWith("/project/.rulesync");
@@ -54,7 +54,7 @@ describe("checkRulesyncDirExists", () => {
   it("should return false when .rulesync directory does not exist", async () => {
     vi.mocked(fileExists).mockResolvedValue(false);
 
-    const result = await checkRulesyncDirExists({ outputRoot: "/project" });
+    const result = await checkRulesyncDirExists({ inputRoot: "/project" });
 
     expect(result).toBe(false);
     expect(fileExists).toHaveBeenCalledWith("/project/.rulesync");

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -45,7 +45,7 @@ describe("checkRulesyncDirExists", () => {
   it("should return true when .rulesync directory exists", async () => {
     vi.mocked(fileExists).mockResolvedValue(true);
 
-    const result = await checkRulesyncDirExists({ baseDir: "/project" });
+    const result = await checkRulesyncDirExists({ outputRoot: "/project" });
 
     expect(result).toBe(true);
     expect(fileExists).toHaveBeenCalledWith("/project/.rulesync");
@@ -54,7 +54,7 @@ describe("checkRulesyncDirExists", () => {
   it("should return false when .rulesync directory does not exist", async () => {
     vi.mocked(fileExists).mockResolvedValue(false);
 
-    const result = await checkRulesyncDirExists({ baseDir: "/project" });
+    const result = await checkRulesyncDirExists({ outputRoot: "/project" });
 
     expect(result).toBe(false);
     expect(fileExists).toHaveBeenCalledWith("/project/.rulesync");
@@ -70,7 +70,7 @@ describe("generate", () => {
   let mockConfig: {
     getVerbose: ReturnType<typeof vi.fn>;
     getSilent: ReturnType<typeof vi.fn>;
-    getBaseDirs: ReturnType<typeof vi.fn>;
+    getOutputRoots: ReturnType<typeof vi.fn>;
     getTargets: ReturnType<typeof vi.fn>;
     getFeatures: ReturnType<typeof vi.fn>;
     getFeatureOptions: ReturnType<typeof vi.fn>;
@@ -88,7 +88,7 @@ describe("generate", () => {
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
       getSilent: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getTargets: vi.fn().mockReturnValue(["claudecode"]),
       getFeatures: vi.fn().mockReturnValue(["rules"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
@@ -174,7 +174,7 @@ describe("generate", () => {
       expect(result.rulesCount).toBe(1);
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           simulateCommands: false,
@@ -199,7 +199,7 @@ describe("generate", () => {
       mockConfig.getFeatures.mockReturnValue(["rules", "skills"]);
 
       const mockSkill = new RulesyncSkill({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".rulesync/skills/test",
         dirName: "test",
         frontmatter: { name: "test-skill", targets: ["*"], description: "Test skill" },
@@ -279,14 +279,14 @@ describe("generate", () => {
 
     it("should process multiple base directories", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue(["dir1", "dir2"]);
+      mockConfig.getOutputRoots.mockReturnValue(["dir1", "dir2"]);
 
       const result = await generate({ logger, config: mockConfig as never });
 
       expect(result.rulesCount).toBe(2);
       expect(RulesProcessor).toHaveBeenCalledTimes(2);
-      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ baseDir: "dir1" }));
-      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ baseDir: "dir2" }));
+      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ outputRoot: "dir1" }));
+      expect(RulesProcessor).toHaveBeenCalledWith(expect.objectContaining({ outputRoot: "dir2" }));
     });
   });
 
@@ -361,7 +361,7 @@ describe("generate", () => {
       expect(result.mcpCount).toBe(1);
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -388,7 +388,7 @@ describe("generate", () => {
       expect(result.commandsCount).toBe(1);
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -427,7 +427,7 @@ describe("generate", () => {
       expect(result.subagentsCount).toBe(1);
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -477,7 +477,7 @@ describe("generate", () => {
       expect(result.skillsCount).toBe(1);
       expect(SkillsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
           dryRun: false,
@@ -499,7 +499,7 @@ describe("generate", () => {
       mockConfig.getFeatures.mockReturnValue(["skills"]);
 
       const mockSkill = new RulesyncSkill({
-        baseDir: ".",
+        outputRoot: ".",
         relativeDirPath: ".rulesync/skills/test",
         dirName: "test",
         frontmatter: { name: "test-skill", targets: ["*"], description: "Test skill" },
@@ -561,7 +561,7 @@ describe("generate", () => {
       expect(result.permissionsCount).toBe(1);
       expect(PermissionsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           dryRun: false,
         }),
@@ -589,7 +589,7 @@ describe("generate", () => {
       expect(result.permissionsCount).toBe(1);
       expect(PermissionsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -165,9 +165,13 @@ function warnUnsupportedTargets(params: {
 
 /**
  * Check if .rulesync directory exists.
+ *
+ * The `.rulesync/` directory lives under the *input* root (where source rules
+ * are read from), not under any individual output root, so callers always pass
+ * `config.getInputRoot()` here.
  */
-export async function checkRulesyncDirExists(params: { outputRoot: string }): Promise<boolean> {
-  return fileExists(join(params.outputRoot, RULESYNC_RELATIVE_DIR_PATH));
+export async function checkRulesyncDirExists(params: { inputRoot: string }): Promise<boolean> {
+  return fileExists(join(params.inputRoot, RULESYNC_RELATIVE_DIR_PATH));
 }
 
 /**

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -166,8 +166,8 @@ function warnUnsupportedTargets(params: {
 /**
  * Check if .rulesync directory exists.
  */
-export async function checkRulesyncDirExists(params: { baseDir: string }): Promise<boolean> {
-  return fileExists(join(params.baseDir, RULESYNC_RELATIVE_DIR_PATH));
+export async function checkRulesyncDirExists(params: { outputRoot: string }): Promise<boolean> {
+  return fileExists(join(params.outputRoot, RULESYNC_RELATIVE_DIR_PATH));
 }
 
 /**
@@ -241,7 +241,7 @@ async function generateRulesCore(params: {
   const toolTargets = intersection(config.getTargets(), supportedTargets);
   warnUnsupportedTargets({ config, supportedTargets, featureName: "rules", logger });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if rules feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("rules")) {
@@ -249,7 +249,7 @@ async function generateRulesCore(params: {
       }
 
       const processor = new RulesProcessor({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),
@@ -302,15 +302,15 @@ async function generateIgnoreCore(params: {
       continue;
     }
 
-    for (const baseDir of config.getBaseDirs()) {
+    for (const outputRoot of config.getOutputRoots()) {
       try {
         const processor = new IgnoreProcessor({
-          // Pass `baseDir` verbatim. The legacy
-          // `baseDir === process.cwd() ? "." : baseDir` heuristic was a
-          // leftover from before `baseDirs` was always resolved to absolute
+          // Pass `outputRoot` verbatim. The legacy
+          // `outputRoot === process.cwd() ? "." : outputRoot` heuristic was a
+          // leftover from before `outputRoots` was always resolved to absolute
           // paths in `ConfigResolver`; with that change it is now consistent
-          // to pass the same `baseDir` value the other processors receive.
-          baseDir,
+          // to pass the same `outputRoot` value the other processors receive.
+          outputRoot,
           inputRoot: config.getInputRoot(),
           toolTarget,
           dryRun: config.isPreviewMode(),
@@ -326,7 +326,7 @@ async function generateIgnoreCore(params: {
         if (result.hasDiff) hasDiff = true;
       } catch (error) {
         logger.warn(
-          `Failed to generate ${toolTarget} ignore files for ${baseDir}: ${formatError(error)}`,
+          `Failed to generate ${toolTarget} ignore files for ${outputRoot}: ${formatError(error)}`,
         );
         continue;
       }
@@ -355,7 +355,7 @@ async function generateMcpCore(params: {
     logger,
   });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if mcp feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("mcp")) {
@@ -363,7 +363,7 @@ async function generateMcpCore(params: {
       }
 
       const processor = new McpProcessor({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),
@@ -406,7 +406,7 @@ async function generateCommandsCore(params: {
     logger,
   });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if commands feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("commands")) {
@@ -414,7 +414,7 @@ async function generateCommandsCore(params: {
       }
 
       const processor = new CommandsProcessor({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),
@@ -462,7 +462,7 @@ async function generateSubagentsCore(params: {
     logger,
   });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if subagents feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("subagents")) {
@@ -470,7 +470,7 @@ async function generateSubagentsCore(params: {
       }
 
       const processor = new SubagentsProcessor({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),
@@ -514,7 +514,7 @@ async function generateSkillsCore(params: {
     logger,
   });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if skills feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("skills")) {
@@ -522,7 +522,7 @@ async function generateSkillsCore(params: {
       }
 
       const processor = new SkillsProcessor({
-        baseDir: baseDir,
+        outputRoot: outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),
@@ -574,7 +574,7 @@ async function generateHooksCore(params: {
     logger,
   });
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of toolTargets) {
       // Check if hooks feature is enabled for this specific target
       if (!config.getFeatures(toolTarget).includes("hooks")) {
@@ -582,7 +582,7 @@ async function generateHooksCore(params: {
       }
 
       const processor = new HooksProcessor({
-        baseDir,
+        outputRoot,
         inputRoot: config.getInputRoot(),
         toolTarget,
         global: config.getGlobal(),
@@ -622,7 +622,7 @@ async function generatePermissionsCore(params: {
   const allPaths: string[] = [];
   let hasDiff = false;
 
-  for (const baseDir of config.getBaseDirs()) {
+  for (const outputRoot of config.getOutputRoots()) {
     for (const toolTarget of intersection(config.getTargets(), supportedPermissionsTargets)) {
       if (!config.getFeatures(toolTarget).includes("permissions")) {
         continue;
@@ -630,7 +630,7 @@ async function generatePermissionsCore(params: {
 
       try {
         const processor = new PermissionsProcessor({
-          baseDir,
+          outputRoot,
           inputRoot: config.getInputRoot(),
           toolTarget,
           global: config.getGlobal(),
@@ -646,7 +646,7 @@ async function generatePermissionsCore(params: {
         if (result.hasDiff) hasDiff = true;
       } catch (error) {
         logger.warn(
-          `Failed to generate ${toolTarget} permissions files for ${baseDir}: ${formatError(error)}`,
+          `Failed to generate ${toolTarget} permissions files for ${outputRoot}: ${formatError(error)}`,
         );
         continue;
       }

--- a/src/lib/gh/gh-install.test.ts
+++ b/src/lib/gh/gh-install.test.ts
@@ -118,7 +118,7 @@ describe("installGh", () => {
   }
 
   it("returns early on empty sources", async () => {
-    const result = await installGh({ baseDir: testDir, sources: [], logger });
+    const result = await installGh({ outputRoot: testDir, sources: [], logger });
     expect(result).toEqual({
       sourcesProcessed: 0,
       installedSkillCount: 0,
@@ -129,7 +129,7 @@ describe("installGh", () => {
   it("rejects non-github sources with a clear error", async () => {
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [source({ source: "https://gitlab.com/owner/repo" })],
         logger,
       }),
@@ -139,7 +139,7 @@ describe("installGh", () => {
   it("rejects entry.transport='git' with a field-specific error", async () => {
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [source({ source: "owner/repo", transport: "git" })],
         logger,
       }),
@@ -149,7 +149,7 @@ describe("installGh", () => {
   it("rejects entry.path with a field-specific error", async () => {
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [source({ source: "owner/repo", path: "exports/skills" })],
         logger,
       }),
@@ -161,7 +161,7 @@ describe("installGh", () => {
     // sources — the second has no installations at all in the lock.
     setupSingleSkill("s");
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/first" })],
       logger,
     });
@@ -174,7 +174,7 @@ describe("installGh", () => {
 
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [source({ source: "owner/first" }), source({ source: "owner/added" })],
         options: { frozen: true },
         logger,
@@ -210,7 +210,7 @@ describe("installGh", () => {
     mockClientInstance.getFileContent.mockResolvedValue("# original\n");
 
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [
         source({ source: "owner/repo", agent: "github-copilot" }),
         source({ source: "owner/repo", agent: "claude-code" }),
@@ -239,7 +239,7 @@ describe("installGh", () => {
 
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [
           source({ source: "owner/repo", agent: "github-copilot" }),
           source({ source: "owner/repo", agent: "claude-code" }),
@@ -259,7 +259,7 @@ describe("installGh", () => {
   it("discovers skills via skills/<name>/SKILL.md and writes them with default agent (github-copilot)", async () => {
     setupSingleSkill("git-commit");
     const result = await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -294,7 +294,7 @@ describe("installGh", () => {
   it("honors entry.agent (claude-code) and writes under .claude/skills", async () => {
     setupSingleSkill("git-commit");
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo", agent: "claude-code" })],
       logger,
     });
@@ -326,7 +326,7 @@ describe("installGh", () => {
 
     const localLogger = createMockLogger();
     const result = await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo", skills: ["wanted", "missing"] })],
       logger: localLogger,
     });
@@ -341,7 +341,7 @@ describe("installGh", () => {
   it("uses entry.ref when present, skipping latest-release lookup", async () => {
     setupSingleSkill("s");
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo", ref: "feature-branch" })],
       logger,
     });
@@ -359,7 +359,7 @@ describe("installGh", () => {
     mockClientInstance.getDefaultBranch.mockResolvedValue("trunk");
 
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -376,7 +376,7 @@ describe("installGh", () => {
     setupSingleSkill("s");
     await expect(
       installGh({
-        baseDir: testDir,
+        outputRoot: testDir,
         sources: [source({ source: "owner/repo" })],
         options: { frozen: true },
         logger,
@@ -387,7 +387,7 @@ describe("installGh", () => {
   it("--update re-resolves refs even when the lockfile is present", async () => {
     setupSingleSkill("s");
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -396,7 +396,7 @@ describe("installGh", () => {
     // Bump SHA to simulate upstream movement and re-run with --update.
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       options: { update: true },
       logger,
@@ -429,7 +429,7 @@ describe("installGh", () => {
     );
 
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -450,7 +450,7 @@ describe("installGh", () => {
     );
 
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       options: { update: true },
       logger,
@@ -465,7 +465,7 @@ describe("installGh", () => {
   it("writes the lockfile path correctly", async () => {
     setupSingleSkill("s");
     await installGh({
-      baseDir: testDir,
+      outputRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });

--- a/src/lib/gh/gh-install.test.ts
+++ b/src/lib/gh/gh-install.test.ts
@@ -118,7 +118,7 @@ describe("installGh", () => {
   }
 
   it("returns early on empty sources", async () => {
-    const result = await installGh({ outputRoot: testDir, sources: [], logger });
+    const result = await installGh({ projectRoot: testDir, sources: [], logger });
     expect(result).toEqual({
       sourcesProcessed: 0,
       installedSkillCount: 0,
@@ -129,7 +129,7 @@ describe("installGh", () => {
   it("rejects non-github sources with a clear error", async () => {
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [source({ source: "https://gitlab.com/owner/repo" })],
         logger,
       }),
@@ -139,7 +139,7 @@ describe("installGh", () => {
   it("rejects entry.transport='git' with a field-specific error", async () => {
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [source({ source: "owner/repo", transport: "git" })],
         logger,
       }),
@@ -149,7 +149,7 @@ describe("installGh", () => {
   it("rejects entry.path with a field-specific error", async () => {
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [source({ source: "owner/repo", path: "exports/skills" })],
         logger,
       }),
@@ -161,7 +161,7 @@ describe("installGh", () => {
     // sources — the second has no installations at all in the lock.
     setupSingleSkill("s");
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/first" })],
       logger,
     });
@@ -174,7 +174,7 @@ describe("installGh", () => {
 
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [source({ source: "owner/first" }), source({ source: "owner/added" })],
         options: { frozen: true },
         logger,
@@ -210,7 +210,7 @@ describe("installGh", () => {
     mockClientInstance.getFileContent.mockResolvedValue("# original\n");
 
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [
         source({ source: "owner/repo", agent: "github-copilot" }),
         source({ source: "owner/repo", agent: "claude-code" }),
@@ -239,7 +239,7 @@ describe("installGh", () => {
 
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [
           source({ source: "owner/repo", agent: "github-copilot" }),
           source({ source: "owner/repo", agent: "claude-code" }),
@@ -259,7 +259,7 @@ describe("installGh", () => {
   it("discovers skills via skills/<name>/SKILL.md and writes them with default agent (github-copilot)", async () => {
     setupSingleSkill("git-commit");
     const result = await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -294,7 +294,7 @@ describe("installGh", () => {
   it("honors entry.agent (claude-code) and writes under .claude/skills", async () => {
     setupSingleSkill("git-commit");
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo", agent: "claude-code" })],
       logger,
     });
@@ -326,7 +326,7 @@ describe("installGh", () => {
 
     const localLogger = createMockLogger();
     const result = await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo", skills: ["wanted", "missing"] })],
       logger: localLogger,
     });
@@ -341,7 +341,7 @@ describe("installGh", () => {
   it("uses entry.ref when present, skipping latest-release lookup", async () => {
     setupSingleSkill("s");
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo", ref: "feature-branch" })],
       logger,
     });
@@ -359,7 +359,7 @@ describe("installGh", () => {
     mockClientInstance.getDefaultBranch.mockResolvedValue("trunk");
 
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -376,7 +376,7 @@ describe("installGh", () => {
     setupSingleSkill("s");
     await expect(
       installGh({
-        outputRoot: testDir,
+        projectRoot: testDir,
         sources: [source({ source: "owner/repo" })],
         options: { frozen: true },
         logger,
@@ -387,7 +387,7 @@ describe("installGh", () => {
   it("--update re-resolves refs even when the lockfile is present", async () => {
     setupSingleSkill("s");
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -396,7 +396,7 @@ describe("installGh", () => {
     // Bump SHA to simulate upstream movement and re-run with --update.
     mockClientInstance.resolveRefToSha.mockResolvedValue(SECOND_SHA);
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       options: { update: true },
       logger,
@@ -429,7 +429,7 @@ describe("installGh", () => {
     );
 
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });
@@ -450,7 +450,7 @@ describe("installGh", () => {
     );
 
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       options: { update: true },
       logger,
@@ -465,7 +465,7 @@ describe("installGh", () => {
   it("writes the lockfile path correctly", async () => {
     setupSingleSkill("s");
     await installGh({
-      outputRoot: testDir,
+      projectRoot: testDir,
       sources: [source({ source: "owner/repo" })],
       logger,
     });

--- a/src/lib/gh/gh-install.ts
+++ b/src/lib/gh/gh-install.ts
@@ -77,12 +77,12 @@ type SkillInstallation = {
  * to pin commits and per-skill content hashes.
  */
 export async function installGh(params: {
-  baseDir: string;
+  outputRoot: string;
   sources: SourceEntry[];
   options?: GhInstallOptions;
   logger: Logger;
 }): Promise<GhInstallResult> {
-  const { baseDir, sources, options = {}, logger } = params;
+  const { outputRoot, sources, options = {}, logger } = params;
 
   if (sources.length === 0) {
     return { sourcesProcessed: 0, installedSkillCount: 0, failedSourceCount: 0 };
@@ -129,7 +129,7 @@ export async function installGh(params: {
     };
   });
 
-  const existingLock = await readGhLock(baseDir);
+  const existingLock = await readGhLock(outputRoot);
   const frozen = options.frozen ?? false;
   const update = options.update ?? false;
 
@@ -203,7 +203,7 @@ export async function installGh(params: {
       rs,
       client,
       semaphore,
-      baseDir,
+      outputRoot,
       existingLock,
       frozen,
       update,
@@ -285,7 +285,7 @@ export async function installGh(params: {
         await removeStaleFile({
           relativePath: deployed,
           scope: prev.scope === "user" ? "user" : "project",
-          baseDir,
+          outputRoot,
           logger,
         });
       }
@@ -294,7 +294,7 @@ export async function installGh(params: {
 
   if (!frozen) {
     newLock.generated_at = new Date().toISOString();
-    await writeGhLock({ baseDir, lock: newLock });
+    await writeGhLock({ outputRoot, lock: newLock });
     if (failedCount === 0) {
       logger.debug("rulesync-gh.lock.yaml updated.");
     } else {
@@ -315,13 +315,13 @@ async function installSource(params: {
   rs: ResolvedSource;
   client: GitHubClient;
   semaphore: Semaphore;
-  baseDir: string;
+  outputRoot: string;
   existingLock: GhLock | null;
   frozen: boolean;
   update: boolean;
   logger: Logger;
 }): Promise<SkillInstallation[]> {
-  const { rs, client, semaphore, baseDir, existingLock, frozen, update, logger } = params;
+  const { rs, client, semaphore, outputRoot, existingLock, frozen, update, logger } = params;
   const { entry, owner, repo, agent, scope } = rs;
   const sourceKey = entry.source;
 
@@ -419,7 +419,7 @@ async function installSource(params: {
 
   const results: SkillInstallation[] = [];
   const installRelDir = relativeInstallDirFor({ agent, scope });
-  const scopeRoot = scope === "user" ? getHomeDirectory() : baseDir;
+  const scopeRoot = scope === "user" ? getHomeDirectory() : outputRoot;
 
   // Source URL recorded in injected frontmatter. Mirrors the canonical form
   // used by `gh skill install`.
@@ -579,15 +579,15 @@ async function installSource(params: {
 async function removeStaleFile(params: {
   relativePath: string;
   scope: GhScope;
-  baseDir: string;
+  outputRoot: string;
   logger: Logger;
 }): Promise<void> {
-  const { relativePath, scope, baseDir, logger } = params;
+  const { relativePath, scope, outputRoot, logger } = params;
   if (posix.isAbsolute(relativePath) || relativePath.split(/[/\\]/).includes("..")) {
     logger.warn(`Refusing to remove stale gh file with suspicious path: "${relativePath}".`);
     return;
   }
-  const scopeRoot = scope === "user" ? getHomeDirectory() : baseDir;
+  const scopeRoot = scope === "user" ? getHomeDirectory() : outputRoot;
   try {
     checkPathTraversal({ relativePath, intendedRootDir: scopeRoot });
   } catch {

--- a/src/lib/gh/gh-install.ts
+++ b/src/lib/gh/gh-install.ts
@@ -77,12 +77,12 @@ type SkillInstallation = {
  * to pin commits and per-skill content hashes.
  */
 export async function installGh(params: {
-  outputRoot: string;
+  projectRoot: string;
   sources: SourceEntry[];
   options?: GhInstallOptions;
   logger: Logger;
 }): Promise<GhInstallResult> {
-  const { outputRoot, sources, options = {}, logger } = params;
+  const { projectRoot, sources, options = {}, logger } = params;
 
   if (sources.length === 0) {
     return { sourcesProcessed: 0, installedSkillCount: 0, failedSourceCount: 0 };
@@ -129,7 +129,7 @@ export async function installGh(params: {
     };
   });
 
-  const existingLock = await readGhLock(outputRoot);
+  const existingLock = await readGhLock(projectRoot);
   const frozen = options.frozen ?? false;
   const update = options.update ?? false;
 
@@ -203,7 +203,7 @@ export async function installGh(params: {
       rs,
       client,
       semaphore,
-      outputRoot,
+      projectRoot,
       existingLock,
       frozen,
       update,
@@ -285,7 +285,7 @@ export async function installGh(params: {
         await removeStaleFile({
           relativePath: deployed,
           scope: prev.scope === "user" ? "user" : "project",
-          outputRoot,
+          projectRoot,
           logger,
         });
       }
@@ -294,7 +294,7 @@ export async function installGh(params: {
 
   if (!frozen) {
     newLock.generated_at = new Date().toISOString();
-    await writeGhLock({ outputRoot, lock: newLock });
+    await writeGhLock({ projectRoot, lock: newLock });
     if (failedCount === 0) {
       logger.debug("rulesync-gh.lock.yaml updated.");
     } else {
@@ -315,13 +315,13 @@ async function installSource(params: {
   rs: ResolvedSource;
   client: GitHubClient;
   semaphore: Semaphore;
-  outputRoot: string;
+  projectRoot: string;
   existingLock: GhLock | null;
   frozen: boolean;
   update: boolean;
   logger: Logger;
 }): Promise<SkillInstallation[]> {
-  const { rs, client, semaphore, outputRoot, existingLock, frozen, update, logger } = params;
+  const { rs, client, semaphore, projectRoot, existingLock, frozen, update, logger } = params;
   const { entry, owner, repo, agent, scope } = rs;
   const sourceKey = entry.source;
 
@@ -419,7 +419,7 @@ async function installSource(params: {
 
   const results: SkillInstallation[] = [];
   const installRelDir = relativeInstallDirFor({ agent, scope });
-  const scopeRoot = scope === "user" ? getHomeDirectory() : outputRoot;
+  const scopeRoot = scope === "user" ? getHomeDirectory() : projectRoot;
 
   // Source URL recorded in injected frontmatter. Mirrors the canonical form
   // used by `gh skill install`.
@@ -579,15 +579,15 @@ async function installSource(params: {
 async function removeStaleFile(params: {
   relativePath: string;
   scope: GhScope;
-  outputRoot: string;
+  projectRoot: string;
   logger: Logger;
 }): Promise<void> {
-  const { relativePath, scope, outputRoot, logger } = params;
+  const { relativePath, scope, projectRoot, logger } = params;
   if (posix.isAbsolute(relativePath) || relativePath.split(/[/\\]/).includes("..")) {
     logger.warn(`Refusing to remove stale gh file with suspicious path: "${relativePath}".`);
     return;
   }
-  const scopeRoot = scope === "user" ? getHomeDirectory() : outputRoot;
+  const scopeRoot = scope === "user" ? getHomeDirectory() : projectRoot;
   try {
     checkPathTraversal({ relativePath, intendedRootDir: scopeRoot });
   } catch {

--- a/src/lib/gh/gh-install.user-scope.test.ts
+++ b/src/lib/gh/gh-install.user-scope.test.ts
@@ -138,7 +138,7 @@ describe("installGh — user scope", () => {
     setupSingleSkill("git-commit", [{ name: "SKILL.md" }]);
 
     const result = await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger,
     });
@@ -159,7 +159,7 @@ describe("installGh — user scope", () => {
     setupSingleSkill("av-skill", [{ name: "SKILL.md" }]);
 
     await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "antigravity", scope: "user" })],
       logger,
     });
@@ -195,7 +195,7 @@ describe("installGh — user scope", () => {
 
     const localLogger = createMockLogger();
     await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger: localLogger,
     });
@@ -234,7 +234,7 @@ describe("installGh — user scope", () => {
     );
 
     await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger,
     });
@@ -256,7 +256,7 @@ describe("installGh — user scope", () => {
     );
 
     await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       options: { update: true },
       logger,
@@ -270,7 +270,7 @@ describe("installGh — user scope", () => {
     // Re-run install to trigger another stale-cleanup pass; the sentinel
     // (which is not in any lockfile entry) must survive.
     await installGh({
-      outputRoot: projectDir,
+      projectRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       options: { update: true },
       logger,

--- a/src/lib/gh/gh-install.user-scope.test.ts
+++ b/src/lib/gh/gh-install.user-scope.test.ts
@@ -138,7 +138,7 @@ describe("installGh — user scope", () => {
     setupSingleSkill("git-commit", [{ name: "SKILL.md" }]);
 
     const result = await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger,
     });
@@ -159,7 +159,7 @@ describe("installGh — user scope", () => {
     setupSingleSkill("av-skill", [{ name: "SKILL.md" }]);
 
     await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "antigravity", scope: "user" })],
       logger,
     });
@@ -195,7 +195,7 @@ describe("installGh — user scope", () => {
 
     const localLogger = createMockLogger();
     await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger: localLogger,
     });
@@ -234,7 +234,7 @@ describe("installGh — user scope", () => {
     );
 
     await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       logger,
     });
@@ -256,7 +256,7 @@ describe("installGh — user scope", () => {
     );
 
     await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       options: { update: true },
       logger,
@@ -270,7 +270,7 @@ describe("installGh — user scope", () => {
     // Re-run install to trigger another stale-cleanup pass; the sentinel
     // (which is not in any lockfile entry) must survive.
     await installGh({
-      baseDir: projectDir,
+      outputRoot: projectDir,
       sources: [source({ source: "owner/repo", agent: "claude-code", scope: "user" })],
       options: { update: true },
       logger,

--- a/src/lib/gh/gh-lock.test.ts
+++ b/src/lib/gh/gh-lock.test.ts
@@ -201,7 +201,7 @@ installations:
         install_dir: ".claude/skills",
         deployed_files: [],
       });
-      await writeGhLock({ baseDir: testDir, lock });
+      await writeGhLock({ outputRoot: testDir, lock });
       const written = await readFileContent(getGhLockPath(testDir));
       expect(written).toContain("lockfile_version:");
       const readBack = await readGhLock(testDir);

--- a/src/lib/gh/gh-lock.test.ts
+++ b/src/lib/gh/gh-lock.test.ts
@@ -201,7 +201,7 @@ installations:
         install_dir: ".claude/skills",
         deployed_files: [],
       });
-      await writeGhLock({ outputRoot: testDir, lock });
+      await writeGhLock({ projectRoot: testDir, lock });
       const written = await readFileContent(getGhLockPath(testDir));
       expect(written).toContain("lockfile_version:");
       const readBack = await readGhLock(testDir);

--- a/src/lib/gh/gh-lock.ts
+++ b/src/lib/gh/gh-lock.ts
@@ -54,12 +54,12 @@ export const GhLockSchema = z.looseObject({
 });
 export type GhLock = z.infer<typeof GhLockSchema>;
 
-export function getGhLockPath(outputRoot: string): string {
-  return join(outputRoot, GH_LOCKFILE_FILE_NAME);
+export function getGhLockPath(projectRoot: string): string {
+  return join(projectRoot, GH_LOCKFILE_FILE_NAME);
 }
 
-export async function ghLockExists(outputRoot: string): Promise<boolean> {
-  return fileExists(getGhLockPath(outputRoot));
+export async function ghLockExists(projectRoot: string): Promise<boolean> {
+  return fileExists(getGhLockPath(projectRoot));
 }
 
 /**
@@ -106,8 +106,8 @@ export function parseGhLock(content: string): GhLock | null {
   return parsed.data;
 }
 
-export async function readGhLock(outputRoot: string): Promise<GhLock | null> {
-  const path = getGhLockPath(outputRoot);
+export async function readGhLock(projectRoot: string): Promise<GhLock | null> {
+  const path = getGhLockPath(projectRoot);
   if (!(await fileExists(path))) {
     return null;
   }
@@ -115,8 +115,8 @@ export async function readGhLock(outputRoot: string): Promise<GhLock | null> {
   return parseGhLock(content);
 }
 
-export async function writeGhLock(params: { outputRoot: string; lock: GhLock }): Promise<void> {
-  const path = getGhLockPath(params.outputRoot);
+export async function writeGhLock(params: { projectRoot: string; lock: GhLock }): Promise<void> {
+  const path = getGhLockPath(params.projectRoot);
   const content = serializeGhLock(params.lock);
   await writeFileContent(path, content);
 }

--- a/src/lib/gh/gh-lock.ts
+++ b/src/lib/gh/gh-lock.ts
@@ -54,12 +54,12 @@ export const GhLockSchema = z.looseObject({
 });
 export type GhLock = z.infer<typeof GhLockSchema>;
 
-export function getGhLockPath(baseDir: string): string {
-  return join(baseDir, GH_LOCKFILE_FILE_NAME);
+export function getGhLockPath(outputRoot: string): string {
+  return join(outputRoot, GH_LOCKFILE_FILE_NAME);
 }
 
-export async function ghLockExists(baseDir: string): Promise<boolean> {
-  return fileExists(getGhLockPath(baseDir));
+export async function ghLockExists(outputRoot: string): Promise<boolean> {
+  return fileExists(getGhLockPath(outputRoot));
 }
 
 /**
@@ -106,8 +106,8 @@ export function parseGhLock(content: string): GhLock | null {
   return parsed.data;
 }
 
-export async function readGhLock(baseDir: string): Promise<GhLock | null> {
-  const path = getGhLockPath(baseDir);
+export async function readGhLock(outputRoot: string): Promise<GhLock | null> {
+  const path = getGhLockPath(outputRoot);
   if (!(await fileExists(path))) {
     return null;
   }
@@ -115,8 +115,8 @@ export async function readGhLock(baseDir: string): Promise<GhLock | null> {
   return parseGhLock(content);
 }
 
-export async function writeGhLock(params: { baseDir: string; lock: GhLock }): Promise<void> {
-  const path = getGhLockPath(params.baseDir);
+export async function writeGhLock(params: { outputRoot: string; lock: GhLock }): Promise<void> {
+  const path = getGhLockPath(params.outputRoot);
   const content = serializeGhLock(params.lock);
   await writeFileContent(path, content);
 }

--- a/src/lib/gh/gh-paths.test.ts
+++ b/src/lib/gh/gh-paths.test.ts
@@ -61,13 +61,13 @@ describe("resolveGhInstallDir", () => {
     await cleanup();
   });
 
-  it("returns absolute path under outputRoot for project scope", () => {
-    const outputRoot = "/tmp/some-project";
-    expect(resolveGhInstallDir({ agent: "github-copilot", scope: "project", outputRoot })).toBe(
-      join(outputRoot, ".agents", "skills"),
+  it("returns absolute path under projectRoot for project scope", () => {
+    const projectRoot = "/tmp/some-project";
+    expect(resolveGhInstallDir({ agent: "github-copilot", scope: "project", projectRoot })).toBe(
+      join(projectRoot, ".agents", "skills"),
     );
-    expect(resolveGhInstallDir({ agent: "claude-code", scope: "project", outputRoot })).toBe(
-      join(outputRoot, ".claude", "skills"),
+    expect(resolveGhInstallDir({ agent: "claude-code", scope: "project", projectRoot })).toBe(
+      join(projectRoot, ".claude", "skills"),
     );
   });
 
@@ -77,7 +77,7 @@ describe("resolveGhInstallDir", () => {
       ["antigravity", "user", join(testDir, ".gemini", "antigravity", "skills")],
     ];
     for (const [agent, scope, expected] of cases) {
-      expect(resolveGhInstallDir({ agent, scope, outputRoot: "/ignored" })).toBe(expected);
+      expect(resolveGhInstallDir({ agent, scope, projectRoot: "/ignored" })).toBe(expected);
     }
   });
 });

--- a/src/lib/gh/gh-paths.test.ts
+++ b/src/lib/gh/gh-paths.test.ts
@@ -61,13 +61,13 @@ describe("resolveGhInstallDir", () => {
     await cleanup();
   });
 
-  it("returns absolute path under baseDir for project scope", () => {
-    const baseDir = "/tmp/some-project";
-    expect(resolveGhInstallDir({ agent: "github-copilot", scope: "project", baseDir })).toBe(
-      join(baseDir, ".agents", "skills"),
+  it("returns absolute path under outputRoot for project scope", () => {
+    const outputRoot = "/tmp/some-project";
+    expect(resolveGhInstallDir({ agent: "github-copilot", scope: "project", outputRoot })).toBe(
+      join(outputRoot, ".agents", "skills"),
     );
-    expect(resolveGhInstallDir({ agent: "claude-code", scope: "project", baseDir })).toBe(
-      join(baseDir, ".claude", "skills"),
+    expect(resolveGhInstallDir({ agent: "claude-code", scope: "project", outputRoot })).toBe(
+      join(outputRoot, ".claude", "skills"),
     );
   });
 
@@ -77,7 +77,7 @@ describe("resolveGhInstallDir", () => {
       ["antigravity", "user", join(testDir, ".gemini", "antigravity", "skills")],
     ];
     for (const [agent, scope, expected] of cases) {
-      expect(resolveGhInstallDir({ agent, scope, baseDir: "/ignored" })).toBe(expected);
+      expect(resolveGhInstallDir({ agent, scope, outputRoot: "/ignored" })).toBe(expected);
     }
   });
 });

--- a/src/lib/gh/gh-paths.ts
+++ b/src/lib/gh/gh-paths.ts
@@ -24,27 +24,27 @@ export type GhScope = "project" | "user";
  * Resolve the absolute install directory for a given agent + scope, matching
  * the layout expected by `gh skill install`.
  *
- * Project scope writes inside `baseDir`. The `github-copilot` agent uses the
+ * Project scope writes inside `outputRoot`. The `github-copilot` agent uses the
  * shared `.agents/skills` directory (the host-agnostic project layout); other
  * agents that share that location (cursor, codex, gemini, antigravity) write
  * to `.agents/skills` for project scope and to their own `.<tool>/skills`
  * directory for user scope. Claude Code is the exception: project and user
- * scope both use `.claude/skills`, just rooted at `baseDir` vs the home
+ * scope both use `.claude/skills`, just rooted at `outputRoot` vs the home
  * directory respectively.
  */
 export function resolveGhInstallDir(params: {
   agent: GhAgent;
   scope: GhScope;
-  baseDir: string;
+  outputRoot: string;
 }): string {
-  const { agent, scope, baseDir } = params;
-  const home = scope === "user" ? getHomeDirectory() : baseDir;
+  const { agent, scope, outputRoot } = params;
+  const home = scope === "user" ? getHomeDirectory() : outputRoot;
   const relative = relativeInstallDirFor({ agent, scope });
   return join(home, relative);
 }
 
 /**
- * Returns the install directory relative to its scope root (baseDir for
+ * Returns the install directory relative to its scope root (outputRoot for
  * project scope, home for user scope). Exposed separately so the lockfile can
  * record the same canonical relative path it deploys to.
  */

--- a/src/lib/gh/gh-paths.ts
+++ b/src/lib/gh/gh-paths.ts
@@ -24,27 +24,27 @@ export type GhScope = "project" | "user";
  * Resolve the absolute install directory for a given agent + scope, matching
  * the layout expected by `gh skill install`.
  *
- * Project scope writes inside `outputRoot`. The `github-copilot` agent uses the
+ * Project scope writes inside `projectRoot`. The `github-copilot` agent uses the
  * shared `.agents/skills` directory (the host-agnostic project layout); other
  * agents that share that location (cursor, codex, gemini, antigravity) write
  * to `.agents/skills` for project scope and to their own `.<tool>/skills`
  * directory for user scope. Claude Code is the exception: project and user
- * scope both use `.claude/skills`, just rooted at `outputRoot` vs the home
+ * scope both use `.claude/skills`, just rooted at `projectRoot` vs the home
  * directory respectively.
  */
 export function resolveGhInstallDir(params: {
   agent: GhAgent;
   scope: GhScope;
-  outputRoot: string;
+  projectRoot: string;
 }): string {
-  const { agent, scope, outputRoot } = params;
-  const home = scope === "user" ? getHomeDirectory() : outputRoot;
+  const { agent, scope, projectRoot } = params;
+  const home = scope === "user" ? getHomeDirectory() : projectRoot;
   const relative = relativeInstallDirFor({ agent, scope });
   return join(home, relative);
 }
 
 /**
- * Returns the install directory relative to its scope root (outputRoot for
+ * Returns the install directory relative to its scope root (projectRoot for
  * project scope, home for user scope). Exposed separately so the lockfile can
  * record the same canonical relative path it deploys to.
  */

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -187,7 +187,7 @@ type WalkContext = { totalFiles: number; totalSize: number };
 
 async function walkDirectory(
   dir: string,
-  baseDir: string,
+  outputRoot: string,
   depth: number = 0,
   ctx: WalkContext = { totalFiles: 0, totalSize: 0 },
   logger?: Logger,
@@ -206,7 +206,7 @@ async function walkDirectory(
       continue;
     }
     if (await directoryExists(fullPath)) {
-      results.push(...(await walkDirectory(fullPath, baseDir, depth + 1, ctx, logger)));
+      results.push(...(await walkDirectory(fullPath, outputRoot, depth + 1, ctx, logger)));
     } else {
       const size = await getFileSize(fullPath);
       if (size > MAX_FILE_SIZE) {
@@ -228,7 +228,7 @@ async function walkDirectory(
         );
       }
       const content = await readFileContent(fullPath);
-      results.push({ relativePath: relative(baseDir, fullPath), content, size });
+      results.push({ relativePath: relative(outputRoot, fullPath), content, size });
     }
   }
   return results;

--- a/src/lib/import.test.ts
+++ b/src/lib/import.test.ts
@@ -26,7 +26,7 @@ describe("importFromTool", () => {
   let mockConfig: {
     getVerbose: ReturnType<typeof vi.fn>;
     getSilent: ReturnType<typeof vi.fn>;
-    getBaseDirs: ReturnType<typeof vi.fn>;
+    getOutputRoots: ReturnType<typeof vi.fn>;
     getFeatures: ReturnType<typeof vi.fn>;
     getFeatureOptions: ReturnType<typeof vi.fn>;
     getGlobal: ReturnType<typeof vi.fn>;
@@ -37,7 +37,7 @@ describe("importFromTool", () => {
     mockConfig = {
       getVerbose: vi.fn().mockReturnValue(false),
       getSilent: vi.fn().mockReturnValue(false),
-      getBaseDirs: vi.fn().mockReturnValue(["."]),
+      getOutputRoots: vi.fn().mockReturnValue(["."]),
       getFeatures: vi.fn().mockReturnValue(["rules"]),
       getFeatureOptions: vi.fn().mockReturnValue(undefined),
       getGlobal: vi.fn().mockReturnValue(false),
@@ -108,7 +108,7 @@ describe("importFromTool", () => {
       expect(result.rulesCount).toBe(1);
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -182,7 +182,7 @@ describe("importFromTool", () => {
       expect(result.ignoreCount).toBe(1);
       expect(IgnoreProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
         }),
       );
@@ -268,7 +268,7 @@ describe("importFromTool", () => {
       expect(result.mcpCount).toBe(1);
       expect(McpProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -341,7 +341,7 @@ describe("importFromTool", () => {
       expect(result.commandsCount).toBe(1);
       expect(CommandsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -425,7 +425,7 @@ describe("importFromTool", () => {
       expect(result.subagentsCount).toBe(1);
       expect(SubagentsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -509,7 +509,7 @@ describe("importFromTool", () => {
       expect(result.skillsCount).toBe(1);
       expect(SkillsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -605,7 +605,7 @@ describe("importFromTool", () => {
       expect(result.hooksCount).toBe(1);
       expect(HooksProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: false,
         }),
@@ -664,7 +664,7 @@ describe("importFromTool", () => {
       expect(result.permissionsCount).toBe(1);
       expect(PermissionsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
         }),
       );
@@ -699,7 +699,7 @@ describe("importFromTool", () => {
       expect(result.permissionsCount).toBe(1);
       expect(PermissionsProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
           toolTarget: "claudecode",
           global: true,
         }),
@@ -806,29 +806,29 @@ describe("importFromTool", () => {
     });
   });
 
-  describe("baseDir handling", () => {
-    it("should use first baseDir from config", async () => {
+  describe("outputRoot handling", () => {
+    it("should use first outputRoot from config", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue(["/custom/path", "/other/path"]);
+      mockConfig.getOutputRoots.mockReturnValue(["/custom/path", "/other/path"]);
 
       await importFromTool({ logger, config: mockConfig as never, tool: "claudecode" });
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: "/custom/path",
+          outputRoot: "/custom/path",
         }),
       );
     });
 
-    it("should fall back to '.' when baseDirs is empty", async () => {
+    it("should fall back to '.' when outputRoots is empty", async () => {
       mockConfig.getFeatures.mockReturnValue(["rules"]);
-      mockConfig.getBaseDirs.mockReturnValue([]);
+      mockConfig.getOutputRoots.mockReturnValue([]);
 
       await importFromTool({ logger, config: mockConfig as never, tool: "claudecode" });
 
       expect(RulesProcessor).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseDir: ".",
+          outputRoot: ".",
         }),
       );
     });

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -72,7 +72,7 @@ async function importRulesCore(params: {
   }
 
   const rulesProcessor = new RulesProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global,
     logger,
@@ -115,7 +115,7 @@ async function importIgnoreCore(params: {
   }
 
   const ignoreProcessor = new IgnoreProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     logger,
     featureOptions: config.getFeatureOptions(tool, "ignore"),
@@ -161,7 +161,7 @@ async function importMcpCore(params: {
   }
 
   const mcpProcessor = new McpProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global,
     logger,
@@ -203,7 +203,7 @@ async function importCommandsCore(params: {
   }
 
   const commandsProcessor = new CommandsProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global,
     logger,
@@ -244,7 +244,7 @@ async function importSubagentsCore(params: {
   }
 
   const subagentsProcessor = new SubagentsProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global: config.getGlobal(),
     logger,
@@ -286,7 +286,7 @@ async function importSkillsCore(params: {
   }
 
   const skillsProcessor = new SkillsProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global,
     logger,
@@ -333,7 +333,7 @@ async function importHooksCore(params: {
   }
 
   const hooksProcessor = new HooksProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global,
     logger,
@@ -382,7 +382,7 @@ async function importPermissionsCore(params: {
   }
 
   const permissionsProcessor = new PermissionsProcessor({
-    baseDir: config.getBaseDirs()[0] ?? ".",
+    outputRoot: config.getOutputRoots()[0] ?? ".",
     toolTarget: tool,
     global: config.getGlobal(),
     logger,

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -55,7 +55,7 @@ async function createConfigFile(): Promise<InitFileResult> {
         $schema: RULESYNC_CONFIG_SCHEMA_URL,
         targets: ["copilot", "cursor", "claudecode", "codexcli"],
         features: ["rules", "ignore", "mcp", "commands", "subagents", "skills", "hooks"],
-        baseDirs: ["."],
+        outputRoots: ["."],
         delete: true,
         verbose: false,
         silent: false,

--- a/src/lib/sources-lock.test.ts
+++ b/src/lib/sources-lock.test.ts
@@ -48,7 +48,7 @@ describe("sources-lock", () => {
     });
 
     it("should return empty lock when file does not exist", async () => {
-      const lock = await readLockFile({ logger, outputRoot: testDir });
+      const lock = await readLockFile({ logger, projectRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -68,7 +68,7 @@ describe("sources-lock", () => {
 
       await writeFileContent(join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH), lockContent);
 
-      const lock = await readLockFile({ logger, outputRoot: testDir });
+      const lock = await readLockFile({ logger, projectRoot: testDir });
 
       expect(lock.sources["https://github.com/org/repo"]).toEqual({
         resolvedRef: VALID_SHA,
@@ -82,7 +82,7 @@ describe("sources-lock", () => {
     it("should return empty lock for invalid JSON", async () => {
       await writeFileContent(join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH), "not-json");
 
-      const lock = await readLockFile({ logger, outputRoot: testDir });
+      const lock = await readLockFile({ logger, projectRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -92,7 +92,7 @@ describe("sources-lock", () => {
         JSON.stringify({ wrong: "shape" }),
       );
 
-      const lock = await readLockFile({ logger, outputRoot: testDir });
+      const lock = await readLockFile({ logger, projectRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -111,7 +111,7 @@ describe("sources-lock", () => {
         legacyContent,
       );
 
-      const lock = await readLockFile({ logger, outputRoot: testDir });
+      const lock = await readLockFile({ logger, projectRoot: testDir });
 
       expect(lock).toEqual({
         lockfileVersion: 1,
@@ -155,7 +155,7 @@ describe("sources-lock", () => {
         },
       };
 
-      await writeLockFile({ logger, outputRoot: testDir, lock });
+      await writeLockFile({ logger, projectRoot: testDir, lock });
 
       const expectedPath = join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
       const written = await readFileContent(expectedPath);

--- a/src/lib/sources-lock.test.ts
+++ b/src/lib/sources-lock.test.ts
@@ -48,7 +48,7 @@ describe("sources-lock", () => {
     });
 
     it("should return empty lock when file does not exist", async () => {
-      const lock = await readLockFile({ logger, baseDir: testDir });
+      const lock = await readLockFile({ logger, outputRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -68,7 +68,7 @@ describe("sources-lock", () => {
 
       await writeFileContent(join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH), lockContent);
 
-      const lock = await readLockFile({ logger, baseDir: testDir });
+      const lock = await readLockFile({ logger, outputRoot: testDir });
 
       expect(lock.sources["https://github.com/org/repo"]).toEqual({
         resolvedRef: VALID_SHA,
@@ -82,7 +82,7 @@ describe("sources-lock", () => {
     it("should return empty lock for invalid JSON", async () => {
       await writeFileContent(join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH), "not-json");
 
-      const lock = await readLockFile({ logger, baseDir: testDir });
+      const lock = await readLockFile({ logger, outputRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -92,7 +92,7 @@ describe("sources-lock", () => {
         JSON.stringify({ wrong: "shape" }),
       );
 
-      const lock = await readLockFile({ logger, baseDir: testDir });
+      const lock = await readLockFile({ logger, outputRoot: testDir });
       expect(lock).toEqual({ lockfileVersion: 1, sources: {} });
     });
 
@@ -111,7 +111,7 @@ describe("sources-lock", () => {
         legacyContent,
       );
 
-      const lock = await readLockFile({ logger, baseDir: testDir });
+      const lock = await readLockFile({ logger, outputRoot: testDir });
 
       expect(lock).toEqual({
         lockfileVersion: 1,
@@ -155,7 +155,7 @@ describe("sources-lock", () => {
         },
       };
 
-      await writeLockFile({ logger, baseDir: testDir, lock });
+      await writeLockFile({ logger, outputRoot: testDir, lock });
 
       const expectedPath = join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
       const written = await readFileContent(expectedPath);

--- a/src/lib/sources-lock.ts
+++ b/src/lib/sources-lock.ts
@@ -90,11 +90,11 @@ export function createEmptyLock(): SourcesLock {
  * @returns The parsed lockfile, or an empty lockfile if it doesn't exist or is invalid.
  */
 export async function readLockFile(params: {
-  baseDir: string;
+  outputRoot: string;
   logger: Logger;
 }): Promise<SourcesLock> {
   const { logger } = params;
-  const lockPath = join(params.baseDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
+  const lockPath = join(params.outputRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
 
   if (!(await fileExists(lockPath))) {
     logger.debug("No sources lockfile found, starting fresh.");
@@ -133,12 +133,12 @@ export async function readLockFile(params: {
  * Write the lockfile to disk.
  */
 export async function writeLockFile(params: {
-  baseDir: string;
+  outputRoot: string;
   lock: SourcesLock;
   logger: Logger;
 }): Promise<void> {
   const { logger } = params;
-  const lockPath = join(params.baseDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
+  const lockPath = join(params.outputRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
   const content = JSON.stringify(params.lock, null, 2) + "\n";
   await writeFileContent(lockPath, content);
   logger.debug(`Wrote sources lockfile to ${lockPath}`);

--- a/src/lib/sources-lock.ts
+++ b/src/lib/sources-lock.ts
@@ -90,11 +90,11 @@ export function createEmptyLock(): SourcesLock {
  * @returns The parsed lockfile, or an empty lockfile if it doesn't exist or is invalid.
  */
 export async function readLockFile(params: {
-  outputRoot: string;
+  projectRoot: string;
   logger: Logger;
 }): Promise<SourcesLock> {
   const { logger } = params;
-  const lockPath = join(params.outputRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
+  const lockPath = join(params.projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
 
   if (!(await fileExists(lockPath))) {
     logger.debug("No sources lockfile found, starting fresh.");
@@ -133,12 +133,12 @@ export async function readLockFile(params: {
  * Write the lockfile to disk.
  */
 export async function writeLockFile(params: {
-  outputRoot: string;
+  projectRoot: string;
   lock: SourcesLock;
   logger: Logger;
 }): Promise<void> {
   const { logger } = params;
-  const lockPath = join(params.outputRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
+  const lockPath = join(params.projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
   const content = JSON.stringify(params.lock, null, 2) + "\n";
   await writeFileContent(lockPath, content);
   logger.debug(`Wrote sources lockfile to ${lockPath}`);

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -109,7 +109,7 @@ describe("resolveAndFetchSources", () => {
   });
 
   it("should return zero counts with empty sources", async () => {
-    const result = await resolveAndFetchSources({ logger, sources: [], baseDir: testDir });
+    const result = await resolveAndFetchSources({ logger, sources: [], outputRoot: testDir });
 
     expect(result).toEqual({ fetchedSkillCount: 0, sourcesProcessed: 0 });
   });
@@ -118,7 +118,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
       options: { skipSources: true },
     });
 
@@ -158,7 +158,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Only old-skill-a should be removed (it existed on disk)
@@ -191,7 +191,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Should not call listDirectory (no re-fetch)
@@ -221,7 +221,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -257,7 +257,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Skill should be skipped since local takes precedence
@@ -285,7 +285,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo", skills: ["skill-a"] }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Only skill-a should be fetched
@@ -318,7 +318,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://github.com/org/repo-a" },
         { source: "https://github.com/org/repo-b" },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // First source fetches it, second source skips it
@@ -332,7 +332,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Should not throw, just skip the source
@@ -371,7 +371,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
       options: { updateSources: true },
     });
 
@@ -411,7 +411,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://github.com/org/failing-repo" },
         { source: "https://github.com/org/good-repo" },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Second source should succeed despite first failing
@@ -423,7 +423,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "gitlab:org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Should not throw, but log error and skip
@@ -458,7 +458,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/new-repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // The written lock should NOT contain the old-removed-repo entry
@@ -494,7 +494,7 @@ describe("resolveAndFetchSources", () => {
       logger,
       // Config uses full URL but lock has normalized key
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Lockfile should be unchanged (not written) since SHA matches and nothing new
@@ -527,7 +527,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Only the good skill should be fetched; the traversal one is skipped
@@ -546,7 +546,7 @@ describe("resolveAndFetchSources", () => {
       resolveAndFetchSources({
         logger,
         sources: [{ source: "https://github.com/org/repo" }],
-        baseDir: testDir,
+        outputRoot: testDir,
         options: { frozen: true },
       }),
     ).rejects.toThrow("Frozen install failed");
@@ -575,7 +575,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
       options: { frozen: true },
     });
 
@@ -617,7 +617,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
       options: { frozen: true },
     });
 
@@ -662,7 +662,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // Should have warned about integrity mismatch
@@ -721,7 +721,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // The written lock should still have both skills
@@ -746,7 +746,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/project/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -769,7 +769,7 @@ describe("resolveAndFetchSources", () => {
       sources: [
         { source: "file:///local/clone", transport: "git", ref: "develop", path: "exports/skills" },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(vi.mocked(resolveRefToSha)).toHaveBeenCalledWith("file:///local/clone", "develop");
@@ -799,7 +799,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
       options: { frozen: true },
     });
 
@@ -831,7 +831,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -855,7 +855,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["skill-a"],
         },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -881,7 +881,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -901,7 +901,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://dev.azure.com/org/_git/repo-a", transport: "git" },
         { source: "https://dev.azure.com/org/_git/repo-b", transport: "git" },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // First source fetches it, second source skips it
@@ -933,7 +933,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Integrity mismatch"));
@@ -961,7 +961,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://dev.azure.com/org/_git/failing", transport: "git" },
         { source: "https://dev.azure.com/org/_git/good", transport: "git" },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -997,7 +997,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     // The lockfile should contain only "new-skill", not "old-skill"
@@ -1027,7 +1027,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1053,7 +1053,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1079,7 +1079,7 @@ describe("resolveAndFetchSources", () => {
           // no skills → defaults to ["*"]
         },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -1109,7 +1109,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "org/humanizer:skills", skills: ["humanizer"] }],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1135,7 +1135,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      baseDir: testDir,
+      outputRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -109,7 +109,7 @@ describe("resolveAndFetchSources", () => {
   });
 
   it("should return zero counts with empty sources", async () => {
-    const result = await resolveAndFetchSources({ logger, sources: [], outputRoot: testDir });
+    const result = await resolveAndFetchSources({ logger, sources: [], projectRoot: testDir });
 
     expect(result).toEqual({ fetchedSkillCount: 0, sourcesProcessed: 0 });
   });
@@ -118,7 +118,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
       options: { skipSources: true },
     });
 
@@ -158,7 +158,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Only old-skill-a should be removed (it existed on disk)
@@ -191,7 +191,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Should not call listDirectory (no re-fetch)
@@ -221,7 +221,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -257,7 +257,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Skill should be skipped since local takes precedence
@@ -285,7 +285,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo", skills: ["skill-a"] }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Only skill-a should be fetched
@@ -318,7 +318,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://github.com/org/repo-a" },
         { source: "https://github.com/org/repo-b" },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // First source fetches it, second source skips it
@@ -332,7 +332,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Should not throw, just skip the source
@@ -371,7 +371,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
       options: { updateSources: true },
     });
 
@@ -411,7 +411,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://github.com/org/failing-repo" },
         { source: "https://github.com/org/good-repo" },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Second source should succeed despite first failing
@@ -423,7 +423,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "gitlab:org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Should not throw, but log error and skip
@@ -458,7 +458,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/new-repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // The written lock should NOT contain the old-removed-repo entry
@@ -494,7 +494,7 @@ describe("resolveAndFetchSources", () => {
       logger,
       // Config uses full URL but lock has normalized key
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Lockfile should be unchanged (not written) since SHA matches and nothing new
@@ -527,7 +527,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Only the good skill should be fetched; the traversal one is skipped
@@ -546,7 +546,7 @@ describe("resolveAndFetchSources", () => {
       resolveAndFetchSources({
         logger,
         sources: [{ source: "https://github.com/org/repo" }],
-        outputRoot: testDir,
+        projectRoot: testDir,
         options: { frozen: true },
       }),
     ).rejects.toThrow("Frozen install failed");
@@ -575,7 +575,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
       options: { frozen: true },
     });
 
@@ -617,7 +617,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
       options: { frozen: true },
     });
 
@@ -662,7 +662,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // Should have warned about integrity mismatch
@@ -721,7 +721,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://github.com/org/repo" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // The written lock should still have both skills
@@ -746,7 +746,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/project/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -769,7 +769,7 @@ describe("resolveAndFetchSources", () => {
       sources: [
         { source: "file:///local/clone", transport: "git", ref: "develop", path: "exports/skills" },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(vi.mocked(resolveRefToSha)).toHaveBeenCalledWith("file:///local/clone", "develop");
@@ -799,7 +799,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
       options: { frozen: true },
     });
 
@@ -831,7 +831,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -855,7 +855,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["skill-a"],
         },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -881,7 +881,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -901,7 +901,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://dev.azure.com/org/_git/repo-a", transport: "git" },
         { source: "https://dev.azure.com/org/_git/repo-b", transport: "git" },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // First source fetches it, second source skips it
@@ -933,7 +933,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Integrity mismatch"));
@@ -961,7 +961,7 @@ describe("resolveAndFetchSources", () => {
         { source: "https://dev.azure.com/org/_git/failing", transport: "git" },
         { source: "https://dev.azure.com/org/_git/good", transport: "git" },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -997,7 +997,7 @@ describe("resolveAndFetchSources", () => {
     await resolveAndFetchSources({
       logger,
       sources: [{ source: "https://dev.azure.com/org/_git/repo", transport: "git" }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     // The lockfile should contain only "new-skill", not "old-skill"
@@ -1027,7 +1027,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1053,7 +1053,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1079,7 +1079,7 @@ describe("resolveAndFetchSources", () => {
           // no skills → defaults to ["*"]
         },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(0);
@@ -1109,7 +1109,7 @@ describe("resolveAndFetchSources", () => {
     const result = await resolveAndFetchSources({
       logger,
       sources: [{ source: "org/humanizer:skills", skills: ["humanizer"] }],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);
@@ -1135,7 +1135,7 @@ describe("resolveAndFetchSources", () => {
           skills: ["humanizer"],
         },
       ],
-      outputRoot: testDir,
+      projectRoot: testDir,
     });
 
     expect(result.fetchedSkillCount).toBe(1);

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -68,11 +68,11 @@ type RemoteSkillFile = {
  */
 export async function resolveAndFetchSources(params: {
   sources: SourceEntry[];
-  baseDir: string;
+  outputRoot: string;
   options?: ResolveAndFetchSourcesOptions;
   logger: Logger;
 }): Promise<ResolveAndFetchSourcesResult> {
-  const { sources, baseDir, options = {}, logger } = params;
+  const { sources, outputRoot, options = {}, logger } = params;
 
   if (sources.length === 0) {
     return { fetchedSkillCount: 0, sourcesProcessed: 0 };
@@ -86,7 +86,7 @@ export async function resolveAndFetchSources(params: {
   // Read existing lockfile
   let lock: SourcesLock = options.updateSources
     ? createEmptyLock()
-    : await readLockFile({ baseDir, logger });
+    : await readLockFile({ outputRoot, logger });
 
   // Frozen mode: validate lockfile covers all declared sources.
   // Missing curated skills are fetched using locked refs.
@@ -113,7 +113,7 @@ export async function resolveAndFetchSources(params: {
   const client = new GitHubClient({ token });
 
   // Determine local skills (in .rulesync/skills/ but not in .curated/)
-  const localSkillNames = await getLocalSkillDirNames(baseDir);
+  const localSkillNames = await getLocalSkillDirNames(outputRoot);
 
   let totalSkillCount = 0;
   const allFetchedSkillNames = new Set<string>();
@@ -125,7 +125,7 @@ export async function resolveAndFetchSources(params: {
       if (transport === "git") {
         result = await fetchSourceViaGit({
           sourceEntry,
-          baseDir,
+          outputRoot,
           lock,
           localSkillNames,
           alreadyFetchedSkillNames: allFetchedSkillNames,
@@ -137,7 +137,7 @@ export async function resolveAndFetchSources(params: {
         result = await fetchSource({
           sourceEntry,
           client,
-          baseDir,
+          outputRoot,
           lock,
           localSkillNames,
           alreadyFetchedSkillNames: allFetchedSkillNames,
@@ -176,7 +176,7 @@ export async function resolveAndFetchSources(params: {
 
   // Only write lockfile if it has changed (and not in frozen mode)
   if (!options.frozen && JSON.stringify(lock) !== originalLockJson) {
-    await writeLockFile({ baseDir, lock, logger });
+    await writeLockFile({ outputRoot, lock, logger });
   } else {
     logger.debug("Lockfile unchanged, skipping write.");
   }
@@ -418,7 +418,7 @@ function groupRemoteFilesBySkillRoot(params: {
 async function fetchSource(params: {
   sourceEntry: SourceEntry;
   client: GitHubClient;
-  baseDir: string;
+  outputRoot: string;
   lock: SourcesLock;
   localSkillNames: Set<string>;
   alreadyFetchedSkillNames: Set<string>;
@@ -432,7 +432,7 @@ async function fetchSource(params: {
   const {
     sourceEntry,
     client,
-    baseDir,
+    outputRoot,
     localSkillNames,
     alreadyFetchedSkillNames,
     updateSources,
@@ -470,7 +470,7 @@ async function fetchSource(params: {
     logger.debug(`Resolved ${sourceKey} ref "${requestedRef}" to SHA: ${resolvedSha}`);
   }
 
-  const curatedDir = join(baseDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const curatedDir = join(outputRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
 
   // Skip re-fetch if SHA matches lockfile and curated skills exist on disk
   if (locked && resolvedSha === locked.resolvedRef && !updateSources) {
@@ -653,7 +653,7 @@ async function fetchSource(params: {
  */
 async function fetchSourceViaGit(params: {
   sourceEntry: SourceEntry;
-  baseDir: string;
+  outputRoot: string;
   lock: SourcesLock;
   localSkillNames: Set<string>;
   alreadyFetchedSkillNames: Set<string>;
@@ -663,7 +663,7 @@ async function fetchSourceViaGit(params: {
 }): Promise<{ skillCount: number; fetchedSkillNames: string[]; updatedLock: SourcesLock }> {
   const {
     sourceEntry,
-    baseDir,
+    outputRoot,
     localSkillNames,
     alreadyFetchedSkillNames,
     updateSources,
@@ -693,7 +693,7 @@ async function fetchSourceViaGit(params: {
     resolvedSha = def.sha;
   }
 
-  const curatedDir = join(baseDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const curatedDir = join(outputRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
   if (locked && resolvedSha === locked.resolvedRef && !updateSources) {
     if (await checkLockedSkillsExist(curatedDir, lockedSkillNames)) {
       return { skillCount: 0, fetchedSkillNames: lockedSkillNames, updatedLock: lock };

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -68,11 +68,11 @@ type RemoteSkillFile = {
  */
 export async function resolveAndFetchSources(params: {
   sources: SourceEntry[];
-  outputRoot: string;
+  projectRoot: string;
   options?: ResolveAndFetchSourcesOptions;
   logger: Logger;
 }): Promise<ResolveAndFetchSourcesResult> {
-  const { sources, outputRoot, options = {}, logger } = params;
+  const { sources, projectRoot, options = {}, logger } = params;
 
   if (sources.length === 0) {
     return { fetchedSkillCount: 0, sourcesProcessed: 0 };
@@ -86,7 +86,7 @@ export async function resolveAndFetchSources(params: {
   // Read existing lockfile
   let lock: SourcesLock = options.updateSources
     ? createEmptyLock()
-    : await readLockFile({ outputRoot, logger });
+    : await readLockFile({ projectRoot, logger });
 
   // Frozen mode: validate lockfile covers all declared sources.
   // Missing curated skills are fetched using locked refs.
@@ -113,7 +113,7 @@ export async function resolveAndFetchSources(params: {
   const client = new GitHubClient({ token });
 
   // Determine local skills (in .rulesync/skills/ but not in .curated/)
-  const localSkillNames = await getLocalSkillDirNames(outputRoot);
+  const localSkillNames = await getLocalSkillDirNames(projectRoot);
 
   let totalSkillCount = 0;
   const allFetchedSkillNames = new Set<string>();
@@ -125,7 +125,7 @@ export async function resolveAndFetchSources(params: {
       if (transport === "git") {
         result = await fetchSourceViaGit({
           sourceEntry,
-          outputRoot,
+          projectRoot,
           lock,
           localSkillNames,
           alreadyFetchedSkillNames: allFetchedSkillNames,
@@ -137,7 +137,7 @@ export async function resolveAndFetchSources(params: {
         result = await fetchSource({
           sourceEntry,
           client,
-          outputRoot,
+          projectRoot,
           lock,
           localSkillNames,
           alreadyFetchedSkillNames: allFetchedSkillNames,
@@ -176,7 +176,7 @@ export async function resolveAndFetchSources(params: {
 
   // Only write lockfile if it has changed (and not in frozen mode)
   if (!options.frozen && JSON.stringify(lock) !== originalLockJson) {
-    await writeLockFile({ outputRoot, lock, logger });
+    await writeLockFile({ projectRoot, lock, logger });
   } else {
     logger.debug("Lockfile unchanged, skipping write.");
   }
@@ -418,7 +418,7 @@ function groupRemoteFilesBySkillRoot(params: {
 async function fetchSource(params: {
   sourceEntry: SourceEntry;
   client: GitHubClient;
-  outputRoot: string;
+  projectRoot: string;
   lock: SourcesLock;
   localSkillNames: Set<string>;
   alreadyFetchedSkillNames: Set<string>;
@@ -432,7 +432,7 @@ async function fetchSource(params: {
   const {
     sourceEntry,
     client,
-    outputRoot,
+    projectRoot,
     localSkillNames,
     alreadyFetchedSkillNames,
     updateSources,
@@ -470,7 +470,7 @@ async function fetchSource(params: {
     logger.debug(`Resolved ${sourceKey} ref "${requestedRef}" to SHA: ${resolvedSha}`);
   }
 
-  const curatedDir = join(outputRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const curatedDir = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
 
   // Skip re-fetch if SHA matches lockfile and curated skills exist on disk
   if (locked && resolvedSha === locked.resolvedRef && !updateSources) {
@@ -653,7 +653,7 @@ async function fetchSource(params: {
  */
 async function fetchSourceViaGit(params: {
   sourceEntry: SourceEntry;
-  outputRoot: string;
+  projectRoot: string;
   lock: SourcesLock;
   localSkillNames: Set<string>;
   alreadyFetchedSkillNames: Set<string>;
@@ -663,7 +663,7 @@ async function fetchSourceViaGit(params: {
 }): Promise<{ skillCount: number; fetchedSkillNames: string[]; updatedLock: SourcesLock }> {
   const {
     sourceEntry,
-    outputRoot,
+    projectRoot,
     localSkillNames,
     alreadyFetchedSkillNames,
     updateSources,
@@ -693,7 +693,7 @@ async function fetchSourceViaGit(params: {
     resolvedSha = def.sha;
   }
 
-  const curatedDir = join(outputRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const curatedDir = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
   if (locked && resolvedSha === locked.resolvedRef && !updateSources) {
     if (await checkLockedSkillsExist(curatedDir, lockedSkillNames)) {
       return { skillCount: 0, fetchedSkillNames: lockedSkillNames, updatedLock: lock };

--- a/src/mcp/commands.ts
+++ b/src/mcp/commands.ts
@@ -154,7 +154,7 @@ async function putCommand({
     // Create a new RulesyncCommand instance
     const fileContent = stringifyFrontmatter(body, frontmatter);
     const command = new RulesyncCommand({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
       relativeFilePath: filename,
       frontmatter,

--- a/src/mcp/convert.ts
+++ b/src/mcp/convert.ts
@@ -13,7 +13,7 @@ import { type McpResultCounts } from "./types.js";
 /**
  * Schema for convert options
  * Excluded parameters:
- * - baseDirs: Always use [process.cwd()] in MCP context
+ * - outputRoots: Always use [process.cwd()] in MCP context
  * - verbose: Meaningless in MCP (no console output)
  * - silent: Meaningless in MCP
  * - configPath: Always use default path from process.cwd()
@@ -98,7 +98,7 @@ export async function executeConvert(options: ConvertOptions): Promise<McpConver
       features: (options.features ?? ["*"]) as RulesyncFeatures,
       global: options.global,
       dryRun: options.dryRun,
-      // Always use default baseDirs (process.cwd()) and configPath
+      // Always use default outputRoots (process.cwd()) and configPath
       // verbose and silent are meaningless in MCP context
       verbose: false,
       silent: true,

--- a/src/mcp/generate.ts
+++ b/src/mcp/generate.ts
@@ -13,7 +13,7 @@ import { type McpResultCounts } from "./types.js";
 /**
  * Schema for generate options
  * Excluded parameters:
- * - baseDirs: Always use [process.cwd()] in MCP context
+ * - outputRoots: Always use [process.cwd()] in MCP context
  * - verbose: Meaningless in MCP (no console output)
  * - silent: Meaningless in MCP
  * - configPath: Always use default path from process.cwd()
@@ -52,7 +52,7 @@ export type McpGenerateResult = {
 export async function executeGenerate(options: GenerateOptions = {}): Promise<McpGenerateResult> {
   try {
     // Check if .rulesync directory exists
-    const exists = await checkRulesyncDirExists({ baseDir: process.cwd() });
+    const exists = await checkRulesyncDirExists({ outputRoot: process.cwd() });
     if (!exists) {
       return {
         success: false,
@@ -74,7 +74,7 @@ export async function executeGenerate(options: GenerateOptions = {}): Promise<Mc
       simulateCommands: options.simulateCommands,
       simulateSubagents: options.simulateSubagents,
       simulateSkills: options.simulateSkills,
-      // Always use default baseDirs (process.cwd()) and configPath
+      // Always use default outputRoots (process.cwd()) and configPath
       // verbose and silent are meaningless in MCP context
       verbose: false,
       silent: true,

--- a/src/mcp/generate.ts
+++ b/src/mcp/generate.ts
@@ -52,7 +52,7 @@ export type McpGenerateResult = {
 export async function executeGenerate(options: GenerateOptions = {}): Promise<McpGenerateResult> {
   try {
     // Check if .rulesync directory exists
-    const exists = await checkRulesyncDirExists({ outputRoot: process.cwd() });
+    const exists = await checkRulesyncDirExists({ inputRoot: process.cwd() });
     if (!exists) {
       return {
         success: false,

--- a/src/mcp/hooks.ts
+++ b/src/mcp/hooks.ts
@@ -67,16 +67,16 @@ async function putHooksFile({ content }: { content: string }): Promise<{
   }
 
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncHooks.getSettablePaths();
 
     const relativeDirPath = paths.relativeDirPath;
     const relativeFilePath = paths.relativeFilePath;
-    const fullPath = join(baseDir, relativeDirPath, relativeFilePath);
+    const fullPath = join(outputRoot, relativeDirPath, relativeFilePath);
 
     // Create a RulesyncHooks instance to validate the content
     const rulesyncHooks = new RulesyncHooks({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: content,
@@ -84,7 +84,7 @@ async function putHooksFile({ content }: { content: string }): Promise<{
     });
 
     // Ensure directory exists
-    await ensureDir(join(baseDir, relativeDirPath));
+    await ensureDir(join(outputRoot, relativeDirPath));
 
     // Write the file
     await writeFileContent(fullPath, content);
@@ -112,10 +112,10 @@ async function deleteHooksFile(): Promise<{
   relativePathFromCwd: string;
 }> {
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncHooks.getSettablePaths();
 
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
 
     await removeFile(filePath);
 

--- a/src/mcp/import.ts
+++ b/src/mcp/import.ts
@@ -14,7 +14,7 @@ import { type McpResultCounts } from "./types.js";
  * Schema for import options
  * Note: Import requires exactly one target tool
  * Excluded parameters:
- * - baseDirs: Always use [process.cwd()] in MCP context
+ * - outputRoots: Always use [process.cwd()] in MCP context
  * - verbose: Meaningless in MCP (no console output)
  * - silent: Meaningless in MCP
  * - configPath: Always use default path from process.cwd()
@@ -63,7 +63,7 @@ export async function executeImport(options: ImportOptions): Promise<McpImportRe
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       features: options.features as RulesyncFeatures | undefined,
       global: options.global,
-      // Always use default baseDirs (process.cwd()) and configPath
+      // Always use default outputRoots (process.cwd()) and configPath
       // verbose and silent are meaningless in MCP context
       verbose: false,
       silent: true,

--- a/src/mcp/mcp.ts
+++ b/src/mcp/mcp.ts
@@ -67,17 +67,17 @@ async function putMcpFile({ content }: { content: string }): Promise<{
   }
 
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncMcp.getSettablePaths();
 
     // Use recommended path
     const relativeDirPath = paths.recommended.relativeDirPath;
     const relativeFilePath = paths.recommended.relativeFilePath;
-    const fullPath = join(baseDir, relativeDirPath, relativeFilePath);
+    const fullPath = join(outputRoot, relativeDirPath, relativeFilePath);
 
     // Create a RulesyncMcp instance to validate the content
     const rulesyncMcp = new RulesyncMcp({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: content,
@@ -85,7 +85,7 @@ async function putMcpFile({ content }: { content: string }): Promise<{
     });
 
     // Ensure directory exists
-    await ensureDir(join(baseDir, relativeDirPath));
+    await ensureDir(join(outputRoot, relativeDirPath));
 
     // Write the file
     await writeFileContent(fullPath, content);
@@ -113,16 +113,20 @@ async function deleteMcpFile(): Promise<{
   relativePathFromCwd: string;
 }> {
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncMcp.getSettablePaths();
 
     // Try to delete both recommended and legacy paths
     const recommendedPath = join(
-      baseDir,
+      outputRoot,
       paths.recommended.relativeDirPath,
       paths.recommended.relativeFilePath,
     );
-    const legacyPath = join(baseDir, paths.legacy.relativeDirPath, paths.legacy.relativeFilePath);
+    const legacyPath = join(
+      outputRoot,
+      paths.legacy.relativeDirPath,
+      paths.legacy.relativeFilePath,
+    );
 
     // Remove recommended path if it exists
     await removeFile(recommendedPath);

--- a/src/mcp/permissions.ts
+++ b/src/mcp/permissions.ts
@@ -67,16 +67,16 @@ async function putPermissionsFile({ content }: { content: string }): Promise<{
   }
 
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncPermissions.getSettablePaths();
 
     const relativeDirPath = paths.relativeDirPath;
     const relativeFilePath = paths.relativeFilePath;
-    const fullPath = join(baseDir, relativeDirPath, relativeFilePath);
+    const fullPath = join(outputRoot, relativeDirPath, relativeFilePath);
 
     // Create a RulesyncPermissions instance to validate the content
     const rulesyncPermissions = new RulesyncPermissions({
-      baseDir,
+      outputRoot,
       relativeDirPath,
       relativeFilePath,
       fileContent: content,
@@ -84,7 +84,7 @@ async function putPermissionsFile({ content }: { content: string }): Promise<{
     });
 
     // Ensure directory exists
-    await ensureDir(join(baseDir, relativeDirPath));
+    await ensureDir(join(outputRoot, relativeDirPath));
 
     // Write the file
     await writeFileContent(fullPath, content);
@@ -112,10 +112,10 @@ async function deletePermissionsFile(): Promise<{
   relativePathFromCwd: string;
 }> {
   try {
-    const baseDir = process.cwd();
+    const outputRoot = process.cwd();
     const paths = RulesyncPermissions.getSettablePaths();
 
-    const filePath = join(baseDir, paths.relativeDirPath, paths.relativeFilePath);
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
 
     await removeFile(filePath);
 

--- a/src/mcp/rules.ts
+++ b/src/mcp/rules.ts
@@ -150,7 +150,7 @@ async function putRule({
 
     // Create a new RulesyncRule instance
     const rule = new RulesyncRule({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
       relativeFilePath: filename,
       frontmatter,

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -207,7 +207,7 @@ async function putSkill({
 
     // Create a new RulesyncSkill instance for validation
     const skill = new RulesyncSkill({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName,
       frontmatter,

--- a/src/mcp/subagents.ts
+++ b/src/mcp/subagents.ts
@@ -152,7 +152,7 @@ async function putSubagent({
 
     // Create a new RulesyncSubagent instance
     const subagent = new RulesyncSubagent({
-      baseDir: process.cwd(),
+      outputRoot: process.cwd(),
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
       relativeFilePath: filename,
       frontmatter,

--- a/src/types/ai-dir.ts
+++ b/src/types/ai-dir.ts
@@ -18,7 +18,7 @@ export type AiDirFile = {
 };
 
 export type AiDirParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   dirName: string;
   mainFile?: {
@@ -32,14 +32,14 @@ export type AiDirParams = {
 
 export type AiDirFromDirParams = Pick<
   AiDirParams,
-  "baseDir" | "relativeDirPath" | "dirName" | "global"
+  "outputRoot" | "relativeDirPath" | "dirName" | "global"
 >;
 
 export abstract class AiDir {
   /**
    * @example "."
    */
-  protected readonly baseDir: string;
+  protected readonly outputRoot: string;
 
   /**
    * @example ".rulesync/skills"
@@ -71,7 +71,7 @@ export abstract class AiDir {
   protected readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     dirName,
     mainFile,
@@ -83,7 +83,7 @@ export abstract class AiDir {
       throw new Error(`Directory name cannot contain path separators: dirName="${dirName}"`);
     }
 
-    this.baseDir = baseDir;
+    this.outputRoot = outputRoot;
     this.relativeDirPath = relativeDirPath;
     this.dirName = dirName;
     this.mainFile = mainFile;
@@ -95,8 +95,8 @@ export abstract class AiDir {
     throw new Error("Please implement this method in the subclass.");
   }
 
-  getBaseDir(): string {
-    return this.baseDir;
+  getOutputRoot(): string {
+    return this.outputRoot;
   }
 
   getRelativeDirPath(): string {
@@ -108,19 +108,19 @@ export abstract class AiDir {
   }
 
   getDirPath(): string {
-    const fullPath = path.join(this.baseDir, this.relativeDirPath, this.dirName);
+    const fullPath = path.join(this.outputRoot, this.relativeDirPath, this.dirName);
 
-    // Security check: ensure the final path doesn't escape baseDir via path traversal
+    // Security check: ensure the final path doesn't escape outputRoot via path traversal
     // This prevents attacks like: new AiDir({ relativeDirPath: "../../etc", ... })
     const resolvedFull = resolve(fullPath);
-    const resolvedBase = resolve(this.baseDir);
+    const resolvedBase = resolve(this.outputRoot);
     const rel = relative(resolvedBase, resolvedFull);
 
-    // Check if the resolved path is outside baseDir
+    // Check if the resolved path is outside outputRoot
     if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error(
-        `Path traversal detected: Final path escapes baseDir. ` +
-          `baseDir="${this.baseDir}", relativeDirPath="${this.relativeDirPath}", ` +
+        `Path traversal detected: Final path escapes outputRoot. ` +
+          `outputRoot="${this.outputRoot}", relativeDirPath="${this.relativeDirPath}", ` +
           `dirName="${this.dirName}"`,
       );
     }
@@ -161,19 +161,19 @@ export abstract class AiDir {
    * Recursively collects all files from a directory, excluding the specified main file.
    * This is a common utility for loading additional files alongside the main file.
    *
-   * @param baseDir - The base directory path
+   * @param outputRoot - The base directory path
    * @param relativeDirPath - The relative path to the directory containing the skill
    * @param dirName - The name of the directory
    * @param excludeFileName - The name of the file to exclude (typically the main file)
    * @returns Array of files with their relative paths and buffers
    */
   protected static async collectOtherFiles(
-    baseDir: string,
+    outputRoot: string,
     relativeDirPath: string,
     dirName: string,
     excludeFileName: string,
   ): Promise<AiDirFile[]> {
-    const dirPath = join(baseDir, relativeDirPath, dirName);
+    const dirPath = join(outputRoot, relativeDirPath, dirName);
     const glob = join(dirPath, "**", "*");
     const filePaths = await findFilesByGlobs(glob, { type: "file" });
     const filteredPaths = filePaths.filter((filePath) => basename(filePath) !== excludeFileName);

--- a/src/types/ai-file.ts
+++ b/src/types/ai-file.ts
@@ -13,7 +13,7 @@ export type ValidationResult =
     };
 
 export type AiFileParams = {
-  baseDir?: string;
+  outputRoot?: string;
   relativeDirPath: string;
   relativeFilePath: string;
   fileContent: string;
@@ -23,7 +23,7 @@ export type AiFileParams = {
 
 export type AiFileFromFileParams = Pick<
   AiFileParams,
-  "baseDir" | "validate" | "relativeFilePath" | "global"
+  "outputRoot" | "validate" | "relativeFilePath" | "global"
 > & {
   relativeDirPath?: string;
 };
@@ -31,7 +31,7 @@ export abstract class AiFile {
   /**
    * @example "."
    */
-  protected readonly baseDir: string;
+  protected readonly outputRoot: string;
 
   /**
    * @example ".claude/agents"
@@ -53,13 +53,13 @@ export abstract class AiFile {
   protected readonly global: boolean;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
     fileContent,
     global = false,
   }: AiFileParams) {
-    this.baseDir = baseDir;
+    this.outputRoot = outputRoot;
     this.relativeDirPath = relativeDirPath;
     this.relativeFilePath = relativeFilePath;
     this.fileContent = fileContent;
@@ -70,8 +70,8 @@ export abstract class AiFile {
     throw new Error("Please implement this method in the subclass.");
   }
 
-  getBaseDir(): string {
-    return this.baseDir;
+  getOutputRoot(): string {
+    return this.outputRoot;
   }
 
   getRelativeDirPath(): string {
@@ -83,19 +83,19 @@ export abstract class AiFile {
   }
 
   getFilePath(): string {
-    const fullPath = path.join(this.baseDir, this.relativeDirPath, this.relativeFilePath);
+    const fullPath = path.join(this.outputRoot, this.relativeDirPath, this.relativeFilePath);
 
-    // Security check: ensure the final path doesn't escape baseDir via path traversal
+    // Security check: ensure the final path doesn't escape outputRoot via path traversal
     // This prevents attacks like: new AiFile({ relativeDirPath: "../../etc", ... })
     const resolvedFull = resolve(fullPath);
-    const resolvedBase = resolve(this.baseDir);
+    const resolvedBase = resolve(this.outputRoot);
     const rel = relative(resolvedBase, resolvedFull);
 
-    // Check if the resolved path is outside baseDir
+    // Check if the resolved path is outside outputRoot
     if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error(
-        `Path traversal detected: Final path escapes baseDir. ` +
-          `baseDir="${this.baseDir}", relativeDirPath="${this.relativeDirPath}", ` +
+        `Path traversal detected: Final path escapes outputRoot. ` +
+          `outputRoot="${this.outputRoot}", relativeDirPath="${this.relativeDirPath}", ` +
           `relativeFilePath="${this.relativeFilePath}"`,
       );
     }

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -69,7 +69,7 @@ describe("DirFeatureProcessor", () => {
 
   describe("removeOrphanAiDirs", () => {
     it("should remove dirs that exist in existing but not in generated", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingDirs = [
         createMockDir("/path/to/orphan1"),
@@ -88,7 +88,7 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should not remove any dirs when all existing dirs are in generated", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
 
@@ -101,7 +101,7 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should remove all dirs when generated is empty", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
 
@@ -118,7 +118,7 @@ describe("DirFeatureProcessor", () => {
     it("should return count without removing dirs in dry-run mode", async () => {
       const processor = new TestDirProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         dryRun: true,
       });
 
@@ -137,7 +137,7 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should not remove any dirs when existing is empty", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingDirs: AiDir[] = [];
       const generatedDirs = [createMockDir("/path/to/dir1")];
@@ -171,7 +171,7 @@ describe("DirFeatureProcessor", () => {
 
     it("should write all dirs and return count when dirs are new", async () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue(null);
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const dirs = [
         createMockDirWithFiles({ dirPath: "/path/to/dir1", mainFileBody: "body1" }),
@@ -190,7 +190,7 @@ describe("DirFeatureProcessor", () => {
 
     it("should skip unchanged dirs and return 0", async () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue("body1\n");
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const dirs = [createMockDirWithFiles({ dirPath: "/path/to/dir1", mainFileBody: "body1" })];
 
@@ -203,7 +203,7 @@ describe("DirFeatureProcessor", () => {
 
     it("should detect changes in other files", async () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue(null);
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const otherFile: AiDirFile = {
         relativeFilePathToDirPath: "extra.txt",
@@ -222,7 +222,7 @@ describe("DirFeatureProcessor", () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue(null);
       const processor = new TestDirProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         dryRun: true,
       });
 
@@ -244,7 +244,7 @@ describe("DirFeatureProcessor", () => {
 
   describe("removeAiDirs", () => {
     it("should remove all dirs", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const dirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
 

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -15,26 +15,26 @@ import { AiDir, AiDirFile } from "./ai-dir.js";
 import { ToolTarget } from "./tool-targets.js";
 
 export abstract class DirFeatureProcessor {
-  protected readonly baseDir: string;
+  protected readonly outputRoot: string;
   protected readonly inputRoot: string;
   protected readonly dryRun: boolean;
   protected readonly avoidBlockScalars: boolean;
   protected readonly logger: Logger;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     dryRun = false,
     avoidBlockScalars = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     dryRun?: boolean;
     avoidBlockScalars?: boolean;
     logger: Logger;
   }) {
-    this.baseDir = baseDir;
+    this.outputRoot = outputRoot;
     this.inputRoot = inputRoot;
     this.dryRun = dryRun;
     this.avoidBlockScalars = avoidBlockScalars;

--- a/src/types/feature-processor.test.ts
+++ b/src/types/feature-processor.test.ts
@@ -60,7 +60,7 @@ describe("FeatureProcessor", () => {
 
   describe("removeOrphanAiFiles", () => {
     it("should remove files that exist in existing but not in generated", async () => {
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingFiles = [
         createMockFile("/path/to/orphan1.md"),
@@ -79,7 +79,7 @@ describe("FeatureProcessor", () => {
     });
 
     it("should not remove any files when all existing files are in generated", async () => {
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingFiles = [
         createMockFile("/path/to/file1.md"),
@@ -98,7 +98,7 @@ describe("FeatureProcessor", () => {
     });
 
     it("should remove all files when generated is empty", async () => {
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingFiles = [
         createMockFile("/path/to/file1.md"),
@@ -118,7 +118,7 @@ describe("FeatureProcessor", () => {
     it("should return count without removing files in dry-run mode", async () => {
       const processor = new TestProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         dryRun: true,
       });
 
@@ -137,7 +137,7 @@ describe("FeatureProcessor", () => {
     });
 
     it("should not remove any files when existing is empty", async () => {
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const existingFiles: AiFile[] = [];
       const generatedFiles = [createMockFile("/path/to/file1.md")];
@@ -151,7 +151,7 @@ describe("FeatureProcessor", () => {
   describe("writeAiFiles", () => {
     it("should write all files and return count when files are new", async () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue(null);
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
@@ -163,7 +163,7 @@ describe("FeatureProcessor", () => {
 
     it("should skip unchanged files and return 0", async () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue("content\n");
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
@@ -177,7 +177,7 @@ describe("FeatureProcessor", () => {
       vi.mocked(readFileContentOrNull)
         .mockResolvedValueOnce("content\n") // file1: unchanged
         .mockResolvedValueOnce(null); // file2: new
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 
@@ -191,7 +191,7 @@ describe("FeatureProcessor", () => {
       vi.mocked(readFileContentOrNull).mockResolvedValue(null);
       const processor = new TestProcessor({
         logger: createMockLogger(),
-        baseDir: testDir,
+        outputRoot: testDir,
         dryRun: true,
       });
 
@@ -206,7 +206,7 @@ describe("FeatureProcessor", () => {
 
   describe("removeAiFiles", () => {
     it("should remove all files", async () => {
-      const processor = new TestProcessor({ logger: createMockLogger(), baseDir: testDir });
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 
       const files = [createMockFile("/path/to/file1.md"), createMockFile("/path/to/file2.md")];
 

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -13,23 +13,23 @@ import { ToolFile } from "./tool-file.js";
 import { ToolTarget } from "./tool-targets.js";
 
 export abstract class FeatureProcessor {
-  protected readonly baseDir: string;
+  protected readonly outputRoot: string;
   protected readonly inputRoot: string;
   protected readonly dryRun: boolean;
   protected readonly logger: Logger;
 
   constructor({
-    baseDir = process.cwd(),
+    outputRoot = process.cwd(),
     inputRoot = process.cwd(),
     dryRun = false,
     logger,
   }: {
-    baseDir?: string;
+    outputRoot?: string;
     inputRoot?: string;
     dryRun?: boolean;
     logger: Logger;
   }) {
-    this.baseDir = baseDir;
+    this.outputRoot = outputRoot;
     this.inputRoot = inputRoot;
     this.dryRun = dryRun;
     this.logger = logger;

--- a/src/types/tool-file.test.ts
+++ b/src/types/tool-file.test.ts
@@ -23,7 +23,7 @@ class TestToolFile extends ToolFile {
 
   static async fromFilePath(_params: any): Promise<TestToolFile> {
     return new TestToolFile({
-      baseDir: _params.baseDir,
+      outputRoot: _params.outputRoot,
       relativeDirPath: _params.relativeDirPath,
       relativeFilePath: _params.relativeFilePath,
       fileContent: "test content from file path",
@@ -52,7 +52,7 @@ describe("ToolFile", () => {
       "should output forward slashes only for %s",
       (_, relativeDirPath, relativeFilePath, expected) => {
         const file = new TestToolFile({
-          baseDir: testDir,
+          outputRoot: testDir,
           relativeDirPath,
           relativeFilePath,
           fileContent: "content",
@@ -111,7 +111,7 @@ describe("ToolFile", () => {
   describe("concrete implementation functionality", () => {
     it("should work as concrete implementation", async () => {
       const file = await TestToolFile.fromFilePath({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".tool",
         relativeFilePath: "config.txt",
         filePath: join(testDir, ".tool", "config.txt"),
@@ -158,7 +158,7 @@ describe("ToolFile", () => {
   describe("path traversal security", () => {
     it("should prevent path traversal via relativeDirPath", () => {
       const file = new TestToolFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "../../etc",
         relativeFilePath: "passwd",
         fileContent: "malicious content",
@@ -170,7 +170,7 @@ describe("ToolFile", () => {
 
     it("should prevent path traversal via relativeFilePath", () => {
       const file = new TestToolFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".tool",
         relativeFilePath: "../../etc/passwd",
         fileContent: "malicious content",
@@ -182,7 +182,7 @@ describe("ToolFile", () => {
 
     it("should prevent complex path traversal attacks", () => {
       const file = new TestToolFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "foo/../../..",
         relativeFilePath: "etc/passwd",
         fileContent: "malicious content",
@@ -192,9 +192,9 @@ describe("ToolFile", () => {
       expect(() => file.getFilePath()).toThrow("Path traversal detected");
     });
 
-    it("should allow safe relative paths within baseDir", () => {
+    it("should allow safe relative paths within outputRoot", () => {
       const file = new TestToolFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: ".tool/config",
         relativeFilePath: "settings.txt",
         fileContent: "safe content",
@@ -205,9 +205,9 @@ describe("ToolFile", () => {
       expect(file.getFilePath()).toBe(join(testDir, ".tool", "config", "settings.txt"));
     });
 
-    it("should allow nested directories within baseDir", () => {
+    it("should allow nested directories within outputRoot", () => {
       const file = new TestToolFile({
-        baseDir: testDir,
+        outputRoot: testDir,
         relativeDirPath: "deeply/nested/path",
         relativeFilePath: "file.txt",
         fileContent: "safe content",
@@ -218,9 +218,9 @@ describe("ToolFile", () => {
       expect(file.getFilePath()).toBe(join(testDir, "deeply", "nested", "path", "file.txt"));
     });
 
-    it("should handle baseDir with subdirectory correctly", () => {
+    it("should handle outputRoot with subdirectory correctly", () => {
       const file = new TestToolFile({
-        baseDir: join(testDir, "project"),
+        outputRoot: join(testDir, "project"),
         relativeDirPath: "src",
         relativeFilePath: "index.ts",
         fileContent: "safe content",
@@ -231,9 +231,9 @@ describe("ToolFile", () => {
       expect(file.getFilePath()).toBe(join(testDir, "project", "src", "index.ts"));
     });
 
-    it("should prevent escaping from nested baseDir", () => {
+    it("should prevent escaping from nested outputRoot", () => {
       const file = new TestToolFile({
-        baseDir: join(testDir, "project", "src"),
+        outputRoot: join(testDir, "project", "src"),
         relativeDirPath: "../../etc",
         relativeFilePath: "passwd",
         fileContent: "malicious content",

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -27,7 +27,7 @@ import {
   resolvePath,
   toKebabCaseFilename,
   toPosixPath,
-  validateBaseDir,
+  validateOutputRoot,
   writeFileContent,
   writeJsonFile,
 } from "./file.js";
@@ -119,7 +119,7 @@ describe("file utilities", () => {
   });
 
   describe("resolvePath", () => {
-    it("should return path as-is when no baseDir provided", () => {
+    it("should return path as-is when no outputRoot provided", () => {
       const path = "some/path";
       expect(resolvePath(path)).toBe(path);
     });
@@ -142,13 +142,13 @@ describe("file utilities", () => {
   });
 
   describe("createPathResolver", () => {
-    it("should create a resolver function bound to baseDir", () => {
+    it("should create a resolver function bound to outputRoot", () => {
       const resolver = createPathResolver(testDir);
       const resolved = resolver("subdir/file.txt");
       expect(resolved).toBe(resolve(testDir, "subdir/file.txt"));
     });
 
-    it("should work without baseDir", () => {
+    it("should work without outputRoot", () => {
       const resolver = createPathResolver();
       const path = "some/path";
       expect(resolver(path)).toBe(path);
@@ -642,59 +642,61 @@ describe("file utilities", () => {
     });
   });
 
-  describe("validateBaseDir", () => {
+  describe("validateOutputRoot", () => {
     describe("should allow safe paths", () => {
       it("should allow simple directory names", () => {
-        expect(() => validateBaseDir("src")).not.toThrow();
-        expect(() => validateBaseDir("config")).not.toThrow();
+        expect(() => validateOutputRoot("src")).not.toThrow();
+        expect(() => validateOutputRoot("config")).not.toThrow();
       });
 
       it("should allow nested relative paths", () => {
-        expect(() => validateBaseDir("path/to/dir")).not.toThrow();
-        expect(() => validateBaseDir("deeply/nested/path/here")).not.toThrow();
+        expect(() => validateOutputRoot("path/to/dir")).not.toThrow();
+        expect(() => validateOutputRoot("deeply/nested/path/here")).not.toThrow();
       });
 
       it("should allow paths with dots in names", () => {
-        expect(() => validateBaseDir(RULESYNC_RELATIVE_DIR_PATH)).not.toThrow();
-        expect(() => validateBaseDir("my.project")).not.toThrow();
+        expect(() => validateOutputRoot(RULESYNC_RELATIVE_DIR_PATH)).not.toThrow();
+        expect(() => validateOutputRoot("my.project")).not.toThrow();
       });
 
       it("should allow absolute paths within current directory", () => {
-        // Absolute paths are now allowed as baseDirs are resolved to absolute paths
+        // Absolute paths are now allowed as outputRoots are resolved to absolute paths
         const safePath = resolve(testDir, "safe/path");
-        expect(() => validateBaseDir(safePath)).not.toThrow();
+        expect(() => validateOutputRoot(safePath)).not.toThrow();
       });
     });
 
     describe("should reject path traversal", () => {
       it("should reject parent directory reference", () => {
-        expect(() => validateBaseDir("..")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("..")).toThrow("Path traversal detected");
       });
 
       it("should reject multiple parent directory references", () => {
-        expect(() => validateBaseDir("../..")).toThrow("Path traversal detected");
-        expect(() => validateBaseDir("../../../../../../etc")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("../..")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("../../../../../../etc")).toThrow(
+          "Path traversal detected",
+        );
       });
 
       it("should reject path traversal in middle of path", () => {
-        expect(() => validateBaseDir("foo/../bar")).toThrow("Path traversal detected");
-        expect(() => validateBaseDir("path/../../sensitive")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("foo/../bar")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("path/../../sensitive")).toThrow("Path traversal detected");
       });
 
       it("should reject path traversal at end", () => {
-        expect(() => validateBaseDir("foo/bar/..")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("foo/bar/..")).toThrow("Path traversal detected");
       });
     });
 
     describe("should reject empty strings", () => {
       it("should reject empty string", () => {
-        expect(() => validateBaseDir("")).toThrow("cannot be an empty string");
+        expect(() => validateOutputRoot("")).toThrow("cannot be an empty string");
       });
 
       it("should reject whitespace-only strings", () => {
-        expect(() => validateBaseDir("   ")).toThrow("cannot be an empty string");
-        expect(() => validateBaseDir("\t")).toThrow("cannot be an empty string");
-        expect(() => validateBaseDir("\n")).toThrow("cannot be an empty string");
+        expect(() => validateOutputRoot("   ")).toThrow("cannot be an empty string");
+        expect(() => validateOutputRoot("\t")).toThrow("cannot be an empty string");
+        expect(() => validateOutputRoot("\n")).toThrow("cannot be an empty string");
       });
     });
 
@@ -704,67 +706,69 @@ describe("file utilities", () => {
       // programmatic callers can pass them too — accept them to avoid a
       // surprise breaking change.
       it("should accept `.`", () => {
-        expect(() => validateBaseDir(".")).not.toThrow();
+        expect(() => validateOutputRoot(".")).not.toThrow();
       });
 
       it("should accept `./`", () => {
-        expect(() => validateBaseDir("./")).not.toThrow();
+        expect(() => validateOutputRoot("./")).not.toThrow();
       });
 
       it("should accept `.\\`", () => {
-        expect(() => validateBaseDir(".\\")).not.toThrow();
+        expect(() => validateOutputRoot(".\\")).not.toThrow();
       });
     });
 
     describe("edge cases", () => {
       it("should handle normalized paths correctly", () => {
         // After normalization, these should be caught
-        expect(() => validateBaseDir("./foo/../../../etc")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("./foo/../../../etc")).toThrow("Path traversal detected");
       });
 
       it("should allow dot directories that are not parent references", () => {
-        expect(() => validateBaseDir(".config")).not.toThrow();
-        expect(() => validateBaseDir(".local/share")).not.toThrow();
+        expect(() => validateOutputRoot(".config")).not.toThrow();
+        expect(() => validateOutputRoot(".local/share")).not.toThrow();
       });
     });
 
     describe("absolute paths", () => {
       it("should allow normalized absolute paths that do not contain '..' segments", () => {
-        expect(() => validateBaseDir("/usr/local/share")).not.toThrow();
-        expect(() => validateBaseDir("/Users/someone/project")).not.toThrow();
+        expect(() => validateOutputRoot("/usr/local/share")).not.toThrow();
+        expect(() => validateOutputRoot("/Users/someone/project")).not.toThrow();
       });
 
       it("should allow absolute paths outside the current working directory", () => {
         // The traversal check intentionally does not apply to absolute paths
         // (callers may point at anything). This guards against over-eager
         // rejection of legitimate central-rules directories.
-        expect(() => validateBaseDir("/tmp")).not.toThrow();
+        expect(() => validateOutputRoot("/tmp")).not.toThrow();
       });
 
       it("should reject the filesystem root", () => {
         // The filesystem root is almost certainly a misconfiguration, not a
         // real source directory.
-        expect(() => validateBaseDir("/")).toThrow("must not be the filesystem root");
+        expect(() => validateOutputRoot("/")).toThrow("must not be the filesystem root");
       });
 
       it("should reject unnormalized absolute paths containing '..' segments", () => {
         // The defense-in-depth segment check catches `..` first.
-        expect(() => validateBaseDir("/foo/../bar")).toThrow("Path traversal detected");
-        expect(() => validateBaseDir("/foo/../../etc")).toThrow("Path traversal detected");
-        expect(() => validateBaseDir("/..")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("/foo/../bar")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("/foo/../../etc")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("/..")).toThrow("Path traversal detected");
       });
 
       it("should reject unnormalized absolute paths with redundant segments", () => {
         // Paths without `..` but still unnormalized (e.g. `//`, `/./`) are
         // rejected by the normalized-equality check.
-        expect(() => validateBaseDir("/foo//bar")).toThrow("must be a normalized absolute path");
-        expect(() => validateBaseDir("/foo/./bar")).toThrow("must be a normalized absolute path");
+        expect(() => validateOutputRoot("/foo//bar")).toThrow("must be a normalized absolute path");
+        expect(() => validateOutputRoot("/foo/./bar")).toThrow(
+          "must be a normalized absolute path",
+        );
       });
 
       it("should reject absolute paths with backslash '..' segments", () => {
         // Mixed separators should still be caught so Windows-style input
         // constructed unsafely is not silently accepted on POSIX callers.
-        expect(() => validateBaseDir("/foo\\..\\bar")).toThrow("Path traversal detected");
+        expect(() => validateOutputRoot("/foo\\..\\bar")).toThrow("Path traversal detected");
       });
     });
   });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -63,19 +63,19 @@ export function checkPathTraversal({
  * Resolves a path relative to a base directory, handling both absolute and relative paths
  * Includes protection against path traversal attacks
  */
-export function resolvePath(relativePath: string, baseDir?: string): string {
-  if (!baseDir) return relativePath;
+export function resolvePath(relativePath: string, outputRoot?: string): string {
+  if (!outputRoot) return relativePath;
 
-  checkPathTraversal({ relativePath, intendedRootDir: baseDir });
+  checkPathTraversal({ relativePath, intendedRootDir: outputRoot });
 
-  return resolve(baseDir, relativePath);
+  return resolve(outputRoot, relativePath);
 }
 
 /**
  * Creates a path resolver function bound to a specific base directory
  */
-export function createPathResolver(baseDir?: string) {
-  return (relativePath: string) => resolvePath(relativePath, baseDir);
+export function createPathResolver(outputRoot?: string) {
+  return (relativePath: string) => resolvePath(relativePath, outputRoot);
 }
 
 /**
@@ -275,12 +275,12 @@ export function getHomeDirectory(): string {
 }
 
 /**
- * Validates that a baseDir is safe to use as the source/output root.
+ * Validates that a outputRoot is safe to use as the source/output root.
  *
  * Contract:
  * - Rejects empty strings.
  * - For absolute paths: requires the path to already be normalized (i.e.
- *   `resolve(baseDir) === baseDir`). This rejects sneaky inputs like
+ *   `resolve(outputRoot) === outputRoot`). This rejects sneaky inputs like
  *   `/foo/../bar` and forces callers to pass an explicit, normalized intent.
  *   Also rejects the filesystem root (`/` on POSIX, `C:\\` etc. on Windows)
  *   because that is almost certainly a misconfiguration, not a real source
@@ -295,35 +295,35 @@ export function getHomeDirectory(): string {
  * root" should resolve it to absolute first and then pass it here, or use
  * `checkPathTraversal` directly with the appropriate `intendedRootDir`.
  *
- * @throws {Error} if the baseDir is dangerous, unnormalized, or the
+ * @throws {Error} if the outputRoot is dangerous, unnormalized, or the
  * filesystem root.
  */
-export function validateBaseDir(baseDir: string): void {
+export function validateOutputRoot(outputRoot: string): void {
   // Reject empty strings
-  if (baseDir.trim() === "") {
-    throw new Error("baseDir cannot be an empty string");
+  if (outputRoot.trim() === "") {
+    throw new Error("outputRoot cannot be an empty string");
   }
 
-  if (isAbsolute(baseDir)) {
+  if (isAbsolute(outputRoot)) {
     // Defense-in-depth: split on both POSIX and Windows separators and
     // reject any `..` segment. POSIX `resolve()` ignores `\` as a separator,
     // and Windows `resolve()` ignores `/` in some legacy paths, so a
     // cross-platform attacker-style input like `/foo\..\bar` or `C:/foo/../bar`
     // would otherwise slip past the normalized-equality check below. This
     // layered check applies on both platforms.
-    const segments = baseDir.split(/[/\\]/);
+    const segments = outputRoot.split(/[/\\]/);
     if (segments.includes("..")) {
-      throw new Error(`Path traversal detected: ${baseDir}`);
+      throw new Error(`Path traversal detected: ${outputRoot}`);
     }
 
-    // Reject unnormalized absolute paths. After `resolve(baseDir)` collapses
+    // Reject unnormalized absolute paths. After `resolve(outputRoot)` collapses
     // any `.`/`..` segments and normalizes separators, the result must equal
     // the input — otherwise the caller passed a path that hides traversal
     // intent inside an absolute prefix (e.g. `/foo/./bar` or `/foo//bar`).
-    const normalized = resolve(baseDir);
-    if (normalized !== baseDir) {
+    const normalized = resolve(outputRoot);
+    if (normalized !== outputRoot) {
       throw new Error(
-        `baseDir must be a normalized absolute path: ${baseDir} (normalized: ${normalized})`,
+        `outputRoot must be a normalized absolute path: ${outputRoot} (normalized: ${normalized})`,
       );
     }
 
@@ -331,7 +331,7 @@ export function validateBaseDir(baseDir: string): void {
     // standard cross-platform way to detect the root of the volume.
     if (dirname(normalized) === normalized) {
       throw new Error(
-        `baseDir must not be the filesystem root: ${baseDir}. ` +
+        `outputRoot must not be the filesystem root: ${outputRoot}. ` +
           `Pass a specific project directory instead.`,
       );
     }
@@ -344,7 +344,7 @@ export function validateBaseDir(baseDir: string): void {
   // have always been accepted by the resolver path (which `resolve()`s before
   // calling here), so we accept them in direct programmatic callers too to
   // avoid an accidental breaking change.
-  checkPathTraversal({ relativePath: baseDir, intendedRootDir: process.cwd() });
+  checkPathTraversal({ relativePath: outputRoot, intendedRootDir: process.cwd() });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Renames pervasive identifier `baseDir` → `outputRoot` (and `baseDirs` → `outputRoots`) across the codebase so the naming is symmetric with the `inputRoot` concept introduced in #1514.
- Preserves public API via deprecated aliases: `--base-dir` CLI flag, `baseDirs` config-file field, programmatic `Config.getBaseDirs()`, and `ConfigResolver.resolve({ baseDirs })`. Each emits a one-shot deprecation warning the first time it is used per process and can be silenced with `RULESYNC_SILENT_DEPRECATION=1`.
- When both new and deprecated names are supplied, the new `outputRoots` wins; the resolver/CLI also surfaces an override warning when the values differ as a set.
- Updates docs (`docs/api/programmatic-api.md`, `docs/guide/configuration.md`) and the synced `skills/rulesync/` mirror to document the rename and the deprecation path.
- Adds regression tests for each deprecation path (`Config.getBaseDirs()`, `baseDirs` config field, programmatic `baseDirs` resolver param, `--base-dir` CLI flag) covering: alias still maps to new behavior, warning is emitted, warning fires once per process, warning is silenced via `RULESYNC_SILENT_DEPRECATION`.

Closes #1519. Related to #1514.

## Test plan

- [x] `pnpm cicheck` (5318 tests pass; lint, typecheck, fmt, cspell, secretlint clean)
- [x] Programmatic `Config.getBaseDirs()` returns the same array as `getOutputRoots()` and emits the deprecation warning exactly once per process
- [x] Config-file `baseDirs` is mapped to `outputRoots` with warning; when both are present `outputRoots` wins
- [x] CLI `--base-dir` is still accepted, mapped to `outputRoots`, and emits a deprecation warning whenever used
- [x] `RULESYNC_SILENT_DEPRECATION=1` suppresses every new deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)