### PR TITLE
docs(feature-research): address #1616 follow-ups (items 1-4)

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/SKILL.md
+++ b/.rulesync/skills/rulesync-feature-research/SKILL.md
@@ -68,8 +68,15 @@ Collect:
 1. Canonical target and feature lists from `references/rulesync-source-map.md`.
 2. Rulesync support labels from README, source, processor gates, and dry-run.
 3. Official docs from the selected client map.
-4. Re-check any `No dedicated upstream ... in map` row through official docs/site,
-   then web search if needed; confirm candidate URLs with Curl or Fetch.
+4. Re-check sentinel rows through official docs/site, then web search if needed;
+   confirm candidate URLs with Curl or Fetch. Recognized sentinel phrases:
+   - `No dedicated upstream <feature> surface in map` — upstream has no
+     dedicated docs surface that this row could point at.
+   - `No Rulesync-supported <feature> target in map` — no Rulesync adapter is
+     known to target this feature.
+   - `Rulesync maps <surface>; verify upstream before expanding behavior` —
+     Rulesync ships an adapter, but the upstream docs surface is thin or
+     missing; treat as low confidence until re-verified.
 5. Client anchors for surfaces not obvious from naming rules.
 6. Dry-run output for generator gates and output roots.
 
@@ -120,9 +127,8 @@ deprecated surfaces that should be replaced. Each bullet should name the
 feature and user-visible missing capability. Write `None` only when every
 observed difference is an intentional mapping or already covered behavior.
 
-For gaps based on `No dedicated upstream ... in map` or
-`No Rulesync-supported ... in map`, re-check during the current run before
-claiming absence.
+For gaps based on any of the sentinel phrases listed in Collect step 4,
+re-check during the current run before claiming absence or low confidence.
 
 Do not list tests, fixtures, refactors, source locations, or implementation
 chores unless they are necessary to explain the capability gap. Do not write

--- a/.rulesync/skills/rulesync-feature-research/references/augmentcode.md
+++ b/.rulesync/skills/rulesync-feature-research/references/augmentcode.md
@@ -7,7 +7,7 @@
 | index         | `https://docs.augmentcode.com/`                                    | Augment documentation index                                                                      |
 | `rules`       | `https://docs.augmentcode.com/cli/rules`                           | `.augment/rules`, `~/.augment/rules`, AGENTS.md and CLAUDE.md hierarchical rules                 |
 | `ignore`      | `https://docs.augmentcode.com/cli/setup-auggie/workspace-indexing` | `.augmentignore`, `.gitignore` interaction, workspace indexing filters                           |
-| `mcp`         | No dedicated upstream MCP surface in map                           | MCP tool names appear in permissions; no Rulesync-supported AugmentCode MCP target               |
+| `mcp`         | No dedicated upstream MCP surface in map                           | MCP tool names appear in permissions                                                             |
 | `commands`    | No dedicated upstream commands surface in map                      | No Rulesync-supported AugmentCode commands target in map                                         |
 | `subagents`   | No dedicated upstream subagents surface in map                     | No Rulesync-supported AugmentCode subagents target in map                                        |
 | `skills`      | No dedicated upstream skills surface in map                        | No Rulesync-supported AugmentCode skills target in map                                           |

--- a/.rulesync/skills/rulesync-feature-research/references/cline.md
+++ b/.rulesync/skills/rulesync-feature-research/references/cline.md
@@ -11,7 +11,7 @@
 | `commands`    | `https://docs.cline.bot/core-workflows/using-commands`      | Slash commands and workflow-style reusable commands                              |
 | `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Cline subagents target in map                              |
 | `skills`      | `https://docs.cline.bot/customization/skills`               | `.cline/skills`, `~/.cline/skills`, `.clinerules/skills`, `.claude/skills`       |
-| `hooks`       | `https://docs.cline.bot/cline-cli/configuration`            | CLI configuration exposes Hooks tab; no Rulesync-supported Cline hooks target    |
+| `hooks`       | `https://docs.cline.bot/cline-cli/configuration`            | CLI configuration exposes a Hooks tab                                            |
 | `permissions` | `https://docs.cline.bot/features/auto-approve`              | Auto approve settings for read, edit, commands, browser, MCP, and request limits |
 
 ## Client Anchors

--- a/.rulesync/skills/rulesync-feature-research/references/copilotcli.md
+++ b/.rulesync/skills/rulesync-feature-research/references/copilotcli.md
@@ -12,7 +12,7 @@
 | `subagents`   | `https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli` | Custom agent profiles used as subagents, `.github/agents/*.agent.md`, `~/.copilot/agents/*.agent.md`                                   |
 | `skills`      | `https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills`                   | Agent skills in `.github/skills`, `.claude/skills`, `.agents/skills`, `~/.copilot/skills`, `~/.agents/skills`                          |
 | `hooks`       | `https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks`                    | `.github/hooks/<name>.json`, hook events, `bash`/`powershell` command entries                                                          |
