### PR TITLE
docs: update CONTRIBUTING example and add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: dyoshikawa

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ You can also create `.rulesync/rules/overview.local.md` to configure language pr
 ```md
 ---
 root: false
+localRoot: true
 targets: ["*"]
 description: "It's a rule about language. If the rule file exists, you must always follow this."
 globs: ["**/*"]


### PR DESCRIPTION
## Summary
- Add `localRoot: true` to the language rule example in `CONTRIBUTING.md` so it matches the current recommended setup for `overview.local.md`.
- Add `.github/FUNDING.yml` pointing to `dyoshikawa` to enable the GitHub Sponsors button on the repository.

## Test plan
- [x] `pnpm cicheck` passes locally
- [ ] Verify the Sponsor button appears on the repository page after merge