### PR TITLE
docs(commands): add GHA workflow status check to review-pr commands

### DIFF
--- a/.rulesync/commands/review-pr-lite.md
+++ b/.rulesync/commands/review-pr-lite.md
@@ -49,3 +49,12 @@ Integrate all findings into one review result. Please output the PR number in th
 - Present findings first, ordered by severity.
 - If no findings are discovered, explicitly state that no findings were found.
 - Keep the summary brief and focused on risk and testing gaps.
+
+## Step 4: Check GitHub Actions Workflows
+
+After completing the content review, check the status of the GitHub Actions workflows for $target_pr (for example, using `gh pr checks` or `gh run list`).
+
+- Report the status of every workflow run to the user, including runs that are still in progress.
+- For each failing workflow, also report:
+  - The likely cause of the failure (based on the relevant logs or job output).
+  - Candidate solutions or next steps to resolve it.

--- a/.rulesync/commands/review-pr.md
+++ b/.rulesync/commands/review-pr.md
@@ -22,3 +22,12 @@ Integrate and report the execution results from each subagent. Additionaly, plea
 
 - Assign a severity level to each finding: low, mid, high, or critical.
 - Assign a sequential number to each finding (e.g., #1, #2, #3, ...).
+
+## After the Review: Check GitHub Actions Workflows
+
+After completing the content review, check the status of the GitHub Actions workflows for $target_pr (for example, using `gh pr checks` or `gh run list`).
+
+- Report the status of every workflow run to the user, including runs that are still in progress.
+- For each failing workflow, also report:
+  - The likely cause of the failure (based on the relevant logs or job output).
+  - Candidate solutions or next steps to resolve it.


### PR DESCRIPTION
## Summary
- Add a post-review step to both `/review-pr` and `/review-pr-lite` commands to check GitHub Actions workflow status after content review completes.
- Instruct the assistant to report the status of every workflow run (including runs still in progress) and, for any failing workflow, to surface the likely cause and candidate solutions.

## Test plan
- [ ] Run `/review-pr` on a PR and confirm GHA status is reported after the content review.
- [ ] Run `/review-pr-lite` on a PR and confirm GHA status is reported after the content review.
- [ ] Verify that for a PR with failing checks, the failure cause and remediation suggestions are included.