### PR TITLE
fix(kilo-subagent): default mode to 'all' to match Kilo CLI docs

### DIFF
--- a/src/e2e/e2e-subagents.spec.ts
+++ b/src/e2e/e2e-subagents.spec.ts
@@ -140,6 +140,61 @@ You are a primary agent. You appear in the Tab rotation.
     expect(generatedContent).toContain("A primary mode agent");
   });
 
+  it("should default kilo.mode to 'all' when omitted in source", async () => {
+    const testDir = getTestDir();
+
+    // Kilo's documented default for user-defined agents is `all`
+    // (https://kilocode.ai/docs/customize/custom-modes). Rulesync must
+    // emit `mode: all` when source frontmatter has no `kilo.mode`,
+    // otherwise generated agents are hidden from Kilo's agent picker.
+    const subagentContent = `---
+name: planner
+targets: ["*"]
+description: "Plans implementation tasks"
+---
+You are the planner. Analyze files and create a plan.
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
+      subagentContent,
+    );
+
+    await runGenerate({ target: "kilo", features: "subagents" });
+
+    const generatedContent = await readFileContent(join(testDir, ".kilo", "agent", "planner.md"));
+    expect(generatedContent).toContain("mode: all");
+    expect(generatedContent).not.toContain("mode: subagent");
+    expect(generatedContent).toContain("Analyze files and create a plan.");
+  });
+
+  it("should preserve explicit kilo.mode: subagent override", async () => {
+    const testDir = getTestDir();
+
+    // Users who want the previous (hidden) behavior can opt back in by
+    // explicitly setting `kilo.mode: subagent` in source frontmatter.
+    const subagentContent = `---
+name: hidden-helper
+targets: ["*"]
+description: "A subagent-only helper"
+kilo:
+  mode: subagent
+---
+You are a subagent-only helper.
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "hidden-helper.md"),
+      subagentContent,
+    );
+
+    await runGenerate({ target: "kilo", features: "subagents" });
+
+    const generatedContent = await readFileContent(
+      join(testDir, ".kilo", "agent", "hidden-helper.md"),
+    );
+    expect(generatedContent).toContain("mode: subagent");
+    expect(generatedContent).not.toContain("mode: all");
+  });
+
   it.each([
     { target: "claudecode", orphanPath: join(".claude", "agents", "orphan.md") },
     { target: "cursor", orphanPath: join(".cursor", "agents", "orphan.md") },

--- a/src/features/subagents/kilo-subagent.test.ts
+++ b/src/features/subagents/kilo-subagent.test.ts
@@ -165,6 +165,36 @@ describe("KiloSubagent", () => {
     expect(toolSubagent.getFrontmatter().mode).toBe("subagent");
   });
 
+  it("should honour explicit kilo.mode = 'all' override (matches default)", () => {
+    // Symmetry test: explicit `kilo.mode: all` matches the new default but
+    // is a valid explicit value. Guards against any future regression
+    // where the defaulting logic accidentally overrides user intent.
+    const rulesyncSubagent = new RulesyncSubagent({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "explicit-all.md",
+      frontmatter: {
+        targets: ["kilo"],
+        name: "explicit-all",
+        description: "Explicitly all mode",
+        kilo: {
+          mode: "all",
+        },
+      },
+      body: "Body",
+      validate: false,
+    });
+
+    const toolSubagent = KiloSubagent.fromRulesyncSubagent({
+      rulesyncSubagent,
+      global: true,
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    }) as KiloSubagent;
+
+    expect(toolSubagent.getFrontmatter().mode).toBe("all");
+  });
+
   it("should preserve primary mode for Kilo subagent", () => {
     // Regression test for: kilo.mode was hardcoded to 'subagent' instead of being preserved
     const rulesyncSubagent = new RulesyncSubagent({

--- a/src/features/subagents/kilo-subagent.test.ts
+++ b/src/features/subagents/kilo-subagent.test.ts
@@ -97,7 +97,12 @@ describe("KiloSubagent", () => {
     expect(toolSubagent.getRelativeDirPath()).toBe(join(".config", "kilo", "agent"));
   });
 
-  it("should build Kilo subagent with default mode when not specified", () => {
+  it("should build Kilo subagent with default mode 'all' when not specified", () => {
+    // Kilo's documented default for user-defined agents is `all` (available
+    // both as a top-level pick AND as a subagent). See:
+    // https://kilocode.ai/docs/customize/custom-modes
+    // Previously rulesync defaulted to "subagent", which hid generated
+    // agents from the Kilo agent picker.
     const rulesyncSubagent = new RulesyncSubagent({
       outputRoot: testDir,
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -126,9 +131,38 @@ describe("KiloSubagent", () => {
       name: "docs-writer",
       description: "Writes documentation",
       model: "model-x",
-      mode: "subagent",
+      mode: "all",
     });
     expect(toolSubagent.getRelativeDirPath()).toBe(join(".config", "kilo", "agent"));
+  });
+
+  it("should still honour explicit kilo.mode = 'subagent' override", () => {
+    // Users who want the old behavior (hidden, subagent-only) can opt in
+    // by setting `kilo: { mode: subagent }` in source frontmatter.
+    const rulesyncSubagent = new RulesyncSubagent({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      relativeFilePath: "hidden-helper.md",
+      frontmatter: {
+        targets: ["kilo"],
+        name: "hidden-helper",
+        description: "Subagent-only helper",
+        kilo: {
+          mode: "subagent",
+        },
+      },
+      body: "Body",
+      validate: false,
+    });
+
+    const toolSubagent = KiloSubagent.fromRulesyncSubagent({
+      rulesyncSubagent,
+      global: true,
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    }) as KiloSubagent;
+
+    expect(toolSubagent.getFrontmatter().mode).toBe("subagent");
   });
 
   it("should preserve primary mode for Kilo subagent", () => {

--- a/src/features/subagents/kilo-subagent.ts
+++ b/src/features/subagents/kilo-subagent.ts
@@ -50,7 +50,16 @@ export class KiloSubagent extends OpenCodeStyleSubagent {
     const kiloFrontmatter: KiloSubagentFrontmatter = {
       ...kiloSection,
       description: rulesyncFrontmatter.description,
-      mode: typeof kiloSection.mode === "string" ? kiloSection.mode : "subagent",
+      // Kilo CLI's documented default for user-defined agents is "all"
+      // (available both as a top-level pick AND as a subagent). See
+      // https://kilocode.ai/docs/customize/custom-modes — "mode" reference:
+      //   all — Available both as a top-level pick and as a subagent
+      //         (default for user-defined agents).
+      // Previously this defaulted to "subagent", which hid generated
+      // agents from Kilo's agent picker. The explicit `kilo.mode` override
+      // in source frontmatter still wins, so users wanting subagent-only
+      // can opt in with `kilo: { mode: subagent }`.
+      mode: typeof kiloSection.mode === "string" ? kiloSection.mode : "all",
       ...(rulesyncFrontmatter.name && { name: rulesyncFrontmatter.name }),
     };
 


### PR DESCRIPTION
## Summary

Kilo CLI's documented default for user-defined agents is `all` (available both as a top-level pick AND as a subagent). See https://kilocode.ai/docs/customize/custom-modes — the `mode` reference states:

> `all` — Available both as a top-level pick and as a subagent (default for user-defined agents).

Rulesync previously defaulted to `subagent`, which hid every generated agent from Kilo's agent picker. Users had to either set `kilo: { mode: all }` explicitly in every source subagent, or post-process the output with sed.

After this PR, omitting `kilo.mode` writes `mode: all` — matching Kilo's own default for user-defined agents. The explicit override still wins, so users wanting subagent-only behaviour can opt in with `kilo: { mode: subagent }` in source frontmatter.

## Changes

- `src/features/subagents/kilo-subagent.ts`: change default from `"subagent"` → `"all"` in `fromRulesyncSubagent`. Added an inline comment linking to the Kilo docs reference.
- `src/features/subagents/kilo-subagent.test.ts`: updated the existing default-mode test to expect `mode: all`. Added regression test: explicit `kilo: { mode: subagent }` override is preserved.

## Tests

All 10 kilo-subagent tests pass. `pnpm cicheck` clean.

## Risk

Behaviour change for users who relied on the previous default. Opt-out path is a one-line frontmatter addition (`kilo: { mode: subagent }`). The new default matches Kilo's own documented default, so most users will see no behaviour change in practice — the generated agents simply become visible in the picker as Kilo's docs already say they should be.
