### PR TITLE
fix(deps): bump smol-toml to 1.6.1 (GHSA-v3rj-xjv7-4jmq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "gray-matter": "4.0.3",
     "js-yaml": "4.1.1",
     "jsonc-parser": "3.3.1",
-    "smol-toml": "1.6.0",
+    "smol-toml": "1.6.1",
     "sury": "10.0.4",
     "zod": "4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
       smol-toml:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: 1.6.1
+        version: 1.6.1
       sury:
         specifier: 10.0.4
         version: 10.0.4
@@ -4343,8 +4343,8 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   sort-object-keys@2.1.0:
@@ -7124,7 +7124,7 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 9.7.0
       comment-json: 4.6.2
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       yaml: 2.8.2
 
   cspell-dictionary@9.7.0:
@@ -8457,7 +8457,7 @@ snapshots:
       oxc-resolver: 11.19.1
       picocolors: 1.1.1
       picomatch: 4.0.3
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       unbash: 2.2.0
@@ -9390,7 +9390,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   sort-object-keys@2.1.0: {}
 


### PR DESCRIPTION
## Summary

- Bump `smol-toml` from `1.6.0` to `1.6.1` to address [GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq) (medium severity DoS via TOML documents containing thousands of consecutive commented lines).
- The current pin is exact (`"smol-toml": "1.6.0"`), so downstream consumers cannot resolve to the patched release through normal `npm install`. `npm audit fix --force` ends up proposing a downgrade to `rulesync@0.65.0` — the last release before `smol-toml` was added as a dependency — losing every feature since (permissions, native subagents, skills sources, Gemini Policy Engine, etc.).
- `1.6.1` is a semver-compatible patch release, so no API changes.

Closes #1594

## Test plan

- [x] `pnpm install` regenerates `pnpm-lock.yaml` cleanly
- [x] `pnpm typecheck` passes
- [x] `pnpm exec vitest run --testNamePattern "toml|TOML|smol"` — 54 TOML-related tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)