-| `permissions` | `https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/allowing-tools`                 | Tool allow/deny behavior and interactive approval; no Rulesync-supported Copilot CLI permissions target                                |
+| `permissions` | `https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/allowing-tools`                 | Tool allow/deny behavior and interactive approval                                                                                      |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/deepagents.md
+++ b/.rulesync/skills/rulesync-feature-research/references/deepagents.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                                | Upstream surface                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| index         | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | Deep Agents CLI overview                                                                                         |
-| `rules`       | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | AGENTS.md files, memory, persistent project context                                                              |
-| `ignore`      | No dedicated upstream ignore surface in map                                  | No Rulesync-supported Deep Agents ignore target in map                                                           |
-| `mcp`         | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | MCP tools surfaced through CLI configuration                                                                     |
-| `commands`    | No dedicated upstream commands surface in map                                | No Rulesync-supported Deep Agents commands target in map                                                         |
-| `subagents`   | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | `task` delegation to subagents                                                                                   |
-| `skills`      | `https://docs.langchain.com/oss/javascript/deepagents/cli/memory-and-skills` | `.deepagents/skills`, `.agents/skills`, `~/.deepagents/<agent>/skills`, progressive skill loading                |
-| `hooks`       | No dedicated upstream hooks surface in map                                   | Rulesync maps `.deepagents/hooks.json`; verify upstream before expanding hook behavior                           |
-| `permissions` | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | CLI approval controls and non-interactive shell allow list                                                       |
+| Feature       | Official docs                                                                | Upstream surface                                                                                  |
+| ------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| index         | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | Deep Agents CLI overview                                                                          |
+| `rules`       | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | AGENTS.md files, memory, persistent project context                                               |
+| `ignore`      | No dedicated upstream ignore surface in map                                  | No Rulesync-supported Deep Agents ignore target in map                                            |
+| `mcp`         | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | MCP tools surfaced through CLI configuration                                                      |
+| `commands`    | No dedicated upstream commands surface in map                                | No Rulesync-supported Deep Agents commands target in map                                          |
+| `subagents`   | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | `task` delegation to subagents                                                                    |
+| `skills`      | `https://docs.langchain.com/oss/javascript/deepagents/cli/memory-and-skills` | `.deepagents/skills`, `.agents/skills`, `~/.deepagents/<agent>/skills`, progressive skill loading |
+| `hooks`       | No dedicated upstream hooks surface in map                                   | Rulesync maps `.deepagents/hooks.json`; verify upstream before expanding hook behavior            |
+| `permissions` | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | CLI approval controls and non-interactive shell allow list                                        |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/deepagents.md
+++ b/.rulesync/skills/rulesync-feature-research/references/deepagents.md
@@ -12,7 +12,7 @@
 | `subagents`   | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | `task` delegation to subagents                                                                                   |
 | `skills`      | `https://docs.langchain.com/oss/javascript/deepagents/cli/memory-and-skills` | `.deepagents/skills`, `.agents/skills`, `~/.deepagents/<agent>/skills`, progressive skill loading                |
 | `hooks`       | No dedicated upstream hooks surface in map                                   | Rulesync maps `.deepagents/hooks.json`; verify upstream before expanding hook behavior                           |
-| `permissions` | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | CLI approval controls and non-interactive shell allow list; no Rulesync-supported Deep Agents permissions target |
+| `permissions` | `https://docs.langchain.com/oss/javascript/deepagents/cli/overview`          | CLI approval controls and non-interactive shell allow list                                                       |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
+++ b/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
@@ -12,7 +12,7 @@
 | `subagents`   | `https://docs.factory.ai/cli/configuration/custom-droids` | Custom droids in `.factory/droids` and `~/.factory/droids`                                                       |
 | `skills`      | `https://docs.factory.ai/cli/configuration/skills`        | `.factory/skills/<name>/SKILL.md`, `skill.mdx`, invocation controls                                              |
 | `hooks`       | `https://docs.factory.ai/reference/hooks-reference`       | `.factory/settings.json`, hook events, matcher groups, command hooks                                             |
