### PR TITLE
ci(draft-release): pin opencode action to v1.14.30

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,7 +53,7 @@ jobs:
           input-text: ${{ inputs.model }}
 
       - name: Run OpenCode to draft release
-        uses: anomalyco/opencode/github@d7a6e1daaf2271bcd0b611fbb27d4956806e475a # v1.15.5
+        uses: anomalyco/opencode/github@eb4219304358a9b70aa73a61433f8de2eb9e5c95 # v1.14.30
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}


### PR DESCRIPTION
## Summary
- Downgrade `anomalyco/opencode/github` action in the draft-release workflow from v1.15.5 back to v1.14.30 to avoid issues introduced in the newer release.

## Test plan
- [ ] Trigger the draft-release workflow manually and confirm it completes successfully with the pinned version.