### PR TITLE
feat(opencode): add env variable format translation for MCP config

### DIFF
--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -86,33 +86,6 @@ describe("CursorMcp", () => {
       expect(exported.mcpServers["test-server"]?.env?.DEBUG).toBe("true");
     });
 
-    it("should handle multiple env variables embedded in strings", () => {
-      const cursorConfig = {
-        mcpServers: {
-          "test-server": {
-            command: "node",
-            args: ["server.js"],
-            env: {
-              URL: "https://${env:HOST}:${env:PORT}/api",
-              LITERAL: "localhost",
-            },
-          },
-        },
-      };
-
-      const cursorMcp = new CursorMcp({
-        relativeDirPath: ".cursor",
-        relativeFilePath: "mcp.json",
-        fileContent: JSON.stringify(cursorConfig),
-      });
-
-      const rulesyncMcp = cursorMcp.toRulesyncMcp();
-      const exported = JSON.parse(rulesyncMcp.getFileContent());
-
-      expect(exported.mcpServers["test-server"].env.URL).toBe("https://${HOST}:${PORT}/api");
-      expect(exported.mcpServers["test-server"].env.LITERAL).toBe("localhost");
-    });
-
     it("should preserve env variable values through round-trip conversion", async () => {
       const originalConfig = {
         mcpServers: {
@@ -148,33 +121,6 @@ describe("CursorMcp", () => {
       expect(finalConfig.mcpServers["test-server"].env).toEqual(
         originalConfig.mcpServers["test-server"].env,
       );
-    });
-
-    it("should handle server without env field", async () => {
-      const rulesyncConfig = {
-        mcpServers: {
-          "no-env-server": {
-            command: "node",
-            args: ["server.js"],
-          },
-        },
-      };
-
-      const rulesyncMcp = new RulesyncMcp({
-        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
-        relativeFilePath: ".mcp.json",
-        fileContent: JSON.stringify(rulesyncConfig),
-      });
-
-      const cursorMcp = await CursorMcp.fromRulesyncMcp({
-        rulesyncMcp,
-        validate: false,
-      });
-      const exported = cursorMcp.getJson() as {
-        mcpServers: Record<string, { env?: Record<string, string> }>;
-      };
-
-      expect(exported.mcpServers["no-env-server"]?.env).toBeUndefined();
     });
 
     it("should convert env vars in headers when exporting (fromRulesyncMcp)", async () => {

--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -176,6 +176,67 @@ describe("CursorMcp", () => {
 
       expect(exported.mcpServers["no-env-server"]?.env).toBeUndefined();
     });
+
+    it("should convert env vars in headers when exporting (fromRulesyncMcp)", async () => {
+      const rulesyncConfig = {
+        mcpServers: {
+          "remote-server": {
+            type: "sse",
+            url: "https://example.com/api/mcp",
+            headers: {
+              Authorization: "Bearer ${API_KEY}",
+              "X-Static": "plain-value",
+            },
+          },
+        },
+      };
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(rulesyncConfig),
+      });
+
+      const cursorMcp = await CursorMcp.fromRulesyncMcp({
+        rulesyncMcp,
+        validate: false,
+      });
+      const exported = cursorMcp.getJson() as {
+        mcpServers: Record<string, { headers?: Record<string, string> }>;
+      };
+
+      expect(exported.mcpServers["remote-server"]?.headers?.Authorization).toBe(
+        "Bearer ${env:API_KEY}",
+      );
+      expect(exported.mcpServers["remote-server"]?.headers?.["X-Static"]).toBe("plain-value");
+    });
+
+    it("should convert env vars in headers when importing (toRulesyncMcp)", () => {
+      const cursorConfig = {
+        mcpServers: {
+          "remote-server": {
+            type: "sse",
+            url: "https://example.com/api/mcp",
+            headers: {
+              Authorization: "Bearer ${env:API_KEY}",
+              "X-Static": "plain-value",
+            },
+          },
+        },
+      };
+
+      const cursorMcp = new CursorMcp({
+        relativeDirPath: ".cursor",
+        relativeFilePath: "mcp.json",
+        fileContent: JSON.stringify(cursorConfig),
+      });
+
+      const rulesyncMcp = cursorMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["remote-server"].headers.Authorization).toBe("Bearer ${API_KEY}");
+      expect(exported.mcpServers["remote-server"].headers["X-Static"]).toBe("plain-value");
+    });
   });
 
   describe("getSettablePaths", () => {

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -1,9 +1,13 @@
 import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
-import { isMcpServers, type McpServers } from "../../types/mcp.js";
+import { isMcpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import {
+  convertEnvVarRefsFromToolFormat,
+  convertEnvVarRefsToToolFormat,
+} from "./mcp-env-var-format.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -15,52 +19,6 @@ import {
 } from "./tool-mcp.js";
 
 const CURSOR_ENV_VAR_PATTERN = /\$\{env:([^}]+)\}/g;
-
-/**
- * Convert Cursor env format to canonical format
- * - ${env:VAR} -> ${VAR}
- */
-function convertEnvFromCursorFormat(mcpServers: McpServers): McpServers {
-  return Object.fromEntries(
-    Object.entries(mcpServers).map(([name, config]) => [
-      name,
-      {
-        ...config,
-        ...(config.env && {
-          env: Object.fromEntries(
-            Object.entries(config.env).map(([k, v]) => [
-              k,
-              v.replace(CURSOR_ENV_VAR_PATTERN, "${$1}"),
-            ]),
-          ),
-        }),
-      },
-    ]),
-  );
-}
-
-/**
- * Convert canonical env format to Cursor format
- * - ${VAR} -> ${env:VAR} (avoids double-converting)
- */
-function convertEnvToCursorFormat(mcpServers: McpServers): McpServers {
-  return Object.fromEntries(
-    Object.entries(mcpServers).map(([name, config]) => [
-      name,
-      {
-        ...config,
-        ...(config.env && {
-          env: Object.fromEntries(
-            Object.entries(config.env).map(([k, v]) => [
-              k,
-              v.replace(/\$\{(?!env:)([^}:]+)\}/g, "${env:$1}"),
-            ]),
-          ),
-        }),
-      },
-    ]),
-  );
-}
 
 export type CursorMcpParams = ToolMcpParams;
 
@@ -153,7 +111,10 @@ export class CursorMcp extends ToolMcp {
     // codex-only fields (`envVars`) are stripped before writing the
     // cursor config.
     const mcpServers = rulesyncMcp.getMcpServers();
-    const transformedServers = convertEnvToCursorFormat(mcpServers);
+    const transformedServers = convertEnvVarRefsToToolFormat({
+      mcpServers,
+      replacement: "${env:$1}",
+    });
 
     const cursorConfig = { ...json, mcpServers: transformedServers };
 
@@ -169,7 +130,10 @@ export class CursorMcp extends ToolMcp {
 
   toRulesyncMcp(): RulesyncMcp {
     const mcpServers = isMcpServers(this.json.mcpServers) ? this.json.mcpServers : {};
-    const transformedServers = convertEnvFromCursorFormat(mcpServers);
+    const transformedServers = convertEnvVarRefsFromToolFormat({
+      mcpServers,
+      pattern: CURSOR_ENV_VAR_PATTERN,
+    });
 
     const transformedJson = {
       ...this.json,

--- a/src/features/mcp/mcp-env-var-format.test.ts
+++ b/src/features/mcp/mcp-env-var-format.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { McpServers } from "../../types/mcp.js";
+import {
+  convertEnvVarRefsFromToolFormat,
+  convertEnvVarRefsToToolFormat,
+} from "./mcp-env-var-format.js";
+
+const TOOL_PATTERN = /\{tool:([^}:]+)\}/g;
+
+describe("mcp-env-var-format", () => {
+  describe("convertEnvVarRefsFromToolFormat", () => {
+    it("should convert tool-specific format to canonical ${VAR} in env values", () => {
+      const mcpServers: McpServers = {
+        server: {
+          command: "node",
+          env: {
+            KEY: "{tool:API_KEY}",
+            STATIC: "plain",
+          },
+        },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["server"]?.env?.KEY).toBe("${API_KEY}");
+      expect(result["server"]?.env?.STATIC).toBe("plain");
+    });
+
+    it("should convert tool-specific format to canonical ${VAR} in headers values", () => {
+      const mcpServers: McpServers = {
+        server: {
+          type: "sse",
+          url: "https://example.com",
+          headers: {
+            Authorization: "Bearer {tool:TOKEN}",
+            "X-Static": "value",
+          },
+        },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["server"]?.headers?.Authorization).toBe("Bearer ${TOKEN}");
+      expect(result["server"]?.headers?.["X-Static"]).toBe("value");
+    });
+
+    it("should handle multiple env var refs in a single value", () => {
+      const mcpServers: McpServers = {
+        server: {
+          command: "node",
+          env: { URL: "https://{tool:HOST}:{tool:PORT}/api" },
+        },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["server"]?.env?.URL).toBe("https://${HOST}:${PORT}/api");
+    });
+
+    it("should leave servers without env or headers unchanged", () => {
+      const mcpServers: McpServers = {
+        server: { command: "node", args: ["index.js"] },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["server"]?.env).toBeUndefined();
+      expect(result["server"]?.headers).toBeUndefined();
+      expect(result["server"]?.command).toBe("node");
+    });
+
+    it("should process multiple servers independently", () => {
+      const mcpServers: McpServers = {
+        a: { command: "a", env: { K: "{tool:A}" } },
+        b: { command: "b", env: { K: "{tool:B}" } },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["a"]?.env?.K).toBe("${A}");
+      expect(result["b"]?.env?.K).toBe("${B}");
+    });
+  });
+
+  describe("convertEnvVarRefsToToolFormat", () => {
+    it("should convert canonical ${VAR} to tool-specific format in env values", () => {
+      const mcpServers: McpServers = {
+        server: {
+          command: "node",
+          env: {
+            KEY: "${API_KEY}",
+            STATIC: "plain",
+          },
+        },
+      };
+
+      const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
+
+      expect(result["server"]?.env?.KEY).toBe("{tool:API_KEY}");
+      expect(result["server"]?.env?.STATIC).toBe("plain");
+    });
+
+    it("should convert canonical ${VAR} to tool-specific format in headers values", () => {
+      const mcpServers: McpServers = {
+        server: {
+          type: "sse",
+          url: "https://example.com",
+          headers: { Authorization: "Bearer ${TOKEN}" },
+        },
+      };
+
+      const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
+
+      expect(result["server"]?.headers?.Authorization).toBe("Bearer {tool:TOKEN}");
+    });
+
+    it("should not double-convert values already in ${env:VAR} format", () => {
+      const mcpServers: McpServers = {
+        server: {
+          command: "node",
+          env: {
+            ALREADY: "${env:CURSOR_STYLE}",
+            CANONICAL: "${NORMAL}",
+          },
+        },
+      };
+
+      const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
+
+      expect(result["server"]?.env?.ALREADY).toBe("${env:CURSOR_STYLE}");
+      expect(result["server"]?.env?.CANONICAL).toBe("{tool:NORMAL}");
+    });
+
+    it("should leave servers without env or headers unchanged", () => {
+      const mcpServers: McpServers = {
+        server: { command: "node" },
+      };
+
+      const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
+
+      expect(result["server"]?.env).toBeUndefined();
+      expect(result["server"]?.headers).toBeUndefined();
+    });
+  });
+
+  describe("round-trip", () => {
+    it("should preserve values through from-tool then to-tool cycle", () => {
+      const original: McpServers = {
+        server: {
+          command: "node",
+          env: { KEY: "${VAR}", STATIC: "plain" },
+          headers: { Auth: "Bearer ${TOKEN}" },
+        },
+      };
+
+      const toTool = convertEnvVarRefsToToolFormat({
+        mcpServers: original,
+        replacement: "{tool:$1}",
+      });
+      const backToCanonical = convertEnvVarRefsFromToolFormat({
+        mcpServers: toTool,
+        pattern: TOOL_PATTERN,
+      });
+
+      expect(backToCanonical["server"]?.env).toEqual(original["server"]?.env);
+      expect(backToCanonical["server"]?.headers).toEqual(original["server"]?.headers);
+    });
+  });
+});

--- a/src/features/mcp/mcp-env-var-format.ts
+++ b/src/features/mcp/mcp-env-var-format.ts
@@ -1,0 +1,71 @@
+import { McpServers } from "../../types/mcp.js";
+
+const CANONICAL_ENV_VAR_PATTERN = /\$\{(?!env:)([^}:]+)\}/g;
+
+function convertRecordValues({
+  record,
+  pattern,
+  replacement,
+}: {
+  record: Record<string, string>;
+  pattern: RegExp;
+  replacement: string;
+}): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(record).map(([k, v]) => [k, v.replace(pattern, replacement)]),
+  );
+}
+
+export function convertEnvVarRefsFromToolFormat({
+  mcpServers,
+  pattern,
+}: {
+  mcpServers: McpServers;
+  pattern: RegExp;
+}): McpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, config]) => [
+      name,
+      {
+        ...config,
+        ...(config.env && {
+          env: convertRecordValues({ record: config.env, pattern, replacement: "${$1}" }),
+        }),
+        ...(config.headers && {
+          headers: convertRecordValues({ record: config.headers, pattern, replacement: "${$1}" }),
+        }),
+      },
+    ]),
+  );
+}
+
+export function convertEnvVarRefsToToolFormat({
+  mcpServers,
+  replacement,
+}: {
+  mcpServers: McpServers;
+  replacement: string;
+}): McpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, config]) => [
+      name,
+      {
+        ...config,
+        ...(config.env && {
+          env: convertRecordValues({
+            record: config.env,
+            pattern: CANONICAL_ENV_VAR_PATTERN,
+            replacement,
+          }),
+        }),
+        ...(config.headers && {
+          headers: convertRecordValues({
+            record: config.headers,
+            pattern: CANONICAL_ENV_VAR_PATTERN,
+            replacement,
+          }),
+        }),
+      },
+    ]),
+  );
+}

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -2289,34 +2289,6 @@ describe("OpencodeMcp", () => {
       }
     });
 
