### PR TITLE
feat(skills): support Claude Code scheduled-task frontmatter routing

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -261,6 +261,7 @@ claudecode: # for claudecode-specific parameters
     - "Write"
     - "Grep"
   disable-model-invocation: true # (optional) disable model invocation for this skill
+  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
@@ -279,6 +280,8 @@ The skill can include:
 - Any relevant context
 
 Skills are directory-based and can include additional files alongside SKILL.md.
+
+When `claudecode.scheduled-task: true` is set, that skill is emitted only as a Claude Code scheduled task and is not emitted to other tools even if `targets` contains `"*"`.
 ```
 
 ## `.rulesync/mcp.json`

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -261,6 +261,7 @@ claudecode: # for claudecode-specific parameters
     - "Write"
     - "Grep"
   disable-model-invocation: true # (optional) disable model invocation for this skill
+  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
@@ -279,6 +280,8 @@ The skill can include:
 - Any relevant context
 
 Skills are directory-based and can include additional files alongside SKILL.md.
+
+When `claudecode.scheduled-task: true` is set, that skill is emitted only as a Claude Code scheduled task and is not emitted to other tools even if `targets` contains `"*"`.
 ```
 
 ## `.rulesync/mcp.json`

--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -209,11 +209,13 @@ describe("ClaudecodeSkill", () => {
     it("should return default paths", () => {
       const paths = ClaudecodeSkill.getSettablePaths();
       expect(paths.relativeDirPath).toBe(join(".claude", "skills"));
+      expect(paths.alternativeSkillRoots).toEqual([join(".claude", "scheduled-tasks")]);
     });
 
     it("should return same paths for global mode", () => {
       const paths = ClaudecodeSkill.getSettablePaths({ global: true });
       expect(paths.relativeDirPath).toBe(join(".claude", "skills"));
+      expect(paths.alternativeSkillRoots).toEqual([join(".claude", "scheduled-tasks")]);
     });
   });
 
@@ -368,6 +370,23 @@ describe("ClaudecodeSkill", () => {
 
       const rulesyncSkill = skill.toRulesyncSkill();
       expect(rulesyncSkill.getOtherFiles()).toEqual(otherFiles);
+    });
+
+    it("should mark scheduled-task when converting scheduled-task directory", () => {
+      const skill = new ClaudecodeSkill({
+        dirName: "weekly-review",
+        relativeDirPath: join(".claude", "scheduled-tasks"),
+        frontmatter: {
+          name: "weekly-review",
+          description: "Weekly review task",
+        },
+        body: "Run weekly review",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().claudecode).toEqual({
+        "scheduled-task": true,
+      });
     });
   });
 
@@ -568,6 +587,27 @@ describe("ClaudecodeSkill", () => {
 
       expect(claudecodeSkill.getGlobal()).toBe(true);
     });
