### PR TITLE
docs(feature-research): strip mixed-cell Rulesync disclaimers from cline/qwencode/zed maps

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/cline.md
+++ b/.rulesync/skills/rulesync-feature-research/references/cline.md
@@ -11,7 +11,7 @@
 | `commands`    | `https://docs.cline.bot/core-workflows/using-commands`      | Slash commands and workflow-style reusable commands                              |
 | `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Cline subagents target in map                              |
 | `skills`      | `https://docs.cline.bot/customization/skills`               | `.cline/skills`, `~/.cline/skills`, `.clinerules/skills`, `.claude/skills`       |
-| `hooks`       | `https://docs.cline.bot/cline-cli/configuration`            | CLI configuration exposes Hooks tab; no Rulesync-supported Cline hooks target    |
+| `hooks`       | `https://docs.cline.bot/cline-cli/configuration`            | CLI configuration exposes Hooks tab                                              |
 | `permissions` | `https://docs.cline.bot/features/auto-approve`              | Auto approve settings for read, edit, commands, browser, MCP, and request limits |
 
 ## Client Anchors

--- a/.rulesync/skills/rulesync-feature-research/references/qwencode.md
+++ b/.rulesync/skills/rulesync-feature-research/references/qwencode.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                                 | Upstream surface                                                                                 |
-| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| index         | `https://qwenlm.github.io/qwen-code-docs/en/`                                 | Qwen Code documentation index                                                                    |
-| `rules`       | `https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/`           | Context files such as `QWEN.md`, hierarchical instructional context                              |
-| `ignore`      | `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/` | `.qwenignore`, `context.fileFiltering.respectQwenIgnore`                                         |
-| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`; no README-supported Rulesync Qwen Code MCP target                  |
-| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist; no Rulesync-supported Qwen Code commands target           |
-| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents; no Rulesync-supported Qwen Code subagents target                  |
-| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory; no Rulesync-supported Qwen Code skills target |
-| `hooks`       | No dedicated upstream hooks surface in map                                    | No Rulesync-supported Qwen Code hooks target in map                                              |
-| `permissions` | `https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/`    | Approval mode and tool approval controls                                                         |
+| Feature       | Official docs                                                                 | Upstream surface                                                    |
+| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| index         | `https://qwenlm.github.io/qwen-code-docs/en/`                                 | Qwen Code documentation index                                       |
+| `rules`       | `https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/`           | Context files such as `QWEN.md`, hierarchical instructional context |
+| `ignore`      | `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/` | `.qwenignore`, `context.fileFiltering.respectQwenIgnore`            |
+| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`                                        |
+| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist                               |
+| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents                                       |
+| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory                   |
+| `hooks`       | No dedicated upstream hooks surface in map                                    | No Rulesync-supported Qwen Code hooks target in map                 |
+| `permissions` | `https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/`    | Approval mode and tool approval controls                            |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/zed.md
+++ b/.rulesync/skills/rulesync-feature-research/references/zed.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                               | Upstream surface                                                                            |
-| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| index         | `https://zed.dev/docs/ai/overview`                          | Zed AI documentation index                                                                  |
-| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library; no Rulesync-supported Zed rules target |
-| `ignore`      | `https://zed.dev/docs/reference/all-settings#private-files` | `.zed/settings.json`, `private_files` glob list                                             |
-| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents; no Rulesync-supported Zed MCP target                  |
-| `commands`    | No dedicated upstream commands surface in map               | No Rulesync-supported Zed commands target in map                                            |
-| `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Zed subagents target in map                                           |
-| `skills`      | No dedicated upstream skills surface in map                 | No Rulesync-supported Zed skills target in map                                              |
-| `hooks`       | No dedicated upstream hooks surface in map                  | No Rulesync-supported Zed hooks target in map                                               |
-| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`; no Rulesync-supported Zed permissions target                      |
+| Feature       | Official docs                                               | Upstream surface                                    |
+| ------------- | ----------------------------------------------------------- | --------------------------------------------------- |
+| index         | `https://zed.dev/docs/ai/overview`                          | Zed AI documentation index                          |
+| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library |
+| `ignore`      | `https://zed.dev/docs/reference/all-settings#private-files` | `.zed/settings.json`, `private_files` glob list     |
+| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents                |
+| `commands`    | No dedicated upstream commands surface in map               | No Rulesync-supported Zed commands target in map    |
+| `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Zed subagents target in map   |
+| `skills`      | No dedicated upstream skills surface in map                 | No Rulesync-supported Zed skills target in map      |
+| `hooks`       | No dedicated upstream hooks surface in map                  | No Rulesync-supported Zed hooks target in map       |
+| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`                            |
 
 ## Client Anchors
 


### PR DESCRIPTION
## Summary

Addresses item **1** from #1616.

`SKILL.md` for the `rulesync-feature-research` skill prescribes that the `Official docs` / `Upstream surface` columns stay descriptive and that Rulesync-support deltas surface at run time in the **Capability Gaps** output. PR #1611 introduced several new map files that mix the two: they append `"; no (README-)supported Rulesync … target"` to an otherwise valid upstream description, which breaks that separation.

This PR strips the trailing disclaimer in the rows the issue explicitly called out, plus the same pattern on adjacent rows in the same three files:

| File          | Rows touched                                |
| ------------- | ------------------------------------------- |
| `cline.md`    | `hooks`                                     |
| `qwencode.md` | `mcp` · `commands` · `subagents` · `skills` |
| `zed.md`      | `rules` · `mcp` · `permissions`             |

Rows where the disclaimer IS the entire upstream description (zed `commands`/`subagents`/`skills`/`hooks`, qwencode `hooks`) already follow the two-sentinel pattern documented in `SKILL.md` and are left alone.

Tables were re-aligned by `oxfmt` to match the shortened column widths. No upstream URLs change.

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5550 vitest + sync-skill-docs check + cspell + secretlint) passes locally on Node 22.
- [x] Pre-commit `pnpm dev generate` also runs cleanly — the generated mirrors under `.claude/`, `.opencode/`, `.github/`, `.takt/` regenerate without complaint.
- [x] Diff is intentionally narrow: only the three files the issue explicitly listed; no rewrites of `SKILL.md`, no sentinel taxonomy changes, no rescan of other reference maps (those are separate follow-ups in the same issue).

Refs #1616 (item 1 of 5).
