### PR TITLE
test(claudecode-skill): cover paths in fromDir and empty-value round-trips

### DIFF
--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -390,6 +390,45 @@ describe("ClaudecodeSkill", () => {
       });
     });
 
+    it("should preserve an empty paths string through toRulesyncSkill", () => {
+      const frontmatter: ClaudecodeSkillFrontmatter = {
+        name: "empty-paths-string-skill",
+        description: "Skill with an empty comma-separated paths string",
+        paths: "",
+      };
+
+      const skill = new ClaudecodeSkill({
+        dirName: "empty-paths-string-skill",
+        frontmatter,
+        body: "Empty paths string body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+      // Empty string is a defined value, so the spread keeps it in the output.
+      expect(rulesyncFrontmatter.claudecode).toEqual({ paths: "" });
+    });
+
+    it("should preserve an empty paths array through toRulesyncSkill", () => {
+      const frontmatter: ClaudecodeSkillFrontmatter = {
+        name: "empty-paths-array-skill",
+        description: "Skill with an empty paths array",
+        paths: [],
+      };
+
+      const skill = new ClaudecodeSkill({
+        dirName: "empty-paths-array-skill",
+        frontmatter,
+        body: "Empty paths array body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+      expect(rulesyncFrontmatter.claudecode).toEqual({ paths: [] });
+    });
+
     it("should preserve other files during conversion", () => {
       const frontmatter: ClaudecodeSkillFrontmatter = {
         name: "test-skill",
@@ -900,6 +939,52 @@ Global skill content.`;
       });
 
       expect(skill.getGlobal()).toBe(true);
+    });
+
+    it("should load skill with paths as YAML list", async () => {
+      const skillDir = join(testDir, ".claude", "skills", "paths-list-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: paths-list-skill
+description: Skill with paths list
+paths:
+  - "src/**/*.ts"
+  - "test/**/*.ts"
+---
+
+This skill has YAML-list path globs.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await ClaudecodeSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "paths-list-skill",
+      });
+
+      expect(skill.getFrontmatter().paths).toEqual(["src/**/*.ts", "test/**/*.ts"]);
+    });
+
+    it("should load skill with paths as comma-separated string", async () => {
+      const skillDir = join(testDir, ".claude", "skills", "paths-string-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: paths-string-skill
+description: Skill with paths string
+paths: "src/**/*.ts,test/**/*.ts"
+---
+
+This skill has a comma-separated paths string.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await ClaudecodeSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "paths-string-skill",
+      });
+
+      expect(skill.getFrontmatter().paths).toBe("src/**/*.ts,test/**/*.ts");
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses items **1** and **2** from #1618 (review findings for PR #1604, the Claude Code skills `paths` field).

PR #1604 added `paths: z.optional(z.union([z.string(), z.array(z.string())]))` to `ClaudecodeSkillFrontmatterSchema` and wired it through `toRulesyncSkill` / `fromRulesyncSkill`, but the test suite never read `paths` back from a YAML file via `fromDir`, and the round-trip tests skipped the `""` / `[]` corner cases. This PR fills those gaps without touching production code.

Tests added:

- **`fromDir` reads a paths list** — write a `SKILL.md` with a YAML list `paths: ["src/**/*.ts", "test/**/*.ts"]`, load it via `ClaudecodeSkill.fromDir`, assert the parsed frontmatter has the expected string array.
- **`fromDir` reads a comma-separated paths string** — same shape but `paths: "src/**/*.ts,test/**/*.ts"`, assert the string is preserved verbatim (Rulesync defers comma splitting to the consumer).
- **`toRulesyncSkill` preserves `paths: ""`** — empty string is a defined value, so the conditional spread emits it in the `claudecode` section.
- **`toRulesyncSkill` preserves `paths: []`** — same, for the array form.

The empty-value tests pin down the current behavior: `frontmatter.paths !== undefined && { paths: frontmatter.paths }` keeps `""` and `[]` rather than dropping them. If a future change starts treating empty values as "absent", these tests will flag it.

## Test plan

- [x] `pnpm cicheck` (fmt + oxlint + eslint + tsgo + 5554 vitest + sync-skill-docs check + cspell + secretlint) passes locally on Node 22.
- [x] `vitest run src/features/skills/claudecode-skill.test.ts` — 68 tests pass (64 existing + 4 new).
- [x] No production code change; pure test additions in `src/features/skills/claudecode-skill.test.ts`.

Refs #1618 (items 1 and 2 of 6 — items 3 and 4 are addressed in #1649 and #1648; items 5 and 6 are out of scope).
