### PR TITLE
fix(codexcli): use renamed hooks feature flag

### DIFF
--- a/src/features/hooks/codexcli-hooks.test.ts
+++ b/src/features/hooks/codexcli-hooks.test.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";

--- a/src/features/hooks/codexcli-hooks.test.ts
+++ b/src/features/hooks/codexcli-hooks.test.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
@@ -434,9 +433,10 @@ describe("CodexcliConfigToml", () => {
     await cleanup();
   });
 
-  it("should generate config.toml with codex_hooks feature flag", async () => {
+  it("should generate config.toml with hooks feature flag", async () => {
     const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
-    expect(configToml.getFileContent()).toContain("codex_hooks");
+    expect(configToml.getFileContent()).toContain("hooks = true");
+    expect(configToml.getFileContent()).not.toContain("codex_hooks");
   });
 
   it("should preserve existing config.toml content", async () => {
@@ -448,19 +448,34 @@ describe("CodexcliConfigToml", () => {
 
     const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     const content = configToml.getFileContent();
-    expect(content).toContain("codex_hooks");
+    expect(content).toContain("hooks = true");
+    expect(content).not.toContain("codex_hooks");
     expect(content).toContain("mcp_servers");
     expect(content).toContain("myserver");
   });
 
-  it("should preserve existing [features] values when enabling codex_hooks", async () => {
+  it("should preserve existing [features] values when enabling hooks", async () => {
     await ensureDir(join(testDir, ".codex"));
     await writeFileContent(join(testDir, ".codex", "config.toml"), "[features]\nverbose = true\n");
 
     const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
     const content = configToml.getFileContent();
-    expect(content).toContain("codex_hooks = true");
+    expect(content).toContain("hooks = true");
     expect(content).toContain("verbose = true");
+  });
+
+  it("should remove deprecated codex_hooks when enabling hooks", async () => {
+    await ensureDir(join(testDir, ".codex"));
+    await writeFileContent(
+      join(testDir, ".codex", "config.toml"),
+      "[features]\ncodex_hooks = true\nverbose = true\n",
+    );
+
+    const configToml = await CodexcliConfigToml.fromOutputRoot({ outputRoot: testDir });
+    const content = configToml.getFileContent();
+    expect(content).toContain("hooks = true");
+    expect(content).toContain("verbose = true");
+    expect(content).not.toContain("codex_hooks");
   });
 
   it("should throw a readable error when existing config.toml is invalid", async () => {

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -1,8 +1,10 @@
 import { join } from "node:path";
-
 import * as smolToml from "smol-toml";
 
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
+
 import {
   CODEXCLI_HOOK_EVENTS,
   CODEXCLI_TO_CANONICAL_EVENT_NAMES,
@@ -11,8 +13,6 @@ import {
 import { ToolFile } from "../../types/tool-file.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
@@ -32,7 +32,7 @@ const CODEXCLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
 };
 
 /**
- * Build the content for `.codex/config.toml` with `[features] codex_hooks = true`.
+ * Build the content for `.codex/config.toml` with `[features] hooks = true`.
  * Reads the existing file (if any), parses TOML, sets the flag, and returns the content
  * without writing to disk. The caller is responsible for writing via the normal write phase.
  */
@@ -60,7 +60,9 @@ async function buildCodexConfigTomlContent({
     configToml.features = {} as smolToml.TomlTable;
   }
   // eslint-disable-next-line no-type-assertion/no-type-assertion
-  (configToml.features as smolToml.TomlTable).codex_hooks = true;
+  const features = configToml.features as smolToml.TomlTable;
+  delete features.codex_hooks;
+  features.hooks = true;
 
   return smolToml.stringify(configToml);
 }

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -1,10 +1,8 @@
 import { join } from "node:path";
+
 import * as smolToml from "smol-toml";
 
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
-import type { RulesyncHooks } from "./rulesync-hooks.js";
-import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-
 import {
   CODEXCLI_HOOK_EVENTS,
   CODEXCLI_TO_CANONICAL_EVENT_NAMES,
@@ -13,6 +11,8 @@ import {
 import { ToolFile } from "../../types/tool-file.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
 import {
   ToolHooks,


### PR DESCRIPTION
## Summary

Codex CLI 0.129.0 renamed the hooks feature flag from `codex_hooks` to `hooks`.

This updates the Codex CLI hooks generator to emit the new `[features].hooks = true` flag and intentionally drops the deprecated `codex_hooks` key from generated config output.

## References

- Codex CLI changelog: https://developers.openai.com/codex/changelog
- Codex feature flags: https://developers.openai.com/codex/config-basic#feature-flags
- Upstream change: https://github.com/openai/codex/pull/20522

## Test plan

- [x] `pnpm vitest run src/features/hooks/codexcli-hooks.test.ts src/features/hooks/hooks-processor.test.ts`
- [x] `pnpm vitest run --config vitest.e2e.config.ts src/e2e/e2e-hooks.spec.ts`
- [x] `pnpm run typecheck`