-| `permissions` | `https://docs.factory.ai/cli/configuration/settings`      | `commandAllowlist`, `commandDenylist`, autonomy settings; no Rulesync-supported Factory Droid permissions target |
+| `permissions` | `https://docs.factory.ai/cli/configuration/settings`      | `commandAllowlist`, `commandDenylist`, autonomy settings                                                         |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
+++ b/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                             | Upstream surface                                                                                                 |
-| ------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| index         | `https://docs.factory.ai/cli/getting-started/quickstart`  | Factory Droid CLI documentation                                                                                  |
-| `rules`       | `https://docs.factory.ai/cli/configuration/agents-md`     | `AGENTS.md`, nested AGENTS.md, personal `~/.factory/AGENTS.md`                                                   |
-| `ignore`      | No dedicated upstream ignore surface in map               | No Rulesync-supported Factory Droid ignore target in map                                                         |
-| `mcp`         | `https://docs.factory.ai/cli/configuration/mcp`           | `.factory/mcp.json`, `~/.factory/mcp.json`, stdio and HTTP servers                                               |
-| `commands`    | `https://docs.factory.ai/cli/configuration/skills`        | Legacy `.factory/commands` files, now merged with skills                                                         |
-| `subagents`   | `https://docs.factory.ai/cli/configuration/custom-droids` | Custom droids in `.factory/droids` and `~/.factory/droids`                                                       |
-| `skills`      | `https://docs.factory.ai/cli/configuration/skills`        | `.factory/skills/<name>/SKILL.md`, `skill.mdx`, invocation controls                                              |
-| `hooks`       | `https://docs.factory.ai/reference/hooks-reference`       | `.factory/settings.json`, hook events, matcher groups, command hooks                                             |
-| `permissions` | `https://docs.factory.ai/cli/configuration/settings`      | `commandAllowlist`, `commandDenylist`, autonomy settings                                                         |
+| Feature       | Official docs                                             | Upstream surface                                                     |
+| ------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| index         | `https://docs.factory.ai/cli/getting-started/quickstart`  | Factory Droid CLI documentation                                      |
+| `rules`       | `https://docs.factory.ai/cli/configuration/agents-md`     | `AGENTS.md`, nested AGENTS.md, personal `~/.factory/AGENTS.md`       |
+| `ignore`      | No dedicated upstream ignore surface in map               | No Rulesync-supported Factory Droid ignore target in map             |
+| `mcp`         | `https://docs.factory.ai/cli/configuration/mcp`           | `.factory/mcp.json`, `~/.factory/mcp.json`, stdio and HTTP servers   |
+| `commands`    | `https://docs.factory.ai/cli/configuration/skills`        | Legacy `.factory/commands` files, now merged with skills             |
+| `subagents`   | `https://docs.factory.ai/cli/configuration/custom-droids` | Custom droids in `.factory/droids` and `~/.factory/droids`           |
+| `skills`      | `https://docs.factory.ai/cli/configuration/skills`        | `.factory/skills/<name>/SKILL.md`, `skill.mdx`, invocation controls  |
+| `hooks`       | `https://docs.factory.ai/reference/hooks-reference`       | `.factory/settings.json`, hook events, matcher groups, command hooks |
+| `permissions` | `https://docs.factory.ai/cli/configuration/settings`      | `commandAllowlist`, `commandDenylist`, autonomy settings             |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/goose.md
+++ b/.rulesync/skills/rulesync-feature-research/references/goose.md
@@ -7,7 +7,7 @@
 | index         | `https://goose-docs.ai/docs/category/getting-started/`                    | Goose documentation index                                             |
 | `rules`       | `https://goose-docs.ai/docs/guides/context-engineering/using-goosehints/` | `.goosehints`, `AGENTS.md`, nested hints                              |
 | `ignore`      | `https://goose-docs.ai/docs/guides/using-gooseignore/`                    | `.gooseignore`, global `~/.config/goose/.gooseignore`, local override |
-| `mcp`         | No dedicated upstream MCP surface in map                                  | Upstream extensions exist; no Rulesync-supported Goose MCP target     |
+| `mcp`         | No dedicated upstream MCP surface in map                                  | Upstream extensions exist                                             |
 | `commands`    | No dedicated upstream commands surface in map                             | No Rulesync-supported Goose commands target in map                    |
 | `subagents`   | No dedicated upstream subagents surface in map                            | No Rulesync-supported Goose subagents target in map                   |
 | `skills`      | No dedicated upstream skills surface in map                               | No Rulesync-supported Goose skills target in map                      |

--- a/.rulesync/skills/rulesync-feature-research/references/junie.md
+++ b/.rulesync/skills/rulesync-feature-research/references/junie.md
@@ -12,7 +12,7 @@
 | `subagents`   | `https://junie.jetbrains.com/docs/parameters.html`                  | Agent location flags and default per-user/per-project agent discovery        |
 | `skills`      | `https://junie.jetbrains.com/docs/parameters.html`                  | Skill location flags and default per-user/per-project skill discovery        |
 | `hooks`       | No dedicated upstream hooks surface in map                          | No Rulesync-supported Junie hooks target in map                              |
-| `permissions` | `https://junie.jetbrains.com/docs/action-allowlist.html`            | Action Allowlist; no Rulesync-supported Junie permissions target             |
+| `permissions` | `https://junie.jetbrains.com/docs/action-allowlist.html`            | Action Allowlist                                                             |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/kilo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/kilo.md
@@ -6,10 +6,10 @@
 | ------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | index         | `https://kilo.ai/docs/`                                                | Kilo Code documentation index                                                               |
 | `rules`       | `https://kilo.ai/docs/customize/custom-instructions`                   | Custom instructions, `.kilo/rules-*`, `.kilorules-*`, mode-specific instructions            |
-| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface; Rulesync currently maps `.kiloignore`             |
+| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface                                                    |
 | `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions  |
-| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces; Rulesync maps command files                       |
-| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; no README-supported Rulesync Kilo subagents target                     |
+| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces                                                    |
+| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; adapter exists in source, but no README-supported Rulesync Kilo subagents target |
 | `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories         |
 | `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                |
 | `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys |

--- a/.rulesync/skills/rulesync-feature-research/references/kilo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/kilo.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                          | Upstream surface                                                                                      |
-| ------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| index         | `https://kilo.ai/docs/`                                                | Kilo Code documentation index                                                                         |
-| `rules`       | `https://kilo.ai/docs/customize/custom-instructions`                   | Custom instructions, `.kilo/rules-*`, `.kilorules-*`, mode-specific instructions                      |
-| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface                                                              |
-| `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions            |
-| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces                                                              |
-| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; adapter exists in source, but no README-supported Rulesync Kilo subagents target |
-| `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories                   |
-| `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                          |
-| `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys           |
+| Feature       | Official docs                                                          | Upstream surface                                                                                                 |
+| ------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| index         | `https://kilo.ai/docs/`                                                | Kilo Code documentation index                                                                                    |
+| `rules`       | `https://kilo.ai/docs/customize/custom-instructions`                   | Custom instructions, `.kilo/rules-*`, `.kilorules-*`, mode-specific instructions                                 |
+| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface; Rulesync maps `.kiloignore`, verify upstream before expanding behavior |
+| `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions                       |
+| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces                                                                         |
+| `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; adapter exists in source, but no README-supported Rulesync Kilo subagents target            |
+| `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories                              |
+| `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                                     |
+| `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys                      |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/kilo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/kilo.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                          | Upstream surface                                                                            |
-| ------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| index         | `https://kilo.ai/docs/`                                                | Kilo Code documentation index                                                               |
-| `rules`       | `https://kilo.ai/docs/customize/custom-instructions`                   | Custom instructions, `.kilo/rules-*`, `.kilorules-*`, mode-specific instructions            |
-| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface                                                    |
-| `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions  |
-| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces                                                    |
+| Feature       | Official docs                                                          | Upstream surface                                                                                      |
+| ------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| index         | `https://kilo.ai/docs/`                                                | Kilo Code documentation index                                                                         |
+| `rules`       | `https://kilo.ai/docs/customize/custom-instructions`                   | Custom instructions, `.kilo/rules-*`, `.kilorules-*`, mode-specific instructions                      |
+| `ignore`      | `https://kilo.ai/docs/customize/context/kilocodeignore`                | `.kilocodeignore` access-control surface                                                              |
+| `mcp`         | `https://kilo.ai/docs/automate/mcp/using-in-kilo-code`                 | `kilo.jsonc`, `.kilo/kilo.jsonc`, global `~/.config/kilo/kilo.jsonc`, MCP tool permissions            |
+| `commands`    | `https://kilo.ai/docs/customize/custom-modes`                          | Mode and workflow customization surfaces                                                              |
 | `subagents`   | `https://kilo.ai/docs/customize/custom-subagents`                      | Custom modes/agents; adapter exists in source, but no README-supported Rulesync Kilo subagents target |
-| `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories         |
-| `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                |
-| `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys |
+| `skills`      | `https://kilo.ai/docs/customize/skills`                                | `.kilocode/skills`, `~/.kilocode/skills`, mode-specific `skills-{mode}` directories                   |
+| `hooks`       | No dedicated upstream hooks surface in map                             | Adapter exists in source, but no README-supported Rulesync Kilo hooks target                          |
+| `permissions` | `https://kilo.ai/docs/getting-started/settings/auto-approving-actions` | `kilo.jsonc` permission values, `allow`/`ask`/`deny`, built-in and MCP tool permission keys           |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/pi.md
+++ b/.rulesync/skills/rulesync-feature-research/references/pi.md
@@ -12,7 +12,7 @@
 | `subagents`   | No dedicated upstream subagents surface in map   | No Rulesync-supported Pi subagents target in map                                                 |
 | `skills`      | `https://pi.dev/docs/latest/skills`              | `.pi/skills`, `~/.pi/agent/skills`, `.agents/skills`, packages, settings, `--skill`              |
 | `hooks`       | No dedicated upstream hooks surface in map       | No Rulesync-supported Pi hooks target in map                                                     |
-| `permissions` | No dedicated upstream permissions surface in map | Tool selection and settings exist upstream; no Rulesync-supported Pi permissions target          |
+| `permissions` | No dedicated upstream permissions surface in map | Tool selection and settings exist upstream                                                       |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/qwencode.md
+++ b/.rulesync/skills/rulesync-feature-research/references/qwencode.md
@@ -7,10 +7,10 @@
 | index         | `https://qwenlm.github.io/qwen-code-docs/en/`                                 | Qwen Code documentation index                                                                    |
 | `rules`       | `https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/`           | Context files such as `QWEN.md`, hierarchical instructional context                              |
 | `ignore`      | `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/` | `.qwenignore`, `context.fileFiltering.respectQwenIgnore`                                         |
-| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`; no README-supported Rulesync Qwen Code MCP target                  |
-| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist; no Rulesync-supported Qwen Code commands target           |
-| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents; no Rulesync-supported Qwen Code subagents target                  |
-| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory; no Rulesync-supported Qwen Code skills target |
+| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`                                                                     |
+| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist                                                            |
+| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents                                                                    |
+| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory                                                |
 | `hooks`       | No dedicated upstream hooks surface in map                                    | No Rulesync-supported Qwen Code hooks target in map                                              |
 | `permissions` | `https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/`    | Approval mode and tool approval controls                                                         |
 