-    it("should handle multiple env variables embedded in strings", () => {
-      const opencodeConfig = {
-        mcp: {
-          "test-server": {
-            type: "local",
-            command: ["node", "server.js"],
-            environment: {
-              URL: "https://{env:HOST}:{env:PORT}/api",
-              LITERAL: "localhost",
-            },
-            enabled: true,
-          },
-        },
-      };
-
-      const opencodeMcp = new OpencodeMcp({
-        relativeDirPath: ".",
-        relativeFilePath: "opencode.json",
-        fileContent: JSON.stringify(opencodeConfig),
-      });
-
-      const rulesyncMcp = opencodeMcp.toRulesyncMcp();
-      const exported = JSON.parse(rulesyncMcp.getFileContent());
-
-      expect(exported.mcpServers["test-server"].env.URL).toBe("https://${HOST}:${PORT}/api");
-      expect(exported.mcpServers["test-server"].env.LITERAL).toBe("localhost");
-    });
-
     it("should preserve env variable values through round-trip conversion", async () => {
       const originalConfig = {
         mcpServers: {
@@ -2439,36 +2411,6 @@ describe("OpencodeMcp", () => {
 
       expect(exported.mcpServers["test-server"].env.CURSOR_STYLE).toBe("${env:MY_KEY}");
       expect(exported.mcpServers["test-server"].env.OPENCODE_STYLE).toBe("${MY_KEY}");
-    });
-
-    it("should handle server without env or headers fields", async () => {
-      const rulesyncConfig = {
-        mcpServers: {
-          "no-env-server": {
-            command: "node",
-            args: ["server.js"],
-          },
-        },
-      };
-
-      const rulesyncMcp = new RulesyncMcp({
-        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
-        relativeFilePath: ".mcp.json",
-        fileContent: JSON.stringify(rulesyncConfig),
-      });
-
-      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
-        rulesyncMcp,
-        validate: false,
-      });
-      const exported = opencodeMcp.getJson();
-
-      const server = exported.mcp?.["no-env-server"];
-      expect(server).toBeDefined();
-      expect(server?.type).toBe("local");
-      if (server?.type === "local") {
-        expect(server.environment).toBeUndefined();
-      }
     });
 
     it("should preserve header env variable values through round-trip conversion", async () => {

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -2413,6 +2413,64 @@ describe("OpencodeMcp", () => {
       expect(exported.mcpServers["remote-server"].headers.Authorization).toBe("Bearer ${API_KEY}");
     });
 
+    it("should not convert Cursor format ${env:VAR} during OpenCode import", () => {
+      const opencodeConfig = {
+        mcp: {
+          "test-server": {
+            type: "local",
+            command: ["node", "server.js"],
+            environment: {
+              CURSOR_STYLE: "${env:MY_KEY}",
+              OPENCODE_STYLE: "{env:MY_KEY}",
+            },
+            enabled: true,
+          },
+        },
+      };
+
+      const opencodeMcp = new OpencodeMcp({
+        relativeDirPath: ".",
+        relativeFilePath: "opencode.json",
+        fileContent: JSON.stringify(opencodeConfig),
+      });
+
+      const rulesyncMcp = opencodeMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["test-server"].env.CURSOR_STYLE).toBe("${env:MY_KEY}");
+      expect(exported.mcpServers["test-server"].env.OPENCODE_STYLE).toBe("${MY_KEY}");
+    });
+
+    it("should handle server without env or headers fields", async () => {
+      const rulesyncConfig = {
+        mcpServers: {
+          "no-env-server": {
+            command: "node",
+            args: ["server.js"],
+          },
+        },
+      };
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(rulesyncConfig),
+      });
+
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        rulesyncMcp,
+        validate: false,
+      });
+      const exported = opencodeMcp.getJson();
+
+      const server = exported.mcp?.["no-env-server"];
+      expect(server).toBeDefined();
+      expect(server?.type).toBe("local");
+      if (server?.type === "local") {
+        expect(server.environment).toBeUndefined();
+      }
+    });
+
     it("should preserve header env variable values through round-trip conversion", async () => {
       const originalConfig = {
         mcpServers: {

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -2224,4 +2224,238 @@ describe("OpencodeMcp", () => {
       expect(opencodeMcp.getJson().mcp?.fromJson).toBeUndefined();
     });
   });
+
+  describe("env variable format conversion", () => {
+    it("should convert OpenCode env format {env:VAR} to canonical ${VAR} when importing (toRulesyncMcp)", () => {
+      const opencodeConfig = {
+        mcp: {
+          "test-server": {
+            type: "local",
+            command: ["node", "server.js"],
+            environment: {
+              API_KEY: "{env:MY_API_KEY}",
+              DEBUG: "true",
+            },
+            enabled: true,
+          },
+        },
+      };
+
+      const opencodeMcp = new OpencodeMcp({
+        relativeDirPath: ".",
+        relativeFilePath: "opencode.json",
+        fileContent: JSON.stringify(opencodeConfig),
+      });
+
+      const rulesyncMcp = opencodeMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["test-server"].env.API_KEY).toBe("${MY_API_KEY}");
+      expect(exported.mcpServers["test-server"].env.DEBUG).toBe("true");
+    });
+
+    it("should convert canonical env format ${VAR} to OpenCode {env:VAR} when exporting (fromRulesyncMcp)", async () => {
+      const rulesyncConfig = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            args: ["server.js"],
+            env: {
+              API_KEY: "${MY_API_KEY}",
+              DEBUG: "true",
+            },
+          },
+        },
+      };
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(rulesyncConfig),
+      });
+
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        rulesyncMcp,
+        validate: false,
+      });
+      const exported = opencodeMcp.getJson();
+
+      const server = exported.mcp?.["test-server"];
+      expect(server).toBeDefined();
+      expect(server?.type).toBe("local");
+      if (server?.type === "local") {
+        expect(server.environment?.API_KEY).toBe("{env:MY_API_KEY}");
+        expect(server.environment?.DEBUG).toBe("true");
+      }
+    });
+
+    it("should handle multiple env variables embedded in strings", () => {
+      const opencodeConfig = {
+        mcp: {
+          "test-server": {
+            type: "local",
+            command: ["node", "server.js"],
+            environment: {
+              URL: "https://{env:HOST}:{env:PORT}/api",
+              LITERAL: "localhost",
+            },
+            enabled: true,
+          },
+        },
+      };
+
+      const opencodeMcp = new OpencodeMcp({
+        relativeDirPath: ".",
+        relativeFilePath: "opencode.json",
+        fileContent: JSON.stringify(opencodeConfig),
+      });
+
+      const rulesyncMcp = opencodeMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["test-server"].env.URL).toBe("https://${HOST}:${PORT}/api");
+      expect(exported.mcpServers["test-server"].env.LITERAL).toBe("localhost");
+    });
+
+    it("should preserve env variable values through round-trip conversion", async () => {
+      const originalConfig = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            args: ["server.js"],
+            env: {
+              API_KEY: "${MY_API_KEY}",
+              HOST: "${HOST}",
+              LITERAL: "static-value",
+            },
+          },
+        },
+      };
+
+      // Start with canonical format in RulesyncMcp
+      const rulesyncMcp1 = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(originalConfig),
+      });
+
+      // Convert to OpenCode format
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        rulesyncMcp: rulesyncMcp1,
+        validate: false,
+      });
+
+      // Convert back to canonical format
+      const rulesyncMcp2 = opencodeMcp.toRulesyncMcp();
+      const finalConfig = JSON.parse(rulesyncMcp2.getFileContent());
+
+      expect(finalConfig.mcpServers["test-server"].env).toEqual(
+        originalConfig.mcpServers["test-server"].env,
+      );
+    });
+
+    it("should convert env vars in headers for remote servers when exporting (fromRulesyncMcp)", async () => {
+      const rulesyncConfig = {
+        mcpServers: {
+          "remote-server": {
+            type: "sse",
+            url: "https://example.com/api/mcp",
+            headers: {
+              Authorization: "Bearer ${API_KEY}",
+            },
+          },
+        },
+      };
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(rulesyncConfig),
+      });
+
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        rulesyncMcp,
+        validate: false,
+      });
+      const exported = opencodeMcp.getJson();
+
+      const server = exported.mcp?.["remote-server"];
+      expect(server).toBeDefined();
+      expect(server?.type).toBe("remote");
+      if (server?.type === "remote") {
+        expect(server.headers?.Authorization).toBe("Bearer {env:API_KEY}");
+      }
+    });
+
+    it("should convert env vars in headers for remote servers when importing (toRulesyncMcp)", () => {
+      const opencodeConfig = {
+        mcp: {
+          "remote-server": {
+            type: "remote",
+            url: "https://example.com/api/mcp",
+            headers: {
+              Authorization: "Bearer {env:API_KEY}",
+            },
+            enabled: true,
+          },
+        },
+      };
+
+      const opencodeMcp = new OpencodeMcp({
+        relativeDirPath: ".",
+        relativeFilePath: "opencode.json",
+        fileContent: JSON.stringify(opencodeConfig),
+      });
+
+      const rulesyncMcp = opencodeMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["remote-server"].headers.Authorization).toBe("Bearer ${API_KEY}");
+    });
+
+    it("should preserve header env variable values through round-trip conversion", async () => {
+      const originalConfig = {
+        mcpServers: {
+          "remote-server": {
+            type: "sse",
+            url: "https://example.com/api/mcp",
+            headers: {
+              Authorization: "Bearer ${API_KEY}",
+              "X-Custom": "static-value",
+            },
+          },
+        },
+      };
+
+      // Start with canonical format in RulesyncMcp
+      const rulesyncMcp1 = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(originalConfig),
+      });
+
+      // Convert to OpenCode format
+      const opencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        rulesyncMcp: rulesyncMcp1,
+        validate: false,
+      });
+
+      // Verify intermediate OpenCode format
+      const opencodeJson = opencodeMcp.getJson();
+      const server = opencodeJson.mcp?.["remote-server"];
+      expect(server?.type).toBe("remote");
+      if (server?.type === "remote") {
+        expect(server.headers?.Authorization).toBe("Bearer {env:API_KEY}");
+        expect(server.headers?.["X-Custom"]).toBe("static-value");
+      }
+
+      // Convert back to canonical format
+      const rulesyncMcp2 = opencodeMcp.toRulesyncMcp();
+      const finalConfig = JSON.parse(rulesyncMcp2.getFileContent());
+
+      expect(finalConfig.mcpServers["remote-server"].headers).toEqual(
+        originalConfig.mcpServers["remote-server"].headers,
+      );
+    });
+  });
 });

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -6,6 +6,10 @@ import { z } from "zod/mini";
 import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import {
+  convertEnvVarRefsFromToolFormat,
+  convertEnvVarRefsToToolFormat,
+} from "./mcp-env-var-format.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -16,73 +20,8 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
-// OpenCode env variable format: {env:VAR} (no $ prefix)
-// Canonical rulesync format: ${VAR}
-const OPENCODE_ENV_VAR_PATTERN = /(?<!\$)\{env:([^}]+)\}/g;
-
-/**
- * Convert a record's string values from OpenCode {env:VAR} to canonical ${VAR} format.
- * Uses negative lookbehind to avoid matching Cursor's ${env:VAR} format.
- */
-function convertRecordFromOpencodeEnvFormat(
-  record: Record<string, string>,
-): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(record).map(([k, v]) => [k, v.replace(OPENCODE_ENV_VAR_PATTERN, "${$1}")]),
-  );
-}
-
-/**
- * Convert a record's string values from canonical ${VAR} to OpenCode {env:VAR} format.
- * Avoids double-converting values already in {env:} or ${env:} form.
- */
-function convertRecordToOpencodeEnvFormat(record: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(record).map(([k, v]) => [k, v.replace(/\$\{(?!env:)([^}:]+)\}/g, "{env:$1}")]),
-  );
-}
-
-/**
- * Convert OpenCode env format to canonical format across all servers
- * - {env:VAR} -> ${VAR} in env and headers values
- */
-function convertEnvFromOpencodeFormat(mcpServers: McpServers): McpServers {
-  return Object.fromEntries(
-    Object.entries(mcpServers).map(([name, config]) => [
-      name,
-      {
-        ...config,
-        ...(config.env && {
-          env: convertRecordFromOpencodeEnvFormat(config.env),
-        }),
-        ...(config.headers && {
-          headers: convertRecordFromOpencodeEnvFormat(config.headers),
-        }),
-      },
-    ]),
-  );
-}
-
-/**
- * Convert canonical env format to OpenCode format across all servers
- * - ${VAR} -> {env:VAR} in env and headers values
- */
-function convertEnvToOpencodeFormat(mcpServers: McpServers): McpServers {
-  return Object.fromEntries(
-    Object.entries(mcpServers).map(([name, config]) => [
-      name,
-      {
-        ...config,
-        ...(config.env && {
-          env: convertRecordToOpencodeEnvFormat(config.env),
-        }),
-        ...(config.headers && {
-          headers: convertRecordToOpencodeEnvFormat(config.headers),
-        }),
-      },
-    ]),
-  );
-}
+// Negative lookbehind avoids matching Cursor's ${env:VAR} format
+const OPENCODE_ENV_VAR_PATTERN = /(?<!\$)\{env:([^}:]+)\}/g;
 
 // OpenCode MCP server schemas
 // OpenCode uses "local"/"remote" instead of "stdio"/"sse"/"http",
