### PR TITLE
refactor(copilot-rule): reuse toPosixPath and switch sameRelativePath to object params

### DIFF
--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -620,11 +620,11 @@ This should be treated as a non-root rule.`;
       expect(copilotRule.getBody()).toBe("This should be treated as a non-root rule.");
     });
 
-    it("should normalize separators when detecting explicit root paths", async () => {
+    it("should normalize a trailing-backslash relativeDirPath when detecting explicit root paths", async () => {
       const githubDir = join(testDir, ".github");
       await ensureDir(githubDir);
 
-      const rootContent = "Root detected with mixed separators.";
+      const rootContent = "Root detected with a trailing backslash on relativeDirPath.";
       await writeFileContent(join(githubDir, "copilot-instructions.md"), rootContent);
 
       const copilotRule = await CopilotRule.fromFile({
@@ -636,6 +636,40 @@ This should be treated as a non-root rule.`;
 
       expect(copilotRule.isRoot()).toBe(true);
       expect(copilotRule.getBody()).toBe(rootContent);
+    });
+
+    it("should treat non-root paths as non-root when relativeDirPath has a mid-path backslash", async () => {
+      // Symmetric coverage to the forDeletion equivalent — exercises the
+      // sameRelativePath check on the fromFile call site so the original
+      // coverage gap flagged in #1603 is closed on both call sites.
+      //
+      // Note on the fixture path: fromFile reads the file from the *raw*
+      // relativeDirPath after the root check (only the comparison goes
+      // through normalizeRelativePath). On POSIX `\` is a regular filename
+      // character, so we materialize the directory at the literal
+      // ".github\instructions" name so the read inside fromFile succeeds.
+      const literalDir = join(testDir, ".github\\instructions");
+      await ensureDir(literalDir);
+      const fileContent = `---
+description: "Mid-path backslash on relativeDirPath"
+applyTo: "**/*.ts"
+---
+
+This should resolve to a non-root rule.`;
+      await writeFileContent(join(literalDir, "feature.instructions.md"), fileContent);
+
+      const copilotRule = await CopilotRule.fromFile({
+        outputRoot: testDir,
+        // Mid-path backslash (".github\\instructions" → ".github\instructions").
+        // sameRelativePath normalizes both sides before comparing against
+        // paths.root, so the comparison correctly returns false here.
+        relativeDirPath: ".github\\instructions",
+        relativeFilePath: "feature.instructions.md",
+        validate: true,
+      });
+
+      expect(copilotRule.isRoot()).toBe(false);
+      expect(copilotRule.getBody()).toBe("This should resolve to a non-root rule.");
     });
 
     it("should detect root only when both relativeDirPath and filename match", async () => {
@@ -797,7 +831,7 @@ description: "Test trimming"
   });
 
   describe("forDeletion", () => {
-    it("should mark root deletion target when separators are mixed", () => {
+    it("should mark root deletion target when relativeDirPath has a trailing backslash", () => {
       const copilotRule = CopilotRule.forDeletion({
         outputRoot: testDir,
         relativeDirPath: ".github\\",
@@ -807,7 +841,7 @@ description: "Test trimming"
       expect(copilotRule.isRoot()).toBe(true);
     });
 
-    it("should treat non-root paths as non-root even with mixed separators", () => {
+    it("should treat non-root paths as non-root when relativeDirPath has a mid-path backslash", () => {
       const copilotRule = CopilotRule.forDeletion({
         outputRoot: testDir,
         relativeDirPath: ".github\\instructions",

--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -796,6 +796,28 @@ description: "Test trimming"
     });
   });
 
+  describe("forDeletion", () => {
+    it("should mark root deletion target when separators are mixed", () => {
+      const copilotRule = CopilotRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".github\\",
+        relativeFilePath: "copilot-instructions.md",
+      });
+
+      expect(copilotRule.isRoot()).toBe(true);
+    });
+
+    it("should treat non-root paths as non-root even with mixed separators", () => {
+      const copilotRule = CopilotRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".github\\instructions",
+        relativeFilePath: "feature.instructions.md",
+      });
+
+      expect(copilotRule.isRoot()).toBe(false);
+    });
+  });
+
   describe("validate", () => {
     it("should return success for valid frontmatter", () => {
       const copilotRule = new CopilotRule({

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -5,7 +5,7 @@ import { z } from "zod/mini";
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { formatError } from "../../utils/error.js";
-import { readFileContent } from "../../utils/file.js";
+import { readFileContent, toPosixPath } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule, RulesyncRuleFrontmatter } from "./rulesync-rule.js";
 import {
@@ -48,12 +48,18 @@ export type CopilotRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal & {
   };
 };
 
-const normalizeRelativePath = (path: string): string =>
-  path.replace(/\\/g, "/").replace(/\/+/g, "/");
+// toPosixPath converts backslashes to forward slashes so paths compare equally
+// on Windows and POSIX. The extra slash collapse covers a WSL/mixed-separator
+// edge case where `node:path/posix.join` keeps a literal backslash inside an
+// input segment (e.g. ".github\\") and produces ".github//instructions/x.md"
+// after the backslash is rewritten.
+const normalizeRelativePath = (p: string): string => toPosixPath(p).replace(/\/+/g, "/");
 
-const sameRelativePath = (leftDir: string, leftFile: string, rightDir: string, rightFile: string) =>
-  normalizeRelativePath(join(leftDir, leftFile)) ===
-  normalizeRelativePath(join(rightDir, rightFile));
+type RelativePathParts = { dir: string; file: string };
+
+const sameRelativePath = (left: RelativePathParts, right: RelativePathParts): boolean =>
+  normalizeRelativePath(join(left.dir, left.file)) ===
+  normalizeRelativePath(join(right.dir, right.file));
 
 /**
  * Rule generator for GitHub Copilot
@@ -217,10 +223,8 @@ export class CopilotRule extends ToolRule {
     const paths = this.getSettablePaths({ global });
     const isRoot = relativeDirPath
       ? sameRelativePath(
-          relativeDirPath,
-          relativeFilePath,
-          paths.root.relativeDirPath,
-          paths.root.relativeFilePath,
+          { dir: relativeDirPath, file: relativeFilePath },
+          { dir: paths.root.relativeDirPath, file: paths.root.relativeFilePath },
         )
       : relativeFilePath === paths.root.relativeFilePath;
     const resolvedRelativeDirPath =
@@ -282,10 +286,8 @@ export class CopilotRule extends ToolRule {
   }: ToolRuleForDeletionParams): CopilotRule {
     const paths = this.getSettablePaths({ global });
     const isRoot = sameRelativePath(
-      relativeDirPath,
-      relativeFilePath,
-      paths.root.relativeDirPath,
-      paths.root.relativeFilePath,
+      { dir: relativeDirPath, file: relativeFilePath },
+      { dir: paths.root.relativeDirPath, file: paths.root.relativeFilePath },
     );
 
     return new CopilotRule({

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -48,11 +48,15 @@ export type CopilotRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal & {
   };
 };
 
-// toPosixPath converts backslashes to forward slashes so paths compare equally
-// on Windows and POSIX. The extra slash collapse covers a WSL/mixed-separator
-// edge case where `node:path/posix.join` keeps a literal backslash inside an
-// input segment (e.g. ".github\\") and produces ".github//instructions/x.md"
-// after the backslash is rewritten.
+// toPosixPath converts backslashes to forward slashes so paths compare
+// equally on Windows and POSIX. The extra slash collapse covers a
+// mixed-separator edge case where `node:path.join` on POSIX treats a
+// trailing backslash as a literal character: joining `.github\\` (one
+// literal backslash) with `copilot-instructions.md` produces
+// `.github\\/copilot-instructions.md`, which becomes
+// `.github//copilot-instructions.md` after `toPosixPath`. The slash
+// collapse below normalizes that back to a single `/` so the result
+// compares equal to the canonical `.github/copilot-instructions.md`.
 const normalizeRelativePath = (p: string): string => toPosixPath(p).replace(/\/+/g, "/");
 
 type RelativePathParts = { dir: string; file: string };


### PR DESCRIPTION
## Summary

Addresses the refactor checklist in #1603 for `src/features/rules/copilot-rule.ts`:

- **DRY** — Replace the local `path.replace(/\\/g, "/")` with the shared `toPosixPath` utility from `src/utils/file.ts`, in line with the coding guideline that points to `toPosixPath` for non-filesystem path normalization.
- **Keep the slash collapse, but justify it** — The follow-up `replace(/\/+/g, "/")` is still needed: on POSIX, `node:path.join(".github\\", "x.md")` keeps the trailing backslash literal, so after `toPosixPath` runs we get `.github//x.md`. A short comment now spells this out so future readers don't think the collapse is dead code.
- **Avoid the `path` parameter name** — Rename `path` → `p` so it no longer shadows the `node:path` import in the same file.
- **Object-based `sameRelativePath`** — Switch the four positional strings to `{dir, file}` objects per the project's coding guidelines, and update both call sites (`fromFile`, `forDeletion`).

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + vitest 5552 tests + cspell + secretlint) passes locally on Node 22.
- [x] New `forDeletion` tests:
  - Root deletion target is detected when `relativeDirPath` is `".github\\"`.
  - Non-root paths with a mid-path backslash (`".github\\instructions"`) stay non-root.
- [x] Existing root-detection test for `.github\\` continues to pass — behavior is preserved, only the helper implementation changes.

Refs #1603.
