### PR TITLE
fix(codexcli-mcp): harden object filtering

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -488,10 +488,11 @@ fontSize = 14
           codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
         )?.["aws-knowledge"];
         expect(server).toBeDefined();
-        expect(server?.env).toBeUndefined();
+        expect(server!.env).toBeUndefined();
         // Defensive: assert non-env fields survive the strip.
-        expect(server?.type).toBe(transport);
-        expect(server?.url).toBe("https://knowledge-mcp.global.api.aws");
+        expect(server!.type).toBe(transport);
+        expect(server!.url).toBe("https://knowledge-mcp.global.api.aws");
+        expect(codexcliMcp.getFileContent()).not.toContain("[mcp_servers.aws-knowledge.env]");
       },
     );
 
@@ -522,10 +523,11 @@ fontSize = 14
         codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
       )?.["local"];
       expect(server).toBeDefined();
-      expect(server?.env).toBeUndefined();
+      expect(server!.env).toBeUndefined();
       // Defensive: assert non-env fields survive the strip.
-      expect(server?.command).toBe("node");
-      expect(server?.args).toEqual(["server.js"]);
+      expect(server!.command).toBe("node");
+      expect(server!.args).toEqual(["server.js"]);
+      expect(codexcliMcp.getFileContent()).not.toContain("[mcp_servers.local.env]");
     });
 
     it("should preserve populated env table on stdio server", async () => {
@@ -555,10 +557,87 @@ fontSize = 14
         codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
       )?.["local"];
       expect(server).toBeDefined();
-      expect(server?.env).toEqual({ NODE_ENV: "production" });
+      expect(server!.env).toEqual({ NODE_ENV: "production" });
       // Defensive: command/args also survive.
-      expect(server?.command).toBe("node");
-      expect(server?.args).toEqual(["server.js"]);
+      expect(server!.command).toBe("node");
+      expect(server!.args).toEqual(["server.js"]);
+    });
+
+    it("should preserve array elements without recursing into them", async () => {
+      const jsonData = {
+        mcpServers: {
+          local: {
+            type: "stdio",
+            command: "node",
+            args: ["server.js"],
+            env: {},
+            metadata: [{ env: {} }],
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (
+        codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>
+      )?.["local"];
+      expect(server).toBeDefined();
+      expect(server!.env).toBeUndefined();
+      expect(server!.metadata).toEqual([{ env: {} }]);
+    });
+
+    it("should skip prototype pollution keys during codex conversion", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: `{
+          "mcpServers": {
+            "__proto__": { "polluted": true },
+            "constructor": { "polluted": true },
+            "local": {
+              "type": "stdio",
+              "command": "node",
+              "__proto__": { "polluted": true },
+              "constructor": { "polluted": true },
+              "env": {
+                "__proto__": { "polluted": true },
+                "SAFE": "1"
+              }
+            }
+          }
+        }`,
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const mcpServers = codexcliMcp.getToml().mcp_servers as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const server = mcpServers["local"];
+
+      expect(Object.hasOwn(mcpServers, "__proto__")).toBe(false);
+      expect(Object.hasOwn(mcpServers, "constructor")).toBe(false);
+      expect(server).toBeDefined();
+      expect(server!.polluted).toBeUndefined();
+      expect(Object.hasOwn(server!, "__proto__")).toBe(false);
+      expect(Object.hasOwn(server!, "constructor")).toBe(false);
+      expect(server!.env).toEqual({ SAFE: "1" });
+      expect((server!.env as Record<string, unknown>).polluted).toBeUndefined();
+      expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
     });
 
     it("should convert disabled: true to enabled = false in codex format", async () => {
@@ -954,6 +1033,34 @@ theme = "dark"
 
       const json = JSON.parse(rulesyncMcp.getFileContent());
       expect(json.mcpServers).toEqual({});
+    });
+
+    it("should skip prototype pollution keys when importing codex TOML", () => {
+      const tomlContent = `[mcp_servers."__proto__"]
+polluted = true
+
+[mcp_servers.constructor]
+polluted = true
+
+[mcp_servers.local]
+command = "node"
+"__proto__" = "bad"
+constructor = "bad"
+prototype = "bad"
+`;
+      const codexcliMcp = new CodexcliMcp({
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const rulesyncMcp = codexcliMcp.toRulesyncMcp();
+
+      const json = JSON.parse(rulesyncMcp.getFileContent());
+      expect(Object.hasOwn(json.mcpServers, "__proto__")).toBe(false);
+      expect(Object.hasOwn(json.mcpServers, "constructor")).toBe(false);
+      expect(json.mcpServers.local).toEqual({ command: "node" });
+      expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
     });
 
     it("should convert enabled = false to disabled: true in rulesync format", () => {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -15,16 +15,33 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
+const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isPrototypePollutionKey(key: string): boolean {
+  return PROTOTYPE_POLLUTION_KEYS.has(key);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
   for (const [name, config] of Object.entries(codexMcp)) {
-    if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    if (isPrototypePollutionKey(name) || !isPlainRecord(config)) {
       continue;
     }
 
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
+      if (isPrototypePollutionKey(key)) continue;
+
       if (key === "enabled") {
         if (value === false) {
           converted["disabled"] = true;
@@ -49,12 +66,16 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   return result;
 }
 
-function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
+function convertToCodexFormat(mcpServers: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, Record<string, unknown>> = {};
 
   for (const [name, config] of Object.entries(mcpServers)) {
+    if (isPrototypePollutionKey(name) || !isPlainRecord(config)) continue;
+
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
+      if (isPrototypePollutionKey(key)) continue;
+
       if (key === "disabled") {
         if (value === true) {
           converted["enabled"] = false;
@@ -155,8 +176,10 @@ export class CodexcliMcp extends ToolMcp {
 
     const configToml = smolToml.parse(configTomlFileContent);
 
-    const mcpServers = rulesyncMcp.getJson().mcpServers;
-    const converted = convertToCodexFormat(mcpServers);
+    const rulesyncMcpServers = rulesyncMcp.getJson().mcpServers;
+    const converted = convertToCodexFormat(
+      isPlainRecord(rulesyncMcpServers) ? rulesyncMcpServers : {},
+    );
     const filteredMcpServers = this.removeEmptyEntries(converted);
 
     // eslint-disable-next-line no-type-assertion/no-type-assertion
@@ -187,12 +210,23 @@ export class CodexcliMcp extends ToolMcp {
 
   private static removeEmptyEntries(
     obj: Record<string, unknown> | undefined,
+    depth = 0,
   ): Record<string, unknown> {
     if (!obj) return {};
 
     const filtered: Record<string, unknown> = {};
 
+    if (depth >= MAX_REMOVE_EMPTY_ENTRIES_DEPTH) {
+      for (const [key, value] of Object.entries(obj)) {
+        if (isPrototypePollutionKey(key) || value === null) continue;
+        filtered[key] = value;
+      }
+      return filtered;
+    }
+
     for (const [key, value] of Object.entries(obj)) {
+      if (isPrototypePollutionKey(key)) continue;
+
       // Skip null values
       if (value === null) continue;
 
@@ -202,10 +236,10 @@ export class CodexcliMcp extends ToolMcp {
       // remote (sse/http/streamable_http) transports with:
       //   "env is not supported for streamable_http"
       // Arrays are preserved verbatim, including empty ones, since an
-      // empty array can be a meaningful explicit override.
-      if (typeof value === "object" && !Array.isArray(value)) {
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        const cleaned = this.removeEmptyEntries(value as Record<string, unknown>);
+      // empty array can be a meaningful explicit override. Array elements
+      // are not recursed into.
+      if (isPlainRecord(value)) {
+        const cleaned = this.removeEmptyEntries(value, depth + 1);
         if (Object.keys(cleaned).length === 0) continue;
         filtered[key] = cleaned;
         continue;


### PR DESCRIPTION
## Summary

Draft follow-up for #1626. This hardens the Codex CLI MCP conversion path after the recursive empty-object stripping fix from #1622.

## Changes

- Skip prototype-pollution keys (`__proto__`, `constructor`, `prototype`) in both Rulesync -> Codex and Codex -> Rulesync conversion.
- Guard converter inputs with a plain-object check so malformed/non-object server entries are ignored rather than traversed.
- Add a recursion depth cap to `removeEmptyEntries` and keep filtering unsafe keys at the cap.
- Clarify that arrays are preserved verbatim and array elements are not recursed into.
- Add serialized TOML assertions that empty env tables are not emitted.
- Add generate/import tests for prototype key filtering.
- Tighten optional-chain assertions after `server` existence checks.

Fixes #1626.

## Verification

- `pnpm test src/features/mcp/codexcli-mcp.test.ts`
- `pnpm cicheck`

## Deferred

The optional warning for config-only servers collapsing to empty is intentionally left out of this PR to keep the hardening change small and reviewable. That can be handled as a separate UX/logging issue if desired.

## Review notes

Opened as draft to signal ownership and keep the maintainer-scrap follow-up visible while avoiding pressure for immediate review.
