### PR TITLE
refactor(utils): consolidate isPlainObject into shared type-guards module

### DIFF
--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -6,7 +6,7 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { warnWithFallback } from "../../utils/logger.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { isPlainObject, isRecord } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -20,12 +20,6 @@ import {
 const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
 
 const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (!isRecord(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === null || proto === Object.prototype;
-}
 
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -2,12 +2,7 @@ import matter from "gray-matter";
 import { dump, load } from "js-yaml";
 
 import { formatError } from "./error.js";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== "object") return false;
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
+import { isPlainObject } from "./type-guards.js";
 
 function deepRemoveNullishValue(value: unknown): unknown {
   if (value === null || value === undefined) {

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -5,3 +5,20 @@
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+/**
+ * Stricter sibling of {@link isRecord}: narrows to *plain* objects whose
+ * prototype is either ``Object.prototype`` or ``null`` — i.e. object
+ * literals, ``Object.create(null)`` bags, and the output of ``JSON.parse``.
+ *
+ * Rejects class instances even though they pass ``isRecord``. This is the
+ * check needed for prototype-pollution hardening: anything walking
+ * arbitrary user-supplied keys (frontmatter parsing, MCP config
+ * conversion, etc.) should reject inputs whose prototype could carry
+ * malicious accessor descriptors.
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}


### PR DESCRIPTION
## Linked issue

Closes #1638.

## Summary

Two functionally identical `isPlainObject` helpers existed in the tree:

- `src/utils/frontmatter.ts:6-10` — private, predates the prototype-pollution hardening work.
- `src/features/mcp/codexcli-mcp.ts:24-28` — added by #1630 to harden the codexcli MCP converters; delegates to `isRecord`.

Both check `Object.getPrototypeOf(value) === Object.prototype || === null` after excluding arrays/null. This PR hoists the canonical version into `src/utils/type-guards.ts` alongside the existing `isRecord`, and updates both call sites to import it.

## Why the codexcli-mcp form was chosen as canonical

```ts
export function isPlainObject(value: unknown): value is Record<string, unknown> {
  if (!isRecord(value)) return false;
  const proto = Object.getPrototypeOf(value);
  return proto === null || proto === Object.prototype;
}
```

- Delegates the array/null rejection to `isRecord` (single source of truth).
- The frontmatter form was equivalent — array rejection was implicit because `Object.getPrototypeOf([]) === Array.prototype`, not `Object.prototype` — but the explicit `isRecord` call is clearer.

## Diff

```
 src/features/mcp/codexcli-mcp.ts |  8 +-------
 src/utils/frontmatter.ts         |  7 +------
 src/utils/type-guards.ts         | 17 +++++++++++++++++
 3 files changed, 19 insertions(+), 13 deletions(-)
```

## Test plan

- `pnpm run build` (tsup + DTS): clean.
- `npx vitest run src/utils/frontmatter.test.ts src/features/mcp/codexcli-mcp.test.ts`: 89/89 pass.
  - Both modules exercise the helper on realistic inputs: object literals, arrays, `null`, class instances, `Object.create(null)` bags, and prototype-pollution payloads.
- No behaviour change: hoisted helper is byte-identical to the codexcli-mcp definition. The frontmatter caller now goes through the shared form, which is functionally equivalent.