### PR TITLE
docs(file-formats): note comma-separated form for claudecode skill paths

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -296,6 +296,8 @@ Skills are directory-based and can include additional files alongside SKILL.md.
 When `claudecode.scheduled-task: true` is set, that skill is emitted only as a Claude Code scheduled task and is not emitted to other tools even if `targets` contains `"*"`.
 ```
 
+`claudecode.paths` accepts either the YAML list shown above or a comma-separated string (e.g. `paths: "src/**/*.ts,test/**/*.ts"`); the two forms are equivalent.
+
 ## `.rulesync/mcp.json`
 
 Example:

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -296,6 +296,8 @@ Skills are directory-based and can include additional files alongside SKILL.md.
 When `claudecode.scheduled-task: true` is set, that skill is emitted only as a Claude Code scheduled task and is not emitted to other tools even if `targets` contains `"*"`.
 ```
 
+`claudecode.paths` accepts either the YAML list shown above or a comma-separated string (e.g. `paths: "src/**/*.ts,test/**/*.ts"`); the two forms are equivalent.
+
 ## `.rulesync/mcp.json`
 
 Example:


### PR DESCRIPTION
## Summary

Addresses item **3** from #1618 (review findings for PR #1604, the Claude Code skills `paths` field).

`ClaudecodeSkillFrontmatterSchema` declares:

```ts
// src/features/skills/claudecode-skill.ts:27
paths: z.optional(z.union([z.string(), z.array(z.string())])),
```

so `paths` accepts a YAML list **or** a comma-separated string. The `docs/reference/file-formats.md` SKILL.md example only showed the list form, leaving the string form undocumented.

This PR adds a one-sentence callout immediately after the SKILL.md example that names the comma-separated form and shows the equivalent value:

> `claudecode.paths` accepts either the YAML list shown above or a comma-separated string (e.g. `paths: "src/**/*.ts,test/**/*.ts"`); the two forms are equivalent.

No code change. No schema change. `skills/rulesync/file-formats.md` is auto-regenerated from `docs/` by `scripts/sync-skill-docs.ts` (wired through `lint-staged` on every `docs/**/*.md` commit) and is included in this PR for that reason.

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5550 vitest + sync-skill-docs check + cspell + secretlint) passes locally on Node 22.
- [x] Diff is a single inserted sentence in `docs/reference/file-formats.md` plus the mirrored regeneration in `skills/rulesync/file-formats.md`.
- [x] The note is placed **outside** the existing SKILL.md example fence, so it renders as parsed Markdown rather than as code.

Refs #1618 (item 3 of 6 — the other follow-ups in that issue are out of scope here; item 4 is being addressed separately in #1648).
