### PR TITLE
fix(codexcli-mcp): tighten envVars handling

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -400,7 +400,7 @@ env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
 
 - Emitted only into the codex CLI output. Stripped from `RulesyncMcp.getMcpServers()` so it does not appear in other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, Cursor, Cline, Junie, Factorydroid, Rovodev, etc.).
 - Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
-- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined — see codex documentation for the exact resolution rule.
+- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined; see the [Codex configuration reference](https://developers.openai.com/codex/config-reference#mcp_serversid-env_vars) (last checked 2026-05-13) for the exact resolution rule.
 
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -400,7 +400,7 @@ env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
 
 - Emitted only into the codex CLI output. Stripped from `RulesyncMcp.getMcpServers()` so it does not appear in other tools' generated configs (Claude Code, Kilo, OpenCode, Gemini CLI, Cursor, Cline, Junie, Factorydroid, Rovodev, etc.).
 - Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
-- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined — see codex documentation for the exact resolution rule.
+- Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined; see the [Codex configuration reference](https://developers.openai.com/codex/config-reference#mcp_serversid-env_vars) (last checked 2026-05-13) for the exact resolution rule.
 
 ## `.rulesync/.aiignore` or `.rulesyncignore`
 

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -927,6 +927,39 @@ args = ["server.js"]
       expect(server.env).toEqual({ LOG_LEVEL: "debug" });
     });
 
