### PR TITLE
fix(hooks): normalize bare "*" matcher to ".*" in OpenCode/Kilo generator

### DIFF
--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -148,7 +148,6 @@ describe("KiloHooks", () => {
       const content = kiloHooks.getFileContent();
       expect(content).toContain('new RegExp(".*")');
       expect(content).toContain('new RegExp("Read*")');
-      expect(content).not.toContain("const __re =");
       expect(content).toContain("all-tools.sh");
       expect(content).toContain("read-tools.sh");
     });

--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -121,6 +121,37 @@ describe("KiloHooks", () => {
       expect(content).toContain(".rulesync/hooks/lint.sh");
     });
 
+    it("should normalize only bare wildcard matcher to regex match-all pattern", () => {
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", command: "all-tools.sh", matcher: "*" },
+            { type: "command", command: "read-tools.sh", matcher: "Read*" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const kiloHooks = KiloHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = kiloHooks.getFileContent();
+      expect(content).toContain('new RegExp(".*")');
+      expect(content).toContain('new RegExp("Read*")');
+      expect(content).toContain("all-tools.sh");
+      expect(content).toContain("read-tools.sh");
+    });
+
     it("should generate tool event handlers without matcher when not specified", () => {
       const config = {
         version: 1,

--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -148,6 +148,7 @@ describe("KiloHooks", () => {
       const content = kiloHooks.getFileContent();
       expect(content).toContain('new RegExp(".*")');
       expect(content).toContain('new RegExp("Read*")');
+      expect(content).not.toContain("const __re =");
       expect(content).toContain("all-tools.sh");
       expect(content).toContain("read-tools.sh");
     });

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -148,6 +148,7 @@ describe("OpencodeHooks", () => {
       const content = opencodeHooks.getFileContent();
       expect(content).toContain('new RegExp(".*")');
       expect(content).toContain('new RegExp("Read*")');
+      expect(content).not.toContain("const __re =");
       expect(content).toContain("all-tools.sh");
       expect(content).toContain("read-tools.sh");
     });

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -121,6 +121,37 @@ describe("OpencodeHooks", () => {
       expect(content).toContain(".rulesync/hooks/lint.sh");
     });
 
+    it("should normalize only bare wildcard matcher to regex match-all pattern", () => {
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", command: "all-tools.sh", matcher: "*" },
+            { type: "command", command: "read-tools.sh", matcher: "Read*" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = opencodeHooks.getFileContent();
+      expect(content).toContain('new RegExp(".*")');
+      expect(content).toContain('new RegExp("Read*")');
+      expect(content).toContain("all-tools.sh");
+      expect(content).toContain("read-tools.sh");
+    });
+
     it("should generate tool event handlers without matcher when not specified", () => {
       const config = {
         version: 1,

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -148,7 +148,6 @@ describe("OpencodeHooks", () => {
       const content = opencodeHooks.getFileContent();
       expect(content).toContain('new RegExp(".*")');
       expect(content).toContain('new RegExp("Read*")');
-      expect(content).not.toContain("const __re =");
       expect(content).toContain("all-tools.sh");
       expect(content).toContain("read-tools.sh");
     });

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -92,7 +92,8 @@ export function generateOpencodeStylePluginCode(
       const escapedCommand = escapeForTemplateLiteral(handler.command);
       if (handler.matcher) {
         const safeMatcher = validateAndSanitizeMatcher(handler.matcher);
-        lines.push(`      if (new RegExp("${safeMatcher}").test(input.tool)) {`);
+        lines.push(`      const __re = new RegExp("${safeMatcher}");`);
+        lines.push(`      if (__re.test(input.tool)) {`);
         lines.push(`        await $\`${escapedCommand}\`;`);
         lines.push("      }");
       } else {

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -92,8 +92,7 @@ export function generateOpencodeStylePluginCode(
       const escapedCommand = escapeForTemplateLiteral(handler.command);
       if (handler.matcher) {
         const safeMatcher = validateAndSanitizeMatcher(handler.matcher);
-        lines.push(`      const __re = new RegExp("${safeMatcher}");`);
-        lines.push(`      if (__re.test(input.tool)) {`);
+        lines.push(`      if (new RegExp("${safeMatcher}").test(input.tool)) {`);
         lines.push(`        await $\`${escapedCommand}\`;`);
         lines.push("      }");
       } else {

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -11,6 +11,9 @@ function validateAndSanitizeMatcher(matcher: string): string {
   for (const char of CONTROL_CHARS) {
     sanitized = sanitized.replaceAll(char, "");
   }
+  if (sanitized === "*") {
+    sanitized = ".*";
+  }
   try {
     new RegExp(sanitized);
   } catch {


### PR DESCRIPTION
Fixes https://github.com/dyoshikawa/rulesync/issues/1652

## What changed

- Normalize a hook matcher of exactly `"*"` to `".*"` in the shared OpenCode/Kilo hook plugin generator.
- Add regression tests for OpenCode and Kilo.
- Preserve existing regex behavior for non-bare wildcard patterns such as `"Read*"`.

## Why

`matcher: "*"` currently crashes OpenCode/Kilo hook generation because `new RegExp("*")` is invalid JavaScript regex syntax.

The issue suggests normalizing a bare glob-style `*` to the regex match-all pattern `.*`. This keeps the fix small and matches the existing glob-to-regex behavior used elsewhere in Rulesync.

Only the exact bare matcher `"*"` is normalized. Other patterns such as `"**"` or `"Read*"` are still treated as regex and validated normally.

## How tested

- `vitest run --silent=true src/features/hooks/opencode-hooks.test.ts src/features/hooks/kilo-hooks.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run eslint`
- `corepack pnpm run oxlint`
- `oxfmt --check src/features/hooks/opencode-style-generator.ts src/features/hooks/opencode-hooks.test.ts src/features/hooks/kilo-hooks.test.ts`
- `git diff --check`