### PR TITLE
fix(geminicli): translate universal command syntax to Gemini CLI native syntax

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
           },
           { text: "CLI Commands", link: "/reference/cli-commands" },
           { text: "File Formats", link: "/reference/file-formats" },
+          { text: "Command Syntax", link: "/reference/command-syntax" },
           { text: "MCP Server", link: "/reference/mcp-server" },
         ],
       },

--- a/docs/reference/command-syntax.md
+++ b/docs/reference/command-syntax.md
@@ -15,19 +15,19 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool              | `$ARGUMENTS`           | `` !`cmd` ``           |
-| ----------------- | ---------------------- | ---------------------- |
-| Claude Code       | pass-through           | pass-through           |
-| Codex CLI[^codex] | pass-through (literal) | pass-through (literal) |
-| Gemini CLI        | `{{args}}`             | `!{cmd}`               |
-| Pi[^pi]           | pass-through (literal) | pass-through (literal) |
-| Other tools[^1]   | pass-through (literal) | pass-through (literal) |
+| Tool              | `$ARGUMENTS`           | `` !`cmd` ``                |
+| ----------------- | ---------------------- | --------------------------- |
+| Claude Code       | pass-through           | pass-through                |
+| Codex CLI[^codex] | pass-through (literal) | pass-through (literal)      |
+| Gemini CLI        | `{{args}}`             | `!{cmd}`                    |
+| Pi                | pass-through           | pass-through (literal)[^pi] |
+| Other tools[^1]   | pass-through (literal) | pass-through (literal)      |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
 
 [^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
 
-[^pi]: Pi command bodies are forwarded to the model as plain Markdown. rulesync emits the universal placeholders verbatim, but does not assume Pi natively expands `` !`cmd` `` shell snippets.
+[^pi]: Pi natively expands `$ARGUMENTS` (along with `$1`, `$2`, `$@`), so `$ARGUMENTS` is a real pass-through there. rulesync still emits `` !`cmd` `` verbatim for Pi, but does not assume Pi expands inline shell snippets — treat that placeholder as literal text on Pi's side.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 
@@ -62,7 +62,11 @@ Focus on {{args}}.
 ## Notes
 
 - If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
-- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. If you need to show the literal placeholder in documentation, write it outside the universal forms (e.g. as `\$ARGUMENTS`) or hand-author the tool-native body via the per-tool override (see below).
+- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. There is **no escape syntax** for the universal placeholders — backslashes are not consumed by the regex, so `\$ARGUMENTS` becomes `\{{args}}`, not a literal `$ARGUMENTS`. If you need a literal `$ARGUMENTS` or `` !`cmd` `` in the emitted Gemini CLI prompt, your options are:
+  1. Hand-author the Gemini-native body via the per-tool `geminicli.prompt` override (see below) — this skips translation entirely for Gemini CLI.
+  2. Drop `geminicli` from the command's `targets:` so no Gemini CLI file is generated.
+  3. Construct the placeholder so the regex does not match — for example, break `$ARGUMENTS` across two adjacent inline-code spans (`` `$` ``+`` `ARGUMENTS` ``) so the literal `$ARGUMENTS` substring is not present in the source body.
+
 - The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.
 - The reverse rewrite (Gemini CLI → rulesync, on import) is **not** symmetric with the forward direction: a rulesync body that already contains Gemini-native forms (`{{args}}`, `!{cmd}`) is preserved on export, but a Gemini CLI file containing those forms is always rewritten back to the universal syntax on import. In practice this is what users want, but it does mean that an import will canonicalize away any literal `{{args}}` / `!{cmd}` text that you intended as documentation.
@@ -79,7 +83,7 @@ geminicli:
   prompt: "Run !{echo `hello`}."
 ---
 
-Body content here is ignored when geminicli.prompt is set.
+Body content here is ignored only for the Gemini CLI output when geminicli.prompt is set.
 ```
 
-When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely.
+When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely. Note that this override is **scoped to the Gemini CLI output only**: if `targets:` lists other tools (e.g. `["geminicli", "claudecode"]`), the rulesync command body is still used as the source for those other tools — `geminicli.prompt` does not replace the body for them.

--- a/docs/reference/command-syntax.md
+++ b/docs/reference/command-syntax.md
@@ -65,7 +65,6 @@ Focus on {{args}}.
 - The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. There is **no escape syntax** for the universal placeholders — backslashes are not consumed by the regex, so `\$ARGUMENTS` becomes `\{{args}}`, not a literal `$ARGUMENTS`. If you need a literal `$ARGUMENTS` or `` !`cmd` `` in the emitted Gemini CLI prompt, your options are:
   1. Hand-author the Gemini-native body via the per-tool `geminicli.prompt` override (see below) — this skips translation entirely for Gemini CLI.
   2. Drop `geminicli` from the command's `targets:` so no Gemini CLI file is generated.
-  3. Construct the placeholder so the regex does not match — for example, break `$ARGUMENTS` across two adjacent inline-code spans (`` `$` ``+`` `ARGUMENTS` ``) so the literal `$ARGUMENTS` substring is not present in the source body.
 
 - The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.

--- a/docs/reference/command-syntax.md
+++ b/docs/reference/command-syntax.md
@@ -1,0 +1,62 @@
+# Command Syntax
+
+Slash commands authored under `.rulesync/commands/*.md` use a **universal syntax** that mirrors Claude Code's command placeholders. When rulesync generates a tool-specific command file, it rewrites these placeholders into the syntax that the target tool understands. The reverse rewrite happens on import, so a rulesync ↔ tool round-trip preserves the original universal form.
+
+## Universal placeholders
+
+| Placeholder  | Meaning                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `$ARGUMENTS` | The full argument string the user supplied when invoking the command.    |
+| `` !`cmd` `` | Inline shell expansion. The agent runs `cmd` and substitutes its output. |
+
+These are written exactly as Claude Code accepts them, so writing a rulesync command body is the same as writing a Claude Code command body.
+
+## Per-tool translation
+
+The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
+
+| Tool            | `$ARGUMENTS` | `` !`cmd` `` |
+| --------------- | ------------ | ------------ |
+| Claude Code     | pass-through | pass-through |
+| Codex CLI       | pass-through | pass-through |
+| Gemini CLI      | `{{args}}`   | `!{cmd}`     |
+| Pi              | pass-through | pass-through |
+| Other tools[^1] | pass-through | pass-through |
+
+[^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
+
+The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
+
+## Example
+
+Given the following rulesync command:
+
+```md
+---
+targets: ["geminicli"]
+description: "Summarize git diff"
+---
+
+Summarize the diff:
+!`git diff`
+
+Focus on $ARGUMENTS.
+```
+
+rulesync generates `.gemini/commands/summarize.toml`:
+
+```toml
+description = "Summarize git diff"
+prompt = """
+Summarize the diff:
+!{git diff}
+
+Focus on {{args}}.
+"""
+```
+
+## Notes
+
+- If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
+- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported.
+- Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.

--- a/docs/reference/command-syntax.md
+++ b/docs/reference/command-syntax.md
@@ -15,17 +15,19 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool              | `$ARGUMENTS` | `` !`cmd` `` |
-| ----------------- | ------------ | ------------ |
-| Claude Code       | pass-through | pass-through |
-| Codex CLI[^codex] | pass-through | pass-through |
-| Gemini CLI        | `{{args}}`   | `!{cmd}`     |
-| Pi                | pass-through | pass-through |
-| Other tools[^1]   | pass-through | pass-through |
+| Tool              | `$ARGUMENTS`           | `` !`cmd` ``           |
+| ----------------- | ---------------------- | ---------------------- |
+| Claude Code       | pass-through           | pass-through           |
+| Codex CLI[^codex] | pass-through (literal) | pass-through (literal) |
+| Gemini CLI        | `{{args}}`             | `!{cmd}`               |
+| Pi[^pi]           | pass-through (literal) | pass-through (literal) |
+| Other tools[^1]   | pass-through (literal) | pass-through (literal) |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
 
 [^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
+
+[^pi]: Pi command bodies are forwarded to the model as plain Markdown. rulesync emits the universal placeholders verbatim, but does not assume Pi natively expands `` !`cmd` `` shell snippets.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 
@@ -60,5 +62,24 @@ Focus on {{args}}.
 ## Notes
 
 - If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
-- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported.
+- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. If you need to show the literal placeholder in documentation, write it outside the universal forms (e.g. as `\$ARGUMENTS`) or hand-author the tool-native body via the per-tool override (see below).
+- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.
+- The reverse rewrite (Gemini CLI → rulesync, on import) is **not** symmetric with the forward direction: a rulesync body that already contains Gemini-native forms (`{{args}}`, `!{cmd}`) is preserved on export, but a Gemini CLI file containing those forms is always rewritten back to the universal syntax on import. In practice this is what users want, but it does mean that an import will canonicalize away any literal `{{args}}` / `!{cmd}` text that you intended as documentation.
+
+### Per-tool override (Gemini CLI)
+
+If you need to bypass the translation entirely — for example, to embed a literal backtick inside a Gemini-native shell expansion — you can author the prompt directly in the `geminicli` section of the rulesync frontmatter:
+
+```md
+---
+targets: ["geminicli"]
+description: "Hand-authored prompt"
+geminicli:
+  prompt: "Run !{echo `hello`}."
+---
+
+Body content here is ignored when geminicli.prompt is set.
+```
+
+When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely.

--- a/docs/reference/command-syntax.md
+++ b/docs/reference/command-syntax.md
@@ -15,15 +15,17 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool            | `$ARGUMENTS` | `` !`cmd` `` |
-| --------------- | ------------ | ------------ |
-| Claude Code     | pass-through | pass-through |
-| Codex CLI       | pass-through | pass-through |
-| Gemini CLI      | `{{args}}`   | `!{cmd}`     |
-| Pi              | pass-through | pass-through |
-| Other tools[^1] | pass-through | pass-through |
+| Tool              | `$ARGUMENTS` | `` !`cmd` `` |
+| ----------------- | ------------ | ------------ |
+| Claude Code       | pass-through | pass-through |
+| Codex CLI[^codex] | pass-through | pass-through |
+| Gemini CLI        | `{{args}}`   | `!{cmd}`     |
+| Pi                | pass-through | pass-through |
+| Other tools[^1]   | pass-through | pass-through |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
+
+[^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -200,6 +200,8 @@ Execute the following in parallel:
 ...
 ```
 
+The command body itself uses a Claude Code-compatible **universal syntax** (e.g. `$ARGUMENTS`, `` !`cmd` ``). When a target tool expects a different placeholder syntax, rulesync translates it automatically on generation and reverses the translation on import. See [Command Syntax](./command-syntax.md) for the full mapping.
+
 ## `rulesync/subagents/*.md`
 
 Example:

--- a/skills/rulesync/SKILL.md
+++ b/skills/rulesync/SKILL.md
@@ -53,6 +53,6 @@ rulesync generate --targets "*" --features "*"
 
 - [Installation](./installation.md), [Quick Start](./quick-start.md)
 - [Why Rulesync?](./why-rulesync.md), [Configuration](./configuration.md), [Global Mode](./global-mode.md), [Separate Input Root](./separate-input-root.md), [Simulated Features](./simulated-features.md), [Declarative Sources](./declarative-sources.md), [Official Skills](./official-skills.md), [Dry Run](./dry-run.md), [Case Studies](./case-studies.md)
-- [Supported Tools](./supported-tools.md), [CLI Commands](./cli-commands.md), [File Formats](./file-formats.md), [MCP Server](./mcp-server.md)
+- [Supported Tools](./supported-tools.md), [CLI Commands](./cli-commands.md), [File Formats](./file-formats.md), [Command Syntax](./command-syntax.md), [MCP Server](./mcp-server.md)
 - [Programmatic API](./programmatic-api.md)
 - [FAQ](./faq.md)

--- a/skills/rulesync/command-syntax.md
+++ b/skills/rulesync/command-syntax.md
@@ -15,19 +15,19 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool              | `$ARGUMENTS`           | `` !`cmd` ``           |
-| ----------------- | ---------------------- | ---------------------- |
-| Claude Code       | pass-through           | pass-through           |
-| Codex CLI[^codex] | pass-through (literal) | pass-through (literal) |
-| Gemini CLI        | `{{args}}`             | `!{cmd}`               |
-| Pi[^pi]           | pass-through (literal) | pass-through (literal) |
-| Other tools[^1]   | pass-through (literal) | pass-through (literal) |
+| Tool              | `$ARGUMENTS`           | `` !`cmd` ``                |
+| ----------------- | ---------------------- | --------------------------- |
+| Claude Code       | pass-through           | pass-through                |
+| Codex CLI[^codex] | pass-through (literal) | pass-through (literal)      |
+| Gemini CLI        | `{{args}}`             | `!{cmd}`                    |
+| Pi                | pass-through           | pass-through (literal)[^pi] |
+| Other tools[^1]   | pass-through (literal) | pass-through (literal)      |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
 
 [^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
 
-[^pi]: Pi command bodies are forwarded to the model as plain Markdown. rulesync emits the universal placeholders verbatim, but does not assume Pi natively expands `` !`cmd` `` shell snippets.
+[^pi]: Pi natively expands `$ARGUMENTS` (along with `$1`, `$2`, `$@`), so `$ARGUMENTS` is a real pass-through there. rulesync still emits `` !`cmd` `` verbatim for Pi, but does not assume Pi expands inline shell snippets — treat that placeholder as literal text on Pi's side.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 
@@ -62,7 +62,11 @@ Focus on {{args}}.
 ## Notes
 
 - If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
-- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. If you need to show the literal placeholder in documentation, write it outside the universal forms (e.g. as `\$ARGUMENTS`) or hand-author the tool-native body via the per-tool override (see below).
+- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. There is **no escape syntax** for the universal placeholders — backslashes are not consumed by the regex, so `\$ARGUMENTS` becomes `\{{args}}`, not a literal `$ARGUMENTS`. If you need a literal `$ARGUMENTS` or `` !`cmd` `` in the emitted Gemini CLI prompt, your options are:
+  1. Hand-author the Gemini-native body via the per-tool `geminicli.prompt` override (see below) — this skips translation entirely for Gemini CLI.
+  2. Drop `geminicli` from the command's `targets:` so no Gemini CLI file is generated.
+  3. Construct the placeholder so the regex does not match — for example, break `$ARGUMENTS` across two adjacent inline-code spans (`` `$` ``+`` `ARGUMENTS` ``) so the literal `$ARGUMENTS` substring is not present in the source body.
+
 - The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.
 - The reverse rewrite (Gemini CLI → rulesync, on import) is **not** symmetric with the forward direction: a rulesync body that already contains Gemini-native forms (`{{args}}`, `!{cmd}`) is preserved on export, but a Gemini CLI file containing those forms is always rewritten back to the universal syntax on import. In practice this is what users want, but it does mean that an import will canonicalize away any literal `{{args}}` / `!{cmd}` text that you intended as documentation.
@@ -79,7 +83,7 @@ geminicli:
   prompt: "Run !{echo `hello`}."
 ---
 
-Body content here is ignored when geminicli.prompt is set.
+Body content here is ignored only for the Gemini CLI output when geminicli.prompt is set.
 ```
 
-When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely.
+When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely. Note that this override is **scoped to the Gemini CLI output only**: if `targets:` lists other tools (e.g. `["geminicli", "claudecode"]`), the rulesync command body is still used as the source for those other tools — `geminicli.prompt` does not replace the body for them.

--- a/skills/rulesync/command-syntax.md
+++ b/skills/rulesync/command-syntax.md
@@ -65,7 +65,6 @@ Focus on {{args}}.
 - The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. There is **no escape syntax** for the universal placeholders — backslashes are not consumed by the regex, so `\$ARGUMENTS` becomes `\{{args}}`, not a literal `$ARGUMENTS`. If you need a literal `$ARGUMENTS` or `` !`cmd` `` in the emitted Gemini CLI prompt, your options are:
   1. Hand-author the Gemini-native body via the per-tool `geminicli.prompt` override (see below) — this skips translation entirely for Gemini CLI.
   2. Drop `geminicli` from the command's `targets:` so no Gemini CLI file is generated.
-  3. Construct the placeholder so the regex does not match — for example, break `$ARGUMENTS` across two adjacent inline-code spans (`` `$` ``+`` `ARGUMENTS` ``) so the literal `$ARGUMENTS` substring is not present in the source body.
 
 - The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.

--- a/skills/rulesync/command-syntax.md
+++ b/skills/rulesync/command-syntax.md
@@ -1,0 +1,62 @@
+# Command Syntax
+
+Slash commands authored under `.rulesync/commands/*.md` use a **universal syntax** that mirrors Claude Code's command placeholders. When rulesync generates a tool-specific command file, it rewrites these placeholders into the syntax that the target tool understands. The reverse rewrite happens on import, so a rulesync ↔ tool round-trip preserves the original universal form.
+
+## Universal placeholders
+
+| Placeholder  | Meaning                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `$ARGUMENTS` | The full argument string the user supplied when invoking the command.    |
+| `` !`cmd` `` | Inline shell expansion. The agent runs `cmd` and substitutes its output. |
+
+These are written exactly as Claude Code accepts them, so writing a rulesync command body is the same as writing a Claude Code command body.
+
+## Per-tool translation
+
+The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
+
+| Tool            | `$ARGUMENTS` | `` !`cmd` `` |
+| --------------- | ------------ | ------------ |
+| Claude Code     | pass-through | pass-through |
+| Codex CLI       | pass-through | pass-through |
+| Gemini CLI      | `{{args}}`   | `!{cmd}`     |
+| Pi              | pass-through | pass-through |
+| Other tools[^1] | pass-through | pass-through |
+
+[^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
+
+The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
+
+## Example
+
+Given the following rulesync command:
+
+```md
+---
+targets: ["geminicli"]
+description: "Summarize git diff"
+---
+
+Summarize the diff:
+!`git diff`
+
+Focus on $ARGUMENTS.
+```
+
+rulesync generates `.gemini/commands/summarize.toml`:
+
+```toml
+description = "Summarize git diff"
+prompt = """
+Summarize the diff:
+!{git diff}
+
+Focus on {{args}}.
+"""
+```
+
+## Notes
+
+- If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
+- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported.
+- Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.

--- a/skills/rulesync/command-syntax.md
+++ b/skills/rulesync/command-syntax.md
@@ -15,17 +15,19 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool              | `$ARGUMENTS` | `` !`cmd` `` |
-| ----------------- | ------------ | ------------ |
-| Claude Code       | pass-through | pass-through |
-| Codex CLI[^codex] | pass-through | pass-through |
-| Gemini CLI        | `{{args}}`   | `!{cmd}`     |
-| Pi                | pass-through | pass-through |
-| Other tools[^1]   | pass-through | pass-through |
+| Tool              | `$ARGUMENTS`           | `` !`cmd` ``           |
+| ----------------- | ---------------------- | ---------------------- |
+| Claude Code       | pass-through           | pass-through           |
+| Codex CLI[^codex] | pass-through (literal) | pass-through (literal) |
+| Gemini CLI        | `{{args}}`             | `!{cmd}`               |
+| Pi[^pi]           | pass-through (literal) | pass-through (literal) |
+| Other tools[^1]   | pass-through (literal) | pass-through (literal) |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
 
 [^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
+
+[^pi]: Pi command bodies are forwarded to the model as plain Markdown. rulesync emits the universal placeholders verbatim, but does not assume Pi natively expands `` !`cmd` `` shell snippets.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 
@@ -60,5 +62,24 @@ Focus on {{args}}.
 ## Notes
 
 - If you author a command with explicit tool-specific syntax (e.g. you write `{{args}}` directly in a rulesync command body), rulesync does **not** re-translate the already-tool-native form. Stick to the universal placeholders to keep commands portable across tools.
-- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported.
+- The translation is purely textual and is applied to the entire body. It does not skip fenced or inline code blocks, so ` ```js\n$ARGUMENTS\n``` ` in a rulesync body will still be rewritten when generating Gemini CLI output. If you need to show the literal placeholder in documentation, write it outside the universal forms (e.g. as `\$ARGUMENTS`) or hand-author the tool-native body via the per-tool override (see below).
+- The shell expansion regex matches a single backtick-delimited segment without embedded backticks or newlines (`` !`...` ``). Multi-line shell snippets are not supported, and a backtick inside the command body is not allowed — for that case, hand-author the Gemini-native form via `geminicli.prompt`.
 - Gemini CLI accepts both `{{args}}` and `{{ args }}` (with whitespace). rulesync canonicalizes the imported form to `$ARGUMENTS`.
+- The reverse rewrite (Gemini CLI → rulesync, on import) is **not** symmetric with the forward direction: a rulesync body that already contains Gemini-native forms (`{{args}}`, `!{cmd}`) is preserved on export, but a Gemini CLI file containing those forms is always rewritten back to the universal syntax on import. In practice this is what users want, but it does mean that an import will canonicalize away any literal `{{args}}` / `!{cmd}` text that you intended as documentation.
+
+### Per-tool override (Gemini CLI)
+
+If you need to bypass the translation entirely — for example, to embed a literal backtick inside a Gemini-native shell expansion — you can author the prompt directly in the `geminicli` section of the rulesync frontmatter:
+
+```md
+---
+targets: ["geminicli"]
+description: "Hand-authored prompt"
+geminicli:
+  prompt: "Run !{echo `hello`}."
+---
+
+Body content here is ignored when geminicli.prompt is set.
+```
+
+When `geminicli.prompt` is present, rulesync uses it verbatim as the Gemini CLI command body and skips the universal-syntax translation entirely.

--- a/skills/rulesync/command-syntax.md
+++ b/skills/rulesync/command-syntax.md
@@ -15,15 +15,17 @@ These are written exactly as Claude Code accepts them, so writing a rulesync com
 
 The table below shows how each placeholder is translated for the supported tools. "pass-through" means the placeholder is emitted verbatim because the target tool already understands the universal form.
 
-| Tool            | `$ARGUMENTS` | `` !`cmd` `` |
-| --------------- | ------------ | ------------ |
-| Claude Code     | pass-through | pass-through |
-| Codex CLI       | pass-through | pass-through |
-| Gemini CLI      | `{{args}}`   | `!{cmd}`     |
-| Pi              | pass-through | pass-through |
-| Other tools[^1] | pass-through | pass-through |
+| Tool              | `$ARGUMENTS` | `` !`cmd` `` |
+| ----------------- | ------------ | ------------ |
+| Claude Code       | pass-through | pass-through |
+| Codex CLI[^codex] | pass-through | pass-through |
+| Gemini CLI        | `{{args}}`   | `!{cmd}`     |
+| Pi                | pass-through | pass-through |
+| Other tools[^1]   | pass-through | pass-through |
 
 [^1]: Tools not listed do not have a documented translation; their command body is emitted as-is.
+
+[^codex]: Codex CLI prompt files are forwarded to the LLM verbatim; the placeholders are passed to the model as literal text rather than being substituted by the engine.
 
 The translation also runs in reverse when you import an existing tool command file via `rulesync import`, so e.g. a Gemini CLI command containing `{{args}}` becomes `$ARGUMENTS` in the generated `.rulesync/commands/*.md`.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -200,6 +200,8 @@ Execute the following in parallel:
 ...
 ```
 
+The command body itself uses a Claude Code-compatible **universal syntax** (e.g. `$ARGUMENTS`, `` !`cmd` ``). When a target tool expects a different placeholder syntax, rulesync translates it automatically on generation and reverses the translation on import. See [Command Syntax](./command-syntax.md) for the full mapping.
+
 ## `rulesync/subagents/*.md`
 
 Example:

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -421,6 +421,188 @@ Run !{git status} and report.
 
       expect(geminiCommand.getBody()).toBe("Diff: !{git diff}\nFocus on {{args}}.\n");
     });
+
+    it("should not re-translate already-Gemini-native syntax (idempotency)", () => {
+      // A rulesync body that already contains Gemini-native forms should be
+      // emitted verbatim — see docs/reference/command-syntax.md.
+      const nativeBody = "Already native: {{args}} and !{git diff}";
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "idempotent.md",
+        frontmatter: { targets: ["geminicli"], description: "Idempotent" },
+        body: nativeBody,
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe(`${nativeBody}\n`);
+    });
+
+    it("should not translate $ARGUMENTS_FOO (underscore is a word char)", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "word-boundary-underscore.md",
+        frontmatter: { targets: ["geminicli"], description: "Word boundary" },
+        body: "Use $ARGUMENTS_FOO here.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Use $ARGUMENTS_FOO here.\n");
+    });
+
+    it("should not translate $ARGUMENTSx (letter is a word char)", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "word-boundary-letter.md",
+        frontmatter: { targets: ["geminicli"], description: "Word boundary" },
+        body: "Token $ARGUMENTSx remains.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Token $ARGUMENTSx remains.\n");
+    });
+
+    it("should translate $ARGUMENTS-foo (hyphen is not a word char)", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "word-boundary-hyphen.md",
+        frontmatter: { targets: ["geminicli"], description: "Word boundary" },
+        body: "Token $ARGUMENTS-foo here.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Token {{args}}-foo here.\n");
+    });
+
+    it("should translate nested shell expansion containing $ARGUMENTS", () => {
+      // Pin current behavior: !`echo $ARGUMENTS` becomes !{echo {{args}}}
+      // because the shell-expansion replacement runs first.
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "nested.md",
+        frontmatter: { targets: ["geminicli"], description: "Nested" },
+        body: "Run !`echo $ARGUMENTS` now.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Run !{echo {{args}}} now.\n");
+    });
+
+    it("should respect explicit geminicli.prompt override without translation", () => {
+      // When the user provides geminicli.prompt in rulesync frontmatter, it is
+      // assumed to be hand-authored Gemini syntax and emitted verbatim.
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "override.md",
+        frontmatter: {
+          targets: ["geminicli"],
+          description: "Override",
+          geminicli: {
+            prompt: "Hand-written {{args}} body",
+          },
+        },
+        body: "Body containing $ARGUMENTS that should be ignored.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Hand-written {{args}} body\n");
+    });
+  });
+
+  describe("toRulesyncCommand whitespace and inverse round-trip", () => {
+    it("should canonicalize {{ args }} (with whitespace) to $ARGUMENTS", () => {
+      const tomlContent = `description = "Whitespace"
+prompt = """
+Focus on {{ args }}.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "whitespace.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody()).toBe("Focus on $ARGUMENTS.\n");
+    });
+
+    it("should round-trip gemini -> rulesync -> gemini preserving syntax", () => {
+      // The TOML triple-quoted serializer adds a single trailing newline on
+      // round-trip, which is normal. We assert that the meaningful syntax
+      // (placeholders, lines, content) is preserved.
+      const tomlContent = `description = "Inverse"
+prompt = """
+Diff: !{git diff}
+Focus on {{args}}.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "inverse-round-trip.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+      const restored = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      // Trim trailing whitespace introduced by the TOML serializer to compare
+      // the meaningful body content.
+      expect(restored.getBody().trimEnd()).toBe("Diff: !{git diff}\nFocus on {{args}}.");
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -210,6 +210,65 @@ prompt = "Unclosed string`;
       expect(rulesyncCommand.getRelativeFilePath()).toBe("test-command.toml");
     });
 
+    it("should translate {{args}} back to $ARGUMENTS", () => {
+      const tomlContent = `description = "Args"
+prompt = """
+Focus on {{args}}.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "args.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody()).toBe("Focus on $ARGUMENTS.\n");
+    });
+
+    it("should translate !{cmd} back to !`cmd`", () => {
+      const tomlContent = `description = "Shell"
+prompt = """
+Run !{git status} and report.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "shell.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody()).toBe("Run !`git status` and report.\n");
+    });
+
+    it("should round-trip rulesync -> gemini -> rulesync preserving syntax", () => {
+      const originalBody = "Diff: !`git diff`\nFocus on $ARGUMENTS.";
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "round-trip.md",
+        frontmatter: { targets: ["geminicli"], description: "Round trip" },
+        body: originalBody,
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      const restored = geminiCommand.toRulesyncCommand();
+
+      expect(restored.getBody()).toBe(`${originalBody}\n`);
+    });
+
     it("should convert to RulesyncCommand with empty description", () => {
       const command = new GeminiCliCommand({
         outputRoot: testDir,
@@ -280,6 +339,87 @@ prompt = "Unclosed string`;
       });
 
       expect(geminiCommand.getRelativeFilePath()).toBe("complex-command.toml");
+    });
+
+    it("should translate $ARGUMENTS to {{args}}", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "args.md",
+        frontmatter: { targets: ["geminicli"], description: "Args" },
+        body: "Focus on $ARGUMENTS.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Focus on {{args}}.\n");
+      expect(geminiCommand.getFileContent()).toContain("Focus on {{args}}.");
+    });
+
+    it("should translate multiple occurrences of $ARGUMENTS", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "args-multi.md",
+        frontmatter: { targets: ["geminicli"], description: "Args multi" },
+        body: "First: $ARGUMENTS. Second: $ARGUMENTS.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("First: {{args}}. Second: {{args}}.\n");
+    });
+
+    it("should translate !`cmd` shell expansion to !{cmd}", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "shell.md",
+        frontmatter: { targets: ["geminicli"], description: "Shell" },
+        body: "Run !`git status` and report.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Run !{git status} and report.\n");
+    });
+
+    it("should translate combined shell expansion and arguments", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "combined.md",
+        frontmatter: { targets: ["geminicli"], description: "Combined" },
+        body: "Diff: !`git diff`\nFocus on $ARGUMENTS.",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody()).toBe("Diff: !{git diff}\nFocus on {{args}}.\n");
     });
   });
 

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { parse as parseToml } from "smol-toml";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_COMMANDS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
@@ -9,8 +10,6 @@ import {
   GeminiCliCommand,
   GeminiCliCommandFrontmatter,
   GeminiCliCommandFrontmatterSchema,
-  translateGeminiBodyToRulesync,
-  translateRulesyncBodyToGemini,
 } from "./geminicli-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 
@@ -818,74 +817,112 @@ Token {{args}}-foo and prefix{{args}} here.
       });
 
       expect(geminiCommand.getBody().trimEnd()).toBe("Run !{echo `hello`}.");
+
+      // The on-disk TOML must parse cleanly (the basic-string serializer
+      // escapes the embedded backtick as part of the prompt value) and must
+      // not contain an unescaped `"""` triple-quote — a malformed serializer
+      // could otherwise break out of a multi-line literal.
+      const fileContent = geminiCommand.getFileContent();
+      expect(fileContent).not.toContain('"""');
+      expect(() => parseToml(fileContent)).not.toThrow();
+      const parsed = parseToml(fileContent) as { prompt: string };
+      expect(parsed.prompt).toContain("Run !{echo `hello`}.");
     });
   });
 
-  describe("translateRulesyncBodyToGemini (direct unit tests)", () => {
+  describe("forward translation edge cases (rulesync → Gemini CLI)", () => {
+    const translateBody = (body: string): string => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "edge.md",
+        frontmatter: { targets: ["geminicli"], description: "edge" },
+        body,
+        fileContent: "",
+        validate: true,
+      });
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+      // The serializer appends a trailing \n; strip it for comparison so the
+      // assertions focus on the translation output itself.
+      return geminiCommand.getBody().replace(/\n$/, "");
+    };
+
     it("translates $ARGUMENTS to {{args}}", () => {
-      expect(translateRulesyncBodyToGemini("Focus on $ARGUMENTS.")).toBe("Focus on {{args}}.");
+      expect(translateBody("Focus on $ARGUMENTS.")).toBe("Focus on {{args}}.");
     });
 
     it("translates !`cmd` to !{cmd}", () => {
-      expect(translateRulesyncBodyToGemini("Run !`git status`.")).toBe("Run !{git status}.");
+      expect(translateBody("Run !`git status`.")).toBe("Run !{git status}.");
     });
 
     it("preserves $ARGUMENTSx (no leading or trailing word boundary mismatch)", () => {
-      expect(translateRulesyncBodyToGemini("$ARGUMENTSx remains")).toBe("$ARGUMENTSx remains");
+      expect(translateBody("$ARGUMENTSx remains")).toBe("$ARGUMENTSx remains");
     });
 
     it("translates $ARGUMENTS-foo (hyphen is not a word char)", () => {
-      expect(translateRulesyncBodyToGemini("$ARGUMENTS-foo")).toBe("{{args}}-foo");
+      expect(translateBody("$ARGUMENTS-foo")).toBe("{{args}}-foo");
     });
 
     it("translates a leading $ARGUMENTS at start of input", () => {
-      expect(translateRulesyncBodyToGemini("$ARGUMENTS go")).toBe("{{args}} go");
+      expect(translateBody("$ARGUMENTS go")).toBe("{{args}} go");
     });
 
     it("translates a trailing $ARGUMENTS at end of input", () => {
-      expect(translateRulesyncBodyToGemini("go $ARGUMENTS")).toBe("go {{args}}");
+      expect(translateBody("go $ARGUMENTS")).toBe("go {{args}}");
     });
 
     it("translates prefix$ARGUMENTS (no leading boundary anchor)", () => {
-      expect(translateRulesyncBodyToGemini("prefix$ARGUMENTS")).toBe("prefix{{args}}");
+      expect(translateBody("prefix$ARGUMENTS")).toBe("prefix{{args}}");
     });
 
     it("preserves $ARGUMENTS_FOO (underscore is a word char)", () => {
-      expect(translateRulesyncBodyToGemini("$ARGUMENTS_FOO")).toBe("$ARGUMENTS_FOO");
+      expect(translateBody("$ARGUMENTS_FOO")).toBe("$ARGUMENTS_FOO");
     });
 
     it("rewrites nested !`echo $ARGUMENTS` to !{echo {{args}}}", () => {
-      expect(translateRulesyncBodyToGemini("Run !`echo $ARGUMENTS`.")).toBe(
-        "Run !{echo {{args}}}.",
-      );
+      expect(translateBody("Run !`echo $ARGUMENTS`.")).toBe("Run !{echo {{args}}}.");
     });
   });
 
-  describe("translateGeminiBodyToRulesync (direct unit tests)", () => {
+  describe("reverse translation edge cases (Gemini CLI → rulesync)", () => {
+    const translateBody = (body: string): string => {
+      const tomlContent = `description = "edge"\nprompt = ${JSON.stringify(body)}\n`;
+      const geminiCommand = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: join(".gemini", "commands"),
+        relativeFilePath: "edge.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+      return geminiCommand.toRulesyncCommand().getBody();
+    };
+
     it("translates {{args}} to $ARGUMENTS", () => {
-      expect(translateGeminiBodyToRulesync("Focus on {{args}}.")).toBe("Focus on $ARGUMENTS.");
+      expect(translateBody("Focus on {{args}}.")).toBe("Focus on $ARGUMENTS.");
     });
 
     it("translates {{ args }} (with whitespace) to $ARGUMENTS", () => {
-      expect(translateGeminiBodyToRulesync("Focus on {{ args }}.")).toBe("Focus on $ARGUMENTS.");
+      expect(translateBody("Focus on {{ args }}.")).toBe("Focus on $ARGUMENTS.");
     });
 
     it("translates !{cmd} to !`cmd`", () => {
-      expect(translateGeminiBodyToRulesync("Run !{git status}.")).toBe("Run !`git status`.");
+      expect(translateBody("Run !{git status}.")).toBe("Run !`git status`.");
     });
 
     it("translates multiple !{...} occurrences", () => {
-      expect(translateGeminiBodyToRulesync("A !{cmd1} B !{cmd2} C")).toBe("A !`cmd1` B !`cmd2` C");
+      expect(translateBody("A !{cmd1} B !{cmd2} C")).toBe("A !`cmd1` B !`cmd2` C");
     });
 
     it("translates nested !{echo {{args}}} to !`echo $ARGUMENTS` in one pass", () => {
-      expect(translateGeminiBodyToRulesync("Run !{echo {{args}}} now.")).toBe(
-        "Run !`echo $ARGUMENTS` now.",
-      );
+      expect(translateBody("Run !{echo {{args}}} now.")).toBe("Run !`echo $ARGUMENTS` now.");
     });
 
     it("handles multi-line bodies", () => {
-      expect(translateGeminiBodyToRulesync("Line1 !{a}\nLine2 with {{args}}\nLine3 !{b}")).toBe(
+      expect(translateBody("Line1 !{a}\nLine2 with {{args}}\nLine3 !{b}")).toBe(
         "Line1 !`a`\nLine2 with $ARGUMENTS\nLine3 !`b`",
       );
     });
@@ -893,7 +930,7 @@ Token {{args}}-foo and prefix{{args}} here.
     it("does not match across newlines for !{...}", () => {
       // The non-greedy [^}\n]+? still excludes newlines, matching the
       // forward direction's `!\`[^\`\n]+\`` anchor.
-      expect(translateGeminiBodyToRulesync("!{abc\ndef}")).toBe("!{abc\ndef}");
+      expect(translateBody("!{abc\ndef}")).toBe("!{abc\ndef}");
     });
   });
 

--- a/src/features/commands/geminicli-command.test.ts
+++ b/src/features/commands/geminicli-command.test.ts
@@ -9,6 +9,8 @@ import {
   GeminiCliCommand,
   GeminiCliCommandFrontmatter,
   GeminiCliCommandFrontmatterSchema,
+  translateGeminiBodyToRulesync,
+  translateRulesyncBodyToGemini,
 } from "./geminicli-command.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 
@@ -266,7 +268,35 @@ Run !{git status} and report.
 
       const restored = geminiCommand.toRulesyncCommand();
 
-      expect(restored.getBody()).toBe(`${originalBody}\n`);
+      expect(restored.getBody().trimEnd()).toBe(originalBody);
+    });
+
+    it("should round-trip nested !`echo $ARGUMENTS` shell expansion", () => {
+      // Regression test for the previously-greedy reverse regex that ate the
+      // wrapping `!{...}` when the body contained a nested `{{args}}`.
+      const originalBody = "Run !`echo $ARGUMENTS` now.";
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "nested-round-trip.md",
+        frontmatter: { targets: ["geminicli"], description: "Nested" },
+        body: originalBody,
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      // Forward direction
+      expect(geminiCommand.getBody().trimEnd()).toBe("Run !{echo {{args}}} now.");
+
+      // Reverse direction
+      const restored = geminiCommand.toRulesyncCommand();
+      expect(restored.getBody().trimEnd()).toBe(originalBody);
     });
 
     it("should convert to RulesyncCommand with empty description", () => {
@@ -576,9 +606,8 @@ Focus on {{ args }}.
     });
 
     it("should round-trip gemini -> rulesync -> gemini preserving syntax", () => {
-      // The TOML triple-quoted serializer adds a single trailing newline on
-      // round-trip, which is normal. We assert that the meaningful syntax
-      // (placeholders, lines, content) is preserved.
+      // The TOML serializer normalizes trailing whitespace on round-trip, so
+      // we compare with `.trimEnd()` to focus on meaningful body content.
       const tomlContent = `description = "Inverse"
 prompt = """
 Diff: !{git diff}
@@ -599,9 +628,272 @@ Focus on {{args}}.
         validate: true,
       });
 
-      // Trim trailing whitespace introduced by the TOML serializer to compare
-      // the meaningful body content.
       expect(restored.getBody().trimEnd()).toBe("Diff: !{git diff}\nFocus on {{args}}.");
+    });
+
+    it("should canonicalize multiple {{args}} occurrences on import", () => {
+      const tomlContent = `description = "Args multi"
+prompt = """
+First: {{args}}. Second: {{args}}.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "args-multi.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody().trimEnd()).toBe("First: $ARGUMENTS. Second: $ARGUMENTS.");
+    });
+
+    it("should canonicalize multi-line bodies with both placeholders on import", () => {
+      const tomlContent = `description = "Combined"
+prompt = """
+Diff: !{git diff}
+Focus on {{args}}.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "combined-import.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody().trimEnd()).toBe("Diff: !`git diff`\nFocus on $ARGUMENTS.");
+    });
+
+    it("should canonicalize {{args}} adjacent to alphanumeric characters", () => {
+      const tomlContent = `description = "Adjacent"
+prompt = """
+Token {{args}}-foo and prefix{{args}} here.
+"""`;
+      const command = new GeminiCliCommand({
+        outputRoot: testDir,
+        relativeDirPath: ".gemini/commands",
+        relativeFilePath: "adjacent.toml",
+        fileContent: tomlContent,
+        validate: true,
+      });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+
+      expect(rulesyncCommand.getBody().trimEnd()).toBe(
+        "Token $ARGUMENTS-foo and prefix$ARGUMENTS here.",
+      );
+    });
+  });
+
+  describe("TOML escaping in fromRulesyncCommand", () => {
+    it("should escape double quotes in description without breaking TOML", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "quotes-desc.md",
+        frontmatter: {
+          targets: ["geminicli"],
+          description: 'Title with "quoted" word',
+        },
+        body: "body",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getFrontmatter()).toMatchObject({
+        description: 'Title with "quoted" word',
+      });
+      // The TOML must be re-parseable (i.e. quotes were escaped, not raw).
+      expect(geminiCommand.validate().success).toBe(true);
+    });
+
+    it("should escape backslashes in description without breaking TOML", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "backslash-desc.md",
+        frontmatter: {
+          targets: ["geminicli"],
+          description: "Path C:\\foo\\bar",
+        },
+        body: "body",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getFrontmatter()).toMatchObject({
+        description: "Path C:\\foo\\bar",
+      });
+      expect(geminiCommand.validate().success).toBe(true);
+    });
+
+    it("should preserve newlines in description across TOML round-trip", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "newline-desc.md",
+        frontmatter: {
+          targets: ["geminicli"],
+          description: "Line 1\nLine 2",
+        },
+        body: "body",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getFrontmatter()).toMatchObject({
+        description: "Line 1\nLine 2",
+      });
+    });
+
+    it("should preserve embedded triple-quote sequence in prompt body", () => {
+      // Bodies that contain `"""` would have broken the previous
+      // multi-line literal serializer. The smol-toml stringify path encodes
+      // them as `\"\"\"` so they round-trip cleanly.
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "triple-quote.md",
+        frontmatter: { targets: ["geminicli"], description: "Triple" },
+        body: 'Body with """ inside it.',
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody().trimEnd()).toBe('Body with """ inside it.');
+      expect(geminiCommand.validate().success).toBe(true);
+    });
+
+    it("should preserve a backtick inside !{...} on forward translation", () => {
+      // The forward regex requires no backtick inside !`...`, so users who
+      // need a literal backtick in a Gemini-native shell expansion must
+      // hand-author it via the geminicli.prompt override. This test pins
+      // that the override path still emits the body verbatim.
+      const rulesyncCommand = new RulesyncCommand({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "backtick-shell.md",
+        frontmatter: {
+          targets: ["geminicli"],
+          description: "Backtick shell",
+          geminicli: { prompt: "Run !{echo `hello`}." },
+        },
+        body: "ignored",
+        fileContent: "",
+        validate: true,
+      });
+
+      const geminiCommand = GeminiCliCommand.fromRulesyncCommand({
+        outputRoot: testDir,
+        rulesyncCommand,
+        validate: true,
+      });
+
+      expect(geminiCommand.getBody().trimEnd()).toBe("Run !{echo `hello`}.");
+    });
+  });
+
+  describe("translateRulesyncBodyToGemini (direct unit tests)", () => {
+    it("translates $ARGUMENTS to {{args}}", () => {
+      expect(translateRulesyncBodyToGemini("Focus on $ARGUMENTS.")).toBe("Focus on {{args}}.");
+    });
+
+    it("translates !`cmd` to !{cmd}", () => {
+      expect(translateRulesyncBodyToGemini("Run !`git status`.")).toBe("Run !{git status}.");
+    });
+
+    it("preserves $ARGUMENTSx (no leading or trailing word boundary mismatch)", () => {
+      expect(translateRulesyncBodyToGemini("$ARGUMENTSx remains")).toBe("$ARGUMENTSx remains");
+    });
+
+    it("translates $ARGUMENTS-foo (hyphen is not a word char)", () => {
+      expect(translateRulesyncBodyToGemini("$ARGUMENTS-foo")).toBe("{{args}}-foo");
+    });
+
+    it("translates a leading $ARGUMENTS at start of input", () => {
+      expect(translateRulesyncBodyToGemini("$ARGUMENTS go")).toBe("{{args}} go");
+    });
+
+    it("translates a trailing $ARGUMENTS at end of input", () => {
+      expect(translateRulesyncBodyToGemini("go $ARGUMENTS")).toBe("go {{args}}");
+    });
+
+    it("translates prefix$ARGUMENTS (no leading boundary anchor)", () => {
+      expect(translateRulesyncBodyToGemini("prefix$ARGUMENTS")).toBe("prefix{{args}}");
+    });
+
+    it("preserves $ARGUMENTS_FOO (underscore is a word char)", () => {
+      expect(translateRulesyncBodyToGemini("$ARGUMENTS_FOO")).toBe("$ARGUMENTS_FOO");
+    });
+
+    it("rewrites nested !`echo $ARGUMENTS` to !{echo {{args}}}", () => {
+      expect(translateRulesyncBodyToGemini("Run !`echo $ARGUMENTS`.")).toBe(
+        "Run !{echo {{args}}}.",
+      );
+    });
+  });
+
+  describe("translateGeminiBodyToRulesync (direct unit tests)", () => {
+    it("translates {{args}} to $ARGUMENTS", () => {
+      expect(translateGeminiBodyToRulesync("Focus on {{args}}.")).toBe("Focus on $ARGUMENTS.");
+    });
+
+    it("translates {{ args }} (with whitespace) to $ARGUMENTS", () => {
+      expect(translateGeminiBodyToRulesync("Focus on {{ args }}.")).toBe("Focus on $ARGUMENTS.");
+    });
+
+    it("translates !{cmd} to !`cmd`", () => {
+      expect(translateGeminiBodyToRulesync("Run !{git status}.")).toBe("Run !`git status`.");
+    });
+
+    it("translates multiple !{...} occurrences", () => {
+      expect(translateGeminiBodyToRulesync("A !{cmd1} B !{cmd2} C")).toBe("A !`cmd1` B !`cmd2` C");
+    });
+
+    it("translates nested !{echo {{args}}} to !`echo $ARGUMENTS` in one pass", () => {
+      expect(translateGeminiBodyToRulesync("Run !{echo {{args}}} now.")).toBe(
+        "Run !`echo $ARGUMENTS` now.",
+      );
+    });
+
+    it("handles multi-line bodies", () => {
+      expect(translateGeminiBodyToRulesync("Line1 !{a}\nLine2 with {{args}}\nLine3 !{b}")).toBe(
+        "Line1 !`a`\nLine2 with $ARGUMENTS\nLine3 !`b`",
+      );
+    });
+
+    it("does not match across newlines for !{...}", () => {
+      // The non-greedy [^}\n]+? still excludes newlines, matching the
+      // forward direction's `!\`[^\`\n]+\`` anchor.
+      expect(translateGeminiBodyToRulesync("!{abc\ndef}")).toBe("!{abc\ndef}");
     });
   });
 

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { parse as parseToml } from "smol-toml";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { z } from "zod/mini";
 
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
@@ -22,21 +22,48 @@ export const GeminiCliCommandFrontmatterSchema = z.looseObject({
   prompt: z.string(),
 });
 
-// Translate rulesync universal command syntax (Claude Code compatible) into
-// Gemini CLI's native syntax. See docs/reference/command-syntax.md.
-//
-// Note: this translation only rewrites the universal forms (`$ARGUMENTS` and
-// `` !`cmd` ``). Bodies that already contain Gemini-native forms (`{{args}}`
-// or `!{cmd}`) are left untouched, which gives us the documented
-// "we do not re-translate already-Gemini-native forms" property.
-function translateRulesyncBodyToGemini(body: string): string {
+/**
+ * Translate rulesync universal command syntax (Claude Code compatible) into
+ * Gemini CLI's native syntax. See docs/reference/command-syntax.md.
+ *
+ * Replacement order:
+ *   1. `` !`cmd` `` → `!{cmd}`  (backtick shell expansion → brace form)
+ *   2. `$ARGUMENTS` → `{{args}}` (handled after step 1 so that
+ *      `` !`echo $ARGUMENTS` `` survives as `!{echo {{args}}}` rather than
+ *      requiring two passes).
+ *
+ * `$ARGUMENTS\b` uses a trailing word boundary so `$ARGUMENTSx` and
+ * `$ARGUMENTS_FOO` are left alone, while `$ARGUMENTS-foo` (hyphen is not a
+ * word char) is rewritten. There is no leading anchor, so `prefix$ARGUMENTS`
+ * is rewritten to `prefix{{args}}`.
+ *
+ * Bodies that already contain Gemini-native forms (`{{args}}` or `!{cmd}`)
+ * are left untouched, which gives us the documented "we do not re-translate
+ * already-Gemini-native forms" property. This is exported for direct unit
+ * testing.
+ */
+export function translateRulesyncBodyToGemini(body: string): string {
   return body.replace(/!`([^`\n]+)`/g, "!{$1}").replace(/\$ARGUMENTS\b/g, "{{args}}");
 }
 
-// Inverse of translateRulesyncBodyToGemini, used when importing a Gemini CLI
-// command file back into rulesync's universal syntax.
-function translateGeminiBodyToRulesync(body: string): string {
-  return body.replace(/!\{([^}\n]+)\}/g, "!`$1`").replace(/\{\{\s*args\s*\}\}/g, "$ARGUMENTS");
+/**
+ * Inverse of {@link translateRulesyncBodyToGemini}, used when importing a
+ * Gemini CLI command file back into rulesync's universal syntax.
+ *
+ * Replacement order is intentionally inverted from the forward direction:
+ *   1. `{{args}}` → `$ARGUMENTS` (handled first)
+ *   2. `!{cmd}` → `` !`cmd` `` (handled second, with a non-greedy body
+ *      `[^}\n]+?`)
+ *
+ * Doing `{{args}}` first ensures that nested forms like
+ * `!{echo {{args}}}` round-trip back to `` !`echo $ARGUMENTS` `` in a single
+ * pass: the inner `{{args}}` is rewritten to `$ARGUMENTS`, and then the
+ * non-greedy `!{...}` match consumes the smallest possible body.
+ *
+ * Exported for direct unit testing.
+ */
+export function translateGeminiBodyToRulesync(body: string): string {
+  return body.replace(/\{\{\s*args\s*\}\}/g, "$ARGUMENTS").replace(/!\{([^}\n]+?)\}/g, "!`$1`");
 }
 
 export type GeminiCliCommandFrontmatter = z.infer<typeof GeminiCliCommandFrontmatterSchema>;
@@ -108,7 +135,11 @@ export class GeminiCliCommand extends ToolCommand {
 
     const universalBody = translateGeminiBodyToRulesync(this.body);
 
-    // Generate proper file content with Rulesync specific frontmatter
+    // Generate proper file content with Rulesync specific frontmatter. The
+    // `body` and `fileContent` fields below are derived from the same
+    // `universalBody` source string, so they stay in sync — `body` is the
+    // raw markdown content while `fileContent` is the same content wrapped
+    // with YAML frontmatter for on-disk serialization.
     const fileContent = stringifyFrontmatter(universalBody, rulesyncFrontmatter);
 
     return new RulesyncCommand({
@@ -146,16 +177,26 @@ export class GeminiCliCommand extends ToolCommand {
       ...geminicliFields,
     };
 
-    // Generate proper file content with TOML format
-    // Note: TOML format only supports description and prompt fields
-    // Extra fields from geminicli section are stored in the object but not serialized to TOML
-    const descriptionLine =
-      geminiFrontmatter.description !== undefined
-        ? `description = "${geminiFrontmatter.description}"\n`
-        : "";
-    const tomlContent = `${descriptionLine}prompt = """
-${geminiFrontmatter.prompt}
-"""`;
+    // Serialize via smol-toml's stringify so that special characters in the
+    // description / prompt (`"`, `\`, control chars, embedded `"""`, etc.)
+    // are properly escaped instead of breaking out of the TOML literal. The
+    // serializer emits each value as a basic string with JSON-style escaping
+    // — multi-line bodies are encoded with `\n` escape sequences, which
+    // round-trip cleanly through `parseToml`.
+    const tomlObject: Record<string, unknown> = {};
+    if (geminiFrontmatter.description !== undefined) {
+      tomlObject.description = geminiFrontmatter.description;
+    }
+    // Preserve the historical behavior of emitting a trailing newline on the
+    // prompt body. The previous implementation used a `"""\n${body}\n"""`
+    // multi-line literal, which TOML parses as `${body}\n`; downstream code
+    // and tests rely on this trailing newline.
+    tomlObject.prompt = geminiFrontmatter.prompt.endsWith("\n")
+      ? geminiFrontmatter.prompt
+      : `${geminiFrontmatter.prompt}\n`;
+    // Note: TOML output only carries description and prompt. Extra fields
+    // from the `geminicli` rulesync section are intentionally not serialized.
+    const tomlContent = stringifyToml(tomlObject);
 
     const paths = this.getSettablePaths({ global });
 

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -22,6 +22,18 @@ export const GeminiCliCommandFrontmatterSchema = z.looseObject({
   prompt: z.string(),
 });
 
+// Translate rulesync universal command syntax (Claude Code compatible) into
+// Gemini CLI's native syntax. See docs/reference/command-syntax.md.
+function translateRulesyncBodyToGemini(body: string): string {
+  return body.replace(/!`([^`\n]+)`/g, "!{$1}").replace(/\$ARGUMENTS\b/g, "{{args}}");
+}
+
+// Inverse of translateRulesyncBodyToGemini, used when importing a Gemini CLI
+// command file back into rulesync's universal syntax.
+function translateGeminiBodyToRulesync(body: string): string {
+  return body.replace(/!\{([^}\n]+)\}/g, "!`$1`").replace(/\{\{\s*args\s*\}\}/g, "$ARGUMENTS");
+}
+
 export type GeminiCliCommandFrontmatter = z.infer<typeof GeminiCliCommandFrontmatterSchema>;
 
 export type GeminiCliCommandParams = {
@@ -89,13 +101,15 @@ export class GeminiCliCommand extends ToolCommand {
       ...(Object.keys(restFields).length > 0 && { geminicli: restFields }),
     };
 
+    const universalBody = translateGeminiBodyToRulesync(this.body);
+
     // Generate proper file content with Rulesync specific frontmatter
-    const fileContent = stringifyFrontmatter(this.body, rulesyncFrontmatter);
+    const fileContent = stringifyFrontmatter(universalBody, rulesyncFrontmatter);
 
     return new RulesyncCommand({
       outputRoot: process.cwd(), // RulesyncCommand outputRoot is always the project root directory
       frontmatter: rulesyncFrontmatter,
-      body: this.body,
+      body: universalBody,
       relativeDirPath: RulesyncCommand.getSettablePaths().relativeDirPath,
       relativeFilePath: this.relativeFilePath,
       fileContent,
@@ -114,9 +128,14 @@ export class GeminiCliCommand extends ToolCommand {
     // Merge geminicli-specific fields from rulesync frontmatter
     const geminicliFields = rulesyncFrontmatter.geminicli ?? {};
 
+    // Translate universal command syntax to Gemini CLI's native syntax. If the
+    // user provided an explicit `geminicli.prompt` override, respect it as-is to
+    // avoid double-translation when they intentionally hand-write Gemini syntax.
+    const translatedPrompt = translateRulesyncBodyToGemini(rulesyncCommand.getBody());
+
     const geminiFrontmatter: GeminiCliCommandFrontmatter = {
       description: rulesyncFrontmatter.description,
-      prompt: rulesyncCommand.getBody(),
+      prompt: translatedPrompt,
       ...geminicliFields,
     };
 

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -24,6 +24,11 @@ export const GeminiCliCommandFrontmatterSchema = z.looseObject({
 
 // Translate rulesync universal command syntax (Claude Code compatible) into
 // Gemini CLI's native syntax. See docs/reference/command-syntax.md.
+//
+// Note: this translation only rewrites the universal forms (`$ARGUMENTS` and
+// `` !`cmd` ``). Bodies that already contain Gemini-native forms (`{{args}}`
+// or `!{cmd}`) are left untouched, which gives us the documented
+// "we do not re-translate already-Gemini-native forms" property.
 function translateRulesyncBodyToGemini(body: string): string {
   return body.replace(/!`([^`\n]+)`/g, "!{$1}").replace(/\$ARGUMENTS\b/g, "{{args}}");
 }
@@ -128,9 +133,11 @@ export class GeminiCliCommand extends ToolCommand {
     // Merge geminicli-specific fields from rulesync frontmatter
     const geminicliFields = rulesyncFrontmatter.geminicli ?? {};
 
-    // Translate universal command syntax to Gemini CLI's native syntax. If the
-    // user provided an explicit `geminicli.prompt` override, respect it as-is to
-    // avoid double-translation when they intentionally hand-write Gemini syntax.
+    // Translate universal command syntax to Gemini CLI's native syntax. The
+    // translated body is used as the default `prompt`, but any explicit
+    // `geminicli.prompt` field carried in `geminicliFields` will overwrite it
+    // via the spread below — users who hand-author Gemini-native syntax in the
+    // `geminicli` section are assumed to want it emitted verbatim.
     const translatedPrompt = translateRulesyncBodyToGemini(rulesyncCommand.getBody());
 
     const geminiFrontmatter: GeminiCliCommandFrontmatter = {

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -39,10 +39,9 @@ export const GeminiCliCommandFrontmatterSchema = z.looseObject({
  *
  * Bodies that already contain Gemini-native forms (`{{args}}` or `!{cmd}`)
  * are left untouched, which gives us the documented "we do not re-translate
- * already-Gemini-native forms" property. This is exported for direct unit
- * testing.
+ * already-Gemini-native forms" property.
  */
-export function translateRulesyncBodyToGemini(body: string): string {
+function translateRulesyncBodyToGemini(body: string): string {
   return body.replace(/!`([^`\n]+)`/g, "!{$1}").replace(/\$ARGUMENTS\b/g, "{{args}}");
 }
 
@@ -59,10 +58,8 @@ export function translateRulesyncBodyToGemini(body: string): string {
  * `!{echo {{args}}}` round-trip back to `` !`echo $ARGUMENTS` `` in a single
  * pass: the inner `{{args}}` is rewritten to `$ARGUMENTS`, and then the
  * non-greedy `!{...}` match consumes the smallest possible body.
- *
- * Exported for direct unit testing.
  */
-export function translateGeminiBodyToRulesync(body: string): string {
+function translateGeminiBodyToRulesync(body: string): string {
   return body.replace(/\{\{\s*args\s*\}\}/g, "$ARGUMENTS").replace(/!\{([^}\n]+?)\}/g, "!`$1`");
 }
 
@@ -164,12 +161,15 @@ export class GeminiCliCommand extends ToolCommand {
     // Merge geminicli-specific fields from rulesync frontmatter
     const geminicliFields = rulesyncFrontmatter.geminicli ?? {};
 
-    // Translate universal command syntax to Gemini CLI's native syntax. The
-    // translated body is used as the default `prompt`, but any explicit
-    // `geminicli.prompt` field carried in `geminicliFields` will overwrite it
-    // via the spread below — users who hand-author Gemini-native syntax in the
-    // `geminicli` section are assumed to want it emitted verbatim.
-    const translatedPrompt = translateRulesyncBodyToGemini(rulesyncCommand.getBody());
+    // Translate universal command syntax to Gemini CLI's native syntax —
+    // unless an explicit `geminicli.prompt` override is present, in which
+    // case the user is hand-authoring the Gemini-native body and we skip
+    // translation entirely. Short-circuiting here avoids running the regex
+    // pipeline only to discard its result via the spread below.
+    const hasPromptOverride = typeof geminicliFields.prompt === "string";
+    const translatedPrompt = hasPromptOverride
+      ? ""
+      : translateRulesyncBodyToGemini(rulesyncCommand.getBody());
 
     const geminiFrontmatter: GeminiCliCommandFrontmatter = {
       description: rulesyncFrontmatter.description,
@@ -187,10 +187,21 @@ export class GeminiCliCommand extends ToolCommand {
     if (geminiFrontmatter.description !== undefined) {
       tomlObject.description = geminiFrontmatter.description;
     }
-    // Preserve the historical behavior of emitting a trailing newline on the
-    // prompt body. The previous implementation used a `"""\n${body}\n"""`
-    // multi-line literal, which TOML parses as `${body}\n`; downstream code
-    // and tests rely on this trailing newline.
+    // Preserve the historical trailing-newline behavior of the prompt body.
+    //
+    // Before the migration to `stringifyToml`, the serializer wrote
+    // `prompt = """\n${body}\n"""` — a multi-line basic string in which the
+    // surrounding literal newlines are real bytes on disk, parsed back into
+    // a single trailing `\n` by `parseToml`. Downstream code, snapshots, and
+    // round-trip tests rely on that trailing newline being present in
+    // `parsed.prompt`.
+    //
+    // The new `stringifyToml`-based serializer emits a basic single-line
+    // string with `\n` escape sequences instead. The on-disk *shape* is
+    // therefore different (no surrounding `"""`, escaped `\n` in place of
+    // raw newline bytes), but the parsed-string equivalence is preserved by
+    // unconditionally ensuring the in-memory value ends with `\n` before
+    // serialization. This keeps the externally-observable contract stable.
     tomlObject.prompt = geminiFrontmatter.prompt.endsWith("\n")
       ? geminiFrontmatter.prompt
       : `${geminiFrontmatter.prompt}\n`;


### PR DESCRIPTION
## Summary

- Translate rulesync's universal command-body syntax (Claude Code compatible) into Gemini CLI's native syntax when generating `.gemini/commands/*.toml`:
  - `$ARGUMENTS` → `{{args}}`
  - `` !`cmd` `` → `!{cmd}`
- Apply the inverse translation when importing a Gemini CLI command file back into rulesync, so round-trips are stable.
- Add a new docs reference page `docs/reference/command-syntax.md` summarizing the universal command syntax and per-tool translation table, and link it from `file-formats.md` plus the VitePress sidebar.

Closes #1551

## Test plan

- [x] `pnpm cicheck` (lint, type-check, full test suite, content checks)
- [x] New unit tests in `src/features/commands/geminicli-command.test.ts` cover forward translation, multiple occurrences, shell expansion, mixed cases, reverse translation, and a full rulesync → gemini → rulesync round-trip.
- [ ] Manual smoke test: author a rulesync command containing `` !`git diff` `` and `$ARGUMENTS`, run `rulesync generate --targets geminicli`, and verify the produced `.gemini/commands/*.toml` contains `!{git diff}` and `{{args}}`.