### PR TITLE
docs(feature-research/kilo): mirror hooks phrasing for subagents row

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/kilo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/kilo.md
@@ -9,7 +9,7 @@
 | `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface; Rulesync currently maps `.kiloignore`             |
 | `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions  |
 | `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces; Rulesync maps command files                       |
-| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; no README-supported Rulesync Kilo subagents target                     |
+| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Adapter exists in source, but no README-supported Rulesync Kilo subagents target            |
 | `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories         |
 | `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                |
 | `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys |


### PR DESCRIPTION
## Summary

Addresses item **3** from #1616.

The `subagents` row in `.rulesync/skills/rulesync-feature-research/references/kilo.md` previously read:

> `subagents` | `https://kilo.ai/docs/customize/custom-subagents` | **Custom modes/agents; no README-supported Rulesync Kilo subagents target**

That phrasing reads as if Rulesync has no support for Kilo subagents at all. In fact, `KiloSubagent` is registered in `src/features/subagents/subagents-processor.ts` (`import { KiloSubagent } …` at line 22, registered at line 184) — what's actually true is that the README's "Supported Tools and Features" table does not yet claim the target for Kilo.

The `hooks` row on the same file already encodes that exact nuance:

> `hooks` | … | **Adapter exists in source, but no README-supported Rulesync Kilo hooks target**

This PR reuses that hedged phrasing for the `subagents` row, so the two parallel cases now read consistently. The `Official docs` URL is unchanged.

## Test plan

- [x] Single-line edit to one map file; no schema or generator changes.
- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5550 vitest + sync-skill-docs check + cspell + secretlint) passes locally on Node 22.
- [x] Pre-commit `pnpm dev generate` also runs cleanly, so the generated mirrors under `.claude/`, `.opencode/`, `.github/`, `.takt/` regenerate without complaint.

Refs #1616 (item 3 of 5 — the other follow-ups in that issue are out of scope here).