@@ -357,7 +296,10 @@ export class OpencodeMcp extends ToolMcp {
 
     const json = parseJsonc(fileContent);
     const mcpServers = rulesyncMcp.getMcpServers();
-    const transformedServers = convertEnvToOpencodeFormat(mcpServers);
+    const transformedServers = convertEnvVarRefsToToolFormat({
+      mcpServers,
+      replacement: "{env:$1}",
+    });
     const { mcp: convertedMcp, tools: mcpTools } = convertToOpencodeFormat(transformedServers);
 
     const { tools: _existingTools, ...jsonWithoutTools } = json;
@@ -378,7 +320,10 @@ export class OpencodeMcp extends ToolMcp {
 
   toRulesyncMcp(): RulesyncMcp {
     const convertedMcpServers = convertFromOpencodeFormat(this.json.mcp ?? {}, this.json.tools);
-    const transformedServers = convertEnvFromOpencodeFormat(convertedMcpServers);
+    const transformedServers = convertEnvVarRefsFromToolFormat({
+      mcpServers: convertedMcpServers,
+      pattern: OPENCODE_ENV_VAR_PATTERN,
+    });
     return this.toRulesyncMcpDefault({
       fileContent: JSON.stringify({ mcpServers: transformedServers }, null, 2),
     });

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -16,6 +16,74 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
+// OpenCode env variable format: {env:VAR} (no $ prefix)
+// Canonical rulesync format: ${VAR}
+const OPENCODE_ENV_VAR_PATTERN = /(?<!\$)\{env:([^}]+)\}/g;
+
+/**
+ * Convert a record's string values from OpenCode {env:VAR} to canonical ${VAR} format.
+ * Uses negative lookbehind to avoid matching Cursor's ${env:VAR} format.
+ */
+function convertRecordFromOpencodeEnvFormat(
+  record: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(record).map(([k, v]) => [k, v.replace(OPENCODE_ENV_VAR_PATTERN, "${$1}")]),
+  );
+}
+
+/**
+ * Convert a record's string values from canonical ${VAR} to OpenCode {env:VAR} format.
+ * Avoids double-converting values already in {env:} or ${env:} form.
+ */
+function convertRecordToOpencodeEnvFormat(record: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(record).map(([k, v]) => [k, v.replace(/\$\{(?!env:)([^}:]+)\}/g, "{env:$1}")]),
+  );
+}
+
+/**
+ * Convert OpenCode env format to canonical format across all servers
+ * - {env:VAR} -> ${VAR} in env and headers values
+ */
+function convertEnvFromOpencodeFormat(mcpServers: McpServers): McpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, config]) => [
+      name,
+      {
+        ...config,
+        ...(config.env && {
+          env: convertRecordFromOpencodeEnvFormat(config.env),
+        }),
+        ...(config.headers && {
+          headers: convertRecordFromOpencodeEnvFormat(config.headers),
+        }),
+      },
+    ]),
+  );
+}
+
+/**
+ * Convert canonical env format to OpenCode format across all servers
+ * - ${VAR} -> {env:VAR} in env and headers values
+ */
+function convertEnvToOpencodeFormat(mcpServers: McpServers): McpServers {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, config]) => [
+      name,
+      {
+        ...config,
+        ...(config.env && {
+          env: convertRecordToOpencodeEnvFormat(config.env),
+        }),
+        ...(config.headers && {
+          headers: convertRecordToOpencodeEnvFormat(config.headers),
+        }),
+      },
+    ]),
+  );
+}
+
 // OpenCode MCP server schemas
 // OpenCode uses "local"/"remote" instead of "stdio"/"sse"/"http",
 // "environment" instead of "env", and "enabled" instead of "disabled"