+    it("should not leak rulesync-only fields into codex output", async () => {
+      const jsonData = {
+        mcpServers: {
+          pal: {
+            type: "stdio",
+            command: "uvx",
+            args: ["pal-mcp-server"],
+            envVars: ["OPENAI_API_KEY"],
+            targets: ["codexcli"],
+            description: "PAL MCP server",
+            exposed: true,
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const server = (codexcliMcp.getToml().mcp_servers as any).pal;
+      expect(server.env_vars).toEqual(["OPENAI_API_KEY"]);
+      expect(server.targets).toBeUndefined();
+      expect(server.description).toBeUndefined();
+      expect(server.exposed).toBeUndefined();
+    });
+
     it("should round-trip envVars through codex import", async () => {
       // codex config.toml → toRulesyncMcp() → rulesync representation must
       // expose `envVars` in source schema form (camelCase).
@@ -948,6 +981,30 @@ env_vars = ["OPENAI_API_KEY"]
 
       expect(json.mcpServers.pal.envVars).toEqual(["OPENAI_API_KEY"]);
       expect(json.mcpServers.pal.env_vars).toBeUndefined();
+    });
+
+    it("should ignore malformed codex array fields when importing", () => {
+      const tomlContent = `[mcp_servers.pal]
+type = "stdio"
+command = "uvx"
+env_vars = [1, 2, 3]
+enabled_tools = ["read", 2]
+disabled_tools = [false]
+`;
+      const codexcliMcp = new CodexcliMcp({
+        outputRoot: testDir,
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const rulesyncMcp = codexcliMcp.toRulesyncMcp();
+      const json = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(json.mcpServers.pal.envVars).toBeUndefined();
+      expect(json.mcpServers.pal.enabledTools).toBeUndefined();
+      expect(json.mcpServers.pal.disabledTools).toBeUndefined();
+      expect(json.mcpServers.pal.command).toBe("uvx");
     });
 
     it("should convert enabledTools/disabledTools for multiple servers", async () => {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -52,10 +52,7 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
           if (isStringArray(value)) {
             converted[mappedKey] = value;
           } else {
-            warnWithFallback(
-              undefined,
-              `Ignored malformed array for ${key} in MCP server ${name}`,
-            );
+            warnWithFallback(undefined, `Ignored malformed array for ${key} in MCP server ${name}`);
           }
         }
       } else {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -17,6 +17,18 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
+const CODEX_TO_RULESYNC_FIELD_MAP: Record<string, string> = {
+  enabled_tools: "enabledTools",
+  disabled_tools: "disabledTools",
+  env_vars: "envVars",
+};
+
+const RULESYNC_TO_CODEX_FIELD_MAP: Record<string, string> = {
+  enabledTools: "enabled_tools",
+  disabledTools: "disabled_tools",
+  envVars: "env_vars",
+};
+
 const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
 
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -27,12 +39,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === null || proto === Object.prototype;
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
   for (const [name, config] of Object.entries(codexMcp)) {
-    if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
-    if (!isRecord(config)) continue;
+    if (PROTOTYPE_POLLUTION_KEYS.has(name) || !isRecord(config)) continue;
 
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
@@ -41,15 +56,11 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
         if (value === false) {
           converted["disabled"] = true;
         }
-      } else if (key === "enabled_tools") {
-        converted["enabledTools"] = value;
-      } else if (key === "disabled_tools") {
-        converted["disabledTools"] = value;
-      } else if (key === "env_vars") {
-        // codex stores env-var passthrough names in snake_case (`env_vars`);
-        // the rulesync source schema uses camelCase (`envVars`) for
-        // consistency with `enabledTools`/`disabledTools`/etc.
-        converted["envVars"] = value;
+      } else if (key in CODEX_TO_RULESYNC_FIELD_MAP) {
+        const mappedKey = CODEX_TO_RULESYNC_FIELD_MAP[key];
+        if (mappedKey && isStringArray(value)) {
+          converted[mappedKey] = value;
+        }
       } else {
         converted[key] = value;
       }
@@ -74,16 +85,11 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
         if (value === true) {
           converted["enabled"] = false;
         }
-      } else if (key === "enabledTools") {
-        converted["enabled_tools"] = value;
-      } else if (key === "disabledTools") {
-        converted["disabled_tools"] = value;
-      } else if (key === "envVars") {
-        // Rename camelCase source `envVars` → snake_case `env_vars`
-        // for codex's native config.toml format. See `enabledTools`
-        // precedent above. `envVars` itself is stripped from
-        // getMcpServers() so non-codex tools never receive it.
-        converted["env_vars"] = value;
+      } else if (key in RULESYNC_TO_CODEX_FIELD_MAP) {
+        const mappedKey = RULESYNC_TO_CODEX_FIELD_MAP[key];
+        if (mappedKey && isStringArray(value)) {
+          converted[mappedKey] = value;
+        }
       } else {
         converted[key] = value;
       }
@@ -170,8 +176,23 @@ export class CodexcliMcp extends ToolMcp {
 
     const configToml = smolToml.parse(configTomlFileContent);
 
-    const mcpServers = rulesyncMcp.getJson().mcpServers;
-    const converted = convertToCodexFormat(mcpServers);
+    const strippedMcpServers = rulesyncMcp.getMcpServers();
+    const rawMcpServers = rulesyncMcp.getJson().mcpServers;
+    const mcpServersWithCodexFields = Object.fromEntries(
+      Object.entries(strippedMcpServers).map(([serverName, serverConfig]) => {
+        const rawServer = isRecord(rawMcpServers) ? rawMcpServers[serverName] : undefined;
+        return [
+          serverName,
+          {
+            ...serverConfig,
+            ...(isRecord(rawServer) && isStringArray(rawServer.envVars)
+              ? { envVars: rawServer.envVars }
+              : {}),
+          },
+        ];
+      }),
+    );
+    const converted = convertToCodexFormat(mcpServersWithCodexFields);
     const filteredMcpServers = this.removeEmptyEntries(converted);
 
     for (const name of Object.keys(converted)) {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -46,10 +46,17 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
         if (value === false) {
           converted["disabled"] = true;
         }
-      } else if (key in CODEX_TO_RULESYNC_FIELD_MAP) {
+      } else if (Object.hasOwn(CODEX_TO_RULESYNC_FIELD_MAP, key)) {
         const mappedKey = CODEX_TO_RULESYNC_FIELD_MAP[key];
-        if (mappedKey && isStringArray(value)) {
-          converted[mappedKey] = value;
+        if (mappedKey) {
+          if (isStringArray(value)) {
+            converted[mappedKey] = value;
+          } else {
+            warnWithFallback(
+              undefined,
+              `Ignored malformed array for ${key} in MCP server ${name}`,
+            );
+          }
         }
       } else {
         converted[key] = value;
@@ -78,7 +85,7 @@ function convertToCodexFormat(
         if (value === true) {
           converted["enabled"] = false;
         }
-      } else if (key in RULESYNC_TO_CODEX_FIELD_MAP) {
+      } else if (Object.hasOwn(RULESYNC_TO_CODEX_FIELD_MAP, key)) {
         const mappedKey = RULESYNC_TO_CODEX_FIELD_MAP[key];
         if (mappedKey) {
           if (isStringArray(value)) {

--- a/src/types/mcp.test.ts
+++ b/src/types/mcp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isMcpServers } from "./mcp.js";
+import { McpServerSchema, isMcpServers } from "./mcp.js";
 
 describe("isMcpServers", () => {
   it("should return true for a plain object", () => {
@@ -19,5 +19,25 @@ describe("isMcpServers", () => {
     expect(isMcpServers("x")).toBe(false);
     expect(isMcpServers(1)).toBe(false);
     expect(isMcpServers(true)).toBe(false);
+  });
+});
+
+describe("McpServerSchema", () => {
+  it("should accept valid envVars names", () => {
+    const result = McpServerSchema.safeParse({
+      command: "node",
+      envVars: ["OPENAI_API_KEY", "_PRIVATE", "KEY_123"],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid envVars names", () => {
+    const result = McpServerSchema.safeParse({
+      command: "node",
+      envVars: ["1BAD", "HAS-DASH", ""],
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,4 +1,13 @@
-import { z } from "zod/mini";
+import { refine, z } from "zod/mini";
+
+const EnvVarNameSchema = z
+  .string()
+  .check(
+    refine(
+      (value) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(value),
+      "envVars entries must be valid environment variable names",
+    ),
+  );
 
 export const McpServerSchema = z.looseObject({
   type: z.optional(z.enum(["local", "stdio", "sse", "http"])),
@@ -7,6 +16,16 @@ export const McpServerSchema = z.looseObject({
   url: z.optional(z.string()),
   httpUrl: z.optional(z.string()),
   env: z.optional(z.record(z.string(), z.string())),
+  // Codex CLI-specific: list of shell env var names that codex should pass
+  // through from the user's environment to the MCP server process.
+  // Distinct from `env` (a literal name→value map): `envVars` is a list of
+  // variable NAMES whose values come from the user's shell at runtime.
+  // Only honoured by the codex generator (renamed to `env_vars` in codex
+  // TOML output, matching codex's native field name — see the
+  // `enabledTools`→`enabled_tools` precedent in `codexcli-mcp.ts`).
+  // Stripped by `RulesyncMcp.getMcpServers()` so it does not leak into
+  // other tools' configs.
+  envVars: z.optional(z.array(EnvVarNameSchema)),
   disabled: z.optional(z.boolean()),
   networkTimeout: z.optional(z.number()),
   timeout: z.optional(z.number()),
@@ -17,16 +36,6 @@ export const McpServerSchema = z.looseObject({
   tools: z.optional(z.array(z.string())),
   kiroAutoApprove: z.optional(z.array(z.string())),
   kiroAutoBlock: z.optional(z.array(z.string())),
-  // Codex CLI-specific: list of shell env var names that codex should pass
-  // through from the user's environment to the MCP server process.
-  // Distinct from `env` (a literal name→value map): `envVars` is a list of
-  // variable NAMES whose values come from the user's shell at runtime.
-  // Only honoured by the codex generator (renamed to `env_vars` in codex
-  // TOML output, matching codex's native field name — see the
-  // `enabledTools`→`enabled_tools` precedent in `codexcli-mcp.ts`).
-  // Stripped by `RulesyncMcp.getMcpServers()` so it does not leak into
-  // other tools' configs.
-  envVars: z.optional(z.array(z.string())),
   headers: z.optional(z.record(z.string(), z.string())),
   enabledTools: z.optional(z.array(z.string())),
   disabledTools: z.optional(z.array(z.string())),


### PR DESCRIPTION
## Summary

Draft follow-up for #1625. This tightens Codex MCP `envVars` handling and prevents rulesync-only source fields from leaking into Codex output.

## Changes

- Generate Codex MCP from `RulesyncMcp.getMcpServers()` stripped output, then re-merge only valid codex-specific `envVars` from the raw source.
- Replace repeated field rename branches with shared mapping tables for `enabledTools` / `disabledTools` / `envVars`.
- Ignore malformed `env_vars`, `enabled_tools`, and `disabled_tools` arrays when importing Codex TOML.
- Validate `envVars` entries as environment variable names in the Rulesync MCP schema.
- Add regression tests proving Codex output keeps `env_vars` but strips `targets`, `description`, and `exposed`.
- Link docs to the Codex configuration reference with a last-checked date and sync `skills/rulesync` docs.

Fixes #1625.

## Verification

- `pnpm test src/features/mcp/codexcli-mcp.test.ts src/types/mcp.test.ts`
- `pnpm cicheck`

## Deferred

Two cross-generator follow-ups from #1625 are intentionally deferred to keep this PR focused:

- Cursor source-preservation assertion for `targets`.
- Parametric contract test across every non-Codex MCP generator for `envVars` / `targets` / `description` / `exposed` stripping.

Those are valuable, but they touch broader generator behavior and should stay separate from the Codex-specific cleanup.

## Review notes

Opened as draft to signal ownership and keep the maintainer-scrap follow-up visible while avoiding immediate review pressure.