--- a/.rulesync/skills/rulesync-feature-research/references/qwencode.md
+++ b/.rulesync/skills/rulesync-feature-research/references/qwencode.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                                 | Upstream surface                                                                                 |
-| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| index         | `https://qwenlm.github.io/qwen-code-docs/en/`                                 | Qwen Code documentation index                                                                    |
-| `rules`       | `https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/`           | Context files such as `QWEN.md`, hierarchical instructional context                              |
-| `ignore`      | `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/` | `.qwenignore`, `context.fileFiltering.respectQwenIgnore`                                         |
-| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`                                                                     |
-| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist                                                            |
-| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents                                                                    |
-| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory                                                |
-| `hooks`       | No dedicated upstream hooks surface in map                                    | No Rulesync-supported Qwen Code hooks target in map                                              |
-| `permissions` | `https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/`    | Approval mode and tool approval controls                                                         |
+| Feature       | Official docs                                                                 | Upstream surface                                                    |
+| ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| index         | `https://qwenlm.github.io/qwen-code-docs/en/`                                 | Qwen Code documentation index                                       |
+| `rules`       | `https://qwenlm.github.io/qwen-code-docs/en/users/features/memory/`           | Context files such as `QWEN.md`, hierarchical instructional context |
+| `ignore`      | `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/qwen-ignore/` | `.qwenignore`, `context.fileFiltering.respectQwenIgnore`            |
+| `mcp`         | `https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/`              | `settings.json` `mcpServers`                                        |
+| `commands`    | No dedicated upstream commands surface in map                                 | Upstream slash command settings exist                               |
+| `subagents`   | No dedicated upstream subagents surface in map                                | Upstream may expose SubAgents                                       |
+| `skills`      | `https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/`           | `.qwen/skills` noted in project `.qwen` directory                   |
+| `hooks`       | No dedicated upstream hooks surface in map                                    | No Rulesync-supported Qwen Code hooks target in map                 |
+| `permissions` | `https://qwenlm.github.io/qwen-code-docs/en/users/features/approval-mode/`    | Approval mode and tool approval controls                            |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/replit.md
+++ b/.rulesync/skills/rulesync-feature-research/references/replit.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                        | Upstream surface                                                                     |
-| ------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| index         | `https://docs.replit.com/core-concepts/agent`        | Replit Agent documentation                                                           |
-| `rules`       | `https://docs.replit.com/core-concepts/agent`        | Replit Agent project context                                                         |
-| `ignore`      | No dedicated upstream ignore surface in map          | No Rulesync-supported Replit ignore target in map                                    |
-| `mcp`         | No dedicated upstream MCP surface in map             | No Rulesync-supported Replit MCP target in map                                       |
-| `commands`    | No dedicated upstream commands surface in map        | No Rulesync-supported Replit commands target in map                                  |
-| `subagents`   | No dedicated upstream subagents surface in map       | No Rulesync-supported Replit subagents target in map                                 |
-| `skills`      | `https://docs.replit.com/core-concepts/agent/skills` | Project `/.agents/skills`, Agent Skills standard, Skills pane and `npx skills`       |
-| `hooks`       | No dedicated upstream hooks surface in map           | No Rulesync-supported Replit hooks target in map                                     |
-| `permissions` | No dedicated upstream permissions surface in map     | No Rulesync-supported Replit permissions target in map                               |
+| Feature       | Official docs                                        | Upstream surface                                                               |
+| ------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------ |
+| index         | `https://docs.replit.com/core-concepts/agent`        | Replit Agent documentation                                                     |
+| `rules`       | `https://docs.replit.com/core-concepts/agent`        | Replit Agent project context                                                   |
+| `ignore`      | No dedicated upstream ignore surface in map          | No Rulesync-supported Replit ignore target in map                              |
+| `mcp`         | No dedicated upstream MCP surface in map             | No Rulesync-supported Replit MCP target in map                                 |
+| `commands`    | No dedicated upstream commands surface in map        | No Rulesync-supported Replit commands target in map                            |
+| `subagents`   | No dedicated upstream subagents surface in map       | No Rulesync-supported Replit subagents target in map                           |
+| `skills`      | `https://docs.replit.com/core-concepts/agent/skills` | Project `/.agents/skills`, Agent Skills standard, Skills pane and `npx skills` |
+| `hooks`       | No dedicated upstream hooks surface in map           | No Rulesync-supported Replit hooks target in map                               |
+| `permissions` | No dedicated upstream permissions surface in map     | No Rulesync-supported Replit permissions target in map                         |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/replit.md
+++ b/.rulesync/skills/rulesync-feature-research/references/replit.md
@@ -5,9 +5,9 @@
 | Feature       | Official docs                                        | Upstream surface                                                                     |
 | ------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | index         | `https://docs.replit.com/core-concepts/agent`        | Replit Agent documentation                                                           |
-| `rules`       | `https://docs.replit.com/core-concepts/agent`        | Replit Agent project context; Rulesync maps a Replit rules target                    |
+| `rules`       | `https://docs.replit.com/core-concepts/agent`        | Replit Agent project context                                                         |
 | `ignore`      | No dedicated upstream ignore surface in map          | No Rulesync-supported Replit ignore target in map                                    |
