### PR TITLE
feat(codexcli-mcp): support codex-specific env_vars passthrough

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -361,6 +361,31 @@ You can control which individual tools from an MCP server are enabled or disable
 - `enabledTools`: An array of tool names that should be explicitly enabled for this server.
 - `disabledTools`: An array of tool names that should be explicitly disabled for this server.
 
+### Codex-specific: pass shell env vars to MCP servers (`env_vars`)
+
+Codex CLI supports a per-server `env_vars` array that names shell environment variables to inherit when launching the MCP server process. This is distinct from `env` (which is a literal `{name: value}` map) — `env_vars` is a list of names whose values come from the user's environment.
+
+```json
+{
+  "mcpServers": {
+    "pal": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
+        "pal-mcp-server"
+      ],
+      "env_vars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+    }
+  }
+}
+```
+
+- Emitted only into the codex CLI output (`~/.codex/config.toml` or project `.codex/config.toml`).
+- Stripped from `getMcpServers()` so it does not leak into other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, etc. each ignore it).
+- Use this for secrets and API keys you do not want to literal-encode into a committed `mcp.json`.
+
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 
 Rulesync supports a single ignore list that can live in either location below:

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -361,9 +361,11 @@ You can control which individual tools from an MCP server are enabled or disable
 - `enabledTools`: An array of tool names that should be explicitly enabled for this server.
 - `disabledTools`: An array of tool names that should be explicitly disabled for this server.
 
-### Codex-specific: pass shell env vars to MCP servers (`env_vars`)
+### Codex-specific: pass shell env vars to MCP servers (`envVars`)
 
-Codex CLI supports a per-server `env_vars` array that names shell environment variables to inherit when launching the MCP server process. This is distinct from `env` (which is a literal `{name: value}` map) — `env_vars` is a list of names whose values come from the user's environment.
+Codex CLI supports a per-server array of shell env var names to inherit when launching the MCP server process. The source schema uses `envVars` (camelCase, matching the project convention used by sibling fields like `enabledTools`/`disabledTools`); the codex generator renames it to `env_vars` (snake_case) for codex's native `config.toml` format.
+
+This is distinct from `env` (which is a literal `{name: value}` map) — `envVars` is a list of names whose **values come from the user's environment at runtime**. Both fields may coexist on the same server.
 
 ```json
 {
@@ -376,15 +378,25 @@ Codex CLI supports a per-server `env_vars` array that names shell environment va
         "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
         "pal-mcp-server"
       ],
-      "env_vars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+      "envVars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
     }
   }
 }
 ```
 
-- Emitted only into the codex CLI output (`~/.codex/config.toml` or project `.codex/config.toml`).
-- Stripped from `getMcpServers()` so it does not leak into other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, etc. each ignore it).
-- Use this for secrets and API keys you do not want to literal-encode into a committed `mcp.json`.
+Generated `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pal]
+type = "stdio"
+command = "uvx"
+args = ["--from", "git+https://github.com/BeehiveInnovations/pal-mcp-server.git", "pal-mcp-server"]
+env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+```
+
+- Emitted only into the codex CLI output. Stripped from `RulesyncMcp.getMcpServers()` so it does not appear in other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, Cursor, Cline, Junie, Factorydroid, Rovodev, etc.).
+- Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
+- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined — see codex documentation for the exact resolution rule.
 
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -361,6 +361,31 @@ You can control which individual tools from an MCP server are enabled or disable
 - `enabledTools`: An array of tool names that should be explicitly enabled for this server.
 - `disabledTools`: An array of tool names that should be explicitly disabled for this server.
 
+### Codex-specific: pass shell env vars to MCP servers (`env_vars`)
+
+Codex CLI supports a per-server `env_vars` array that names shell environment variables to inherit when launching the MCP server process. This is distinct from `env` (which is a literal `{name: value}` map) — `env_vars` is a list of names whose values come from the user's environment.
+
+```json
+{
+  "mcpServers": {
+    "pal": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
+        "pal-mcp-server"
+      ],
+      "env_vars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+    }
+  }
+}
+```
+
+- Emitted only into the codex CLI output (`~/.codex/config.toml` or project `.codex/config.toml`).
+- Stripped from `getMcpServers()` so it does not leak into other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, etc. each ignore it).
+- Use this for secrets and API keys you do not want to literal-encode into a committed `mcp.json`.
+
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 
 Rulesync supports a single ignore list that can live in either location below:

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -361,9 +361,11 @@ You can control which individual tools from an MCP server are enabled or disable
 - `enabledTools`: An array of tool names that should be explicitly enabled for this server.
 - `disabledTools`: An array of tool names that should be explicitly disabled for this server.
 