+
+    it("should route scheduled-task skills to scheduled-tasks directory", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "weekly-review",
+        frontmatter: {
+          name: "weekly-review",
+          description: "Weekly review task",
+          claudecode: {
+            "scheduled-task": true,
+          },
+        },
+        body: "Run weekly review",
+      });
+
+      const claudecodeSkill = ClaudecodeSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        global: true,
+      });
+
+      expect(claudecodeSkill.getRelativeDirPath()).toBe(join(".claude", "scheduled-tasks"));
+    });
   });
 
   describe("isTargetedByRulesyncSkill", () => {
@@ -581,6 +621,23 @@ describe("ClaudecodeSkill", () => {
         dirName: "test-skill",
         frontmatter: rulesyncFrontmatter,
         body: "Test body",
+      });
+
+      expect(ClaudecodeSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should target scheduled-task even when targets does not include claudecode", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        dirName: "scheduled-only",
+        frontmatter: {
+          name: "scheduled-only",
+          description: "Scheduled task",
+          targets: ["cursor"],
+          claudecode: {
+            "scheduled-task": true,
+          },
+        },
+        body: "Scheduled body",
       });
 
       expect(ClaudecodeSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -15,6 +15,9 @@ import {
   ToolSkillSettablePaths,
 } from "./tool-skill.js";
 
+const CLAUDE_SKILLS_DIR_PATH = join(".claude", "skills");
+const CLAUDE_SCHEDULED_TASKS_DIR_PATH = join(".claude", "scheduled-tasks");
+
 export const ClaudecodeSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
@@ -78,12 +81,9 @@ export class ClaudecodeSkill extends ToolSkill {
   }: {
     global?: boolean;
   } = {}): ToolSkillSettablePaths {
-    // Claude Code skills use the same relative path for both project and global modes
-    // The actual location differs based on outputRoot:
-    // - Project mode: {process.cwd()}/.claude/skills/
-    // - Global mode: {getHomeDirectory()}/.claude/skills/
     return {
-      relativeDirPath: join(".claude", "skills"),
+      relativeDirPath: CLAUDE_SKILLS_DIR_PATH,
+      alternativeSkillRoots: [CLAUDE_SCHEDULED_TASKS_DIR_PATH],
     };
   }
 
@@ -124,6 +124,7 @@ export class ClaudecodeSkill extends ToolSkill {
       ...(frontmatter["disable-model-invocation"] !== undefined && {
         "disable-model-invocation": frontmatter["disable-model-invocation"],
       }),
+      ...(this.relativeDirPath === CLAUDE_SCHEDULED_TASKS_DIR_PATH && { "scheduled-task": true }),
     };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
@@ -167,10 +168,13 @@ export class ClaudecodeSkill extends ToolSkill {
     };
 
     const settablePaths = ClaudecodeSkill.getSettablePaths({ global });
+    const relativeDirPath = rulesyncFrontmatter.claudecode?.["scheduled-task"]
+      ? CLAUDE_SCHEDULED_TASKS_DIR_PATH
+      : settablePaths.relativeDirPath;
 
     return new ClaudecodeSkill({
       outputRoot,
-      relativeDirPath: settablePaths.relativeDirPath,
+      relativeDirPath,
       dirName: rulesyncSkill.getDirName(),
       frontmatter: claudecodeFrontmatter,
       body: rulesyncSkill.getBody(),
@@ -181,7 +185,11 @@ export class ClaudecodeSkill extends ToolSkill {
   }
 
   static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
-    const targets = rulesyncSkill.getFrontmatter().targets;
+    const frontmatter = rulesyncSkill.getFrontmatter();
+    const targets = frontmatter.targets;
+    if (frontmatter.claudecode?.["scheduled-task"]) {
+      return true;
+    }
     return targets.includes("*") || targets.includes("claudecode");
   }
 

--- a/src/features/skills/rulesync-skill.test.ts
+++ b/src/features/skills/rulesync-skill.test.ts
@@ -91,6 +91,7 @@ describe("RulesyncSkill", () => {
         description: "Claude Code specific skill",
         claudecode: {
           "allowed-tools": ["Bash", "Read", "Write"],
+          "scheduled-task": true,
         },
       };
 
@@ -103,6 +104,7 @@ describe("RulesyncSkill", () => {
 
       expect(skill.getFrontmatter().claudecode).toEqual({
         "allowed-tools": ["Bash", "Read", "Write"],
+        "scheduled-task": true,
       });
     });
 

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -19,6 +19,7 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
       model: z.optional(z.string()),
       "disable-model-invocation": z.optional(z.boolean()),
+      "scheduled-task": z.optional(z.boolean()),
     }),
   ),
   codexcli: z.optional(
@@ -68,6 +69,7 @@ export type RulesyncSkillFrontmatterInput = {
     "allowed-tools"?: string[];
     model?: string;
     "disable-model-invocation"?: boolean;
+    "scheduled-task"?: boolean;
   };
   codexcli?: {
     "short-description"?: string;

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -209,6 +209,33 @@ describe("SkillsProcessor", () => {
       expect(toolDirs[0]).toBeInstanceOf(ClaudecodeSkill);
     });
 
+    it("should not convert claudecode scheduled-task skills for non-claudecode targets", async () => {
+      const cursorProcessor = new SkillsProcessor({
+        logger: createMockLogger(),
+        outputRoot: testDir,
+        toolTarget: "cursor",
+      });
+
+      const scheduledTaskSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "scheduled-task-only",
+        frontmatter: {
+          name: "scheduled-task-only",
+          description: "Scheduled task only",
+          targets: ["*"],
+          claudecode: {
+            "scheduled-task": true,
+          },
+        },
+        body: "Content",
+        validate: false,
+      });
+
+      const toolDirs = await cursorProcessor.convertRulesyncDirsToToolDirs([scheduledTaskSkill]);
+      expect(toolDirs).toEqual([]);
+    });
+
     it("should throw error for unsupported tool target", async () => {
       // Create processor with mock tool target (bypassing constructor validation)
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -336,6 +336,16 @@ export class SkillsProcessor extends DirFeatureProcessor {
 
     const toolSkills = rulesyncSkills
       .map((rulesyncSkill) => {
+        const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+        const isClaudecodeScheduledTask =
+          rulesyncFrontmatter.claudecode?.["scheduled-task"] === true;
+        if (
+          isClaudecodeScheduledTask &&
+          this.toolTarget !== "claudecode" &&
+          this.toolTarget !== "claudecode-legacy"
+        ) {
+          return null;
+        }
         if (!factory.class.isTargetedByRulesyncSkill(rulesyncSkill)) {
           return null;
         }


### PR DESCRIPTION
### Motivation
- Add explicit support for Claude Code scheduled tasks as requested in the issue by allowing a frontmatter flag to mark skills that should be emitted as Claude scheduled tasks instead of regular skills. 
- Ensure scheduled-task skills are routed to the Claude scheduled-tasks directory and are not emitted to other tools even when `targets: ["*"]`.

### Description
- Extended the Rulesync skill frontmatter schema with `claudecode.scheduled-task?: boolean` in `src/features/skills/rulesync-skill.ts` and corresponding TypeScript types. 
- Implemented Claude scheduled-task routing in `src/features/skills/claudecode-skill.ts` by adding constants for `.claude/skills` and `.claude/scheduled-tasks`, including `.claude/scheduled-tasks` in import/search roots, and routing `fromRulesyncSkill`/`toRulesyncSkill` accordingly. 
- Updated `SkillsProcessor` in `src/features/skills/skills-processor.ts` to exclude `claudecode.scheduled-task`-flagged skills from non-Claude targets so they are effectively Claude-only. 
- Added/updated unit tests covering schema acceptance, conversion, routing, and exclusive emission behavior in `src/features/skills/*.{test.ts}`. 
- Documented the new `claudecode.scheduled-task` flag in `docs/reference/file-formats.md` and synced the change to `skills/rulesync/file-formats.md`.

### Testing
- Ran the focused unit tests with `pnpm vitest run src/features/skills/rulesync-skill.test.ts src/features/skills/claudecode-skill.test.ts src/features/skills/skills-processor.test.ts` and all tests in those files passed. 
- Ran the full repository checks with `pnpm cicheck` (includes formatting, lint, typecheck and the full test suite) and it completed successfully after syncing docs; tests in the repo passed and content checks succeeded. 
- Also ran `pnpm run cspell` and `pnpm run secretlint` as part of CI checks which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09e168f2083309cd817edddd4c61a)

close https://github.com/dyoshikawa/rulesync/issues/1510