### PR TITLE
feat(qoder): add Qoder rules support (1/4)

### DIFF
--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -220,6 +220,9 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "pi", feature: "commands", entry: "**/.pi/prompts/" },
   { target: "pi", feature: "skills", entry: "**/.pi/skills/" },
 
+  // Qoder
+  { target: "qoder", feature: "rules", entry: "**/.qoder/rules/" },
+
   // Qwen Code
   { target: "qwencode", feature: "rules", entry: "**/QWEN.md" },
   { target: "qwencode", feature: "general", entry: "**/.qwen/memories/" },

--- a/src/features/rules/qoder-rule.test.ts
+++ b/src/features/rules/qoder-rule.test.ts
@@ -1,0 +1,500 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { QoderRule } from "./qoder-rule.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+
+describe("QoderRule", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create instance with frontmatter and body", () => {
+      const rule = new QoderRule({
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { trigger: "always_on", alwaysApply: true },
+        body: "# Test Rule\n\nThis is a test qoder rule.",
+      });
+
+      expect(rule).toBeInstanceOf(QoderRule);
+      expect(rule.getRelativeDirPath()).toBe(".qoder/rules");
+      expect(rule.getRelativeFilePath()).toBe("test-rule.md");
+      expect(rule.getFrontmatter()).toEqual({ trigger: "always_on", alwaysApply: true });
+      expect(rule.getBody()).toBe("# Test Rule\n\nThis is a test qoder rule.");
+    });
+
+    it("should generate file content with YAML frontmatter", () => {
+      const rule = new QoderRule({
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { trigger: "always_on", alwaysApply: true, description: "Test rule" },
+        body: "# Test Rule",
+      });
+
+      const content = rule.getFileContent();
+      expect(content).toContain("---");
+      expect(content).toContain("trigger: always_on");
+      expect(content).toContain("alwaysApply: true");
+      expect(content).toContain("description: Test rule");
+      expect(content).toContain("# Test Rule");
+    });
+
+    it("should create instance with empty frontmatter", () => {
+      const rule = new QoderRule({
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: {},
+        body: "# Test Rule",
+      });
+
+      expect(rule).toBeInstanceOf(QoderRule);
+      expect(rule.getFrontmatter()).toEqual({});
+    });
+
+    it("should create instance with custom outputRoot", () => {
+      const rule = new QoderRule({
+        outputRoot: "/custom/path",
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "custom-rule.md",
+        frontmatter: {},
+        body: "# Custom Rule",
+      });
+
+      expect(rule.getFilePath()).toBe("/custom/path/.qoder/rules/custom-rule.md");
+    });
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return correct paths for nonRoot", () => {
+      const paths = QoderRule.getSettablePaths();
+      expect(paths.nonRoot).toEqual({
+        relativeDirPath: ".qoder/rules",
+      });
+    });
+  });
+
+  describe("fromRulesyncRule", () => {
+    it("should use explicit qoder trigger when set", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "Test description",
+          globs: [],
+          qoder: {
+            trigger: "always_on",
+            alwaysApply: true,
+          },
+        },
+        body: "# Source Rule\n\nThis is a source rule.",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+
+      expect(qoderRule).toBeInstanceOf(QoderRule);
+      expect(qoderRule.getRelativeDirPath()).toBe(".qoder/rules");
+      expect(qoderRule.getRelativeFilePath()).toBe("source-rule.md");
+      expect(qoderRule.getFrontmatter().trigger).toBe("always_on");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBe(true);
+      expect(qoderRule.getFrontmatter().description).toBeUndefined();
+      expect(qoderRule.getBody()).toBe("# Source Rule\n\nThis is a source rule.");
+    });
+
+    it("should use explicit qoder trigger: glob with glob field", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: [],
+          qoder: {
+            trigger: "glob",
+            globs: ["*.java", "*.kt"],
+          },
+        },
+        body: "# Source Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("glob");
+      expect(qoderRule.getFrontmatter().glob).toBe("*.java,*.kt");
+    });
+
+    it("should use explicit qoder trigger: model_decision with description", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: [],
+          qoder: {
+            trigger: "model_decision",
+            description: "Qoder specific desc",
+          },
+        },
+        body: "# Source Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("model_decision");
+      expect(qoderRule.getFrontmatter().description).toBe("Qoder specific desc");
+    });
+
+    it("should infer always_on from cursor.alwaysApply", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: ["**/*"],
+          cursor: { alwaysApply: true, globs: ["**/*"] },
+        },
+        body: "# Always On Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("always_on");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBe(true);
+      expect(qoderRule.getFrontmatter().glob).toBeUndefined();
+      expect(qoderRule.getFrontmatter().description).toBeUndefined();
+    });
+
+    it("should infer always_on from catch-all globs without cursor section", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: ["**/*"],
+        },
+        body: "# Always On Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("always_on");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBe(true);
+    });
+
+    it("should infer glob from specific globs", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: ["*.ts", "*.js"],
+        },
+        body: "# Glob Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("glob");
+      expect(qoderRule.getFrontmatter().glob).toBe("*.ts,*.js");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBeUndefined();
+    });
+
+    it("should infer model_decision from description with empty globs", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "开发参考：API 模式、代码示例",
+          globs: [],
+        },
+        body: "# Dev Reference",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("model_decision");
+      expect(qoderRule.getFrontmatter().description).toBe("开发参考：API 模式、代码示例");
+      expect(qoderRule.getFrontmatter().glob).toBeUndefined();
+    });
+
+    it("should infer manual when no description and no globs", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: [],
+        },
+        body: "# Manual Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("manual");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBe(false);
+      expect(qoderRule.getFrontmatter().glob).toBeUndefined();
+      expect(qoderRule.getFrontmatter().description).toBeUndefined();
+    });
+
+    it("should infer from qoder.alwaysApply without explicit trigger", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: [],
+          qoder: { alwaysApply: true },
+        },
+        body: "# Source Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("always_on");
+      expect(qoderRule.getFrontmatter().alwaysApply).toBe(true);
+    });
+
+    it("should prefer qoder.globs over common globs for inference", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          globs: ["**/*"],
+          qoder: { globs: ["*.java"] },
+        },
+        body: "# Source Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({ rulesyncRule });
+      expect(qoderRule.getFrontmatter().trigger).toBe("glob");
+      expect(qoderRule.getFrontmatter().glob).toBe("*.java");
+    });
+
+    it("should create QoderRule with custom outputRoot", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: "/source/path",
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "source-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "",
+          globs: [],
+        },
+        body: "# Source Rule",
+      });
+
+      const qoderRule = QoderRule.fromRulesyncRule({
+        outputRoot: "/target/path",
+        rulesyncRule,
+      });
+
+      expect(qoderRule.getFilePath()).toBe("/target/path/.qoder/rules/source-rule.md");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should create QoderRule from file with frontmatter", async () => {
+      const rulesDir = join(testDir, ".qoder", "rules");
+      await ensureDir(rulesDir);
+      await writeFileContent(
+        join(rulesDir, "test-rule.md"),
+        "---\ntrigger: always_on\nalwaysApply: true\n---\n# Test Rule\n\nThis is a test rule from file.",
+      );
+
+      const rule = await QoderRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "test-rule.md",
+      });
+
+      expect(rule).toBeInstanceOf(QoderRule);
+      expect(rule.getFrontmatter().trigger).toBe("always_on");
+      expect(rule.getFrontmatter().alwaysApply).toBe(true);
+      expect(rule.getBody()).toBe("# Test Rule\n\nThis is a test rule from file.");
+    });
+
+    it("should handle file content without frontmatter", async () => {
+      const rulesDir = join(testDir, ".qoder", "rules");
+      await ensureDir(rulesDir);
+      await writeFileContent(
+        join(rulesDir, "no-frontmatter.md"),
+        "# Simple Rule\n\nNo frontmatter here.",
+      );
+
+      const rule = await QoderRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "no-frontmatter.md",
+      });
+
+      expect(rule.getFrontmatter()).toEqual({});
+      expect(rule.getBody()).toBe("# Simple Rule\n\nNo frontmatter here.");
+    });
+
+    it("should throw error when file does not exist", async () => {
+      await expect(
+        QoderRule.fromFile({
+          outputRoot: testDir,
+          relativeFilePath: "nonexistent-rule.md",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("toRulesyncRule", () => {
+    it("should convert QoderRule to RulesyncRule preserving frontmatter", () => {
+      const rule = new QoderRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { trigger: "always_on", alwaysApply: true, description: "Test" },
+        body: "# Test Rule\n\nThis is a test rule.",
+      });
+
+      const rulesyncRule = rule.toRulesyncRule();
+
+      expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
+      expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
+      expect(rulesyncRule.getRelativeFilePath()).toBe("test-rule.md");
+      expect(rulesyncRule.getBody()).toBe("# Test Rule\n\nThis is a test rule.");
+      expect(rulesyncRule.getFrontmatter().description).toBe("Test");
+      expect(rulesyncRule.getFrontmatter().qoder?.trigger).toBe("always_on");
+      expect(rulesyncRule.getFrontmatter().qoder?.alwaysApply).toBe(true);
+    });
+
+    it("should set globs to **/* when alwaysApply is true", () => {
+      const rule = new QoderRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { alwaysApply: true },
+        body: "# Test Rule",
+      });
+
+      const rulesyncRule = rule.toRulesyncRule();
+      expect(rulesyncRule.getFrontmatter().globs).toEqual(["**/*"]);
+    });
+
+    it("should parse comma-separated glob", () => {
+      const rule = new QoderRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { trigger: "glob", glob: "*.ts, *.js" },
+        body: "# Test Rule",
+      });
+
+      const rulesyncRule = rule.toRulesyncRule();
+      expect(rulesyncRule.getFrontmatter().globs).toEqual(["*.ts", "*.js"]);
+    });
+  });
+
+  describe("validate", () => {
+    it("should return successful validation for valid frontmatter", () => {
+      const rule = new QoderRule({
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: { trigger: "always_on", alwaysApply: true },
+        body: "# Test Rule",
+        validate: false,
+      });
+
+      const result = rule.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBe(null);
+    });
+
+    it("should return successful validation for empty frontmatter", () => {
+      const rule = new QoderRule({
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test-rule.md",
+        frontmatter: {},
+        body: "",
+        validate: false,
+      });
+
+      const result = rule.validate();
+      expect(result.success).toBe(true);
+      expect(result.error).toBe(null);
+    });
+  });
+
+  describe("isTargetedByRulesyncRule", () => {
+    it("should return true for rules targeting qoder", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["qoder"] },
+        body: "Test content",
+      });
+
+      expect(QoderRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("should return true for rules targeting all tools (*)", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"] },
+        body: "Test content",
+      });
+
+      expect(QoderRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("should return false for rules not targeting qoder", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["cursor", "copilot"] },
+        body: "Test content",
+      });
+
+      expect(QoderRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(false);
+    });
+
+    it("should return false for empty targets", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: [] },
+        body: "Test content",
+      });
+
+      expect(QoderRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(false);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a QoderRule instance for deletion", () => {
+      const rule = QoderRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".qoder/rules",
+        relativeFilePath: "to-delete.md",
+      });
+
+      expect(rule).toBeInstanceOf(QoderRule);
+    });
+  });
+});