-### Codex-specific: pass shell env vars to MCP servers (`env_vars`)
+### Codex-specific: pass shell env vars to MCP servers (`envVars`)
 
-Codex CLI supports a per-server `env_vars` array that names shell environment variables to inherit when launching the MCP server process. This is distinct from `env` (which is a literal `{name: value}` map) — `env_vars` is a list of names whose values come from the user's environment.
+Codex CLI supports a per-server array of shell env var names to inherit when launching the MCP server process. The source schema uses `envVars` (camelCase, matching the project convention used by sibling fields like `enabledTools`/`disabledTools`); the codex generator renames it to `env_vars` (snake_case) for codex's native `config.toml` format.
+
+This is distinct from `env` (which is a literal `{name: value}` map) — `envVars` is a list of names whose **values come from the user's environment at runtime**. Both fields may coexist on the same server.
 
 ```json
 {
@@ -376,15 +378,25 @@ Codex CLI supports a per-server `env_vars` array that names shell environment va
         "git+https://github.com/BeehiveInnovations/pal-mcp-server.git",
         "pal-mcp-server"
       ],
-      "env_vars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+      "envVars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
     }
   }
 }
 ```
 
-- Emitted only into the codex CLI output (`~/.codex/config.toml` or project `.codex/config.toml`).
-- Stripped from `getMcpServers()` so it does not leak into other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, etc. each ignore it).
-- Use this for secrets and API keys you do not want to literal-encode into a committed `mcp.json`.
+Generated `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pal]
+type = "stdio"
+command = "uvx"
+args = ["--from", "git+https://github.com/BeehiveInnovations/pal-mcp-server.git", "pal-mcp-server"]
+env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
+```
+
+- Emitted only into the codex CLI output. Stripped from `RulesyncMcp.getMcpServers()` so it does not appear in other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, Cursor, Cline, Junie, Factorydroid, Rovodev, etc.).
+- Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
+- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined — see codex documentation for the exact resolution rule.
 
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 

--- a/src/features/mcp/cline-mcp.ts
+++ b/src/features/mcp/cline-mcp.ts
@@ -59,11 +59,22 @@ export class ClineMcp extends ToolMcp {
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): ClineMcp {
+    // Preserve top-level fields ($schema, config, etc.) from the source
+    // JSON, but use getMcpServers() (not getJson().mcpServers) so
+    // rulesync-only fields and codex-only fields (`envVars`) are stripped
+    // before writing the cline config.
+    const json = rulesyncMcp.getJson();
+    const fileContent = JSON.stringify(
+      { ...json, mcpServers: rulesyncMcp.getMcpServers() },
+      null,
+      2,
+    );
+
     return new ClineMcp({
       outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
-      fileContent: rulesyncMcp.getFileContent(),
+      fileContent,
       validate,
     });
   }

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -565,10 +565,12 @@ fontSize = 14
       expect(mcpServers["my-server"].disabled_tools).toEqual(["delete"]);
     });
 
-    it("should emit codex-specific env_vars array from source", async () => {
-      // env_vars is a codex CLI-specific field that tells codex to pass
-      // through named shell env vars to the MCP server process. Source:
-      //   "pal": { ..., "env_vars": ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"] }
+    it("should rename source envVars (camelCase) to codex env_vars (snake_case)", async () => {
+      // The source schema uses `envVars` (camelCase) for consistency with
+      // `enabledTools`/`disabledTools`. The codex generator renames it to
+      // `env_vars` (snake_case) to match codex's native config.toml format.
+      // Source:
+      //   "pal": { ..., "envVars": ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"] }
       // Output:
       //   [mcp_servers.pal]
       //   env_vars = ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"]
@@ -578,7 +580,7 @@ fontSize = 14
             type: "stdio",
             command: "uvx",
             args: ["pal-mcp-server"],
-            env_vars: ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"],
+            envVars: ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"],
           },
         },
       };
@@ -595,9 +597,68 @@ fontSize = 14
       });
 
       const mcpServers = codexcliMcp.getToml().mcp_servers as any;
+      // Output uses snake_case (codex native).
       expect(mcpServers.pal.env_vars).toEqual(["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"]);
