### PR TITLE
fix(opencode-subagent): pass global through forDeletion

### DIFF
--- a/src/features/subagents/opencode-subagent.ts
+++ b/src/features/subagents/opencode-subagent.ts
@@ -109,6 +109,7 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
     outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
+    global = false,
   }: ToolSubagentForDeletionParams): OpenCodeSubagent {
     return new OpenCodeSubagent({
       outputRoot,
@@ -118,6 +119,7 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
       body: "",
       fileContent: "",
       validate: false,
+      global,
     });
   }
 }


### PR DESCRIPTION
## Summary

Addresses follow-up item **2** from #1639.

`SubagentsProcessor.loadToolFiles({ forDeletion: true })` builds deletion placeholders via:

```ts
factory.class.forDeletion({
  outputRoot: this.outputRoot,
  relativeDirPath: paths.relativeDirPath,
  relativeFilePath: basename(path),
  global: this.global,
});
```

`KiloSubagent.forDeletion` already destructures `global` and forwards it to the constructor (PR #1635). `OpenCodeSubagent.forDeletion` did not, so the flag was silently dropped and the resulting placeholder always defaulted to `global: false`. This patch mirrors the kilo precedent — destructure `global = false` from the params, forward it on the constructor call.

No behavior change for project-scope deletions (which were always the default anyway). Removes the inconsistency between the two opencode-style classes called out in #1639.

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5550 vitest + cspell + secretlint) passes locally on Node 22.
- [x] Diff is a single file, two added lines, mirroring the kilo fix at the same call site shape — low risk.

Refs #1639 (item 2 of 2 — the `KiloSubagent.validate()` schema-override item is out of scope here).
