### PR TITLE
fix: normalize copilot root path comparisons

### DIFF
--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -620,6 +620,24 @@ This should be treated as a non-root rule.`;
       expect(copilotRule.getBody()).toBe("This should be treated as a non-root rule.");
     });
 
+    it("should normalize separators when detecting explicit root paths", async () => {
+      const githubDir = join(testDir, ".github");
+      await ensureDir(githubDir);
+
+      const rootContent = "Root detected with mixed separators.";
+      await writeFileContent(join(githubDir, "copilot-instructions.md"), rootContent);
+
+      const copilotRule = await CopilotRule.fromFile({
+        outputRoot: testDir,
+        relativeDirPath: ".github\\",
+        relativeFilePath: "copilot-instructions.md",
+        validate: true,
+      });
+
+      expect(copilotRule.isRoot()).toBe(true);
+      expect(copilotRule.getBody()).toBe(rootContent);
+    });
+
     it("should detect root only when both relativeDirPath and filename match", async () => {
       const githubDir = join(testDir, ".github");
       await ensureDir(githubDir);

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -48,6 +48,13 @@ export type CopilotRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal & {
   };
 };
 
+const normalizeRelativePath = (path: string): string =>
+  path.replace(/\\/g, "/").replace(/\/+/g, "/");
+
+const sameRelativePath = (leftDir: string, leftFile: string, rightDir: string, rightFile: string) =>
+  normalizeRelativePath(join(leftDir, leftFile)) ===
+  normalizeRelativePath(join(rightDir, rightFile));
+
 /**
  * Rule generator for GitHub Copilot
  *
@@ -209,8 +216,12 @@ export class CopilotRule extends ToolRule {
   }: ToolRuleFromFileParams): Promise<CopilotRule> {
     const paths = this.getSettablePaths({ global });
     const isRoot = relativeDirPath
-      ? join(relativeDirPath, relativeFilePath) ===
-        join(paths.root.relativeDirPath, paths.root.relativeFilePath)
+      ? sameRelativePath(
+          relativeDirPath,
+          relativeFilePath,
+          paths.root.relativeDirPath,
+          paths.root.relativeFilePath,
+        )
       : relativeFilePath === paths.root.relativeFilePath;
     const resolvedRelativeDirPath =
       relativeDirPath ??
@@ -270,9 +281,12 @@ export class CopilotRule extends ToolRule {
     global = false,
   }: ToolRuleForDeletionParams): CopilotRule {
     const paths = this.getSettablePaths({ global });
-    const isRoot =
-      join(relativeDirPath, relativeFilePath) ===
-      join(paths.root.relativeDirPath, paths.root.relativeFilePath);
+    const isRoot = sameRelativePath(
+      relativeDirPath,
+      relativeFilePath,
+      paths.root.relativeDirPath,
+      paths.root.relativeFilePath,
+    );
 
     return new CopilotRule({
       outputRoot,


### PR DESCRIPTION
## Summary
Fixes #1544

Normalize Copilot rule relative paths before comparing explicit paths against the root Copilot instruction path. This preserves directory-aware root detection while handling mixed path separators from Windows/WSL-style inputs.

## Changes
- Add shared relative-path normalization for Copilot root detection.
- Use it in both `fromFile` and `forDeletion` root checks.
- Add regression coverage for same-filename non-root detection and mixed-separator root detection.

## Test Plan
- `npx -y -p node@22 -p pnpm@10 pnpm exec vitest run src/features/rules/copilot-rule.test.ts --silent=true`
- `npx -y -p node@22 -p pnpm@10 pnpm run fmt:check`
- `npx -y -p node@22 -p pnpm@10 pnpm run typecheck`
- `npx -y -p node@22 -p pnpm@10 pnpm run oxlint -- src/features/rules/copilot-rule.ts src/features/rules/copilot-rule.test.ts`
- `npx -y -p node@22 -p pnpm@10 pnpm run eslint -- src/features/rules/copilot-rule.ts src/features/rules/copilot-rule.test.ts`

Note: the local host has Node v20.19.2, while the repo declares Node >=22.0.0, so checks were run via `node@22`/`pnpm@10` from npx.
