### PR TITLE
fix(opencode-style-generator): normalize glob wildcard `*` to `.*` before regex validation

### DIFF
--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -11,6 +11,9 @@ function validateAndSanitizeMatcher(matcher: string): string {
   for (const char of CONTROL_CHARS) {
     sanitized = sanitized.replaceAll(char, "");
   }
+  // Normalize glob-style wildcard `*` to regex equivalent `.*` before validation.
+  // rulesync already applies this glob→regex convention in other features (e.g. file-formats.md).
+  sanitized = sanitized.replace(/^\*$/, ".*");
   try {
     new RegExp(sanitized);
   } catch {


### PR DESCRIPTION
## Fixes: dyoshikawa/rulesync#1652

### Problem
The opencode and kilo generators validate matchers via `new RegExp()` at code-generation time. A bare `*` (the conventional glob-style 'match all tools' wildcard) throws `SyntaxError: Nothing to repeat` because `*` is a regex quantifier with no preceding token. Other generators (claudecode, cursor, geminicli) pass the matcher through untouched and succeed — making this an inconsistency, not invalid user input.

### Root Cause
`validateAndSanitizeMatcher()` in `opencode-style-generator.ts` runs `new RegExp(sanitized)` as a validation pass, but never normalizes the glob-style `*` wildcard to its regex equivalent `.*`.

### Fix
Normalize `*` → `.*` immediately after control-character sanitization, before the regex validation check. This is consistent with rulesync's own documented glob→regex convention (file-formats.md, AugmentCode permissions section) which already applies the same mapping elsewhere in the codebase.

### Verification
`npx vitest run` passes all 5570 tests (217 test files).

### Before / After
```ts
// Before: new RegExp('*') throws SyntaxError
// After: new RegExp('.*') is valid, matches all tool names
```