### PR TITLE
ci(dependabot): add Docker ecosystem and switch reviewers to assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    reviewers:
+    assignees:
       - "dyoshikawa"
       - "cm-dyoshikawa"
     allow:
@@ -52,6 +52,28 @@ updates:
     labels:
       - "ci"
       - "automated"
-    reviewers:
+    assignees:
+      - "dyoshikawa"
+      - "cm-dyoshikawa"
+
+  # Automatic updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 1
+    groups:
+      all-docker:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "automated"
+    assignees:
       - "dyoshikawa"
       - "cm-dyoshikawa"


### PR DESCRIPTION
## Summary

- Add Docker ecosystem updates for `/.devcontainer` with weekly schedule, grouped updates, and a 1-day cooldown
- Switch existing npm and github-actions entries from `reviewers` to `assignees` (Dependabot deprecated the `reviewers` field)

## Test plan

- [x] `pnpm cicheck` passes locally
- [ ] Verify Dependabot picks up the new Docker configuration on the next scheduled run
- [ ] Confirm new PRs are assigned (rather than requesting review) to the listed users