### PR TITLE
test: cover claudecode global mcp deletion guard

### DIFF
--- a/src/features/mcp/claudecode-mcp.test.ts
+++ b/src/features/mcp/claudecode-mcp.test.ts
@@ -351,6 +351,7 @@ describe("ClaudecodeMcp", () => {
       expect(claudecodeMcp).toBeInstanceOf(ClaudecodeMcp);
       expect(claudecodeMcp.getJson()).toEqual({ mcpServers: {} });
       expect(claudecodeMcp.getFilePath()).toBe(join(testDir, ".claude/.claude.json"));
+      expect(claudecodeMcp.isDeletable()).toBe(false);
     });
 
     it("should preserve non-mcpServers properties in global mode", async () => {


### PR DESCRIPTION
## Summary
- Add explicit regression coverage that `ClaudecodeMcp.fromFile({ global: true })` keeps global Claude MCP config non-deletable when initializing a missing global config file.
- This guards the issue where factory-created global instances must preserve the constructor's `global` flag so `isDeletable()` remains false.

Fixes #1275

## Tests
- `pnpm --config.engine-strict=false vitest run src/features/mcp/claudecode-mcp.test.ts --silent=true`
- `NPM_CONFIG_ENGINE_STRICT=false pnpm --config.engine-strict=false run check`
- `NPM_CONFIG_ENGINE_STRICT=false pnpm --config.engine-strict=false run test`

Note: local Node is v20.19.2 while the package declares Node >=22, so commands were run with pnpm engine-strict disabled.

## Orbit assessment
- Complexity: XS
- Risk: Low; test-only regression assertion in the existing Claudecode MCP test suite
- Routing: safe direct PR