-| `mcp`         | `https://docs.replit.com/tutorials/agent-skills`     | MCP is discussed as complementary to skills; no Rulesync-supported Replit MCP target |
+| `mcp`         | No dedicated upstream MCP surface in map             | No Rulesync-supported Replit MCP target in map                                       |
 | `commands`    | No dedicated upstream commands surface in map        | No Rulesync-supported Replit commands target in map                                  |
 | `subagents`   | No dedicated upstream subagents surface in map       | No Rulesync-supported Replit subagents target in map                                 |
 | `skills`      | `https://docs.replit.com/core-concepts/agent/skills` | Project `/.agents/skills`, Agent Skills standard, Skills pane and `npx skills`       |

--- a/.rulesync/skills/rulesync-feature-research/references/roo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/roo.md
@@ -9,10 +9,10 @@
 | `ignore`      | `https://docs.roocode.com/features/rooignore`            | `.rooignore` file surface                                                               |
 | `mcp`         | `https://docs.roocode.com/features/mcp/using-mcp-in-roo` | MCP server configuration                                                                |
 | `commands`    | `https://docs.roocode.com/features/slash-commands`       | `.roo/commands` reusable command files                                                  |
-| `subagents`   | `https://docs.roocode.com/features/custom-modes`         | Custom modes / orchestrator-style delegation; Rulesync maps this as simulated subagents |
+| `subagents`   | `https://docs.roocode.com/features/custom-modes`         | Custom modes and orchestrator-style delegation                                          |
 | `skills`      | `https://docs.roocode.com/features/skills`               | Roo skills surface                                                                      |
 | `hooks`       | No dedicated upstream hooks surface in map               | No Rulesync-supported Roo hooks target in map                                           |
-| `permissions` | No dedicated upstream permissions surface in map         | Roo modes can constrain tool groups, but no Rulesync-supported Roo permissions target   |
+| `permissions` | No dedicated upstream permissions surface in map         | Roo modes can constrain tool groups                                                     |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/roo.md
+++ b/.rulesync/skills/rulesync-feature-research/references/roo.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                            | Upstream surface                                                                        |
-| ------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| index         | `https://docs.roocode.com/`                              | Roo Code documentation index and shutdown notice                                        |
-| `rules`       | `https://docs.roocode.com/features/custom-instructions`  | `.roo/rules`, `.roorules`, mode-specific rules, AGENTS.md compatibility                 |
-| `ignore`      | `https://docs.roocode.com/features/rooignore`            | `.rooignore` file surface                                                               |
-| `mcp`         | `https://docs.roocode.com/features/mcp/using-mcp-in-roo` | MCP server configuration                                                                |
-| `commands`    | `https://docs.roocode.com/features/slash-commands`       | `.roo/commands` reusable command files                                                  |
-| `subagents`   | `https://docs.roocode.com/features/custom-modes`         | Custom modes and orchestrator-style delegation                                          |
-| `skills`      | `https://docs.roocode.com/features/skills`               | Roo skills surface                                                                      |
-| `hooks`       | No dedicated upstream hooks surface in map               | No Rulesync-supported Roo hooks target in map                                           |
-| `permissions` | No dedicated upstream permissions surface in map         | Roo modes can constrain tool groups                                                     |
+| Feature       | Official docs                                            | Upstream surface                                                        |
+| ------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| index         | `https://docs.roocode.com/`                              | Roo Code documentation index and shutdown notice                        |
+| `rules`       | `https://docs.roocode.com/features/custom-instructions`  | `.roo/rules`, `.roorules`, mode-specific rules, AGENTS.md compatibility |
+| `ignore`      | `https://docs.roocode.com/features/rooignore`            | `.rooignore` file surface                                               |
+| `mcp`         | `https://docs.roocode.com/features/mcp/using-mcp-in-roo` | MCP server configuration                                                |
+| `commands`    | `https://docs.roocode.com/features/slash-commands`       | `.roo/commands` reusable command files                                  |
+| `subagents`   | `https://docs.roocode.com/features/custom-modes`         | Custom modes and orchestrator-style delegation                          |
+| `skills`      | `https://docs.roocode.com/features/skills`               | Roo skills surface                                                      |
+| `hooks`       | No dedicated upstream hooks surface in map               | No Rulesync-supported Roo hooks target in map                           |
+| `permissions` | No dedicated upstream permissions surface in map         | Roo modes can constrain tool groups                                     |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/rovodev.md
+++ b/.rulesync/skills/rulesync-feature-research/references/rovodev.md
@@ -12,7 +12,7 @@
 | `subagents`   | `https://support.atlassian.com/rovo/docs/use-subagents-in-rovo-dev-cli/`            | `.rovodev/subagents`, `~/.rovodev/subagents`, Markdown files with YAML frontmatter           |
 | `skills`      | `https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/`    | `.rovodev/skills`, Agent Skills directories                                                  |
 | `hooks`       | No dedicated upstream hooks surface in map                                          | No Rulesync-supported Rovo Dev hooks target in map                                           |
