### PR TITLE
fix: address mid-severity follow-ups from PR #1570 and PR #1585

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -235,6 +235,7 @@
     "roomodes",
     "roorules",
     "rooveterinaryinc",
+    "roundtrippable",
     "Rovo",
     "Rovodev",
     "rovodev",

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -188,7 +188,10 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "kilo", feature: "commands", entry: "**/.kilo/workflows/" },
   { target: "kilo", feature: "mcp", entry: "**/.kilo/mcp.json" },
   { target: "kilo", feature: "ignore", entry: "**/.kiloignore" },
-  { target: "kilo", feature: "permissions", entry: "**/kilo.jsonc" },
+  // No `**/kilo.jsonc` entry: structurally identical to `opencode.jsonc` (no
+  // entry). The Kilo translator preserves non-permissions Kilo settings on
+  // round-trip, so the file is intended to be checked in by the user — adding
+  // `**/kilo.jsonc` would be too aggressive.
 
   // Kiro
   { target: "kiro", feature: "rules", entry: "**/.kiro/steering/" },

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -6,8 +6,12 @@ import { calculateTotalCount } from "../../utils/result.js";
 
 // `inputRoot` is intentionally excluded: it only affects where source rules
 // are *read from* during `generate`, and `import` does not consume them. Keeping
-// it in the option type would be misleading and would surface a noisy
-// "Ignoring global: true" warning from the resolver during `import`.
+// it in the option type would be misleading. Note that this avoids surfacing
+// the "Ignoring `global: true`" warning on direct programmatic / CLI callers;
+// users with a `inputRoot` set in their config file (e.g. `rulesync.jsonc`) may
+// still see the warning because `ConfigResolver.resolve` reads `configByFile`
+// regardless of this `Omit`. That residual warning is actionable — it tells
+// the user their config-file `inputRoot` is being ignored during `import`.
 //
 // The deprecated `baseDirs` programmatic alias is also excluded so that the
 // CLI's import options never expose a deprecated field — `outputRoots` is the

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -8,7 +8,7 @@ import { calculateTotalCount } from "../../utils/result.js";
 // are *read from* during `generate`, and `import` does not consume them. Keeping
 // it in the option type would be misleading. Note that this avoids surfacing
 // the "Ignoring `global: true`" warning on direct programmatic / CLI callers;
-// users with a `inputRoot` set in their config file (e.g. `rulesync.jsonc`) may
+// users with an `inputRoot` set in their config file (e.g. `rulesync.jsonc`) may
 // still see the warning because `ConfigResolver.resolve` reads `configByFile`
 // regardless of this `Omit`. That residual warning is actionable — it tells
 // the user their config-file `inputRoot` is being ignored during `import`.

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -123,6 +123,36 @@ describe("HooksProcessor", () => {
       expect(files).toHaveLength(1);
       expect(files[0]).toBeInstanceOf(RulesyncHooks);
     });
+
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncFiles
+    // reads `<inputRoot>/.rulesync/hooks.json` instead of
+    // `<process.cwd()>/.rulesync/hooks.json`.
+    it("should read rulesync hooks file from inputRoot instead of process.cwd()", async () => {
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      await ensureDir(join(customInputRoot, RULESYNC_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(customInputRoot, RULESYNC_HOOKS_RELATIVE_FILE_PATH),
+        JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: [{ type: "command", command: "from-input-root" }] },
+        }),
+      );
+
+      // outputRoot is testDir; no hooks file exists there, so a successful
+      // load proves the processor read from inputRoot.
+      const processor = new HooksProcessor({
+        logger,
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "claudecode",
+      });
+      const files = await processor.loadRulesyncFiles();
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(RulesyncHooks);
+      const json = (files[0] as RulesyncHooks).getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("from-input-root");
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -132,6 +132,34 @@ describe("IgnoreProcessor", () => {
         expect.stringContaining("Failed to load rulesync ignore file"),
       );
     });
