### PR TITLE
docs(file-formats): align claudecode skill paths/scheduled-task order with code emission

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -270,10 +270,10 @@ claudecode: # for claudecode-specific parameters
     - "Write"
     - "Grep"
   disable-model-invocation: true # (optional) disable model invocation for this skill
-  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
   paths: # (optional) glob patterns (string or list) limiting auto-activation
     - "src/**/*.ts"
     - "test/**/*.ts"
+  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -270,10 +270,10 @@ claudecode: # for claudecode-specific parameters
     - "Write"
     - "Grep"
   disable-model-invocation: true # (optional) disable model invocation for this skill
-  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
   paths: # (optional) glob patterns (string or list) limiting auto-activation
     - "src/**/*.ts"
     - "test/**/*.ts"
+  scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)


### PR DESCRIPTION
## Summary

Addresses item **4** from #1618 (review findings for PR #1604, the Claude Code skills `paths` field).

`ClaudecodeSkill.toRulesyncSkill` emits the `claudecode` section in this order:

```ts
// src/features/skills/claudecode-skill.ts:122-130
const claudecodeSection = {
  ...(frontmatter["allowed-tools"] && { ... }),
  ...(frontmatter.model && { model: frontmatter.model }),
  ...(frontmatter["disable-model-invocation"] !== undefined && { ... }),
  ...(frontmatter.paths !== undefined && { paths: frontmatter.paths }),               // ← paths
  ...(this.relativeDirPath === CLAUDE_SCHEDULED_TASKS_DIR_PATH && { "scheduled-task": true }), // ← scheduled-task
};
```

Object spread order determines the YAML key order in serialized output, so generated skill files put `paths` **before** `scheduled-task`. But `docs/reference/file-formats.md` had them swapped (`scheduled-task` then `paths`), which made the example diverge from the actual generated output users see in their working tree.

This PR moves the `paths:` block in the doc example up so the YAML key order matches the spread order in code. No code change, no schema change, no URL change.

`skills/rulesync/file-formats.md` is auto-regenerated from `docs/` by `scripts/sync-skill-docs.ts` (wired through `lint-staged` on every `docs/**/*.md` commit) and is included in this PR for that reason.

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5550 vitest + sync-skill-docs check + cspell + secretlint) passes locally on Node 22.
- [x] Diff is a single key reorder in `docs/reference/file-formats.md` plus the mirrored regeneration in `skills/rulesync/file-formats.md`.

Refs #1618 (item 4 of 6 — the other follow-ups in that issue are out of scope here).