--- a/src/features/rules/qoder-rule.ts
+++ b/src/features/rules/qoder-rule.ts
@@ -1,0 +1,260 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import type { RulesyncTargets } from "../../types/tool-targets.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContent } from "../../utils/file.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
+import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
+import {
+  ToolRule,
+  ToolRuleForDeletionParams,
+  ToolRuleFromFileParams,
+  ToolRuleFromRulesyncRuleParams,
+  ToolRuleSettablePaths,
+  buildToolPath,
+} from "./tool-rule.js";
+
+export const QoderRuleFrontmatterSchema = z.looseObject({
+  trigger: z.optional(z.string()),
+  alwaysApply: z.optional(z.boolean()),
+  description: z.optional(z.string()),
+  glob: z.optional(z.string()),
+});
+
+export type QoderRuleFrontmatter = z.infer<typeof QoderRuleFrontmatterSchema>;
+
+export type QoderRuleParams = {
+  frontmatter: QoderRuleFrontmatter;
+  body: string;
+} & Omit<AiFileParams, "fileContent">;
+
+export type QoderRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
+  nonRoot: {
+    relativeDirPath: string;
+  };
+};
+
+export class QoderRule extends ToolRule {
+  private readonly frontmatter: QoderRuleFrontmatter;
+  private readonly body: string;
+
+  static getSettablePaths(
+    _options: {
+      global?: boolean;
+      excludeToolDir?: boolean;
+    } = {},
+  ): QoderRuleSettablePaths {
+    return {
+      nonRoot: {
+        relativeDirPath: buildToolPath(".qoder", "rules", _options.excludeToolDir),
+      },
+    };
+  }
+
+  constructor({ frontmatter, body, ...rest }: QoderRuleParams) {
+    if (rest.validate) {
+      const result = QoderRuleFrontmatterSchema.safeParse(frontmatter);
+      if (!result.success) {
+        throw new Error(
+          `Invalid frontmatter in ${join(rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true }),
+    });
+
+    this.frontmatter = frontmatter;
+    this.body = body;
+  }
+
+  toRulesyncRule(): RulesyncRule {
+    const targets: RulesyncTargets = ["*"];
+
+    const isAlways = this.frontmatter.alwaysApply === true;
+    const hasGlob = this.frontmatter.glob && this.frontmatter.glob.trim() !== "";
+
+    let globs: string[];
+    if (hasGlob && this.frontmatter.glob) {
+      globs = this.frontmatter.glob
+        .split(",")
+        .map((g) => g.trim())
+        .filter((g) => g.length > 0);
+    } else if (isAlways) {
+      globs = ["**/*"];
+    } else {
+      globs = [];
+    }
+
+    const rulesyncFrontmatter: RulesyncRuleFrontmatter = {
+      targets,
+      root: false,
+      description: this.frontmatter.description,
+      globs,
+      qoder: {
+        trigger: this.frontmatter.trigger,
+        alwaysApply: this.frontmatter.alwaysApply,
+        description: this.frontmatter.description,
+        globs: globs.length > 0 ? globs : undefined,
+      },
+    };
+
+    return new RulesyncRule({
+      frontmatter: rulesyncFrontmatter,
+      body: this.body,
+      relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+      relativeFilePath: this.relativeFilePath,
+      validate: true,
+    });
+  }
+
+  /**
+   * Infer the best Qoder trigger mode from rulesync canonical frontmatter.
+   *
+   * Priority: explicit qoder section > cursor hints > common fields.
+   *
+   * Mapping:
+   *   alwaysApply / catch-all globs  → trigger: always_on
+   *   specific globs                 → trigger: glob
+   *   description only               → trigger: model_decision
+   *   fallback                        → trigger: manual
+   */
+  static fromRulesyncRule({
+    outputRoot = process.cwd(),
+    rulesyncRule,
+    validate = true,
+  }: ToolRuleFromRulesyncRuleParams): QoderRule {
+    const fm = rulesyncRule.getFrontmatter();
+
+    // If the qoder section already has an explicit trigger, honour it directly
+    if (fm.qoder?.trigger) {
+      const qoderFrontmatter: QoderRuleFrontmatter = {
+        trigger: fm.qoder.trigger,
+        ...(fm.qoder.alwaysApply !== undefined && { alwaysApply: fm.qoder.alwaysApply }),
+        ...(fm.qoder.description !== undefined && { description: fm.qoder.description }),
+        ...(fm.qoder.globs !== undefined && { glob: fm.qoder.globs.join(",") }),
+      };
+
+      return new QoderRule({
+        outputRoot,
+        frontmatter: qoderFrontmatter,
+        body: rulesyncRule.getBody(),
+        relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+        relativeFilePath: rulesyncRule.getRelativeFilePath(),
+        validate,
+      });
+    }
+
+    // Infer from common / cursor fields
+    const alwaysApply = fm.qoder?.alwaysApply ?? fm.cursor?.alwaysApply;
+    const globs = fm.qoder?.globs ?? fm.globs;
+    const description = fm.qoder?.description ?? fm.description;
+
+    const isCatchAll =
+      globs != null && globs.length > 0 && globs.every((g) => g === "**/*" || g === "**");
+    const hasSpecificGlobs = globs != null && globs.length > 0 && !isCatchAll;
+
+    let qoderFrontmatter: QoderRuleFrontmatter;
+
+    if (alwaysApply === true || isCatchAll) {
+      qoderFrontmatter = { trigger: "always_on", alwaysApply: true };
+    } else if (hasSpecificGlobs) {
+      qoderFrontmatter = { trigger: "glob", glob: globs!.join(",") };
+    } else if (description) {
+      qoderFrontmatter = { trigger: "model_decision", description };
+    } else {
+      qoderFrontmatter = { trigger: "manual", alwaysApply: false };
+    }
+
+    return new QoderRule({
+      outputRoot,
+      frontmatter: qoderFrontmatter,
+      body: rulesyncRule.getBody(),
+      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath: rulesyncRule.getRelativeFilePath(),
+      validate,
+    });
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    relativeFilePath,
+    validate = true,
+  }: ToolRuleFromFileParams): Promise<QoderRule> {
+    const filePath = join(
+      outputRoot,
+      this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath,
+    );
+    const fileContent = await readFileContent(filePath);
+    const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
+
+    const result = QoderRuleFrontmatterSchema.safeParse(frontmatter);
+    if (!result.success) {
+      throw new Error(`Invalid frontmatter in ${filePath}: ${formatError(result.error)}`);
+    }
+
+    return new QoderRule({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath,
+      frontmatter: result.data,
+      body: content.trim(),
+      validate,
+    });
+  }
+
+  validate(): ValidationResult {
+    if (!this.frontmatter) {
+      return { success: true, error: null };
+    }
+
+    const result = QoderRuleFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    } else {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+  }
+
+  getFrontmatter(): QoderRuleFrontmatter {
+    return this.frontmatter;
+  }
+
+  getBody(): string {
+    return this.body;
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): QoderRule {
+    return new QoderRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      frontmatter: {},
+      body: "",
+      validate: false,
+    });
+  }
+
+  static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {
+    return this.isTargetedByRulesyncRuleDefault({
+      rulesyncRule,
+      toolTarget: "qoder",
+    });
+  }
+}

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -51,6 +51,7 @@ import { KiloRule } from "./kilo-rule.js";
 import { KiroRule } from "./kiro-rule.js";
 import { OpenCodeRule } from "./opencode-rule.js";
 import { PiRule } from "./pi-rule.js";
+import { QoderRule } from "./qoder-rule.js";
 import { QwencodeRule } from "./qwencode-rule.js";
 import { ReplitRule } from "./replit-rule.js";
 import { RooRule } from "./roo-rule.js";
@@ -89,6 +90,7 @@ const rulesProcessorToolTargets: ToolTarget[] = [
   "kiro",
   "opencode",
   "pi",
+  "qoder",
   "qwencode",
   "replit",
   "roo",
@@ -467,6 +469,17 @@ const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
         extension: "md",
         supportsGlobal: true,
         ruleDiscoveryMode: "toon",
+      },
+    },
+  ],
+  [
+    "qoder",
+    {
+      class: QoderRule,
+      meta: {
+        extension: "md",
+        supportsGlobal: false,
+        ruleDiscoveryMode: "auto",
       },
     },
   ],

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -43,6 +43,14 @@ export const RulesyncRuleFrontmatterSchema = z.object({
       globs: z.optional(z.array(z.string())),
     }),
   ),
+  qoder: z.optional(
+    z.looseObject({
+      trigger: z.optional(z.string()),
+      alwaysApply: z.optional(z.boolean()),
+      description: z.optional(z.string()),
+      globs: z.optional(z.array(z.string())),
+    }),
+  ),
   copilot: z.optional(
     z.looseObject({
       excludeAgent: z.optional(z.union([z.literal("code-review"), z.literal("coding-agent")])),

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -33,6 +33,7 @@ describe("tool targets", () => {
         "kiro",
         "opencode",
         "pi",
+        "qoder",
         "qwencode",
         "replit",
         "roo",

--- a/src/types/tool-targets.ts
+++ b/src/types/tool-targets.ts
@@ -25,6 +25,7 @@ export const ALL_TOOL_TARGETS = [
   "kiro",
   "opencode",
   "pi",
+  "qoder",
   "qwencode",
   "replit",
   "roo",


### PR DESCRIPTION
## Summary

Add [Qoder](https://qoder.com) as a new tool target with **rules** support — the first PR in a series of 4 to add full Qoder integration.

**About Qoder:**
[Qoder](https://qoder.com) is an AI coding tool developed by **Alibaba Group**, designed for enterprise-grade intelligent code generation and development assistance. It supports IDE integration (JetBrains, VS Code) with features including rules, MCP, commands, subagents, skills, and hooks.

- **Official Website:** https://qoder.com
- **Documentation:** https://docs.qoder.com
- **Rules Documentation:** https://docs.qoder.com/user-guide/rules

## Changes

- Add `"qoder"` to `ALL_TOOL_TARGETS`
- Add `qoder`-specific fields (`trigger`, `alwaysApply`, `description`, `globs`) to `RulesyncRuleFrontmatterSchema`
- Implement `QoderRule` adapter for `.qoder/rules/*.md` with YAML frontmatter
- Smart trigger inference maps rulesync canonical fields (`description`, `globs`, `cursor.alwaysApply`) to Qoder's four native trigger modes: `always_on`, `glob`, `model_decision`, `manual`
- Register `QoderRule` in `rules-processor`
- Add `.qoder/rules/` gitignore entry

## PR Series

This is **PR 1 of 4** for full Qoder support:
1. **Rules** (this PR)
2. MCP + Commands
3. Subagents + Skills
4. Hooks

## Test plan

- [x] All existing tests pass (`pnpm test`)
- [x] Type checking passes (`tsgo --noEmit`)
- [x] Format check passes (`oxfmt --check .`)
- [x] Verified `rulesync generate --targets "qoder" --features "rules"` produces correct YAML frontmatter

Made with [Cursor](https://cursor.com)