-| `permissions` | `https://support.atlassian.com/rovo/docs/use-tools-in-rovo-dev-cli/`                | Tool controls exist upstream; no Rulesync-supported Rovo Dev permissions target              |
+| `permissions` | `https://support.atlassian.com/rovo/docs/use-tools-in-rovo-dev-cli/`                | Tool controls exist upstream                                                                 |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/windsurf.md
+++ b/.rulesync/skills/rulesync-feature-research/references/windsurf.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                         | Upstream surface                                                                     |
-| ------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| index         | `https://docs.windsurf.com/`                          | Windsurf documentation index                                                         |
-| `rules`       | `https://docs.windsurf.com/windsurf/cascade/memories` | `.windsurf/rules/*.md`, global rules, AGENTS.md, activation modes                    |
-| `ignore`      | No dedicated upstream ignore surface in map           | Rulesync maps a Windsurf ignore target; verify upstream before expanding behavior    |
-| `mcp`         | `https://docs.windsurf.com/windsurf/cascade/mcp`      | MCP server configuration with stdio, HTTP, and SSE transports                        |
-| `commands`    | `https://docs.windsurf.com/windsurf/cascade/workflows` | Cascade workflows as Markdown files invoked via slash commands                      |
-| `subagents`   | No dedicated upstream subagents surface in map        | No Rulesync-supported Windsurf subagents target in map                               |
-| `skills`      | `https://docs.windsurf.com/windsurf/cascade/skills`   | Skills as bundled procedures with supporting files                                   |
-| `hooks`       | `https://docs.windsurf.com/windsurf/cascade/hooks`    | Cascade pre/post hooks for shell commands at workflow events                         |
-| `permissions` | No dedicated upstream permissions surface in map      | No Rulesync-supported Windsurf permissions target in map                             |
+| Feature       | Official docs                                          | Upstream surface                                                                  |
+| ------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| index         | `https://docs.windsurf.com/`                           | Windsurf documentation index                                                      |
+| `rules`       | `https://docs.windsurf.com/windsurf/cascade/memories`  | `.windsurf/rules/*.md`, global rules, AGENTS.md, activation modes                 |
+| `ignore`      | No dedicated upstream ignore surface in map            | Rulesync maps a Windsurf ignore target; verify upstream before expanding behavior |
+| `mcp`         | `https://docs.windsurf.com/windsurf/cascade/mcp`       | MCP server configuration with stdio, HTTP, and SSE transports                     |
+| `commands`    | `https://docs.windsurf.com/windsurf/cascade/workflows` | Cascade workflows as Markdown files invoked via slash commands                    |
+| `subagents`   | No dedicated upstream subagents surface in map         | No Rulesync-supported Windsurf subagents target in map                            |
+| `skills`      | `https://docs.windsurf.com/windsurf/cascade/skills`    | Skills as bundled procedures with supporting files                                |
+| `hooks`       | `https://docs.windsurf.com/windsurf/cascade/hooks`     | Cascade pre/post hooks for shell commands at workflow events                      |
+| `permissions` | No dedicated upstream permissions surface in map       | No Rulesync-supported Windsurf permissions target in map                          |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/windsurf.md
+++ b/.rulesync/skills/rulesync-feature-research/references/windsurf.md
@@ -7,11 +7,11 @@
 | index         | `https://docs.windsurf.com/`                          | Windsurf documentation index                                                         |
 | `rules`       | `https://docs.windsurf.com/windsurf/cascade/memories` | `.windsurf/rules/*.md`, global rules, AGENTS.md, activation modes                    |
 | `ignore`      | No dedicated upstream ignore surface in map           | Rulesync maps a Windsurf ignore target; verify upstream before expanding behavior    |
-| `mcp`         | No dedicated upstream MCP surface in map              | No Rulesync-supported Windsurf MCP target in map                                     |
-| `commands`    | `https://docs.windsurf.com/windsurf/cascade/memories` | Workflows exist upstream; no Rulesync-supported Windsurf commands target             |
+| `mcp`         | `https://docs.windsurf.com/windsurf/cascade/mcp`      | MCP server configuration with stdio, HTTP, and SSE transports                        |
+| `commands`    | `https://docs.windsurf.com/windsurf/cascade/workflows` | Cascade workflows as Markdown files invoked via slash commands                      |
 | `subagents`   | No dedicated upstream subagents surface in map        | No Rulesync-supported Windsurf subagents target in map                               |
-| `skills`      | `https://docs.windsurf.com/windsurf/cascade/memories` | Skills as bundled procedures with supporting files; Rulesync maps `.windsurf/skills` |
-| `hooks`       | No dedicated upstream hooks surface in map            | No Rulesync-supported Windsurf hooks target in map                                   |
+| `skills`      | `https://docs.windsurf.com/windsurf/cascade/skills`   | Skills as bundled procedures with supporting files                                   |
+| `hooks`       | `https://docs.windsurf.com/windsurf/cascade/hooks`    | Cascade pre/post hooks for shell commands at workflow events                         |
 | `permissions` | No dedicated upstream permissions surface in map      | No Rulesync-supported Windsurf permissions target in map                             |
 
 ## Client Anchors

