### PR TITLE
feat(kilo-mcp): enable global mode support

### DIFF
--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -16,7 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Factory Droid       | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode            | opencode     | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline               | cline        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |
-| Kilo Code           | kilo         | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
+| Kilo Code           | kilo         | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
 | Roo Code            | roo          |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                | takt         | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -16,7 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Factory Droid       | factorydroid | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode            | opencode     | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline               | cline        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |
-| Kilo Code           | kilo         | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
+| Kilo Code           | kilo         | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
 | Roo Code            | roo          |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                | takt         | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |

--- a/src/features/mcp/mcp-processor.test.ts
+++ b/src/features/mcp/mcp-processor.test.ts
@@ -1095,6 +1095,16 @@ describe("McpProcessor", () => {
       expect(targets).toContain("cursor");
       expect(targets).toContain("roo");
       expect(targets).toContain("codexcli"); // codexcli supports both project and global
+      expect(targets).toContain("kilo"); // kilo supports both project and global
+    });
+
+    it("should include kilo in global tool targets", () => {
+      // Kilo CLI is an OpenCode fork and reads global MCP from
+      // ~/.config/kilo/kilo.json(c), so it must be present in the
+      // global-mode supported targets list.
+      const globalTargets = McpProcessor.getToolTargets({ global: true });
+      expect(globalTargets).toContain("kilo");
+      expect(globalTargets).toContain("opencode"); // sanity: parity with opencode
     });
   });
 

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -215,7 +215,13 @@ const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
       class: KiloMcp,
       meta: {
         supportsProject: true,
-        supportsGlobal: false,
+        // Kilo CLI reads global MCP from `~/.config/kilo/kilo.json` (or
+        // `kilo.jsonc`). The path machinery in `KiloMcp.getSettablePaths`
+        // already routes global mode to that location; only this flag
+        // was gating it off. Kilo is an OpenCode fork and uses an
+        // identical native MCP schema, so global parity with opencode
+        // is the natural state.
+        supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,
       },


### PR DESCRIPTION
## Summary

Kilo CLI reads global MCP from `~/.config/kilo/kilo.json` (or
`kilo.jsonc`). The path machinery in `KiloMcp.getSettablePaths` already
routes global mode to that location — only the factory metadata flag
in `McpProcessor` was gating it off.

Kilo is an OpenCode fork and uses an identical native MCP schema
(`type: local|remote`, `environment` instead of `env`, `enabled`
instead of `disabled`), so global parity with the `opencode` target is
the natural state.

## Before

```
$ rulesync generate -g
Target 'kilo' does not support the feature 'mcp'. Skipping.
```

Users running `rulesync generate -g` to manage global MCP across the
opencode family had to keep a separate Kilo-only source file, or
post-process with `jq` to copy the `.mcp` block from `opencode.json`
into `kilo.json` (since the schemas match).

## After

`~/.config/kilo/kilo.json` is generated alongside `opencode.json`,
`config.toml` (codex), `settings.json` (gemini), and `.claude.json`
(claude code) on every `rulesync generate -g`.

## Changes

- `src/features/mcp/mcp-processor.ts`: flip `supportsGlobal: false → true`
  in the Kilo factory metadata.
- `src/features/mcp/mcp-processor.test.ts`: assert `kilo` is present in
  both project- and global-mode tool-target lists.
- `docs/reference/supported-tools.md`: Kilo MCP cell `✅` → `✅ 🌏`.
- `skills/rulesync/supported-tools.md`: synced via `sync-skill-docs.ts`.

## Tests

All 75 existing kilo-mcp tests pass (including the existing global
fromFile / fromRulesyncMcp / preserve-non-mcp-properties cases at lines
283-456). All 46 mcp-processor tests pass. Added 1 new test asserting
`kilo` is in the global target list. `pnpm cicheck` clean.

## Risk

Very low — pure flag flip. The implementation in `KiloMcp` already
supports global mode and is already covered by tests. The fix is just
enabling the processor to route to it.