### PR TITLE
chore: add session-start hook and soften pr-policy workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "git pull && pnpm i"
           }
         ]
       }

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read # Minimum required
-  pull-requests: write # Required for commenting and closing PRs
+  pull-requests: write # Required for commenting on PRs
 
 jobs:
   check-policy:
@@ -51,8 +51,7 @@ jobs:
           EOF
             )
             gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
-            echo "::error::PR exceeds the addition line limit for external contributors ($PR_ADDITIONS > $MAX_ADDITIONS)."
-            exit 1
+            echo "::warning::PR exceeds the addition line limit for external contributors ($PR_ADDITIONS > $MAX_ADDITIONS)."
           fi
 
           # Check 2: Open PR count (on 'opened' and 'reopened' events; skipped on synchronize
@@ -66,14 +65,10 @@ jobs:
           Thank you for your contribution! Unfortunately, you currently have **${OPEN_PR_COUNT} open PRs** (including this one), which exceeds the limit of **${MAX_OPEN_PRS}** for external contributors.
 
           Please wait for an existing PR to be reviewed/merged, or close one before opening a new one. See [CONTRIBUTING.md](https://github.com/${GH_REPO}/blob/main/CONTRIBUTING.md) for details.
-
-          This PR has been automatically closed.
           EOF
             )
               gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
-              gh pr close "$PR_NUMBER"
-              echo "::error::Author has too many open PRs ($OPEN_PR_COUNT > $MAX_OPEN_PRS)."
-              exit 1
+              echo "::warning::Author has too many open PRs ($OPEN_PR_COUNT > $MAX_OPEN_PRS)."
             fi
           fi
 

--- a/.rulesync/hooks.json
+++ b/.rulesync/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "command": "git pull && pnpm i"
+      }
+    ]
+  }
+}

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -12,21 +12,24 @@
       "commands": true,
       "mcp": false,
       "subagents": true,
-      "skills": true
+      "skills": true,
+      "hooks": true
     },
     "claudecode": {
       "rules": true,
       "commands": true,
       "mcp": true,
       "subagents": true,
-      "skills": true
+      "skills": true,
+      "hooks": true
     },
     "opencode": {
       "rules": true,
       "commands": true,
       "mcp": true,
       "subagents": true,
-      "skills": true
+      "skills": true,
+      "hooks": true
     },
     "takt": {
       "rules": true,


### PR DESCRIPTION
## Summary

- Add `.rulesync/hooks.json` with a `sessionStart` hook that runs `git pull && pnpm i`. Enable the `hooks` feature for `claudecode`, `opencode`, and `copilot` targets in `rulesync.jsonc` so the hook is materialized for each tool on `rulesync generate`.
- Soften `.github/workflows/pr-policy.yml`: violations now leave only a PR comment. The workflow no longer exits non-zero and no longer auto-closes PRs; the annotation level is downgraded from `::error::` to `::warning::`.

## Test plan

- [x] `pnpm cicheck` passes locally
- [x] `pnpm dev generate` writes the expected files (`.claude/settings.json` hook entry, `.github/hooks/copilot-hooks.json`, `.opencode/plugins/rulesync-hooks.js`)
- [ ] Confirm the PR Policy workflow runs without failing on an external contributor PR that exceeds the limits (next external PR will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)