### PR TITLE
fix: harden codexcli-mcp converters against prototype pollution and add regression tests

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -488,10 +488,10 @@ fontSize = 14
           codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
         )?.["aws-knowledge"];
         expect(server).toBeDefined();
-        expect(server?.env).toBeUndefined();
+        expect(server!.env).toBeUndefined();
         // Defensive: assert non-env fields survive the strip.
-        expect(server?.type).toBe(transport);
-        expect(server?.url).toBe("https://knowledge-mcp.global.api.aws");
+        expect(server!.type).toBe(transport);
+        expect(server!.url).toBe("https://knowledge-mcp.global.api.aws");
       },
     );
 
@@ -522,10 +522,10 @@ fontSize = 14
         codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
       )?.["local"];
       expect(server).toBeDefined();
-      expect(server?.env).toBeUndefined();
+      expect(server!.env).toBeUndefined();
       // Defensive: assert non-env fields survive the strip.
-      expect(server?.command).toBe("node");
-      expect(server?.args).toEqual(["server.js"]);
+      expect(server!.command).toBe("node");
+      expect(server!.args).toEqual(["server.js"]);
     });
 
     it("should preserve populated env table on stdio server", async () => {
@@ -555,10 +555,73 @@ fontSize = 14
         codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
       )?.["local"];
       expect(server).toBeDefined();
-      expect(server?.env).toEqual({ NODE_ENV: "production" });
+      expect(server!.env).toEqual({ NODE_ENV: "production" });
       // Defensive: command/args also survive.
-      expect(server?.command).toBe("node");
-      expect(server?.args).toEqual(["server.js"]);
+      expect(server!.command).toBe("node");
+      expect(server!.args).toEqual(["server.js"]);
+    });
+
+    it("should not emit .env] in serialized TOML for server with env: {}", async () => {
+      // The actual failure mode is smol-toml emitting a `[mcp_servers.X.env]`
+      // header that Codex CLI rejects. This test asserts directly on the
+      // serialized TOML string to map to the Codex 0.130+ rejection condition.
+      const jsonData = {
+        mcpServers: {
+          "aws-knowledge": {
+            type: "streamable_http",
+            url: "https://knowledge-mcp.global.api.aws",
+            env: {},
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      expect(codexcliMcp.getFileContent()).not.toContain(".env]");
+    });
+
+    it("should preserve array elements verbatim even when they are empty objects", async () => {
+      // Arrays are not recursed into by removeEmptyEntries. If an array
+      // element is a plain object like `{}`, it survives unmodified so the
+      // empty inline table is preserved in TOML output. This boundary is
+      // intentional: the current mcp_servers.* schema is a map, not an
+      // array, and an empty inline table in TOML (`[{}, "a"]`) differs from
+      // a table header (`[mcp_servers.X.env]`) that Codex CLI rejects.
+      const jsonData = {
+        mcpServers: {
+          local: {
+            type: "stdio",
+            command: "node",
+            args: [{}, { flag: "--verbose" }],
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      expect(server!.args).toEqual([{}, { flag: "--verbose" }]);
     });
 
     it("should convert disabled: true to enabled = false in codex format", async () => {

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -624,6 +624,127 @@ fontSize = 14
       expect(server!.args).toEqual([{}, { flag: "--verbose" }]);
     });
 
+    it("should strip prototype-pollution keys at server-name level on outbound conversion", async () => {
+      // Use JSON string so that `__proto__` becomes an own enumerable
+      // property rather than setting the prototype of the object literal.
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: `{
+          "mcpServers": {
+            "__proto__": { "command": "evil" },
+            "constructor": { "command": "evil" },
+            "prototype": { "command": "evil" },
+            "ok": { "type": "stdio", "command": "node", "args": ["server.js"] }
+          }
+        }`,
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const servers = codexcliMcp.getToml().mcp_servers as Record<string, unknown>;
+      expect(Object.hasOwn(servers, "__proto__")).toBe(false);
+      expect(Object.hasOwn(servers, "constructor")).toBe(false);
+      expect(Object.hasOwn(servers, "prototype")).toBe(false);
+      expect(Object.hasOwn(servers, "ok")).toBe(true);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it("should strip prototype-pollution keys at config-key level on outbound conversion", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: `{
+          "mcpServers": {
+            "local": {
+              "type": "stdio",
+              "command": "node",
+              "args": ["server.js"],
+              "__proto__": "x",
+              "constructor": "x",
+              "prototype": "x"
+            }
+          }
+        }`,
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      expect(Object.hasOwn(server!, "__proto__")).toBe(false);
+      expect(Object.hasOwn(server!, "constructor")).toBe(false);
+      expect(Object.hasOwn(server!, "prototype")).toBe(false);
+      expect(server!.command).toBe("node");
+    });
+
+    it("should strip prototype-pollution keys in nested env via removeEmptyEntries", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: `{
+          "mcpServers": {
+            "local": {
+              "type": "stdio",
+              "command": "node",
+              "args": ["server.js"],
+              "env": { "__proto__": "x", "NODE_ENV": "production" }
+            }
+          }
+        }`,
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      const env = server!.env as Record<string, unknown>;
+      expect(Object.hasOwn(env, "__proto__")).toBe(false);
+      expect(env.NODE_ENV).toBe("production");
+    });
+
+    it("should strip prototype-pollution server-name keys on inbound conversion", () => {
+      // smol-toml installs `__proto__` as an own enumerable data property
+      // (via `Object.defineProperty`), so this round-trip exercises the
+      // `PROTOTYPE_POLLUTION_KEYS.has(name)` guard in convertFromCodexFormat.
+      const tomlContent = `[mcp_servers."__proto__"]
+command = "evil"
+
+[mcp_servers.ok]
+command = "node"
+args = ["server.js"]
+`;
+
+      const codexcliMcp = new CodexcliMcp({
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const rulesyncMcp = codexcliMcp.toRulesyncMcp();
+      const parsed = JSON.parse(rulesyncMcp.getFileContent()) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(Object.hasOwn(parsed.mcpServers, "__proto__")).toBe(false);
+      expect(Object.hasOwn(parsed.mcpServers, "ok")).toBe(true);
+    });
+
     it("should convert disabled: true to enabled = false in codex format", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -5,6 +5,7 @@ import * as smolToml from "smol-toml";
 import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { isRecord } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -19,10 +20,6 @@ const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
 
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!isRecord(value)) return false;
   const proto = Object.getPrototypeOf(value);
@@ -33,6 +30,7 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
   for (const [name, config] of Object.entries(codexMcp)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
     if (!isRecord(config)) continue;
 
     const converted: Record<string, unknown> = {};
@@ -66,6 +64,7 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   const result: Record<string, Record<string, unknown>> = {};
 
   for (const [name, config] of Object.entries(mcpServers)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
       if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
@@ -174,7 +173,7 @@ export class CodexcliMcp extends ToolMcp {
     const filteredMcpServers = this.removeEmptyEntries(converted);
 
     for (const name of Object.keys(converted)) {
-      if (!(name in filteredMcpServers)) {
+      if (!Object.hasOwn(filteredMcpServers, name)) {
         // oxlint-disable-next-line no-console
         console.warn(
           `MCP server "${name}" had no non-empty configuration and was dropped from the codex CLI config`,
@@ -213,7 +212,13 @@ export class CodexcliMcp extends ToolMcp {
     depth = 0,
   ): Record<string, unknown> {
     if (!obj) return {};
-    if (depth > MAX_REMOVE_EMPTY_ENTRIES_DEPTH) return obj;
+    if (depth > MAX_REMOVE_EMPTY_ENTRIES_DEPTH) {
+      // oxlint-disable-next-line no-console
+      console.warn(
+        `removeEmptyEntries: maximum recursion depth (${MAX_REMOVE_EMPTY_ENTRIES_DEPTH}) exceeded; empty nested objects may remain`,
+      );
+      return obj;
+    }
 
     const filtered: Record<string, unknown> = {};
 

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -15,16 +15,29 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
+const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
+
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}
+
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
   for (const [name, config] of Object.entries(codexMcp)) {
-    if (typeof config !== "object" || config === null || Array.isArray(config)) {
-      continue;
-    }
+    if (!isRecord(config)) continue;
 
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
       if (key === "enabled") {
         if (value === false) {
           converted["disabled"] = true;
@@ -55,6 +68,7 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   for (const [name, config] of Object.entries(mcpServers)) {
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
       if (key === "disabled") {
         if (value === true) {
           converted["enabled"] = false;
@@ -159,6 +173,15 @@ export class CodexcliMcp extends ToolMcp {
     const converted = convertToCodexFormat(mcpServers);
     const filteredMcpServers = this.removeEmptyEntries(converted);
 
+    for (const name of Object.keys(converted)) {
+      if (!(name in filteredMcpServers)) {
+        // oxlint-disable-next-line no-console
+        console.warn(
+          `MCP server "${name}" had no non-empty configuration and was dropped from the codex CLI config`,
+        );
+      }
+    }
+
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     configToml["mcp_servers"] = filteredMcpServers as smolToml.TomlTable;
 
@@ -187,12 +210,15 @@ export class CodexcliMcp extends ToolMcp {
 
   private static removeEmptyEntries(
     obj: Record<string, unknown> | undefined,
+    depth = 0,
   ): Record<string, unknown> {
     if (!obj) return {};
+    if (depth > MAX_REMOVE_EMPTY_ENTRIES_DEPTH) return obj;
 
     const filtered: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(obj)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
       // Skip null values
       if (value === null) continue;
 
@@ -201,11 +227,12 @@ export class CodexcliMcp extends ToolMcp {
       // empty `[mcp_servers.X.env]` header, which codex CLI rejects for
       // remote (sse/http/streamable_http) transports with:
       //   "env is not supported for streamable_http"
-      // Arrays are preserved verbatim, including empty ones, since an
-      // empty array can be a meaningful explicit override.
-      if (typeof value === "object" && !Array.isArray(value)) {
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        const cleaned = this.removeEmptyEntries(value as Record<string, unknown>);
+      // Arrays are preserved verbatim — individual array elements are not
+      // recursed into because an empty inline table like `[{}, "a"]` in
+      // TOML differs from a table header `[mcp_servers.X.env]` that codex
+      // CLI rejects. Only plain objects trigger the recursive strip.
+      if (isPlainObject(value)) {
+        const cleaned = this.removeEmptyEntries(value, depth + 1);
         if (Object.keys(cleaned).length === 0) continue;
         filtered[key] = cleaned;
         continue;

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -5,6 +5,7 @@ import * as smolToml from "smol-toml";
 import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { warnWithFallback } from "../../utils/logger.js";
 import { isRecord } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
@@ -65,6 +66,7 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
 
   for (const [name, config] of Object.entries(mcpServers)) {
     if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
+    if (!isRecord(config)) continue;
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
       if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
@@ -174,8 +176,8 @@ export class CodexcliMcp extends ToolMcp {
 
     for (const name of Object.keys(converted)) {
       if (!Object.hasOwn(filteredMcpServers, name)) {
-        // oxlint-disable-next-line no-console
-        console.warn(
+        warnWithFallback(
+          undefined,
           `MCP server "${name}" had no non-empty configuration and was dropped from the codex CLI config`,
         );
       }
@@ -213,8 +215,8 @@ export class CodexcliMcp extends ToolMcp {
   ): Record<string, unknown> {
     if (!obj) return {};
     if (depth > MAX_REMOVE_EMPTY_ENTRIES_DEPTH) {
-      // oxlint-disable-next-line no-console
-      console.warn(
+      warnWithFallback(
+        undefined,
         `removeEmptyEntries: maximum recursion depth (${MAX_REMOVE_EMPTY_ENTRIES_DEPTH}) exceeded; empty nested objects may remain`,
       );
       return obj;


### PR DESCRIPTION
## Summary

Closes #1626

### Security hardening
- Skip `__proto__` / `constructor` / `prototype` keys in `removeEmptyEntries`, `convertToCodexFormat`, and `convertFromCodexFormat` to prevent prototype pollution
- Add `isPlainObject` guard to replace broad `typeof === 'object'` check, avoiding misclassification of Date/Map/Set as empty plain objects
- Add `isRecord` type guard helper to replace `as`-casts and `eslint-disable` comments

### Robustness
- Add recursion depth cap (`MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32`) to prevent stack overflow on deeply nested input
- Warn when a server entry collapses to empty after `removeEmptyEntries`

### Test coverage
- Add TOML-string-level regression test asserting `getFileContent()` never contains `.env]` for server with `env: {}`
- Add regression test for arrays-of-objects not recursed into (`args: [{}]`)
- Tighten test assertions: replace optional chaining with non-null assertion after `expect().toBeDefined()`

### Related
- PR #1622 (previous fix that made `removeEmptyEntries` recursive)