@@ -288,9 +356,9 @@ export class OpencodeMcp extends ToolMcp {
     }
 
     const json = parseJsonc(fileContent);
-    const { mcp: convertedMcp, tools: mcpTools } = convertToOpencodeFormat(
-      rulesyncMcp.getMcpServers(),
-    );
+    const mcpServers = rulesyncMcp.getMcpServers();
+    const transformedServers = convertEnvToOpencodeFormat(mcpServers);
+    const { mcp: convertedMcp, tools: mcpTools } = convertToOpencodeFormat(transformedServers);
 
     const { tools: _existingTools, ...jsonWithoutTools } = json;
     const newJson = {
@@ -310,8 +378,9 @@ export class OpencodeMcp extends ToolMcp {
 
   toRulesyncMcp(): RulesyncMcp {
     const convertedMcpServers = convertFromOpencodeFormat(this.json.mcp ?? {}, this.json.tools);
+    const transformedServers = convertEnvFromOpencodeFormat(convertedMcpServers);
     return this.toRulesyncMcpDefault({
-      fileContent: JSON.stringify({ mcpServers: convertedMcpServers }, null, 2),
+      fileContent: JSON.stringify({ mcpServers: transformedServers }, null, 2),
     });
   }
 


### PR DESCRIPTION
## Summary

OpenCode uses `{env:VAR}` format for environment variable references in its MCP config ([docs](https://opencode.ai/docs/mcp-servers/#remote), while rulesync's canonical format uses `${VAR}`. This PR adds bidirectional translation and extracts a shared env var conversion utility used by both OpenCode and Cursor.

I ran into an issue while configuring SourceBot with API key, where this config didn't get translated into working MCP config for OpenCode.
```
    "sourcebot": {
      "description": "Internal Red Hat code search via Sourcebot (requires VPN)",
      "type": "http",
      "url": "https://sourcebot.XXX.com/api/mcp",
      "headers": {
        "Authorization": "Bearer ${SOURCEBOT_API_KEY}"
      }
```

## Changes

### `src/features/mcp/mcp-env-var-format.ts` (new)
- Shared utility with `convertEnvVarRefsFromToolFormat()` and `convertEnvVarRefsToToolFormat()`
- Translates env var references in both `env` and `headers` fields across all MCP servers
- `CANONICAL_ENV_VAR_PATTERN` regex avoids double-converting values already in `${env:}` form

### `src/features/mcp/mcp-env-var-format.test.ts` (new)
- 10 dedicated tests using a generic `{tool:VAR}` pattern, independent of any specific tool
- Covers: env values, headers values, multiple refs, no-env servers, multiple servers, double-convert avoidance, round-trip

### `src/features/mcp/opencode-mcp.ts`
- Add `OPENCODE_ENV_VAR_PATTERN` regex for matching `{env:VAR}` (with negative lookbehind to avoid matching Cursor's `${env:VAR}`)
- Wire up shared utility in `fromRulesyncMcp()` (export: `${VAR}` -> `{env:VAR}`) and `toRulesyncMcp()` (import: `{env:VAR}` -> `${VAR}`)

### `src/features/mcp/cursor-mcp.ts`
- Replace inline env var conversion functions with shared utility calls
- Cursor now also translates env var refs in `headers` (was `env`-only before)

## Design Decisions

- **Shared utility**: Extracted common env var conversion logic into `mcp-env-var-format.ts` to eliminate duplication between OpenCode and Cursor. Each tool only provides its tool-specific regex pattern and replacement string.
- **Headers translation for both tools**: Both OpenCode and Cursor now translate env var refs in `headers`, since remote MCP servers use env var references in headers (e.g., `Authorization: Bearer {env:API_KEY}`).
- **Negative lookbehind**: The OpenCode import regex `(?<!\$)\{env:...}` avoids matching Cursor's `${env:VAR}` format, preventing cross-tool interference.
- **Consistent capture groups**: Both import and export regexes use `[^}:]+` to exclude colons, ensuring round-trip consistency.
- **Test layering**: Shared utility has dedicated tool-agnostic tests; tool-specific files keep only integration tests that verify wiring and full-pipeline behavior.

## How it was tested

- 21 new tests across 3 files (10 unit + 11 integration) — all pass
- `pnpm cicheck` passes locally (format, lint, typecheck)
- CI passes (Code Quality, Build, E2E on ubuntu/macOS/macOS-intel/Windows)
- 3 rounds of `/review-pr` with parallel code-review and security-review agents — all mid/high findings fixed, final iteration has only low-severity findings remaining