### PR TITLE
fix(codexcli): emit project-root filesystem globs

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -472,6 +472,8 @@ For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml`
 - `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
+Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":project_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated project-root rules contain unbounded `**` patterns.
+
 For Gemini CLI, this generates a Policy Engine file at `.gemini/policies/rulesync.toml` (project mode) or `~/.gemini/policies/rulesync.toml` (global mode). Gemini CLI auto-discovers any `*.toml` file under the `policies/` directory, so no `settings.json` modification is required:
 
 - `allow` / `deny` / `ask` rules are converted into Policy Engine `decision` values `allow` / `deny` / `ask_user`

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -472,6 +472,8 @@ For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml`
 - `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
+Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":project_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated project-root rules contain unbounded `**` patterns.
+
 For Gemini CLI, this generates a Policy Engine file at `.gemini/policies/rulesync.toml` (project mode) or `~/.gemini/policies/rulesync.toml` (global mode). Gemini CLI auto-discovers any `*.toml` file under the `policies/` directory, so no `settings.json` modification is required:
 
 - `allow` / `deny` / `ask` rules are converted into Policy Engine `decision` values `allow` / `deny` / `ask_user`

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -48,8 +48,13 @@ describe("E2E: permissions", () => {
         {
           permission: {
             bash: { "git status": "allow", "npm publish": "ask", "rm -rf": "deny" },
-            read: { "/workspace/project/**": "allow", "/workspace/project/.env": "deny" },
-            write: { "/workspace/project/src/**": "allow" },
+            read: {
+              "**/*.tf": "deny",
+              "src/**": "allow",
+              "/workspace/project/**": "allow",
+              "/workspace/project/.env": "deny",
+            },
+            write: { "docs/**": "allow", "/workspace/project/src/**": "allow" },
             webfetch: { "github.com": "allow", "example.com": "deny" },
           },
         },
@@ -68,8 +73,13 @@ describe("E2E: permissions", () => {
     const filesystem = toTable(rulesyncProfile.filesystem);
     const network = toTable(rulesyncProfile.network);
     const domains = toTable(network.domains);
+    const projectRoots = toTable(filesystem[":project_roots"]);
     expect(filesystem["/workspace/project/**"]).toBe("read");
     expect(filesystem["/workspace/project/src/**"]).toBe("write");
+    expect(filesystem.glob_scan_max_depth).toBe(8);
+    expect(projectRoots["**/*.tf"]).toBe("none");
+    expect(projectRoots["src/**"]).toBe("read");
+    expect(projectRoots["docs/**"]).toBe("write");
     expect(domains["github.com"]).toBe("allow");
 
     const rulesContent = await readFileContent(join(testDir, ".codex", "rules", "rulesync.rules"));

--- a/src/features/permissions/codexcli-permissions.test.ts
+++ b/src/features/permissions/codexcli-permissions.test.ts
@@ -54,6 +54,42 @@ describe("CodexcliPermissions", () => {
     expect(fileContent).toContain('"example.com" = "deny"');
   });
 
+  it("should place relative filesystem globs under the Codex project root table", async () => {
+    const logger = createMockLogger();
+    const rulesyncPermissions = new RulesyncPermissions({
+      outputRoot: testDir,
+      relativeDirPath: ".rulesync",
+      relativeFilePath: "permissions.json",
+      fileContent: JSON.stringify({
+        permission: {
+          read: {
+            "**/*.tf": "deny",
+            "src/**": "allow",
+            "/workspace/project/**": "allow",
+          },
+          write: {
+            "docs/**": "allow",
+          },
+        },
+      }),
+    });
+
+    const codexPermissions = await CodexcliPermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions,
+      logger,
+    });
+
+    const fileContent = codexPermissions.getFileContent();
+    expect(fileContent).toContain("[permissions.rulesync.filesystem]");
+    expect(fileContent).toContain("glob_scan_max_depth = 8");
+    expect(fileContent).toContain('"/workspace/project/**" = "read"');
+    expect(fileContent).toContain('[permissions.rulesync.filesystem.":project_roots"]');
+    expect(fileContent).toContain('"**/*.tf" = "none"');
+    expect(fileContent).toContain('"src/**" = "read"');
+    expect(fileContent).toContain('"docs/**" = "write"');
+  });
+
   it("should convert Codex CLI permissions profile to rulesync format", () => {
     const codexPermissions = new CodexcliPermissions({
       outputRoot: testDir,
@@ -83,6 +119,35 @@ default_permissions = "rulesync"
     expect(json.permission.webfetch?.["example.com"]).toBe("deny");
   });
 
+  it("should import nested Codex project root filesystem rules", () => {
+    const codexPermissions = new CodexcliPermissions({
+      outputRoot: testDir,
+      relativeDirPath: ".codex",
+      relativeFilePath: "config.toml",
+      fileContent: `
+default_permissions = "rulesync"
+
+[permissions.rulesync.filesystem]
+glob_scan_max_depth = 8
+"/workspace/project/**" = "read"
+
+[permissions.rulesync.filesystem.":project_roots"]
+"**/*.tf" = "none"
+"src/**" = "read"
+"docs/**" = "write"
+`,
+    });
+
+    const rulesyncPermissions = codexPermissions.toRulesyncPermissions();
+    const json = rulesyncPermissions.getJson();
+
+    expect(json.permission.read?.["/workspace/project/**"]).toBe("allow");
+    expect(json.permission.read?.["**/*.tf"]).toBe("deny");
+    expect(json.permission.edit?.["**/*.tf"]).toBe("deny");
+    expect(json.permission.read?.["src/**"]).toBe("allow");
+    expect(json.permission.edit?.["docs/**"]).toBe("allow");
+  });
+
   it("should load existing .codex/config.toml", async () => {
     const codexDir = join(testDir, ".codex");
     await ensureDir(codexDir);
@@ -108,7 +173,7 @@ default_permissions = "rulesync"
     });
 
     const content = rulesFile.getFileContent();
-    expect(rulesFile.getRelativeDirPath()).toBe(".codex/rules");
+    expect(rulesFile.getRelativeDirPath()).toBe(join(".codex", "rules"));
     expect(rulesFile.getRelativeFilePath()).toBe("rulesync.rules");
     expect(content).toContain('pattern = ["git", "status"]');
     expect(content).toContain('decision = "allow"');

--- a/src/features/permissions/codexcli-permissions.ts
+++ b/src/features/permissions/codexcli-permissions.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import * as smolToml from "smol-toml";
 
@@ -18,9 +18,15 @@ import {
 
 const RULESYNC_PROFILE_NAME = "rulesync";
 const RULESYNC_BASH_RULES_FILE_NAME = "rulesync.rules";
+const CODEX_PROJECT_ROOTS_KEY = ":project_roots";
+const CODEX_GLOB_SCAN_MAX_DEPTH = 8;
+
+type CodexFilesystemAccess = "read" | "write" | "none";
+type CodexFilesystemRuleTable = Record<string, CodexFilesystemAccess>;
+type CodexFilesystem = Record<string, CodexFilesystemAccess | CodexFilesystemRuleTable | number>;
 
 type CodexPermissionProfile = {
-  filesystem?: Record<string, "read" | "write" | "none">;
+  filesystem?: CodexFilesystem;
   network?: {
     domains?: Record<string, "allow" | "deny">;
   };
@@ -162,20 +168,31 @@ function convertRulesyncToCodexProfile({
   config: PermissionsConfig;
   logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
 }): CodexPermissionProfile {
-  const filesystem: Record<string, "read" | "write" | "none"> = {};
+  const filesystem: CodexFilesystem = {};
+  const projectRootFilesystem: CodexFilesystemRuleTable = {};
   const domains: Record<string, "allow" | "deny"> = {};
 
   for (const [toolName, rules] of Object.entries(config.permission)) {
     if (toolName === "read") {
       for (const [pattern, action] of Object.entries(rules)) {
-        filesystem[pattern] = mapReadAction(action);
+        addFilesystemRule({
+          filesystem,
+          projectRootFilesystem,
+          pattern,
+          access: mapReadAction(action),
+        });
       }
       continue;
     }
 
     if (toolName === "edit" || toolName === "write") {
       for (const [pattern, action] of Object.entries(rules)) {
-        filesystem[pattern] = mapWriteAction(action);
+        addFilesystemRule({
+          filesystem,
+          projectRootFilesystem,
+          pattern,
+          access: mapWriteAction(action),
+        });
       }
       continue;
     }
@@ -198,6 +215,13 @@ function convertRulesyncToCodexProfile({
     );
   }
 
+  if (Object.keys(projectRootFilesystem).length > 0) {
+    if (Object.keys(projectRootFilesystem).some((pattern) => pattern.includes("**"))) {
+      filesystem.glob_scan_max_depth = CODEX_GLOB_SCAN_MAX_DEPTH;
+    }
+    filesystem[CODEX_PROJECT_ROOTS_KEY] = projectRootFilesystem;
+  }
+
   return {
     ...(Object.keys(filesystem).length > 0 ? { filesystem } : {}),
     ...(Object.keys(domains).length > 0 ? { network: { domains } } : {}),
@@ -211,13 +235,15 @@ function convertCodexProfileToRulesync(profile?: CodexPermissionProfile): Permis
     permission.read = {};
     permission.edit = {};
     for (const [pattern, access] of Object.entries(profile.filesystem)) {
-      if (access === "none") {
-        permission.read[pattern] = "deny";
-        permission.edit[pattern] = "deny";
-      } else if (access === "read") {
-        permission.read[pattern] = "allow";
-      } else {
-        permission.edit[pattern] = "allow";
+      if (isCodexFilesystemAccess(access)) {
+        addRulesyncFilesystemRule(permission, pattern, access);
+        continue;
+      }
+
+      if (isCodexFilesystemRuleTable(access)) {
+        for (const [nestedPattern, nestedAccess] of Object.entries(access)) {
+          addRulesyncFilesystemRule(permission, nestedPattern, nestedAccess);
+        }
       }
     }
   }
@@ -244,6 +270,54 @@ function toCodexProfile(value: unknown): CodexPermissionProfile | undefined {
   };
 }
 
+function addFilesystemRule({
+  filesystem,
+  projectRootFilesystem,
+  pattern,
+  access,
+}: {
+  filesystem: CodexFilesystem;
+  projectRootFilesystem: CodexFilesystemRuleTable;
+  pattern: string;
+  access: CodexFilesystemAccess;
+}): void {
+  if (canBeCodexFilesystemRoot(pattern)) {
+    filesystem[pattern] = access;
+    return;
+  }
+
+  projectRootFilesystem[pattern] = access;
+}
+
+function canBeCodexFilesystemRoot(pattern: string): boolean {
+  return (
+    isAbsolute(pattern) ||
+    /^[A-Za-z]:[\\/]/.test(pattern) ||
+    pattern.startsWith("~/") ||
+    pattern === "~" ||
+    pattern.startsWith(":")
+  );
+}
+
+function addRulesyncFilesystemRule(
+  permission: PermissionsConfig["permission"],
+  pattern: string,
+  access: CodexFilesystemAccess,
+): void {
+  if (access === "none") {
+    permission.read ??= {};
+    permission.edit ??= {};
+    permission.read[pattern] = "deny";
+    permission.edit[pattern] = "deny";
+  } else if (access === "read") {
+    permission.read ??= {};
+    permission.read[pattern] = "allow";
+  } else {
+    permission.edit ??= {};
+    permission.edit[pattern] = "allow";
+  }
+}
+
 function toMutableTable(value: unknown): UnknownTable {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {};
@@ -251,12 +325,42 @@ function toMutableTable(value: unknown): UnknownTable {
   return { ...value };
 }
 
-function toFilesystemRecord(value: unknown): Record<string, "read" | "write" | "none"> | undefined {
+function toFilesystemRecord(value: unknown): CodexFilesystem | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const result: Record<string, "read" | "write" | "none"> = {};
+  const result: CodexFilesystem = {};
   for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw !== "string") continue;
-    if (raw === "read" || raw === "write" || raw === "none") {
+    if (isCodexFilesystemAccess(raw)) {
+      result[key] = raw;
+      continue;
+    }
+
+    if (key === "glob_scan_max_depth" && typeof raw === "number") {
+      result[key] = raw;
+      continue;
+    }
+
+    const nested = toCodexFilesystemRuleTable(raw);
+    if (nested) {
+      result[key] = nested;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function isCodexFilesystemAccess(value: unknown): value is CodexFilesystemAccess {
+  return value === "read" || value === "write" || value === "none";
+}
+
+function isCodexFilesystemRuleTable(value: unknown): value is CodexFilesystemRuleTable {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every(isCodexFilesystemAccess);
+}
+
+function toCodexFilesystemRuleTable(value: unknown): CodexFilesystemRuleTable | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: CodexFilesystemRuleTable = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (isCodexFilesystemAccess(raw)) {
       result[key] = raw;
     }
   }


### PR DESCRIPTION
## Summary
- Emit relative Codex CLI filesystem globs under the `:project_roots` named root instead of the top-level filesystem table.
- Preserve absolute paths, home paths, and existing named roots at the top level.
- Add `glob_scan_max_depth = 8` when project-root rules contain unbounded `**` patterns.
- Import nested Codex project-root filesystem rules back into Rulesync permissions and document the generated layout.

Fixes #1597

## Testing
- `npx pnpm@10.25.0 exec vitest run --silent=true src/features/permissions/codexcli-permissions.test.ts`
- `npx pnpm@10.25.0 exec oxfmt --check src/features/permissions/codexcli-permissions.ts src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts docs/reference/file-formats.md skills/rulesync/file-formats.md`
- `npx pnpm@10.25.0 exec oxlint src/features/permissions/codexcli-permissions.ts src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts --max-warnings 0`
- `npx pnpm@10.25.0 run typecheck`

Note: `npx pnpm@10.25.0 exec vitest run --config vitest.e2e.config.ts --silent=false src/e2e/e2e-permissions.spec.ts` currently fails before assertions in this Windows environment because the E2E helper spawns `node_modules/.bin/tsx` without the Windows `.cmd` shim.