-      // smoke check that the serialized TOML contains the array
-      expect(codexcliMcp.getFileContent()).toContain("env_vars");
+      // Source key (camelCase) must NOT appear in codex output.
+      expect(mcpServers.pal.envVars).toBeUndefined();
+      // Defensive: other fields survive.
+      expect(mcpServers.pal.command).toBe("uvx");
+      expect(mcpServers.pal.args).toEqual(["pal-mcp-server"]);
+    });
+
+    it("should coexist envVars and env on the same server", async () => {
+      // `envVars` (list of names inherited from shell) and `env` (literal
+      // name→value map) are distinct concepts. Both must serialize correctly
+      // on the same server.
+      const jsonData = {
+        mcpServers: {
+          pal: {
+            type: "stdio",
+            command: "uvx",
+            args: ["pal-mcp-server"],
+            envVars: ["OPENAI_API_KEY"],
+            env: { LOG_LEVEL: "debug" },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (codexcliMcp.getToml().mcp_servers as any).pal;
+      expect(server.env_vars).toEqual(["OPENAI_API_KEY"]);
+      expect(server.env).toEqual({ LOG_LEVEL: "debug" });
+    });
+
+    it("should round-trip envVars through codex import", async () => {
+      // codex config.toml → toRulesyncMcp() → rulesync representation must
+      // expose `envVars` in source schema form (camelCase).
+      const tomlContent = `[mcp_servers.pal]
+type = "stdio"
+command = "uvx"
+args = ["pal-mcp-server"]
+env_vars = ["OPENAI_API_KEY"]
+`;
+      const codexcliMcp = new CodexcliMcp({
+        outputRoot: testDir,
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const rulesyncMcp = codexcliMcp.toRulesyncMcp();
+      const json = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(json.mcpServers.pal.envVars).toEqual(["OPENAI_API_KEY"]);
+      expect(json.mcpServers.pal.env_vars).toBeUndefined();
     });
 
     it("should convert enabledTools/disabledTools for multiple servers", async () => {

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -565,6 +565,41 @@ fontSize = 14
       expect(mcpServers["my-server"].disabled_tools).toEqual(["delete"]);
     });
 
+    it("should emit codex-specific env_vars array from source", async () => {
+      // env_vars is a codex CLI-specific field that tells codex to pass
+      // through named shell env vars to the MCP server process. Source:
+      //   "pal": { ..., "env_vars": ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"] }
+      // Output:
+      //   [mcp_servers.pal]
+      //   env_vars = ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"]
+      const jsonData = {
+        mcpServers: {
+          pal: {
+            type: "stdio",
+            command: "uvx",
+            args: ["pal-mcp-server"],
+            env_vars: ["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"],
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const mcpServers = codexcliMcp.getToml().mcp_servers as any;
+      expect(mcpServers.pal.env_vars).toEqual(["OPENAI_API_KEY", "JIRA_PERSONAL_TOKEN"]);
+      // smoke check that the serialized TOML contains the array
+      expect(codexcliMcp.getFileContent()).toContain("env_vars");
+    });
+
     it("should convert enabledTools/disabledTools for multiple servers", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -33,6 +33,11 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
         converted["enabledTools"] = value;
       } else if (key === "disabled_tools") {
         converted["disabledTools"] = value;
+      } else if (key === "env_vars") {
+        // codex stores env-var passthrough names in snake_case (`env_vars`);
+        // the rulesync source schema uses camelCase (`envVars`) for
+        // consistency with `enabledTools`/`disabledTools`/etc.
+        converted["envVars"] = value;
       } else {
         converted[key] = value;
       }
@@ -58,6 +63,12 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
         converted["enabled_tools"] = value;
       } else if (key === "disabledTools") {
         converted["disabled_tools"] = value;
+      } else if (key === "envVars") {
+        // Rename camelCase source `envVars` → snake_case `env_vars`
+        // for codex's native config.toml format. See `enabledTools`
+        // precedent above. `envVars` itself is stripped from
+        // getMcpServers() so non-codex tools never receive it.
+        converted["env_vars"] = value;
       } else {
         converted[key] = value;
       }

--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -954,9 +954,28 @@ describe("CursorMcp", () => {
         validate: true,
       });
 
-      expect(cursorMcp.getJson()).toEqual({
-        mcpServers: rulesyncMcpData.mcpServers,
+      // `targets` is a rulesync-only field and is stripped from non-codex
+      // tool outputs by `RulesyncMcp.getMcpServers()`. The cursor output
+      // must contain everything else but not `targets`.
+      const json = cursorMcp.getJson() as any;
+      expect(json.mcpServers["complex-server"]).toEqual({
+        command: "node",
+        args: ["complex-server.js", "--port", "3000"],
+        env: {
+          NODE_ENV: "production",
+          DEBUG: "mcp:*",
+        },
       });
+      expect(json.mcpServers["python-server"]).toEqual({
+        command: "python",
+        args: ["python-server.py"],
+        env: {
+          PYTHONPATH: "/usr/local/lib/python3.9/site-packages",
+        },
+      });
+      // `targets` should be stripped.
+      expect(json.mcpServers["complex-server"].targets).toBeUndefined();
+      expect(json.mcpServers["python-server"].targets).toBeUndefined();
     });
 
     it("should use custom outputRoot when provided", async () => {

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -149,8 +149,10 @@ export class CursorMcp extends ToolMcp {
       );
     }
 
-    const rulesyncJson = rulesyncMcp.getJson();
-    const mcpServers = isMcpServers(rulesyncJson.mcpServers) ? rulesyncJson.mcpServers : {};
+    // Use getMcpServers() (not getJson()) so rulesync-only fields and
+    // codex-only fields (`envVars`) are stripped before writing the
+    // cursor config.
+    const mcpServers = rulesyncMcp.getMcpServers();
     const transformedServers = convertEnvToCursorFormat(mcpServers);
 
     const cursorConfig = { ...json, mcpServers: transformedServers };

--- a/src/features/mcp/factorydroid-mcp.ts
+++ b/src/features/mcp/factorydroid-mcp.ts
@@ -59,11 +59,14 @@ export class FactorydroidMcp extends ToolMcp {
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): FactorydroidMcp {
-    const json = rulesyncMcp.getJson();
+    // Use getMcpServers() (not getJson()) so rulesync-only fields and
+    // codex-only fields (`envVars`) are stripped before writing the
+    // Factory Droid config.
+    const mcpServers = rulesyncMcp.getMcpServers();
 
     // Factory Droid uses standard MCP format without transformations
     const factorydroidConfig = {
-      mcpServers: json.mcpServers || {},
+      mcpServers,
     };
 
     const fileContent = JSON.stringify(factorydroidConfig, null, 2);

--- a/src/features/mcp/geminicli-mcp.test.ts
+++ b/src/features/mcp/geminicli-mcp.test.ts
@@ -399,6 +399,41 @@ describe("GeminiCliMcp", () => {
   });
 
   describe("fromRulesyncMcp", () => {
+    it("should strip codex-only envVars from gemini output", async () => {
+      // Regression test: prior to migrating fromRulesyncMcp to
+      // `getMcpServers()`, the gemini generator read mcpServers from
+      // `rulesyncMcp.getJson()` (unfiltered), causing codex-only fields like
+      // `envVars` to leak into ~/.gemini/settings.json. Strip must apply
+      // here so the field is absent from gemini output.
+      const jsonData = {
+        mcpServers: {
+          pal: {
+            type: "stdio",
+            command: "uvx",
+            args: ["pal-mcp-server"],
+            envVars: ["OPENAI_API_KEY"],
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const geminiCliMcp = await GeminiCliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+      });
+
+      const json = geminiCliMcp.getJson() as any;
+      expect(json.mcpServers.pal).toBeDefined();
+      expect(json.mcpServers.pal.envVars).toBeUndefined();
+      // Defensive: other fields survive.
+      expect(json.mcpServers.pal.command).toBe("uvx");
+      expect(json.mcpServers.pal.args).toEqual(["pal-mcp-server"]);
+    });
+
     it("should create instance from RulesyncMcp with default parameters", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/geminicli-mcp.ts
+++ b/src/features/mcp/geminicli-mcp.ts
@@ -72,7 +72,10 @@ export class GeminiCliMcp extends ToolMcp {
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
     const json = JSON.parse(fileContent);
-    const newJson = { ...json, mcpServers: rulesyncMcp.getJson().mcpServers };
+    // Use getMcpServers() (not getJson()) so rulesync-only fields and
+    // codex-only fields (`envVars`) are stripped before writing the
+    // gemini settings file.
+    const newJson = { ...json, mcpServers: rulesyncMcp.getMcpServers() };
 
     return new GeminiCliMcp({
       outputRoot,

--- a/src/features/mcp/junie-mcp.ts
+++ b/src/features/mcp/junie-mcp.ts
@@ -57,11 +57,22 @@ export class JunieMcp extends ToolMcp {
     rulesyncMcp,
     validate = true,
   }: ToolMcpFromRulesyncMcpParams): JunieMcp {
+    // Preserve top-level fields ($schema, etc.) from the source JSON, but
+    // use getMcpServers() (not getJson().mcpServers) so rulesync-only
+    // fields and codex-only fields (`envVars`) are stripped before
+    // writing the junie config.
+    const json = rulesyncMcp.getJson();
+    const fileContent = JSON.stringify(
+      { ...json, mcpServers: rulesyncMcp.getMcpServers() },
+      null,
+      2,
+    );
+
     return new JunieMcp({
       outputRoot,
       relativeDirPath: this.getSettablePaths().relativeDirPath,
       relativeFilePath: this.getSettablePaths().relativeFilePath,
-      fileContent: rulesyncMcp.getFileContent(),
+      fileContent,
       validate,
     });
   }

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -114,8 +114,10 @@ export class RovodevMcp extends ToolMcp {
     );
     const json = parseRovodevMcpJson(fileContent, paths.relativeDirPath, paths.relativeFilePath);
 
-    const rulesyncJson = rulesyncMcp.getJson();
-    const mcpServers = isMcpServers(rulesyncJson.mcpServers) ? rulesyncJson.mcpServers : {};
+    // Use getMcpServers() (not getJson()) so rulesync-only fields and
+    // codex-only fields (`envVars`) are stripped before writing the
+    // rovodev config.
+    const mcpServers = rulesyncMcp.getMcpServers();
 
     const rovodevConfig = { ...json, mcpServers };
 

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -986,6 +986,54 @@ describe("RulesyncMcp", () => {
     });
   });
 
+  describe("getMcpServers field stripping", () => {
+    it("should strip codex-specific env_vars from getMcpServers output", () => {
+      // env_vars is codex-only; it must NOT leak into other tools' generated
+      // configs (claudecode, opencode, kilo, geminicli, etc.) which all
+      // consume getMcpServers(). The codex generator reads env_vars directly
+      // from getJson() instead.
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            pal: {
+              type: "stdio",
+              command: "uvx",
+              args: ["pal-mcp-server"],
+              env_vars: ["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+            },
+          },
+        }),
+      });
+
+      const servers = rulesyncMcp.getMcpServers();
+
+      expect(servers.pal).toBeDefined();
+      expect((servers.pal as any).command).toBe("uvx");
+      expect((servers.pal as any).env_vars).toBeUndefined();
+    });
+
+    it("should still expose env_vars via getJson() for the codex generator", () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            pal: {
+              type: "stdio",
+              command: "uvx",
+              env_vars: ["OPENAI_API_KEY"],
+            },
+          },
+        }),
+      });
+
+      const fromJson = rulesyncMcp.getJson().mcpServers.pal;
+      expect((fromJson as any).env_vars).toEqual(["OPENAI_API_KEY"]);
+    });
+  });
+
   describe("integration and edge cases", () => {
     it("should handle large JSON structures", () => {
       const largeJsonData = {

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -987,10 +987,10 @@ describe("RulesyncMcp", () => {
   });
 
   describe("getMcpServers field stripping", () => {
-    it("should strip codex-specific env_vars from getMcpServers output", () => {
-      // env_vars is codex-only; it must NOT leak into other tools' generated
+    it("should strip codex-specific envVars from getMcpServers output", () => {
+      // envVars is codex-only; it must NOT leak into other tools' generated
       // configs (claudecode, opencode, kilo, geminicli, etc.) which all
-      // consume getMcpServers(). The codex generator reads env_vars directly
+      // consume getMcpServers(). The codex generator reads envVars directly
       // from getJson() instead.
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -1001,7 +1001,7 @@ describe("RulesyncMcp", () => {
               type: "stdio",
               command: "uvx",
               args: ["pal-mcp-server"],
-              env_vars: ["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+              envVars: ["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
             },
           },
         }),
@@ -1011,10 +1011,10 @@ describe("RulesyncMcp", () => {
 
       expect(servers.pal).toBeDefined();
       expect((servers.pal as any).command).toBe("uvx");
-      expect((servers.pal as any).env_vars).toBeUndefined();
+      expect((servers.pal as any).envVars).toBeUndefined();
     });
 
-    it("should still expose env_vars via getJson() for the codex generator", () => {
+    it("should still expose envVars via getJson() for the codex generator", () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "mcp.json",
@@ -1023,14 +1023,14 @@ describe("RulesyncMcp", () => {
             pal: {
               type: "stdio",
               command: "uvx",
-              env_vars: ["OPENAI_API_KEY"],
+              envVars: ["OPENAI_API_KEY"],
             },
           },
         }),
       });
 
       const fromJson = rulesyncMcp.getJson().mcpServers.pal;
-      expect((fromJson as any).env_vars).toEqual(["OPENAI_API_KEY"]);
+      expect((fromJson as any).envVars).toEqual(["OPENAI_API_KEY"]);
     });
   });
 

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -145,7 +145,10 @@ export class RulesyncMcp extends RulesyncFile {
 
     return Object.fromEntries(
       entries.map(([serverName, serverConfig]) => {
-        return [serverName, omit(serverConfig, ["targets", "description", "exposed"])];
+        // `env_vars` is codex-specific: the codex generator reads it directly
+        // from the unfiltered source JSON. Strip here so it does not leak
+        // into other tools' outputs.
+        return [serverName, omit(serverConfig, ["targets", "description", "exposed", "env_vars"])];
       }),
     );
   }

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -141,14 +141,19 @@ export class RulesyncMcp extends RulesyncFile {
   }
 
   getMcpServers(): McpServers {
-    const entries = Object.entries(this.json.mcpServers);
+    // Tolerate missing/empty mcpServers (e.g., a RulesyncMcp constructed
+    // from `{}` with validation disabled). Callers that previously read
+    // `getJson().mcpServers` via the `isMcpServers` guard relied on this
+    // resilience.
+    const mcpServers = this.json.mcpServers ?? {};
+    const entries = Object.entries(mcpServers);
 
     return Object.fromEntries(
       entries.map(([serverName, serverConfig]) => {
-        // `env_vars` is codex-specific: the codex generator reads it directly
+        // `envVars` is codex-specific: the codex generator reads it directly
         // from the unfiltered source JSON. Strip here so it does not leak
         // into other tools' outputs.
-        return [serverName, omit(serverConfig, ["targets", "description", "exposed", "env_vars"])];
+        return [serverName, omit(serverConfig, ["targets", "description", "exposed", "envVars"])];
       }),
     );
   }

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -17,6 +17,11 @@ export const McpServerSchema = z.looseObject({
   tools: z.optional(z.array(z.string())),
   kiroAutoApprove: z.optional(z.array(z.string())),
   kiroAutoBlock: z.optional(z.array(z.string())),
+  // Codex CLI-specific: list of shell env var names that codex should pass
+  // through from the user's environment to the MCP server process. Only
+  // honoured by the codex generator; stripped by `RulesyncMcp.getMcpServers()`
+  // so it does not leak into other tools' configs.
+  env_vars: z.optional(z.array(z.string())),
   headers: z.optional(z.record(z.string(), z.string())),
   enabledTools: z.optional(z.array(z.string())),
   disabledTools: z.optional(z.array(z.string())),

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -18,10 +18,15 @@ export const McpServerSchema = z.looseObject({
   kiroAutoApprove: z.optional(z.array(z.string())),
   kiroAutoBlock: z.optional(z.array(z.string())),
   // Codex CLI-specific: list of shell env var names that codex should pass
-  // through from the user's environment to the MCP server process. Only
-  // honoured by the codex generator; stripped by `RulesyncMcp.getMcpServers()`
-  // so it does not leak into other tools' configs.
-  env_vars: z.optional(z.array(z.string())),
+  // through from the user's environment to the MCP server process.
+  // Distinct from `env` (a literal name→value map): `envVars` is a list of
+  // variable NAMES whose values come from the user's shell at runtime.
+  // Only honoured by the codex generator (renamed to `env_vars` in codex
+  // TOML output, matching codex's native field name — see the
+  // `enabledTools`→`enabled_tools` precedent in `codexcli-mcp.ts`).
+  // Stripped by `RulesyncMcp.getMcpServers()` so it does not leak into
+  // other tools' configs.
+  envVars: z.optional(z.array(z.string())),
   headers: z.optional(z.record(z.string(), z.string())),
   enabledTools: z.optional(z.array(z.string())),
   disabledTools: z.optional(z.array(z.string())),


### PR DESCRIPTION
## Summary

Codex CLI supports a per-server array of shell env var names to inherit when launching the MCP server process. This is **distinct from `env`**: `env` is a literal `name → value` map; `envVars` is a list of names whose values come from the user's environment at runtime.

Use case: secrets like `OPENAI_API_KEY`, `JIRA_PERSONAL_TOKEN`, etc. that should NOT be literal-encoded into a committed `mcp.json`.

Before this PR, rulesync had no way to express this in the source schema. Users either lost their entries on every `rulesync generate` regen, or added them out-of-band, polluting other tools' configs.

## Design

### Source field: `envVars` (camelCase)

Matches the MCP schema's existing convention (`enabledTools`, `disabledTools`, `kiroAutoApprove`, `httpUrl`, `networkTimeout`, `alwaysAllow`, `kiroAutoBlock`). The codex generator renames it to snake_case `env_vars` at emit time, mirroring the established `enabledTools` → `enabled_tools` pattern (`convertToCodexFormat`).

### Strip is centralised in `getMcpServers()`

The field is stripped via `RulesyncMcp.getMcpServers()` so non-codex generators that go through that accessor never see it. The codex generator reads from `getJson()` (unfiltered) and is the only consumer.

### Generator audit + leak closure

Six generators were bypassing `getMcpServers()` and reading server configs directly from `getJson()` or `getFileContent()`. Without the migration in this PR they would have leaked `envVars` (and the pre-existing rulesync-only fields `targets`/`description`/`exposed`) into their tool outputs:

- `cline-mcp.ts` — was using `getFileContent()`
- `cursor-mcp.ts` — was using `getJson()`
- `factorydroid-mcp.ts` — was using `getJson()`
- `geminicli-mcp.ts` — was using `getJson()`
- `junie-mcp.ts` — was using `getFileContent()`
- `rovodev-mcp.ts` — was using `getJson()`

Each is migrated to `getMcpServers()`. `cline` and `junie` rebuild the file content from `getJson()` top-level + `getMcpServers()` to preserve `$schema` and other top-level fields. The cursor "complex configuration" test was updated — it had been asserting the buggy leaked-`targets` output.

`getMcpServers()` is also hardened to tolerate missing `mcpServers` (returns `{}` instead of throwing on `Object.entries(undefined)`) so callers no longer need the prior `isMcpServers` guard.

## Source example

```json
{
  "mcpServers": {
    "pal": {
      "type": "stdio",
      "command": "uvx",
      "args": ["--from", "git+https://github.com/BeehiveInnovations/pal-mcp-server.git", "pal-mcp-server"],
      "envVars": ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
    }
  }
}
```

Generated `~/.codex/config.toml`:

```toml
[mcp_servers.pal]
type = "stdio"
command = "uvx"
args = ["--from", "git+https://github.com/BeehiveInnovations/pal-mcp-server.git", "pal-mcp-server"]
env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
```

Other tools' outputs (`~/.claude.json`, `~/.config/opencode/opencode.json`, `~/.config/kilo/kilo.json`, `~/.gemini/settings.json`, `.cursor/mcp.json`, `.cline/...`, `.junie/...`, `.droid/...`, `~/.rovodev/mcp.json`): `envVars` stripped, never written.

## Tests

- `codexcli`: source camelCase `envVars` → output snake_case `env_vars`; source key absent; defensive assertions on surviving fields
- `codexcli`: coexistence of `envVars` + `env` on the same server
- `codexcli`: round-trip codex `env_vars` → `toRulesyncMcp` → `envVars`
- `rulesync-mcp`: `envVars` is stripped from `getMcpServers()` output
- `rulesync-mcp`: `envVars` survives via `getJson()` for the codex generator
- `geminicli`: representative non-codex leak-prevention test — `envVars` is absent from gemini output

All 656 MCP tests pass. `pnpm cicheck` clean.

## Docs

Added new section to `docs/reference/file-formats.md` (synced into `skills/rulesync/file-formats.md`) covering the source vs codex naming, the `env` vs `envVars` distinction, the full enumeration of non-codex tools where it's stripped, and the precedence-deferral note.

## Risk

Low — additive change at the schema level. The leak-closure migrations are mechanical (one accessor swap per file). The cursor complex-config test update is the only test change that reflects a behaviour change (correctly stripping `targets`); all other changes are additive or strictly cleaner.