--- a/.rulesync/skills/rulesync-feature-research/references/zed.md
+++ b/.rulesync/skills/rulesync-feature-research/references/zed.md
@@ -2,17 +2,17 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                               | Upstream surface                                                                            |
-| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| index         | `https://zed.dev/docs/ai/overview`                          | Zed AI documentation index                                                                  |
-| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library                                         |
-| `ignore`      | `https://zed.dev/docs/reference/all-settings#private-files` | `.zed/settings.json`, `private_files` glob list                                             |
-| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents                                                        |
-| `commands`    | No dedicated upstream commands surface in map               | No Rulesync-supported Zed commands target in map                                            |
-| `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Zed subagents target in map                                           |
-| `skills`      | No dedicated upstream skills surface in map                 | No Rulesync-supported Zed skills target in map                                              |
-| `hooks`       | No dedicated upstream hooks surface in map                  | No Rulesync-supported Zed hooks target in map                                               |
-| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`                                                                    |
+| Feature       | Official docs                                               | Upstream surface                                    |
+| ------------- | ----------------------------------------------------------- | --------------------------------------------------- |
+| index         | `https://zed.dev/docs/ai/overview`                          | Zed AI documentation index                          |
+| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library |
+| `ignore`      | `https://zed.dev/docs/reference/all-settings#private-files` | `.zed/settings.json`, `private_files` glob list     |
+| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents                |
+| `commands`    | No dedicated upstream commands surface in map               | No Rulesync-supported Zed commands target in map    |
+| `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Zed subagents target in map   |
+| `skills`      | No dedicated upstream skills surface in map                 | No Rulesync-supported Zed skills target in map      |
+| `hooks`       | No dedicated upstream hooks surface in map                  | No Rulesync-supported Zed hooks target in map       |
+| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`                            |
 
 ## Client Anchors
 

--- a/.rulesync/skills/rulesync-feature-research/references/zed.md
+++ b/.rulesync/skills/rulesync-feature-research/references/zed.md
@@ -5,14 +5,14 @@
 | Feature       | Official docs                                               | Upstream surface                                                                            |
 | ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | index         | `https://zed.dev/docs/ai/overview`                          | Zed AI documentation index                                                                  |
-| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library; no Rulesync-supported Zed rules target |
+| `rules`       | `https://zed.dev/docs/ai/rules`                             | `.rules`, AGENTS.md-compatible files, Rules Library                                         |
 | `ignore`      | `https://zed.dev/docs/reference/all-settings#private-files` | `.zed/settings.json`, `private_files` glob list                                             |
-| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents; no Rulesync-supported Zed MCP target                  |
+| `mcp`         | `https://zed.dev/docs/ai/configuration`                     | AI configuration and external agents                                                        |
 | `commands`    | No dedicated upstream commands surface in map               | No Rulesync-supported Zed commands target in map                                            |
 | `subagents`   | No dedicated upstream subagents surface in map              | No Rulesync-supported Zed subagents target in map                                           |
 | `skills`      | No dedicated upstream skills surface in map                 | No Rulesync-supported Zed skills target in map                                              |
 | `hooks`       | No dedicated upstream hooks surface in map                  | No Rulesync-supported Zed hooks target in map                                               |
-| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`; no Rulesync-supported Zed permissions target                      |
+| `permissions` | `https://zed.dev/docs/ai/agent-settings`                    | `agent.tool_permissions`                                                                    |
 
 ## Client Anchors
 


### PR DESCRIPTION
Refs #1616

## Summary

Addresses 4 of 5 follow-ups from #1616 in a single pass. Item 5 (sync-check script) is marked optional in the issue and is skipped here.

- **Item 1** — Strip `; no (README-)supported Rulesync … target` clauses from `Official docs` / `Upstream surface` columns across cline, qwencode, zed, factorydroid, copilotcli, augmentcode, pi, junie, roo, rovodev, goose, deepagents, kilo, replit. Rulesync-support deltas belong in the run-time Capability Gaps section per SKILL.md.
- **Item 2** — Re-verify URLs with curl per SKILL.md Collect step 4. Codex CLI subagents/skills/hooks pages all resolve as-is. Replit `mcp` downgraded to sentinel (old URL was a Skills tutorial, not MCP). Windsurf `mcp` / `commands` / `skills` / `hooks` swapped to dedicated Cascade docs.
- **Item 3** — Mirror the hedged hooks phrasing in `kilo.md` subagents row so it reads consistently (`KiloSubagent` is registered in `subagents-processor.ts`).
- **Item 4** — Codify the third sentinel `Rulesync maps X; verify upstream before expanding behavior` in SKILL.md Collect step 4, and simplify the Capability Gaps caveat to reference the documented sentinel list.

Post-review touch-up: Cursor flagged that Item 1 dropped a concrete capability-gap signal on `kilo.md` ignore. Restored using the newly documented third sentinel, since upstream uses `.kilocodeignore` while `src/features/ignore/kilo-ignore.ts` maps `.kiloignore`.

## References

- #1611 introduced the SKILL.md re-check rule and the maps this PR cleans up
- #1646 / #1647 / #1651 — prior narrow-scope drafts for items 3 / 1 / 2

## Test plan

- [x] `pnpm cicheck`
- [x] curl re-check for every URL changed in Item 2
