### PR TITLE
docs(commands): forbid local branch switching in review-pr commands

### DIFF
--- a/.rulesync/commands/review-pr-lite.md
+++ b/.rulesync/commands/review-pr-lite.md
@@ -11,13 +11,22 @@ target_pr = $ARGUMENTS
 
 If target_pr is not provided, use the PR of the current branch.
 
+## Important: Do Not Switch the Local Branch
+
+- Do NOT check out, switch, or otherwise move the local branch (e.g., `git checkout`, `git switch`, `gh pr checkout`).
+- To inspect the PR's changes, use `git` and `gh` commands that read remote state without moving the working tree. For example:
+  - `gh pr view $target_pr` to read PR metadata and description.
+  - `gh pr diff $target_pr` to read the diff.
+  - `gh pr view $target_pr --json files` or `gh api` to list changed files.
+  - `git fetch origin pull/<PR_NUMBER>/head:refs/remotes/origin/pr-<PR_NUMBER>` and `git diff origin/main...origin/pr-<PR_NUMBER>` if a local read-only ref is needed.
+
 ## Step 1: Gather PR Context
 
 Run the following in parallel:
 
-- Get the PR description and metadata.
-- Get the PR diff.
-- If needed, inspect changed files individually for deeper context.
+- Get the PR description and metadata via `gh pr view $target_pr` (do not check out the PR locally).
+- Get the PR diff via `gh pr diff $target_pr`.
+- If needed, inspect changed files individually for deeper context using `gh` / `git` commands (e.g., `gh api`, `git show`) — without switching the local branch.
 
 ## Step 2: Review the Changes
 

--- a/.rulesync/commands/review-pr.md
+++ b/.rulesync/commands/review-pr.md
@@ -11,10 +11,20 @@ target_pr = $ARGUMENTS
 
 If target_pr is not provided, use the PR of the current branch.
 
+## Important: Do Not Switch the Local Branch
+
+- Do NOT check out, switch, or otherwise move the local branch (e.g., `git checkout`, `git switch`, `gh pr checkout`).
+- To inspect the PR's changes, use `git` and `gh` commands that read remote state without moving the working tree. For example:
+  - `gh pr view $target_pr` to read PR metadata and description.
+  - `gh pr diff $target_pr` to read the diff.
+  - `gh pr view $target_pr --json files` or `gh api` to list changed files.
+  - `git fetch origin pull/<PR_NUMBER>/head:refs/remotes/origin/pr-<PR_NUMBER>` and `git diff origin/main...origin/pr-<PR_NUMBER>` if a local read-only ref is needed.
+- When invoking subagents, explicitly instruct them that switching the local branch is forbidden and that they must inspect changes via `git`/`gh` commands only.
+
 Execute the following in parallel:
 
-- Call code-reviewer subagent to review the code changes in $target_pr.
-- Call security-reviewer subagent to review the security issues in $target_pr.
+- Call code-reviewer subagent to review the code changes in $target_pr. Pass along the rule that the local branch must not be switched and that diffs must be obtained via `git`/`gh` commands.
+- Call security-reviewer subagent to review the security issues in $target_pr. Pass along the rule that the local branch must not be switched and that diffs must be obtained via `git`/`gh` commands.
 
 Integrate and report the execution results from each subagent. Additionaly, please output PR number in the result so that the user can easily find the PR.
 


### PR DESCRIPTION
## Summary
- Add a "Do Not Switch the Local Branch" section to both `/.rulesync/commands/review-pr.md` and `/.rulesync/commands/review-pr-lite.md`.
- Direct reviewers (and the orchestrator) to inspect PR changes via `gh` / `git` commands (`gh pr view`, `gh pr diff`, `gh api`, `git fetch ... refs/remotes/...`) instead of `git checkout` / `git switch` / `gh pr checkout`.
- For `review-pr.md`, explicitly forward the same constraint to the `code-reviewer` and `security-reviewer` subagents.

## Motivation
The previous instructions left it ambiguous whether the reviewer could switch the local branch to inspect a PR, which risked moving the working tree out from under any in-progress local work. Diffs can always be read remotely via `gh`/`git`, so we now forbid local branch switching outright and require subagents to follow the same rule.

## Test plan
- [x] `pnpm cicheck`
- [x] `rulesync generate` re-generated `/.claude/commands/`, `/.opencode/command/`, `/.takt/facets/instructions/` review-pr files with the new section (verified via grep).