+
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncFiles
+    // calls RulesyncIgnore.fromFile with `outputRoot === inputRoot` so the
+    // ignore file is read from the custom rulesync dir instead of process.cwd().
+    it("should pass inputRoot to RulesyncIgnore.fromFile when inputRoot is set", async () => {
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      const mockRulesyncIgnore = new MockRulesyncIgnore({
+        outputRoot: customInputRoot,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+        fileContent: "tmp/",
+      });
+      (RulesyncIgnoreMock as any).fromFile.mockResolvedValue(mockRulesyncIgnore as any);
+
+      const processor = new IgnoreProcessor({
+        logger,
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "cursor",
+      });
+
+      const files = await processor.loadRulesyncFiles();
+      expect(files).toHaveLength(1);
+      expect((RulesyncIgnoreMock as any).fromFile).toHaveBeenCalledWith({
+        outputRoot: customInputRoot,
+      });
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/features/permissions/augmentcode-permissions.test.ts
+++ b/src/features/permissions/augmentcode-permissions.test.ts
@@ -492,4 +492,136 @@ describe("AugmentcodePermissions", () => {
     const config = instance.toRulesyncPermissions().getJson();
     expect(config.permission.read).toEqual({ "*": "ask" });
   });
+
+  describe("non-roundtrippable shellInputRegex import behavior (Finding F)", () => {
+    // When a user authors a `shellInputRegex` that is not faithfully
+    // roundtrippable through the glob representation (for example unanchored
+    // `"rm"` or alternation `"rm|del"`), naive conversion would silently
+    // narrow or otherwise change the deny on re-export. Apply asymmetric
+    // fallback: deny -> "*" (fail-closed); allow/ask -> lossy with warning.
+
+    it("should fall back to '*' (fail-closed) for deny with unanchored shellInputRegex", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          toolPermissions: [
+            {
+              toolName: "launch-process",
+              shellInputRegex: "rm",
+              permission: { type: "deny" },
+            },
+          ],
+        }),
+      });
+
+      const config = instance.toRulesyncPermissions().getJson();
+      // Without the broadening, the deny would import as glob `"rm"` and
+      // re-export as `"^rm$"`, narrowing the protection to the literal
+      // string `"rm"`. Broadening to `"*"` keeps the protective intent.
+      expect(config.permission.bash).toEqual({ "*": "deny" });
+    });
+
+    it("should fall back to '*' (fail-closed) for deny with alternation in shellInputRegex", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          toolPermissions: [
+            {
+              toolName: "launch-process",
+              shellInputRegex: "^rm|del$",
+              permission: { type: "deny" },
+            },
+          ],
+        }),
+      });
+
+      const config = instance.toRulesyncPermissions().getJson();
+      expect(config.permission.bash).toEqual({ "*": "deny" });
+    });
+
+    it("should preserve faithful imports for fully roundtrippable deny regex", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          toolPermissions: [
+            {
+              toolName: "launch-process",
+              shellInputRegex: "^rm .*$",
+              permission: { type: "deny" },
+            },
+          ],
+        }),
+      });
+
+      const config = instance.toRulesyncPermissions().getJson();
+      // `^rm .*$` is roundtrippable via shellRegexToGlob → `rm *`.
+      expect(config.permission.bash).toEqual({ "rm *": "deny" });
+    });
+
+    it("should still import (with warning) lossy allow patterns rather than dropping or broadening", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          toolPermissions: [
+            {
+              toolName: "launch-process",
+              shellInputRegex: "git",
+              permission: { type: "allow" },
+            },
+          ],
+        }),
+      });
+
+      const config = instance.toRulesyncPermissions().getJson();
+      // Allow is NOT broadened to `*` (that would weaken security). The lossy
+      // glob `git` is preserved; the warn at import time tells the user the
+      // re-export will produce `^git$`, which differs from the original
+      // unanchored regex.
+      expect(config.permission.bash).toEqual({ git: "allow" });
+    });
+  });
+
+  describe("validate()", () => {
+    it("should succeed for well-formed AugmentCode settings JSON", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          toolPermissions: [{ toolName: "launch-process", permission: { type: "allow" } }],
+        }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should fail when fileContent is not parseable JSON", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        fileContent: "{ not json",
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+
+    it("should fail when fileContent does not match schema", () => {
+      const instance = new AugmentcodePermissions({
+        relativeDirPath: ".augment",
+        relativeFilePath: "settings.json",
+        // `toolPermissions[].permission.type` must be one of "allow"/"deny"/"ask-user".
+        fileContent: JSON.stringify({
+          toolPermissions: [{ toolName: "view", permission: { type: "bogus" } }],
+        }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+  });
 });

--- a/src/features/permissions/augmentcode-permissions.test.ts
+++ b/src/features/permissions/augmentcode-permissions.test.ts
@@ -9,6 +9,7 @@ import {
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { ConsoleLogger } from "../../utils/logger.js";
 import { AugmentcodePermissions } from "./augmentcode-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 
@@ -500,6 +501,16 @@ describe("AugmentcodePermissions", () => {
     // narrow or otherwise change the deny on re-export. Apply asymmetric
     // fallback: deny -> "*" (fail-closed); allow/ask -> lossy with warning.
 
+    // The import path uses the module-level `ConsoleLogger` rather than an
+    // injected logger, so to assert on warn message contents we spy on
+    // `ConsoleLogger.prototype.warn`. The spy bypasses `isSuppressed()` (which
+    // would normally swallow `console.warn` under NODE_ENV=test) because
+    // `vi.spyOn` replaces the method itself, not its underlying `console.warn`.
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(ConsoleLogger.prototype, "warn").mockImplementation(() => {});
+    });
+
     it("should fall back to '*' (fail-closed) for deny with unanchored shellInputRegex", () => {
       const instance = new AugmentcodePermissions({
         relativeDirPath: ".augment",
@@ -520,6 +531,16 @@ describe("AugmentcodePermissions", () => {
       // re-export as `"^rm$"`, narrowing the protection to the literal
       // string `"rm"`. Broadening to `"*"` keeps the protective intent.
       expect(config.permission.bash).toEqual({ "*": "deny" });
+      // Assert the user-visible explanation: the warn must explicitly say the
+      // import broadened to the catch-all `*` (fail-closed) so users can audit
+      // the change.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnMessage = warnSpy.mock.calls[0]?.[0] as string;
+      expect(warnMessage).toContain("'rm'");
+      expect(warnMessage).toContain("launch-process");
+      expect(warnMessage).toContain("not faithfully roundtrippable");
+      expect(warnMessage).toContain("catch-all '*'");
+      expect(warnMessage).toContain("fail-closed");
     });
 
     it("should fall back to '*' (fail-closed) for deny with alternation in shellInputRegex", () => {
@@ -539,6 +560,10 @@ describe("AugmentcodePermissions", () => {
 
       const config = instance.toRulesyncPermissions().getJson();
       expect(config.permission.bash).toEqual({ "*": "deny" });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnMessage = warnSpy.mock.calls[0]?.[0] as string;
+      expect(warnMessage).toContain("'^rm|del$'");
+      expect(warnMessage).toContain("fail-closed");
     });
 
     it("should preserve faithful imports for fully roundtrippable deny regex", () => {
@@ -559,6 +584,9 @@ describe("AugmentcodePermissions", () => {
       const config = instance.toRulesyncPermissions().getJson();
       // `^rm .*$` is roundtrippable via shellRegexToGlob → `rm *`.
       expect(config.permission.bash).toEqual({ "rm *": "deny" });
+      // Roundtrippable inputs should NOT trigger any warning — silence is the
+      // signal that no semantics were lost.
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it("should still import (with warning) lossy allow patterns rather than dropping or broadening", () => {
@@ -582,6 +610,11 @@ describe("AugmentcodePermissions", () => {
       // re-export will produce `^git$`, which differs from the original
       // unanchored regex.
       expect(config.permission.bash).toEqual({ git: "allow" });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnMessage = warnSpy.mock.calls[0]?.[0] as string;
+      expect(warnMessage).toContain("'git'");
+      expect(warnMessage).toContain("Importing as glob 'git'");
+      expect(warnMessage).toContain("may match a different set of inputs after regenerate");
     });
   });
 

--- a/src/features/permissions/augmentcode-permissions.test.ts
+++ b/src/features/permissions/augmentcode-permissions.test.ts
@@ -494,7 +494,7 @@ describe("AugmentcodePermissions", () => {
     expect(config.permission.read).toEqual({ "*": "ask" });
   });
 
-  describe("non-roundtrippable shellInputRegex import behavior (Finding F)", () => {
+  describe("non-roundtrippable shellInputRegex import behavior", () => {
     // When a user authors a `shellInputRegex` that is not faithfully
     // roundtrippable through the glob representation (for example unanchored
     // `"rm"` or alternation `"rm|del"`), naive conversion would silently
@@ -509,6 +509,13 @@ describe("AugmentcodePermissions", () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
     beforeEach(() => {
       warnSpy = vi.spyOn(ConsoleLogger.prototype, "warn").mockImplementation(() => {});
+    });
+    // Restore the prototype-level spy locally instead of relying on the outer
+    // describe's `vi.restoreAllMocks()`. This keeps the cleanup co-located with
+    // the spy so a future refactor (splitting this describe out, or removing
+    // the outer cleanup) cannot silently leak the spy across other test files.
+    afterEach(() => {
+      warnSpy.mockRestore();
     });
 
     it("should fall back to '*' (fail-closed) for deny with unanchored shellInputRegex", () => {
@@ -655,6 +662,50 @@ describe("AugmentcodePermissions", () => {
       const result = instance.validate();
       expect(result.success).toBe(false);
       expect(result.error).not.toBeNull();
+    });
+
+    it("should throw when constructed with validate: true and malformed JSON", () => {
+      // `fromFile({ validate: true })` flows through the constructor with
+      // `validate: true`; the constructor must invoke `validate()` and throw
+      // on failure so callers reading `validate: true` see schema violations
+      // surface immediately rather than deeper in the pipeline.
+      expect(
+        () =>
+          new AugmentcodePermissions({
+            relativeDirPath: ".augment",
+            relativeFilePath: "settings.json",
+            fileContent: "{ not json",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should throw when constructed with validate: true and schema violation", () => {
+      expect(
+        () =>
+          new AugmentcodePermissions({
+            relativeDirPath: ".augment",
+            relativeFilePath: "settings.json",
+            fileContent: JSON.stringify({
+              toolPermissions: [{ toolName: "view", permission: { type: "bogus" } }],
+            }),
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should not throw when constructed with validate: false even with malformed JSON", () => {
+      // `forDeletion` and other permissive paths pass `validate: false` and
+      // must not be rejected at construction time.
+      expect(
+        () =>
+          new AugmentcodePermissions({
+            relativeDirPath: ".augment",
+            relativeFilePath: "settings.json",
+            fileContent: "{ not json",
+            validate: false,
+          }),
+      ).not.toThrow();
     });
   });
 });

--- a/src/features/permissions/augmentcode-permissions.ts
+++ b/src/features/permissions/augmentcode-permissions.ts
@@ -6,6 +6,7 @@ import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import type { PermissionAction, PermissionsConfig } from "../../types/permissions.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import { ConsoleLogger, type Logger } from "../../utils/logger.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 import {
   ToolPermissions,
@@ -14,6 +15,11 @@ import {
   type ToolPermissionsFromRulesyncPermissionsParams,
   type ToolPermissionsSettablePaths,
 } from "./tool-permissions.js";
+
+// Module-level logger used by the importing direction (toRulesyncPermissions),
+// where the instance method has no `logger` parameter. Mirrors the Qwen
+// permissions translator's pattern.
+const moduleLogger: Logger = new ConsoleLogger();
 
 /**
  * AugmentCode CLI uses `.augment/settings.json` (project) or `~/.augment/settings.json` (global).
@@ -142,6 +148,51 @@ function shellRegexToGlob(regex: string): string {
     i += 1;
   }
   return glob;
+}
+
+/**
+ * Detect whether an AugmentCode `shellInputRegex` is faithfully roundtrippable
+ * through our glob-based representation. Rulesync stores patterns as globs,
+ * and on re-export `globToShellRegex` always produces an anchored pattern of
+ * the form `^...$` whose body contains only literal characters, escaped
+ * metacharacters, `.*` (from `*`), and `.` (from `?`).
+ *
+ * A user-authored regex that is unanchored or uses regex features outside
+ * that small subset (`+`, `|`, character classes, groups, quantifiers) cannot
+ * be losslessly converted to a glob; a naive conversion would silently narrow
+ * (e.g. `"rm"` → glob `"rm"` → re-exported as `"^rm$"`, which only matches
+ * the exact string `"rm"`) or otherwise change the matched set.
+ */
+function isShellRegexRoundtrippable(regex: string): boolean {
+  if (!regex.startsWith("^") || !regex.endsWith("$")) {
+    return false;
+  }
+  const body = regex.slice(1, -1);
+  let i = 0;
+  while (i < body.length) {
+    const ch = body[i];
+    if (ch === "\\" && i + 1 < body.length) {
+      // Skip escaped char.
+      i += 2;
+      continue;
+    }
+    if (ch === "." && body[i + 1] === "*") {
+      i += 2;
+      continue;
+    }
+    if (ch === ".") {
+      i += 1;
+      continue;
+    }
+    // Any unescaped regex metacharacter that we don't generate marks the
+    // regex as non-roundtrippable. `.` is handled above; the remaining ones
+    // here are regex-only constructs.
+    if (/[$^|+?*(){}[\]]/.test(ch ?? "")) {
+      return false;
+    }
+    i += 1;
+  }
+  return true;
 }
 
 const MANAGED_AUGMENT_TOOL_NAMES = new Set(Object.values(CANONICAL_TO_AUGMENT_TOOL_NAMES));
@@ -280,6 +331,7 @@ export class AugmentcodePermissions extends ToolPermissions {
 
     const config = convertAugmentToRulesyncPermissions({
       entries: settings.toolPermissions ?? [],
+      logger: moduleLogger,
     });
 
     return this.toRulesyncPermissionsDefault({
@@ -288,7 +340,24 @@ export class AugmentcodePermissions extends ToolPermissions {
   }
 
   validate(): ValidationResult {
-    return { success: true, error: null };
+    // Mirror Kilo's `safeParse`-based pattern: actually verify that the file
+    // content is JSON-parseable and conforms to the AugmentCode settings
+    // schema. A no-op validate would let malformed files slip past the
+    // generate/import boundary and surface as confusing errors deeper in the
+    // pipeline.
+    try {
+      const parsed = JSON.parse(this.fileContent || "{}");
+      const result = AugmentSettingsSchema.safeParse(parsed);
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      return { success: true, error: null };
+    } catch (error) {
+      return {
+        success: false,
+        error: new Error(`Failed to parse AugmentCode permissions JSON: ${formatError(error)}`),
+      };
+    }
   }
 
   static forDeletion({
@@ -444,8 +513,10 @@ function sortAugmentEntries(entries: AugmentToolPermission[]): AugmentToolPermis
 
 function convertAugmentToRulesyncPermissions({
   entries,
+  logger,
 }: {
   entries: AugmentToolPermission[];
+  logger?: Logger;
 }): PermissionsConfig {
   // Iteration-order-independent fail-closed precedence: when multiple entries collapse to the
   // same `(canonical, pattern)` key (which happens for the non-launch-process managed tools that
@@ -468,10 +539,47 @@ function convertAugmentToRulesyncPermissions({
     // AugmentCode schema does not carry per-pattern information, so they are imported as the
     // catch-all `*` pattern. This is the inverse of the fail-closed export side and is documented
     // in `docs/reference/file-formats.md`.
-    const pattern =
-      entry.toolName === "launch-process" && entry.shellInputRegex
-        ? shellRegexToGlob(entry.shellInputRegex)
-        : "*";
+    let pattern: string;
+    if (entry.toolName === "launch-process" && entry.shellInputRegex) {
+      const regex = entry.shellInputRegex;
+      if (isShellRegexRoundtrippable(regex)) {
+        // Faithful import: glob round-trips back to an equivalent regex.
+        pattern = shellRegexToGlob(regex);
+      } else {
+        // Non-roundtrippable user-authored regex (e.g. unanchored `"rm"`,
+        // alternation `"rm|del"`, character classes `"[a-z]+"`). Naively
+        // converting via `shellRegexToGlob` would silently weaken the rule on
+        // re-export — for example `"rm"` would round-trip to `"^rm$"`, which
+        // only matches the exact string. Apply asymmetric fallback per the
+        // category:
+        // - `deny`: broaden to `*` (fail-closed) — over-blocking is safer than
+        //   under-blocking, so a user-authored deny continues to protect
+        //   against the original threat surface (and more).
+        // - `allow` / `ask`: warn but proceed with the lossy conversion. We
+        //   cannot safely broaden these because broadening an allow would
+        //   weaken security; dropping them would silently strip the user's
+        //   rule. Lossy conversion preserves the user's intent on the most
+        //   common patterns at the cost of the narrow regex semantics that
+        //   only AugmentCode supports.
+        if (action === "deny") {
+          logger?.warn(
+            `AugmentCode permissions: shellInputRegex '${regex}' on tool '${entry.toolName}' ` +
+              `is not faithfully roundtrippable to a glob. Importing as the catch-all '*' ` +
+              `pattern (fail-closed) so the deny rule cannot be silently narrowed on regenerate.`,
+          );
+          pattern = "*";
+        } else {
+          pattern = shellRegexToGlob(regex);
+          logger?.warn(
+            `AugmentCode permissions: shellInputRegex '${regex}' on tool '${entry.toolName}' ` +
+              `is not faithfully roundtrippable to a glob. Importing as glob '${pattern}'; ` +
+              `the rule may match a different set of inputs after regenerate.`,
+          );
+        }
+      }
+    } else {
+      pattern = "*";
+    }
 
     if (!permission[canonical]) {
       permission[canonical] = {};

--- a/src/features/permissions/augmentcode-permissions.ts
+++ b/src/features/permissions/augmentcode-permissions.ts
@@ -203,6 +203,17 @@ export class AugmentcodePermissions extends ToolPermissions {
       ...params,
       fileContent: params.fileContent ?? "{}",
     });
+    // Mirror `RulesyncPermissions` so that `fromFile({ validate: true })` actually
+    // verifies schema conformance and throws on malformed input. Without this
+    // wiring, the `validate()` method exists but is never invoked at construction
+    // time, so callers reading `validate: true` would falsely assume validation
+    // already ran.
+    if (params.validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
   }
 
   override isDeletable(): boolean {

--- a/src/features/permissions/cline-permissions.test.ts
+++ b/src/features/permissions/cline-permissions.test.ts
@@ -171,4 +171,40 @@ describe("ClinePermissions", () => {
     });
     expect(instance.isDeletable()).toBe(false);
   });
+
+  describe("validate()", () => {
+    it("should succeed for well-formed Cline command-permissions JSON", () => {
+      const instance = new ClinePermissions({
+        relativeDirPath: ".cline",
+        relativeFilePath: "command-permissions.json",
+        fileContent: JSON.stringify({ allow: ["git *"], deny: ["rm -rf *"] }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should fail when fileContent is not parseable JSON", () => {
+      const instance = new ClinePermissions({
+        relativeDirPath: ".cline",
+        relativeFilePath: "command-permissions.json",
+        fileContent: "{ not json",
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+
+    it("should fail when fileContent does not match schema", () => {
+      const instance = new ClinePermissions({
+        relativeDirPath: ".cline",
+        relativeFilePath: "command-permissions.json",
+        // `allow` must be an array of strings; numbers should fail validation.
+        fileContent: JSON.stringify({ allow: [123] }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+  });
 });

--- a/src/features/permissions/cline-permissions.test.ts
+++ b/src/features/permissions/cline-permissions.test.ts
@@ -206,5 +206,47 @@ describe("ClinePermissions", () => {
       expect(result.success).toBe(false);
       expect(result.error).not.toBeNull();
     });
+
+    it("should throw when constructed with validate: true and malformed JSON", () => {
+      // `fromFile({ validate: true })` flows through the constructor with
+      // `validate: true`; the constructor must invoke `validate()` and throw
+      // on failure so callers reading `validate: true` see schema violations
+      // surface immediately rather than deeper in the pipeline.
+      expect(
+        () =>
+          new ClinePermissions({
+            relativeDirPath: ".cline",
+            relativeFilePath: "command-permissions.json",
+            fileContent: "{ not json",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should throw when constructed with validate: true and schema violation", () => {
+      expect(
+        () =>
+          new ClinePermissions({
+            relativeDirPath: ".cline",
+            relativeFilePath: "command-permissions.json",
+            fileContent: JSON.stringify({ allow: [123] }),
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should not throw when constructed with validate: false even with malformed JSON", () => {
+      // `forDeletion` and other permissive paths pass `validate: false` and
+      // must not be rejected at construction time.
+      expect(
+        () =>
+          new ClinePermissions({
+            relativeDirPath: ".cline",
+            relativeFilePath: "command-permissions.json",
+            fileContent: "{ not json",
+            validate: false,
+          }),
+      ).not.toThrow();
+    });
   });
 });

--- a/src/features/permissions/cline-permissions.ts
+++ b/src/features/permissions/cline-permissions.ts
@@ -216,7 +216,24 @@ export class ClinePermissions extends ToolPermissions {
   }
 
   validate(): ValidationResult {
-    return { success: true, error: null };
+    // Mirror Kilo's `safeParse`-based pattern: actually verify that the file
+    // content is JSON-parseable and conforms to the Cline command-permissions
+    // schema. A no-op validate would let malformed files slip past the
+    // generate/import boundary and surface as confusing errors deeper in the
+    // pipeline.
+    try {
+      const parsed = JSON.parse(this.fileContent || "{}");
+      const result = ClineCommandPermissionsSchema.safeParse(parsed);
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      return { success: true, error: null };
+    } catch (error) {
+      return {
+        success: false,
+        error: new Error(`Failed to parse Cline permissions JSON: ${formatError(error)}`),
+      };
+    }
   }
 
   static forDeletion({

--- a/src/features/permissions/cline-permissions.ts
+++ b/src/features/permissions/cline-permissions.ts
@@ -42,6 +42,17 @@ export class ClinePermissions extends ToolPermissions {
       ...params,
       fileContent: params.fileContent ?? "{}",
     });
+    // Mirror `RulesyncPermissions` so that `fromFile({ validate: true })` actually
+    // verifies schema conformance and throws on malformed input. Without this
+    // wiring, the `validate()` method exists but is never invoked at construction
+    // time, so callers reading `validate: true` would falsely assume validation
+    // already ran.
+    if (params.validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
   }
 
   override isDeletable(): boolean {

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -159,6 +159,38 @@ describe("PermissionsProcessor", () => {
 
       expect(files).toHaveLength(0);
     });
+
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncFiles
+    // reads `<inputRoot>/.rulesync/permissions.json` instead of
+    // `<process.cwd()>/.rulesync/permissions.json`.
+    it("should read rulesync permissions file from inputRoot instead of process.cwd()", async () => {
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      const customRulesyncDir = join(customInputRoot, RULESYNC_RELATIVE_DIR_PATH);
+      await ensureDir(customRulesyncDir);
+      await writeFileContent(
+        join(customRulesyncDir, RULESYNC_PERMISSIONS_FILE_NAME),
+        JSON.stringify({
+          permission: {
+            bash: { "git *": "allow" },
+          },
+        }),
+      );
+
+      // outputRoot is testDir (process.cwd()); no permissions file exists
+      // there, so a successful load proves the processor read from inputRoot.
+      const processor = new PermissionsProcessor({
+        logger,
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "claudecode",
+      });
+
+      const files = await processor.loadRulesyncFiles();
+
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(RulesyncPermissions);
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/features/permissions/qwencode-permissions.test.ts
+++ b/src/features/permissions/qwencode-permissions.test.ts
@@ -207,4 +207,42 @@ describe("QwencodePermissions", () => {
     expect(await fileExists(join(testDir, ".qwen"))).toBe(false);
     expect(await fileExists(join(testDir, ".qwen", "settings.json"))).toBe(false);
   });
+
+  describe("validate()", () => {
+    it("should succeed for well-formed Qwen settings JSON", () => {
+      const instance = new QwencodePermissions({
+        relativeDirPath: ".qwen",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          permissions: { allow: ["Bash(git *)"], deny: ["Bash(rm -rf *)"] },
+        }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it("should fail when fileContent is not parseable JSON", () => {
+      const instance = new QwencodePermissions({
+        relativeDirPath: ".qwen",
+        relativeFilePath: "settings.json",
+        fileContent: "{ not json",
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+
+    it("should fail when fileContent does not match schema", () => {
+      const instance = new QwencodePermissions({
+        relativeDirPath: ".qwen",
+        relativeFilePath: "settings.json",
+        // `permissions.allow` must be an array of strings, not numbers.
+        fileContent: JSON.stringify({ permissions: { allow: [42] } }),
+      });
+      const result = instance.validate();
+      expect(result.success).toBe(false);
+      expect(result.error).not.toBeNull();
+    });
+  });
 });

--- a/src/features/permissions/qwencode-permissions.test.ts
+++ b/src/features/permissions/qwencode-permissions.test.ts
@@ -244,5 +244,47 @@ describe("QwencodePermissions", () => {
       expect(result.success).toBe(false);
       expect(result.error).not.toBeNull();
     });
+
+    it("should throw when constructed with validate: true and malformed JSON", () => {
+      // `fromFile({ validate: true })` flows through the constructor with
+      // `validate: true`; the constructor must invoke `validate()` and throw
+      // on failure so callers reading `validate: true` see schema violations
+      // surface immediately rather than deeper in the pipeline.
+      expect(
+        () =>
+          new QwencodePermissions({
+            relativeDirPath: ".qwen",
+            relativeFilePath: "settings.json",
+            fileContent: "{ not json",
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should throw when constructed with validate: true and schema violation", () => {
+      expect(
+        () =>
+          new QwencodePermissions({
+            relativeDirPath: ".qwen",
+            relativeFilePath: "settings.json",
+            fileContent: JSON.stringify({ permissions: { allow: [42] } }),
+            validate: true,
+          }),
+      ).toThrow();
+    });
+
+    it("should not throw when constructed with validate: false even with malformed JSON", () => {
+      // `forDeletion` and other permissive paths pass `validate: false` and
+      // must not be rejected at construction time.
+      expect(
+        () =>
+          new QwencodePermissions({
+            relativeDirPath: ".qwen",
+            relativeFilePath: "settings.json",
+            fileContent: "{ not json",
+            validate: false,
+          }),
+      ).not.toThrow();
+    });
   });
 });

--- a/src/features/permissions/qwencode-permissions.ts
+++ b/src/features/permissions/qwencode-permissions.ts
@@ -261,7 +261,24 @@ export class QwencodePermissions extends ToolPermissions {
   }
 
   validate(): ValidationResult {
-    return { success: true, error: null };
+    // Mirror Kilo's `safeParse`-based pattern: actually verify that the file
+    // content is JSON-parseable and conforms to the Qwen settings schema.
+    // A no-op validate would let malformed files slip past the
+    // generate/import boundary and surface as confusing errors deeper in the
+    // pipeline.
+    try {
+      const parsed = JSON.parse(this.fileContent || "{}");
+      const result = QwenSettingsSchema.safeParse(parsed);
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      return { success: true, error: null };
+    } catch (error) {
+      return {
+        success: false,
+        error: new Error(`Failed to parse Qwen permissions JSON: ${formatError(error)}`),
+      };
+    }
   }
 
   static forDeletion({

--- a/src/features/permissions/qwencode-permissions.ts
+++ b/src/features/permissions/qwencode-permissions.ts
@@ -114,6 +114,17 @@ export class QwencodePermissions extends ToolPermissions {
       ...params,
       fileContent: params.fileContent ?? "{}",
     });
+    // Mirror `RulesyncPermissions` so that `fromFile({ validate: true })` actually
+    // verifies schema conformance and throws on malformed input. Without this
+    // wiring, the `validate()` method exists but is never invoked at construction
+    // time, so callers reading `validate: true` would falsely assume validation
+    // already ran.
+    if (params.validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
   }
 
   override isDeletable(): boolean {

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -2208,4 +2208,41 @@ targets: ["claudecode"]
       );
     });
   });
+
+  describe("loadRulesyncFiles with inputRoot", () => {
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncFiles
+    // reads from `<inputRoot>/.rulesync/rules` instead of
+    // `<process.cwd()>/.rulesync/rules`.
+    it("should read rulesync rule files from inputRoot instead of process.cwd()", async () => {
+      // Source rules live in a custom directory — NOT under cwd's `.rulesync/`.
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      await ensureDir(join(customInputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(customInputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH, "overview.md"),
+        `---
+root: true
+targets: ["*"]
+---
+# Input-root rule`,
+      );
+
+      // outputRoot is process.cwd() (testDir) where the rulesync directory
+      // does NOT exist. If inputRoot threading is broken, this test fails
+      // because no rules would be found under testDir/.rulesync/rules/.
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncFiles = await processor.loadRulesyncFiles();
+      expect(rulesyncFiles).toHaveLength(1);
+      const content = await readFileContent(
+        join(customInputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH, "overview.md"),
+      );
+      expect(content).toContain("Input-root rule");
+    });
+  });
 });

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -2239,10 +2239,13 @@ targets: ["*"]
 
       const rulesyncFiles = await processor.loadRulesyncFiles();
       expect(rulesyncFiles).toHaveLength(1);
-      const content = await readFileContent(
-        join(customInputRoot, RULESYNC_RULES_RELATIVE_DIR_PATH, "overview.md"),
-      );
-      expect(content).toContain("Input-root rule");
+      // Assert directly on the loaded rule, not by re-reading the file we
+      // just wrote: the meaningful check is that the rule's parsed body and
+      // frontmatter come from the inputRoot file, not from anywhere under
+      // outputRoot/process.cwd().
+      const loadedRule = rulesyncFiles[0] as RulesyncRule;
+      expect(loadedRule.getFrontmatter().root).toBe(true);
+      expect(loadedRule.getBody()).toContain("Input-root rule");
     });
   });
 });

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -467,6 +467,42 @@ This is skill content`;
       const rulesyncSkill = rulesyncDirs[0] as RulesyncSkill;
       expect(rulesyncSkill.getFrontmatter().name).toBe("skill-1");
     });
+
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncDirs
+    // reads from `<inputRoot>/.rulesync/skills` instead of
+    // `<process.cwd()>/.rulesync/skills`.
+    it("should read rulesync skill dirs from inputRoot instead of process.cwd()", async () => {
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      const customSkillsDir = join(customInputRoot, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      await ensureDir(customSkillsDir);
+
+      const skillDir = join(customSkillsDir, "input-root-skill");
+      await ensureDir(skillDir);
+
+      const skillContent = `---
+name: input-root-skill
+description: Skill loaded from inputRoot
+---
+Body from inputRoot`;
+
+      await writeFileContent(join(skillDir, "SKILL.md"), skillContent);
+
+      // outputRoot is testDir (process.cwd()); no skills exist there, so
+      // a successful load proves the inputRoot-aware processor read from inputRoot.
+      const inputRootProcessor = new SkillsProcessor({
+        logger: createMockLogger(),
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncDirs = await inputRootProcessor.loadRulesyncDirs();
+
+      expect(rulesyncDirs).toHaveLength(1);
+      expect(rulesyncDirs[0]).toBeInstanceOf(RulesyncSkill);
+      expect((rulesyncDirs[0] as RulesyncSkill).getFrontmatter().name).toBe("input-root-skill");
+    });
   });
 
   describe("loadToolDirs", () => {

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -563,6 +563,39 @@ Global agent content`;
       const rulesyncSubagent = rulesyncFiles[0] as RulesyncSubagent;
       expect(rulesyncSubagent.getFrontmatter().name).toBe("global-agent");
     });
+
+    // Mirror the per-feature inputRoot threading assertion used in
+    // commands-processor.test.ts: when inputRoot is set, loadRulesyncFiles
+    // reads from `<inputRoot>/.rulesync/subagents` instead of
+    // `<process.cwd()>/.rulesync/subagents`.
+    it("should read rulesync subagent files from inputRoot instead of process.cwd()", async () => {
+      const customInputRoot = join(testDir, "custom-rulesync-dir");
+      const customSubagentsDir = join(customInputRoot, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
+      await ensureDir(customSubagentsDir);
+
+      const subagentContent = `---
+name: input-root-agent
+description: Subagent loaded from inputRoot
+targets: ["*"]
+---
+Body from inputRoot`;
+
+      await writeFileContent(join(customSubagentsDir, "input-root-agent.md"), subagentContent);
+
+      // outputRoot is testDir (process.cwd()); no subagents file exists there,
+      // so a successful load proves the inputRoot-aware processor read from inputRoot.
+      const inputRootProcessor = new SubagentsProcessor({
+        logger: createMockLogger(),
+        outputRoot: testDir,
+        inputRoot: customInputRoot,
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncFiles = await inputRootProcessor.loadRulesyncFiles();
+      expect(rulesyncFiles).toHaveLength(1);
+      expect(rulesyncFiles[0]).toBeInstanceOf(RulesyncSubagent);
+      expect((rulesyncFiles[0] as RulesyncSubagent).getFrontmatter().name).toBe("input-root-agent");
+    });
   });
 
   describe("loadToolFiles", () => {

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -765,10 +765,21 @@ describe("file utilities", () => {
         );
       });
 
-      it("should reject absolute paths with backslash '..' segments", () => {
-        // Mixed separators should still be caught so Windows-style input
-        // constructed unsafely is not silently accepted on POSIX callers.
-        expect(() => validateOutputRoot("/foo\\..\\bar")).toThrow("Path traversal detected");
+      it("should accept POSIX absolute paths whose components contain literal backslashes", () => {
+        // On POSIX `\` is a regular filename character, not a separator. The
+        // segment check intentionally only treats `/` as a separator on POSIX
+        // so that legitimate filenames like `/srv/foo\bar` are not falsely
+        // rejected. (See platform-aware split in `validateOutputRoot`.) On
+        // Windows, the same input would be split on both `/` and `\` and
+        // rejected because `..` becomes a segment.
+        if (process.platform === "win32") {
+          expect(() => validateOutputRoot("/foo\\..\\bar")).toThrow("Path traversal detected");
+        } else {
+          // On POSIX, the input is `resolve()`-equal to itself (no traversal
+          // is collapsed because `\..\` is not a path component), so the
+          // normalized-equality check passes too.
+          expect(() => validateOutputRoot("/foo\\..\\bar")).not.toThrow();
+        }
       });
     });
   });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -305,13 +305,17 @@ export function validateOutputRoot(outputRoot: string): void {
   }
 
   if (isAbsolute(outputRoot)) {
-    // Defense-in-depth: split on both POSIX and Windows separators and
-    // reject any `..` segment. POSIX `resolve()` ignores `\` as a separator,
-    // and Windows `resolve()` ignores `/` in some legacy paths, so a
-    // cross-platform attacker-style input like `/foo\..\bar` or `C:/foo/../bar`
-    // would otherwise slip past the normalized-equality check below. This
-    // layered check applies on both platforms.
-    const segments = outputRoot.split(/[/\\]/);
+    // Defense-in-depth: split on path separators and reject any `..` segment.
+    // The separator set is platform-aware because POSIX paths can legitimately
+    // contain a literal backslash inside a filename component (e.g.
+    // `/srv/foo\bar`), and treating `\` as a separator there would falsely
+    // split such filenames. On Windows, both `/` and `\` are valid path
+    // separators (Windows `resolve()` ignores `/` in some legacy paths), so
+    // we keep the dual-separator split there to catch cross-platform inputs
+    // like `C:/foo\..\bar` that would otherwise slip past the
+    // normalized-equality check below.
+    const separatorRegex = process.platform === "win32" ? /[/\\]/ : /\//;
+    const segments = outputRoot.split(separatorRegex);
     if (segments.includes("..")) {
       throw new Error(`Path traversal detected: ${outputRoot}`);
     }


### PR DESCRIPTION
## Summary

Addresses mid-severity findings from two follow-up issues, plus low-severity quality improvements from a follow-up review.

Closes #1571
Closes #1587

### Issue #1571 — `--input-root` follow-ups (PR #1570)
- **A:** `src/cli/commands/import.ts` — clarify the warning-suppression comment so it accurately reflects that only direct CLI/programmatic callers are protected; users with an `inputRoot` set in `rulesync.jsonc` may still see the actionable warning.
- **B:** Add `inputRoot` threading assertions to the per-feature processor unit tests for rules, subagents, skills, hooks, permissions, and ignore (modeled after `commands-processor.test.ts`). A regression that swaps `inputRoot` for `process.cwd()` is now caught at the unit level.
- **C:** `src/utils/file.ts` — make `validateBaseDir`'s `..`-segment split platform-aware (`/[/\\\\]/` on Windows, `/\\//` on POSIX) so POSIX filenames containing literal backslashes round-trip cleanly.

### Issue #1587 — permissions follow-ups (PR #1585)
- **D:** Implement real `validate()` for cline/augmentcode/qwencode permissions modules via `JSON.parse` + `safeParse` (mirrors Kilo's pattern). The previous no-op meant `fromFile({ validate: true })` did not actually verify schema conformance.
- **E:** Drop the `**/kilo.jsonc` gitignore entry — parity with the structurally-identical `opencode.jsonc` (no entry) since the translator preserves non-permissions Kilo settings on round-trip.
- **F:** AugmentCode `shellInputRegex` import: emit `logger.warn` when the regex is non-roundtrippable. For `deny` only, fall back to `*` (fail-closed). For `allow`/`ask`, warn but keep the lossy conversion to avoid weakening security via broadened allow patterns.

### Quality improvements (commit 655dd252)
- Fix grammatical typo in the `import.ts` warning-suppression comment (`a inputRoot` → `an inputRoot`).
- Replace a redundant post-load `readFileContent` re-read in `rules-processor.test.ts` with assertions on the loaded `RulesyncRule` instance, so the inputRoot test verifies the processor actually parsed content from `inputRoot`.
- Tighten the four "non-roundtrippable shellInputRegex import" tests in `augmentcode-permissions.test.ts` to assert on `logger.warn` message contents (regex, tool name, fail-closed wording for `deny`, "Importing as glob" wording for `allow`/`ask`).

## Test plan
- [x] `pnpm cicheck` passes (216 test files / 5480 tests)
- [x] e2e-permissions and e2e-input-root suites pass
- [x] New unit tests added for Findings B, D, F
- [x] Tool × Feature happy-path E2E coverage preserved
- [x] Agent-team review converged with 0 high/critical, 0 mid, 0 low findings on the quality-improvement commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)