### PR TITLE
fix(codexcli-mcp): strip empty env tables from generated config

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -456,6 +456,99 @@ fontSize = 14
       expect(codexcliMcp.getToml().mcp_servers).toEqual({});
     });
 
+    it("should strip empty env object from remote (sse) server", async () => {
+      // codex CLI rejects empty `[mcp_servers.X.env]` for streamable_http
+      // transports (sse/http) with: "env is not supported for streamable_http".
+      const jsonData = {
+        mcpServers: {
+          "aws-knowledge": {
+            type: "sse",
+            url: "https://knowledge-mcp.global.api.aws",
+            env: {},
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["aws-knowledge"];
+      expect(server).toBeDefined();
+      expect(server?.env).toBeUndefined();
+      // file content should not contain a `[mcp_servers."aws-knowledge".env]` header
+      expect(codexcliMcp.getFileContent()).not.toContain(`.env]`);
+    });
+
+    it("should strip empty env object from stdio server (clean output)", async () => {
+      const jsonData = {
+        mcpServers: {
+          local: {
+            type: "stdio",
+            command: "node",
+            args: ["server.js"],
+            env: {},
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      expect(server?.env).toBeUndefined();
+    });
+
+    it("should preserve populated env table on stdio server", async () => {
+      const jsonData = {
+        mcpServers: {
+          local: {
+            type: "stdio",
+            command: "node",
+            args: ["server.js"],
+            env: { NODE_ENV: "production" },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      expect(server?.env).toEqual({ NODE_ENV: "production" });
+    });
+
     it("should convert disabled: true to enabled = false in codex format", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -456,40 +456,46 @@ fontSize = 14
       expect(codexcliMcp.getToml().mcp_servers).toEqual({});
     });
 
-    it("should strip empty env object from remote (sse) server", async () => {
-      // codex CLI rejects empty `[mcp_servers.X.env]` for streamable_http
-      // transports (sse/http) with: "env is not supported for streamable_http".
-      const jsonData = {
-        mcpServers: {
-          "aws-knowledge": {
-            type: "sse",
-            url: "https://knowledge-mcp.global.api.aws",
-            env: {},
+    // codex CLI rejects empty `[mcp_servers.X.env]` for remote transports
+    // (sse / http / streamable_http) with: "env is not supported for
+    // streamable_http". The recursive `removeEmptyEntries` strip handles all
+    // three transport types uniformly.
+    it.each(["sse", "http", "streamable_http"] as const)(
+      "should strip empty env object from remote (%s) server and preserve other fields",
+      async (transport) => {
+        const jsonData = {
+          mcpServers: {
+            "aws-knowledge": {
+              type: transport,
+              url: "https://knowledge-mcp.global.api.aws",
+              env: {},
+            },
           },
-        },
-      };
-      const rulesyncMcp = new RulesyncMcp({
-        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
-        relativeFilePath: ".mcp.json",
-        fileContent: JSON.stringify(jsonData),
-      });
+        };
+        const rulesyncMcp = new RulesyncMcp({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: ".mcp.json",
+          fileContent: JSON.stringify(jsonData),
+        });
 
-      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
-        outputRoot: testDir,
-        rulesyncMcp,
-        global: true,
-      });
+        const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+          outputRoot: testDir,
+          rulesyncMcp,
+          global: true,
+        });
 
-      const server = (
-        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
-      )?.["aws-knowledge"];
-      expect(server).toBeDefined();
-      expect(server?.env).toBeUndefined();
-      // file content should not contain a `[mcp_servers."aws-knowledge".env]` header
-      expect(codexcliMcp.getFileContent()).not.toContain(`.env]`);
-    });
+        const server = (
+          codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+        )?.["aws-knowledge"];
+        expect(server).toBeDefined();
+        expect(server?.env).toBeUndefined();
+        // Defensive: assert non-env fields survive the strip.
+        expect(server?.type).toBe(transport);
+        expect(server?.url).toBe("https://knowledge-mcp.global.api.aws");
+      },
+    );
 
-    it("should strip empty env object from stdio server (clean output)", async () => {
+    it("should strip empty env object from stdio server and preserve other fields", async () => {
       const jsonData = {
         mcpServers: {
           local: {
@@ -517,6 +523,9 @@ fontSize = 14
       )?.["local"];
       expect(server).toBeDefined();
       expect(server?.env).toBeUndefined();
+      // Defensive: assert non-env fields survive the strip.
+      expect(server?.command).toBe("node");
+      expect(server?.args).toEqual(["server.js"]);
     });
 
     it("should preserve populated env table on stdio server", async () => {
@@ -547,6 +556,9 @@ fontSize = 14
       )?.["local"];
       expect(server).toBeDefined();
       expect(server?.env).toEqual({ NODE_ENV: "production" });
+      // Defensive: command/args also survive.
+      expect(server?.command).toBe("node");
+      expect(server?.args).toEqual(["server.js"]);
     });
 
     it("should convert disabled: true to enabled = false in codex format", async () => {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -182,9 +182,23 @@ export class CodexcliMcp extends ToolMcp {
     const filtered: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(obj)) {
-      // Skip null values and empty objects
+      // Skip null values
       if (value === null) continue;
-      if (typeof value === "object" && Object.keys(value).length === 0) continue;
+
+      // Recurse into nested plain objects so empty inner tables (e.g.
+      // `env: {}`) are stripped too. Without this, smol-toml emits an
+      // empty `[mcp_servers.X.env]` header, which codex CLI rejects for
+      // remote (sse/http/streamable_http) transports with:
+      //   "env is not supported for streamable_http"
+      // Arrays are preserved verbatim, including empty ones, since an
+      // empty array can be a meaningful explicit override.
+      if (typeof value === "object" && !Array.isArray(value)) {
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        const cleaned = this.removeEmptyEntries(value as Record<string, unknown>);
+        if (Object.keys(cleaned).length === 0) continue;
+        filtered[key] = cleaned;
+        continue;
+      }
 
       filtered[key] = value;
     }


### PR DESCRIPTION
## Summary

The codex generator currently emits an empty `[mcp_servers.X.env]` header for any server whose `env` is `{}`. Codex CLI 0.130+ rejects this on remote (sse/http/streamable_http) transports with:

```
Error loading config.toml: env is not supported for streamable_http
in `mcp_servers.X`
```

This is a hard startup failure for any source `mcp.json` that has a remote MCP server with an empty `env` (intentionally, or left over from another tool's schema shape).

## Repro

```jsonc
// .rulesync/mcp.json
{
  "mcpServers": {
    "aws-knowledge": {
      "type": "sse",
      "url": "https://knowledge-mcp.global.api.aws",
      "env": {}
    }
  }
}
```

After `rulesync generate -g`:

```toml
[mcp_servers.aws-knowledge]
type = "sse"
url = "https://knowledge-mcp.global.api.aws"

[mcp_servers.aws-knowledge.env]   ← codex rejects this
```

## Fix

Make `removeEmptyEntries` in `codexcli-mcp.ts` recursive so empty nested objects (`env: {}`) are stripped at any depth, not just at the top level. Arrays are preserved verbatim because an empty array can be a meaningful explicit override.

Side effect: stdio servers also get cleaner output (no more inert empty `[mcp_servers.X.env]` headers). Codex tolerates those, so this is purely cosmetic for stdio.

## Tests added

- `should strip empty env object from remote (sse) server` — repro test
- `should strip empty env object from stdio server (clean output)`
- `should preserve populated env table on stdio server`

All 54 codex MCP tests pass. `pnpm cicheck` is clean.

## Risk

Minimal — recursing into nested objects is a generalization of the existing behaviour (which already strips empty top-level server configs). No existing test relied on empty `env: {}` being preserved inside a server config.
