### PR TITLE
feat: add Kiro hooks support

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -38,7 +38,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 
 ## `.rulesync/hooks.json`
 
-Hooks run scripts at lifecycle events (e.g. session start, before tool use). Events use **canonical camelCase** in this file, and Rulesync translates them per tool: Cursor uses them as-is; Claude Code, Factory Droid, Codex CLI, and Gemini CLI get PascalCase (with a few tool-specific name mappings) in their settings files; OpenCode and Kilo hooks are emitted as JavaScript plugins (`.opencode/plugins/rulesync-hooks.js`, `.kilo/plugins/rulesync-hooks.js`); Copilot and Copilot CLI map event names to their own camelCase (e.g. `beforeSubmitPrompt` → `userPromptSubmitted`, `afterError` → `errorOccurred`) and use `powershell`/`bash` command fields; deepagents-cli uses a dot-notation (e.g. `session.start`, `tool.error`).
+Hooks run scripts at lifecycle events (e.g. session start, before tool use). Events use **canonical camelCase** in this file, and Rulesync translates them per tool: Cursor uses them as-is; Claude Code, Factory Droid, Codex CLI, and Gemini CLI get PascalCase (with a few tool-specific name mappings) in their settings files; OpenCode and Kilo hooks are emitted as JavaScript plugins (`.opencode/plugins/rulesync-hooks.js`, `.kilo/plugins/rulesync-hooks.js`); Copilot and Copilot CLI map event names to their own camelCase (e.g. `beforeSubmitPrompt` → `userPromptSubmitted`, `afterError` → `errorOccurred`) and use `powershell`/`bash` command fields; deepagents-cli uses a dot-notation (e.g. `session.start`, `tool.error`); Kiro emits hooks into `.kiro/agents/default.json` using Kiro's CLI event names (`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop`).
 
 Example:
 
@@ -88,7 +88,7 @@ Example:
 
 - `version`: Schema version (currently `1`).
 - `hooks`: Map of canonical event names to an array of hook entries. These are dispatched to every tool that supports the given event.
-- `cursor.hooks`, `claudecode.hooks`, `opencode.hooks`, `kilo.hooks`, `copilot.hooks`, `copilotcli.hooks`, `factorydroid.hooks`, `geminicli.hooks`, `codexcli.hooks`, `deepagents.hooks`: Tool-specific **override keys**. Entries under these keys are emitted only for the corresponding tool, so tool-only events (e.g. `afterFileEdit` for Cursor/OpenCode/Kilo, `worktreeCreate` for Claude Code, `afterError` for Copilot/Copilot CLI) can coexist with shared ones without leaking to other tools. `copilotcli.hooks` falls back to `copilot.hooks`, which in turn falls back to the shared `hooks` block.
+- `cursor.hooks`, `claudecode.hooks`, `opencode.hooks`, `kilo.hooks`, `copilot.hooks`, `copilotcli.hooks`, `factorydroid.hooks`, `geminicli.hooks`, `codexcli.hooks`, `deepagents.hooks`, `kiro.hooks`: Tool-specific **override keys**. Entries under these keys are emitted only for the corresponding tool, so tool-only events (e.g. `afterFileEdit` for Cursor/OpenCode/Kilo, `worktreeCreate` for Claude Code, `afterError` for Copilot/Copilot CLI) can coexist with shared ones without leaking to other tools. `copilotcli.hooks` falls back to `copilot.hooks`, which in turn falls back to the shared `hooks` block.
 
 **Hook entry keys:**
 
@@ -101,36 +101,36 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 
 ### Hook event × tool matrix
 
-| Event                  | Cursor | Claude Code | OpenCode | Kilo | Copilot | Copilot CLI | Factory Droid | Gemini CLI | Codex CLI | deepagents |
-| ---------------------- | :----: | :---------: | :------: | :--: | :-----: | :---------: | :-----------: | :--------: | :-------: | :--------: |
-| `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |
-| `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |
-| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |
-| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     ✅     |
-| `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `subagentStop`         |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |
-| `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     ✅     |
-| `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeMCPExecution`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterMCPExecution`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeReadFile`       |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeAgentResponse`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `afterAgentResponse`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `afterAgentThought`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeTabFileRead`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterTabFileEdit`     |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeToolSelection`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `permissionRequest`    |   —    |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     —      |    ✅     |     ✅     |
-| `notification`         |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     —      |
-| `setup`                |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |
-| `worktreeCreate`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `worktreeRemove`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |
+| Event                  | Cursor | Claude Code | OpenCode | Kilo | Copilot | Copilot CLI | Factory Droid | Gemini CLI | Codex CLI | deepagents | Kiro |
+| ---------------------- | :----: | :---------: | :------: | :--: | :-----: | :---------: | :-----------: | :--------: | :-------: | :--------: | :--: |
+| `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |  ✅  |
+| `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |
+| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |
+| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     ✅     |  —   |
+| `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `subagentStop`         |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |  —   |
+| `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     ✅     |  —   |
+| `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeMCPExecution`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterMCPExecution`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeReadFile`       |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeAgentResponse`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `afterAgentResponse`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `afterAgentThought`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeTabFileRead`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterTabFileEdit`     |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeToolSelection`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `permissionRequest`    |   —    |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     —      |    ✅     |     ✅     |  —   |
+| `notification`         |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     —      |  —   |
+| `setup`                |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |  —   |
+| `worktreeCreate`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `worktreeRemove`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |  —   |
 
 > **Note:** `worktreeCreate` and `worktreeRemove` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
 
@@ -144,6 +144,8 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 > - **Copilot CLI** — project: `<project>/.github/hooks/copilotcli-hooks.json`; global: `~/.copilot/hooks/copilot-hooks.json`. The Copilot CLI docs let you choose any filename inside `.github/hooks/`, so Rulesync uses the CLI-specific name to avoid colliding with the cloud-agent file when both targets are enabled. The global path is a Rulesync convention; the official Copilot CLI documentation does not currently enumerate a global hooks location, so this placement may change if the spec later mandates an alternate layout.
 
 > **Note:** Because each AI tool evolves its own hook surface at its own pace, the matrix above reflects the events Rulesync currently translates. When a tool ships a new event that Rulesync does not yet support, the most reliable path is to open an issue — the matrix is the intended baseline to compare against.
+
+> **Note:** Kiro hooks are emitted into `.kiro/agents/default.json` under the `hooks` field, merging with any existing agent configuration (tools, allowedTools, etc.). Both `sessionEnd` and `stop` canonical events map to Kiro CLI's `stop` event. Only `command`-type hooks are supported; `prompt`-type hooks are silently skipped. Kiro CLI uses `timeout_ms` (in milliseconds) for per-hook timeouts.
 
 ## `.copilot/mcp-config.json`
 

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -21,7 +21,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                | takt         | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Qwen Code           | qwencode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
-| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
+| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Google Antigravity  | antigravity  |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
 | JetBrains Junie     | junie        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode         | augmentcode  |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -38,7 +38,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 
 ## `.rulesync/hooks.json`
 
-Hooks run scripts at lifecycle events (e.g. session start, before tool use). Events use **canonical camelCase** in this file, and Rulesync translates them per tool: Cursor uses them as-is; Claude Code, Factory Droid, Codex CLI, and Gemini CLI get PascalCase (with a few tool-specific name mappings) in their settings files; OpenCode and Kilo hooks are emitted as JavaScript plugins (`.opencode/plugins/rulesync-hooks.js`, `.kilo/plugins/rulesync-hooks.js`); Copilot and Copilot CLI map event names to their own camelCase (e.g. `beforeSubmitPrompt` → `userPromptSubmitted`, `afterError` → `errorOccurred`) and use `powershell`/`bash` command fields; deepagents-cli uses a dot-notation (e.g. `session.start`, `tool.error`).
+Hooks run scripts at lifecycle events (e.g. session start, before tool use). Events use **canonical camelCase** in this file, and Rulesync translates them per tool: Cursor uses them as-is; Claude Code, Factory Droid, Codex CLI, and Gemini CLI get PascalCase (with a few tool-specific name mappings) in their settings files; OpenCode and Kilo hooks are emitted as JavaScript plugins (`.opencode/plugins/rulesync-hooks.js`, `.kilo/plugins/rulesync-hooks.js`); Copilot and Copilot CLI map event names to their own camelCase (e.g. `beforeSubmitPrompt` → `userPromptSubmitted`, `afterError` → `errorOccurred`) and use `powershell`/`bash` command fields; deepagents-cli uses a dot-notation (e.g. `session.start`, `tool.error`); Kiro emits hooks into `.kiro/agents/default.json` using Kiro's CLI event names (`agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, `stop`).
 
 Example:
 
@@ -88,7 +88,7 @@ Example:
 
 - `version`: Schema version (currently `1`).
 - `hooks`: Map of canonical event names to an array of hook entries. These are dispatched to every tool that supports the given event.
-- `cursor.hooks`, `claudecode.hooks`, `opencode.hooks`, `kilo.hooks`, `copilot.hooks`, `copilotcli.hooks`, `factorydroid.hooks`, `geminicli.hooks`, `codexcli.hooks`, `deepagents.hooks`: Tool-specific **override keys**. Entries under these keys are emitted only for the corresponding tool, so tool-only events (e.g. `afterFileEdit` for Cursor/OpenCode/Kilo, `worktreeCreate` for Claude Code, `afterError` for Copilot/Copilot CLI) can coexist with shared ones without leaking to other tools. `copilotcli.hooks` falls back to `copilot.hooks`, which in turn falls back to the shared `hooks` block.
+- `cursor.hooks`, `claudecode.hooks`, `opencode.hooks`, `kilo.hooks`, `copilot.hooks`, `copilotcli.hooks`, `factorydroid.hooks`, `geminicli.hooks`, `codexcli.hooks`, `deepagents.hooks`, `kiro.hooks`: Tool-specific **override keys**. Entries under these keys are emitted only for the corresponding tool, so tool-only events (e.g. `afterFileEdit` for Cursor/OpenCode/Kilo, `worktreeCreate` for Claude Code, `afterError` for Copilot/Copilot CLI) can coexist with shared ones without leaking to other tools. `copilotcli.hooks` falls back to `copilot.hooks`, which in turn falls back to the shared `hooks` block.
 
 **Hook entry keys:**
 
@@ -101,36 +101,36 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 
 ### Hook event × tool matrix
 
-| Event                  | Cursor | Claude Code | OpenCode | Kilo | Copilot | Copilot CLI | Factory Droid | Gemini CLI | Codex CLI | deepagents |
-| ---------------------- | :----: | :---------: | :------: | :--: | :-----: | :---------: | :-----------: | :--------: | :-------: | :--------: |
-| `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |
-| `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |
-| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |
-| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     ✅     |
-| `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     ✅     |    ✅     |     ✅     |
-| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `subagentStop`         |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |
-| `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     ✅     |
-| `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeMCPExecution`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterMCPExecution`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeReadFile`       |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeAgentResponse`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `afterAgentResponse`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `afterAgentThought`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeTabFileRead`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterTabFileEdit`     |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `beforeToolSelection`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |
-| `permissionRequest`    |   —    |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     —      |    ✅     |     ✅     |
-| `notification`         |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     —      |
-| `setup`                |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |
-| `worktreeCreate`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `worktreeRemove`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |
-| `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |
+| Event                  | Cursor | Claude Code | OpenCode | Kilo | Copilot | Copilot CLI | Factory Droid | Gemini CLI | Codex CLI | deepagents | Kiro |
+| ---------------------- | :----: | :---------: | :------: | :--: | :-----: | :---------: | :-----------: | :--------: | :-------: | :--------: | :--: |
+| `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |  ✅  |
+| `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |
+| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |
+| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     ✅     |  —   |
+| `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |
+| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `subagentStop`         |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |  —   |
+| `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     ✅     |  —   |
+| `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeMCPExecution`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterMCPExecution`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeReadFile`       |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeAgentResponse`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `afterAgentResponse`   |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `afterAgentThought`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeTabFileRead`    |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterTabFileEdit`     |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `beforeToolSelection`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     ✅     |     —     |     —      |  —   |
+| `permissionRequest`    |   —    |     ✅      |    ✅    |  ✅  |    —    |      —      |      ✅       |     —      |    ✅     |     ✅     |  —   |
+| `notification`         |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     ✅     |     —     |     —      |  —   |
+| `setup`                |   —    |     ✅      |    —     |  —   |    —    |      —      |      ✅       |     —      |     —     |     —      |  —   |
+| `worktreeCreate`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `worktreeRemove`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |
+| `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |  —   |
 
 > **Note:** `worktreeCreate` and `worktreeRemove` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
 
@@ -144,6 +144,8 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 > - **Copilot CLI** — project: `<project>/.github/hooks/copilotcli-hooks.json`; global: `~/.copilot/hooks/copilot-hooks.json`. The Copilot CLI docs let you choose any filename inside `.github/hooks/`, so Rulesync uses the CLI-specific name to avoid colliding with the cloud-agent file when both targets are enabled. The global path is a Rulesync convention; the official Copilot CLI documentation does not currently enumerate a global hooks location, so this placement may change if the spec later mandates an alternate layout.
 
 > **Note:** Because each AI tool evolves its own hook surface at its own pace, the matrix above reflects the events Rulesync currently translates. When a tool ships a new event that Rulesync does not yet support, the most reliable path is to open an issue — the matrix is the intended baseline to compare against.
+
+> **Note:** Kiro hooks are emitted into `.kiro/agents/default.json` under the `hooks` field, merging with any existing agent configuration (tools, allowedTools, etc.). Both `sessionEnd` and `stop` canonical events map to Kiro CLI's `stop` event. Only `command`-type hooks are supported; `prompt`-type hooks are silently skipped. Kiro CLI uses `timeout_ms` (in milliseconds) for per-hook timeouts.
 
 ## `.copilot/mcp-config.json`
 

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -21,7 +21,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Rovodev (Atlassian) | rovodev      | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                | takt         | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Qwen Code           | qwencode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
-| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
+| Kiro                | kiro         |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Google Antigravity  | antigravity  |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
 | JetBrains Junie     | junie        |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode         | augmentcode  |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |

--- a/src/e2e/e2e-hooks.spec.ts
+++ b/src/e2e/e2e-hooks.spec.ts
@@ -37,6 +37,7 @@ describe("E2E: hooks", () => {
     { target: "copilot", outputPath: join(".github", "hooks", "copilot-hooks.json") },
     { target: "copilotcli", outputPath: join(".github", "hooks", "copilotcli-hooks.json") },
     { target: "factorydroid", outputPath: join(".factory", "settings.json") },
+    { target: "kiro", outputPath: join(".kiro", "agents", "default.json") },
   ])("should generate $target hooks", async ({ target, outputPath }) => {
     const testDir = getTestDir();
 
@@ -81,6 +82,13 @@ describe("E2E: hooks", () => {
         expect(parsed.hooks).toBeDefined();
         expect(parsed.hooks.sessionStart).toBeDefined();
         expect(parsed.hooks.stop).toBeDefined();
+      } else if (target === "kiro") {
+        // Kiro CLI uses its own event names: sessionStart → agentSpawn, stop → stop
+        expect(parsed.hooks).toBeDefined();
+        expect(parsed.hooks.agentSpawn).toBeDefined();
+        expect(parsed.hooks.stop).toBeDefined();
+        expect(parsed.hooks.agentSpawn[0].command).toBe(".rulesync/hooks/session-start.sh");
+        expect(parsed.hooks.stop[0].command).toBe(".rulesync/hooks/audit.sh");
       } else if (target === "copilot" || target === "copilotcli") {
         // Copilot and Copilot CLI use camelCase event names. Neither supports
         // the `stop` hook event (see COPILOT_HOOK_EVENTS in src/types/hooks.ts),
@@ -98,7 +106,7 @@ describe("E2E: hooks", () => {
   });
 
   it.each([
-    // claudecode, geminicli, factorydroid use settings.json (isDeletable=false) — excluded
+    // claudecode, geminicli, factorydroid, kiro use shared config files (isDeletable=false) — excluded
     { target: "cursor", orphanPath: join(".cursor", "hooks.json") },
     { target: "opencode", orphanPath: join(".opencode", "plugins", "rulesync-hooks.js") },
     { target: "codexcli", orphanPath: join(".codex", "hooks.json") },
@@ -228,6 +236,15 @@ describe("E2E: hooks (import)", () => {
           sessionStart: [
             { matcher: "", hooks: [{ type: "command", command: "echo session started" }] },
           ],
+        },
+      },
+    },
+    {
+      target: "kiro",
+      sourcePath: join(".kiro", "agents", "default.json"),
+      sourceContent: {
+        hooks: {
+          agentSpawn: [{ command: "echo session started" }],
         },
       },
     },

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -481,7 +481,7 @@ describe("HooksProcessor", () => {
   });
 
   describe("getToolTargets", () => {
-    it("should return cursor, claudecode, copilot, copilotcli, opencode, kilo, factorydroid, and geminicli for project mode", () => {
+    it("should return cursor, claudecode, copilot, copilotcli, opencode, kilo, factorydroid, geminicli, and kiro for project mode", () => {
       const targets = HooksProcessor.getToolTargets({ global: false });
       expect(targets).toEqual([
         "cursor",
@@ -493,6 +493,7 @@ describe("HooksProcessor", () => {
         "opencode",
         "factorydroid",
         "geminicli",
+        "kiro",
       ]);
     });
 
@@ -521,6 +522,7 @@ describe("HooksProcessor", () => {
         "copilotcli",
         "factorydroid",
         "geminicli",
+        "kiro",
       ]);
     });
 

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -9,9 +9,10 @@ import {
   CURSOR_HOOK_EVENTS,
   DEEPAGENTS_HOOK_EVENTS,
   FACTORYDROID_HOOK_EVENTS,
-  KILO_HOOK_EVENTS,
-  OPENCODE_HOOK_EVENTS,
   GEMINICLI_HOOK_EVENTS,
+  KILO_HOOK_EVENTS,
+  KIRO_HOOK_EVENTS,
+  OPENCODE_HOOK_EVENTS,
   type HookEvent,
   type HookType,
 } from "../../types/hooks.js";
@@ -29,6 +30,7 @@ import { DeepagentsHooks } from "./deepagents-hooks.js";
 import { FactorydroidHooks } from "./factorydroid-hooks.js";
 import { GeminicliHooks } from "./geminicli-hooks.js";
 import { KiloHooks } from "./kilo-hooks.js";
+import { KiroHooks } from "./kiro-hooks.js";
 import { OpencodeHooks } from "./opencode-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 import type {
@@ -49,6 +51,7 @@ const hooksProcessorToolTargetTuple = [
   "factorydroid",
   "geminicli",
   "deepagents",
+  "kiro",
 ] as const;
 
 export type HooksProcessorToolTarget = (typeof hooksProcessorToolTargetTuple)[number];
@@ -217,6 +220,22 @@ const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFactory>([
       supportedEvents: DEEPAGENTS_HOOK_EVENTS,
       supportedHookTypes: ["command"],
       supportsMatcher: false,
+    },
+  ],
+  [
+    "kiro",
+    {
+      class: KiroHooks,
+      meta: {
+        // Kiro hooks are project-level only (consistent with existing Kiro features).
+        // Hooks are written to .kiro/agents/default.json alongside subagent configs.
+        supportsProject: true,
+        supportsGlobal: false,
+        supportsImport: true,
+      },
+      supportedEvents: KIRO_HOOK_EVENTS,
+      supportedHookTypes: ["command"],
+      supportsMatcher: true,
     },
   ],
 ]);

--- a/src/features/hooks/kiro-hooks.test.ts
+++ b/src/features/hooks/kiro-hooks.test.ts
@@ -84,9 +84,11 @@ describe("KiroHooks", () => {
       expect(parsed.hooks.userPromptSubmit).toBeDefined();
       expect(parsed.hooks.preToolUse).toBeDefined();
       expect(parsed.hooks.postToolUse).toBeDefined();
-      // Both sessionEnd and stop map to kiro's stop. The latter overwrites.
+      // Both sessionEnd and stop map to kiro's stop and are merged.
       expect(parsed.hooks.stop).toBeDefined();
-      expect(parsed.hooks.stop[0].command).toBe("echo stop");
+      expect(parsed.hooks.stop).toHaveLength(2);
+      expect(parsed.hooks.stop[0].command).toBe("echo end");
+      expect(parsed.hooks.stop[1].command).toBe("echo stop");
     });
 
     it("should include matcher and timeout_ms in output", async () => {
@@ -407,7 +409,7 @@ describe("KiroHooks", () => {
         relativeFilePath: "default.json",
       });
       const parsed = JSON.parse(hooks.getFileContent());
-      expect(parsed).toEqual({});
+      expect(parsed).toEqual({ hooks: {} });
     });
   });
 });

--- a/src/features/hooks/kiro-hooks.test.ts
+++ b/src/features/hooks/kiro-hooks.test.ts
@@ -1,0 +1,413 @@
+import { join } from "node:path";
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { readOrInitializeFileContent, ensureDir, writeFileContent } from "../../utils/file.js";
+import { KiroHooks } from "./kiro-hooks.js";
+import { RulesyncHooks } from "./rulesync-hooks.js";
+
+function createMockAiFileParams(
+  override: Partial<ConstructorParameters<typeof RulesyncHooks>[0]> = {},
+) {
+  return {
+    outputRoot: "/mock",
+    relativeDirPath: ".rulesync",
+    relativeFilePath: "hooks.json",
+    fileContent: "{}",
+    ...override,
+  };
+}
+
+describe("KiroHooks", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  describe("fromRulesyncHooks", () => {
+    it("should filter unsupported events and convert to Kiro CLI format", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [{ command: "echo start" }],
+              unsupportedEvent: [{ command: "echo ignored" }],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks).toBeDefined();
+      expect(parsed.hooks.agentSpawn).toBeDefined();
+      expect(parsed.hooks.agentSpawn[0].command).toBe("echo start");
+      expect(parsed.hooks.UnsupportedEvent).toBeUndefined();
+    });
+
+    it("should map canonical event names to Kiro CLI event names", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [{ command: "echo start" }],
+              sessionEnd: [{ command: "echo end" }],
+              beforeSubmitPrompt: [{ command: "echo prompt" }],
+              preToolUse: [{ command: "echo pre", matcher: "Bash" }],
+              postToolUse: [{ command: "echo post" }],
+              stop: [{ command: "echo stop" }],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks.agentSpawn).toBeDefined();
+      expect(parsed.hooks.userPromptSubmit).toBeDefined();
+      expect(parsed.hooks.preToolUse).toBeDefined();
+      expect(parsed.hooks.postToolUse).toBeDefined();
+      // Both sessionEnd and stop map to kiro's stop. The latter overwrites.
+      expect(parsed.hooks.stop).toBeDefined();
+      expect(parsed.hooks.stop[0].command).toBe("echo stop");
+    });
+
+    it("should include matcher and timeout_ms in output", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              preToolUse: [{ command: "echo check", matcher: "Bash", timeout: 5000 }],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks.preToolUse[0].command).toBe("echo check");
+      expect(parsed.hooks.preToolUse[0].matcher).toBe("Bash");
+      expect(parsed.hooks.preToolUse[0].timeout_ms).toBe(5000);
+    });
+
+    it("should skip prompt-type hooks", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [
+                { type: "prompt", prompt: "hello" },
+                { type: "command", command: "echo start" },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks.agentSpawn).toHaveLength(1);
+      expect(parsed.hooks.agentSpawn[0].command).toBe("echo start");
+    });
+
+    it("should merge with existing default.json", async () => {
+      const mockConfig = {
+        allowedTools: ["web_fetch", "web_search"],
+        hooks: {
+          oldEvent: [{ command: "old" }],
+        },
+      };
+
+      const configPath = join(testDir, ".kiro", "agents", "default.json");
+      await ensureDir(join(testDir, ".kiro", "agents"));
+      await readOrInitializeFileContent(configPath, JSON.stringify(mockConfig));
+
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [{ command: "echo start" }],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.allowedTools).toEqual(["web_fetch", "web_search"]);
+      expect(parsed.hooks.agentSpawn).toBeDefined();
+      // Existing hooks are overwritten by Rulesync
+      expect(parsed.hooks.oldEvent).toBeUndefined();
+    });
+
+    it("should process overrides from config.kiro.hooks", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [{ command: "echo start" }],
+            },
+            kiro: {
+              hooks: {
+                sessionStart: [{ command: "echo override" }],
+                stop: [{ command: "echo stop" }],
+              },
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks.agentSpawn[0].command).toBe("echo override");
+      expect(parsed.hooks.stop[0].command).toBe("echo stop");
+    });
+
+    it("should include name and description fields", async () => {
+      const rulesyncHooks = new RulesyncHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              sessionStart: [
+                { command: "echo start", name: "Start Hook", description: "Runs on start" },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: true,
+      });
+
+      const parsed = JSON.parse(kiroHooks.getFileContent());
+      expect(parsed.hooks.agentSpawn[0].name).toBe("Start Hook");
+      expect(parsed.hooks.agentSpawn[0].description).toBe("Runs on start");
+    });
+  });
+
+  describe("toRulesyncHooks", () => {
+    it("should convert Kiro CLI format to canonical format", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              agentSpawn: [
+                {
+                  command: "echo start",
+                  matcher: "",
+                  timeout_ms: 1000,
+                  name: "Start Hook",
+                  description: "Runs on start",
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.sessionStart).toBeDefined();
+      expect(parsed.hooks.sessionStart?.[0]).toEqual({
+        type: "command",
+        command: "echo start",
+        timeout: 1000,
+        name: "Start Hook",
+        description: "Runs on start",
+      });
+    });
+
+    it("should convert preToolUse with matcher", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              preToolUse: [
+                {
+                  command: "echo check",
+                  matcher: "Bash",
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.preToolUse).toBeDefined();
+      expect(parsed.hooks.preToolUse?.[0]).toEqual({
+        type: "command",
+        command: "echo check",
+        matcher: "Bash",
+      });
+    });
+
+    it("should map Kiro CLI stop event to canonical stop", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              stop: [{ command: "echo done" }],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.stop).toBeDefined();
+      expect(parsed.hooks.stop?.[0]?.command).toBe("echo done");
+    });
+
+    it("should skip entries without a command", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              stop: [{ matcher: "test" }, { command: "echo good" }],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.stop).toHaveLength(1);
+      expect(parsed.hooks.stop?.[0]?.command).toBe("echo good");
+    });
+
+    it("should ignore invalid entries", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              agentSpawn: "invalid",
+              stop: ["invalid", { hooks: "invalid" }, 123],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.sessionStart).toBeUndefined();
+      expect(parsed.hooks.stop).toBeUndefined();
+    });
+
+    it("should handle unknown event names gracefully", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              someUnknownEvent: [{ command: "echo unknown" }],
+            },
+          }),
+        }),
+      );
+
+      const rulesyncHooks = kiroHooks.toRulesyncHooks();
+      const parsed = rulesyncHooks.getJson();
+
+      expect(parsed.hooks.someUnknownEvent).toBeDefined();
+      expect(parsed.hooks.someUnknownEvent?.[0]?.command).toBe("echo unknown");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load from .kiro/agents/default.json when it exists", async () => {
+      await ensureDir(join(testDir, ".kiro", "agents"));
+      await writeFileContent(
+        join(testDir, ".kiro", "agents", "default.json"),
+        JSON.stringify({
+          hooks: {
+            agentSpawn: [{ command: "echo start" }],
+          },
+        }),
+      );
+
+      const kiroHooks = await KiroHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(kiroHooks).toBeInstanceOf(KiroHooks);
+      const content = kiroHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.agentSpawn).toHaveLength(1);
+    });
+
+    it("should initialize empty config when default.json does not exist", async () => {
+      const kiroHooks = await KiroHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(kiroHooks).toBeInstanceOf(KiroHooks);
+      const content = kiroHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed).toEqual({});
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("should return false", () => {
+      const hooks = new KiroHooks(createMockAiFileParams());
+      expect(hooks.isDeletable()).toBe(false);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create instance with empty config", () => {
+      const hooks = KiroHooks.forDeletion({
+        relativeDirPath: join(".kiro", "agents"),
+        relativeFilePath: "default.json",
+      });
+      const parsed = JSON.parse(hooks.getFileContent());
+      expect(parsed).toEqual({});
+    });
+  });
+});

--- a/src/features/hooks/kiro-hooks.ts
+++ b/src/features/hooks/kiro-hooks.ts
@@ -9,6 +9,7 @@ import {
   KIRO_HOOK_EVENTS,
   CANONICAL_TO_KIRO_EVENT_NAMES,
   KIRO_TO_CANONICAL_EVENT_NAMES,
+  safeString,
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
@@ -36,6 +37,10 @@ function canonicalToKiroHooks(config: HooksConfig): Record<string, unknown[]> {
   }
   const effectiveHooks: HooksConfig["hooks"] = {
     ...sharedHooks,
+    // Note: Tool-specific overrides (config.kiro?.hooks) bypass the
+    // KIRO_HOOK_EVENTS filter by design — users who define tool-level overrides
+    // are expected to know the target tool's event surface. The HooksProcessor
+    // already warns about unsupported events before calling this function.
     ...config.kiro?.hooks,
   };
   const kiro: Record<string, unknown[]> = {};
@@ -49,14 +54,20 @@ function canonicalToKiroHooks(config: HooksConfig): Record<string, unknown[]> {
         ...(def.matcher !== undefined &&
           def.matcher !== null &&
           def.matcher !== "" && { matcher: def.matcher }),
-        ...(def.timeout !== undefined && def.timeout !== null && { timeout_ms: def.timeout }),
+        ...(def.timeout !== undefined &&
+          def.timeout !== null &&
+          def.timeout > 0 && { timeout_ms: def.timeout }),
         ...(def.name !== undefined && def.name !== null && { name: def.name }),
         ...(def.description !== undefined &&
           def.description !== null && { description: def.description }),
       });
     }
     if (entries.length > 0) {
-      kiro[kiroEventName] = entries;
+      if (kiro[kiroEventName]) {
+        kiro[kiroEventName].push(...entries);
+      } else {
+        kiro[kiroEventName] = entries;
+      }
     }
   }
   return kiro;
@@ -68,7 +79,7 @@ function canonicalToKiroHooks(config: HooksConfig): Record<string, unknown[]> {
  * versions are accepted and silently ignored during import.
  */
 const KiroHookEntrySchema = z.looseObject({
-  command: z.optional(z.string()),
+  command: z.optional(safeString),
   matcher: z.optional(z.string()),
   timeout_ms: z.optional(z.number()),
   name: z.optional(z.string()),
@@ -208,7 +219,7 @@ export class KiroHooks extends ToolHooks {
       outputRoot,
       relativeDirPath,
       relativeFilePath,
-      fileContent: JSON.stringify({}, null, 2),
+      fileContent: JSON.stringify({ hooks: {} }, null, 2),
       validate: false,
     });
   }

--- a/src/features/hooks/kiro-hooks.ts
+++ b/src/features/hooks/kiro-hooks.ts
@@ -1,0 +1,215 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import type { AiFileParams } from "../../types/ai-file.js";
+import type { ValidationResult } from "../../types/ai-file.js";
+import type { HooksConfig } from "../../types/hooks.js";
+import {
+  KIRO_HOOK_EVENTS,
+  CANONICAL_TO_KIRO_EVENT_NAMES,
+  KIRO_TO_CANONICAL_EVENT_NAMES,
+} from "../../types/hooks.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import {
+  ToolHooks,
+  type ToolHooksForDeletionParams,
+  type ToolHooksFromFileParams,
+  type ToolHooksFromRulesyncHooksParams,
+  type ToolHooksSettablePaths,
+} from "./tool-hooks.js";
+
+/**
+ * Convert canonical hooks config to Kiro CLI format.
+ * Filters shared hooks to KIRO_HOOK_EVENTS, merges config.kiro?.hooks,
+ * then maps event names and emits Kiro CLI hook arrays.
+ */
+function canonicalToKiroHooks(config: HooksConfig): Record<string, unknown[]> {
+  const kiroSupported: Set<string> = new Set(KIRO_HOOK_EVENTS);
+  const sharedHooks: HooksConfig["hooks"] = {};
+  for (const [event, defs] of Object.entries(config.hooks)) {
+    if (kiroSupported.has(event)) {
+      sharedHooks[event] = defs;
+    }
+  }
+  const effectiveHooks: HooksConfig["hooks"] = {
+    ...sharedHooks,
+    ...config.kiro?.hooks,
+  };
+  const kiro: Record<string, unknown[]> = {};
+  for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
+    const kiroEventName = CANONICAL_TO_KIRO_EVENT_NAMES[eventName] ?? eventName;
+    const entries: unknown[] = [];
+    for (const def of definitions) {
+      if ((def.type ?? "command") !== "command") continue;
+      entries.push({
+        command: def.command,
+        ...(def.matcher !== undefined &&
+          def.matcher !== null &&
+          def.matcher !== "" && { matcher: def.matcher }),
+        ...(def.timeout !== undefined && def.timeout !== null && { timeout_ms: def.timeout }),
+        ...(def.name !== undefined && def.name !== null && { name: def.name }),
+        ...(def.description !== undefined &&
+          def.description !== null && { description: def.description }),
+      });
+    }
+    if (entries.length > 0) {
+      kiro[kiroEventName] = entries;
+    }
+  }
+  return kiro;
+}
+
+/**
+ * Kiro CLI hook entry as stored in each event's array.
+ * Uses `z.looseObject` so that unknown fields added by future Kiro CLI
+ * versions are accepted and silently ignored during import.
+ */
+const KiroHookEntrySchema = z.looseObject({
+  command: z.optional(z.string()),
+  matcher: z.optional(z.string()),
+  timeout_ms: z.optional(z.number()),
+  name: z.optional(z.string()),
+  description: z.optional(z.string()),
+});
+
+/**
+ * Extract hooks from Kiro CLI agent config into canonical format.
+ */
+function kiroHooksToCanonical(kiroHooks: unknown): HooksConfig["hooks"] {
+  if (kiroHooks === null || kiroHooks === undefined || typeof kiroHooks !== "object") {
+    return {};
+  }
+  const canonical: HooksConfig["hooks"] = {};
+  for (const [kiroEventName, entries] of Object.entries(kiroHooks)) {
+    const eventName = KIRO_TO_CANONICAL_EVENT_NAMES[kiroEventName] ?? kiroEventName;
+    if (!Array.isArray(entries)) continue;
+    const defs: HooksConfig["hooks"][string] = [];
+    for (const rawEntry of entries) {
+      const parseResult = KiroHookEntrySchema.safeParse(rawEntry);
+      if (!parseResult.success) continue;
+      const entry = parseResult.data;
+      if (!entry.command) continue;
+      defs.push({
+        type: "command",
+        command: entry.command,
+        ...(entry.matcher !== undefined &&
+          entry.matcher !== null &&
+          entry.matcher !== "" && { matcher: entry.matcher }),
+        ...(entry.timeout_ms !== undefined &&
+          entry.timeout_ms !== null && { timeout: entry.timeout_ms }),
+        ...(entry.name !== undefined && entry.name !== null && { name: entry.name }),
+        ...(entry.description !== undefined &&
+          entry.description !== null && { description: entry.description }),
+      });
+    }
+    if (defs.length > 0) {
+      canonical[eventName] = defs;
+    }
+  }
+  return canonical;
+}
+
+export class KiroHooks extends ToolHooks {
+  constructor(params: AiFileParams) {
+    super({
+      ...params,
+      fileContent: params.fileContent ?? "{}",
+    });
+  }
+
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
+    return { relativeDirPath: join(".kiro", "agents"), relativeFilePath: "default.json" };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolHooksFromFileParams): Promise<KiroHooks> {
+    const paths = KiroHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? "{}";
+    return new KiroHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncHooks({
+    outputRoot = process.cwd(),
+    rulesyncHooks,
+    validate = true,
+    global = false,
+  }: ToolHooksFromRulesyncHooksParams & { global?: boolean }): Promise<KiroHooks> {
+    const paths = KiroHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = await readOrInitializeFileContent(
+      filePath,
+      JSON.stringify({}, null, 2),
+    );
+    let agentConfig: Record<string, unknown>;
+    try {
+      agentConfig = JSON.parse(existingContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse existing Kiro agent config at ${filePath}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+    const config = rulesyncHooks.getJson();
+    const kiroHooks = canonicalToKiroHooks(config);
+    const merged = { ...agentConfig, hooks: kiroHooks };
+    const fileContent = JSON.stringify(merged, null, 2);
+    return new KiroHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  toRulesyncHooks(): RulesyncHooks {
+    let agentConfig: { hooks?: unknown };
+    try {
+      agentConfig = JSON.parse(this.getFileContent());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Kiro hooks content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+    const hooks = kiroHooksToCanonical(agentConfig.hooks);
+    return this.toRulesyncHooksDefault({
+      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolHooksForDeletionParams): KiroHooks {
+    return new KiroHooks({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({}, null, 2),
+      validate: false,
+    });
+  }
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -196,6 +196,16 @@ export const CODEXCLI_HOOK_EVENTS: readonly HookEvent[] = [
   "permissionRequest",
 ];
 
+/** Hook events supported by Kiro CLI. */
+export const KIRO_HOOK_EVENTS: readonly HookEvent[] = [
+  "sessionStart",
+  "sessionEnd",
+  "beforeSubmitPrompt",
+  "preToolUse",
+  "postToolUse",
+  "stop",
+];
+
 const hooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema));
 
 /**
@@ -214,6 +224,7 @@ export const HooksConfigSchema = z.looseObject({
   geminicli: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   codexcli: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   deepagents: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
+  kiro: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
 });
 
 export type HooksConfig = z.infer<typeof HooksConfigSchema>;
@@ -402,4 +413,26 @@ export const CANONICAL_TO_DEEPAGENTS_EVENT_NAMES: Record<string, string> = {
  */
 export const DEEPAGENTS_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
   Object.entries(CANONICAL_TO_DEEPAGENTS_EVENT_NAMES).map(([k, v]) => [v, k]),
+);
+
+/**
+ * Map canonical camelCase event names to Kiro CLI camelCase.
+ * Kiro CLI uses its own event naming: agentSpawn, userPromptSubmit, preToolUse,
+ * postToolUse, stop. Both `sessionEnd` and `stop` canonical events map to
+ * kiro's `stop`.
+ */
+export const CANONICAL_TO_KIRO_EVENT_NAMES: Record<string, string> = {
+  sessionStart: "agentSpawn",
+  sessionEnd: "stop",
+  beforeSubmitPrompt: "userPromptSubmit",
+  preToolUse: "preToolUse",
+  postToolUse: "postToolUse",
+  stop: "stop",
+};
+
+/**
+ * Map Kiro CLI camelCase event names to canonical camelCase.
+ */
+export const KIRO_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_KIRO_EVENT_NAMES).map(([k, v]) => [v, k]),
 );

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -11,7 +11,7 @@ export const CONTROL_CHARS = ["\n", "\r", "\0"] as const;
  * Used for command and matcher fields that are embedded in generated code.
  */
 const hasControlChars = (val: string): boolean => CONTROL_CHARS.some((char) => val.includes(char));
-const safeString = z.pipe(
+export const safeString = z.pipe(
   z.string(),
   z.custom<string>(
     (val) => typeof val === "string" && !hasControlChars(val),


### PR DESCRIPTION
## Summary

Adds Kiro CLI hooks support to rulesync's `--features hooks` generation pipeline. This completes rulesync's Kiro feature coverage (rules, subagents, skills, MCP, permissions, and now hooks).

## Changes

- **`src/types/hooks.ts`** — Added `KIRO_HOOK_EVENTS`, canonical→Kiro event name mappings, and `kiro` key to `HooksConfigSchema`
- **`src/features/hooks/kiro-hooks.ts`** (new) — `KiroHooks` class extending `ToolHooks`
- **`src/features/hooks/kiro-hooks.test.ts`** (new) — 17 unit tests
- **`src/features/hooks/hooks-processor.ts`** — Registered `kiro` target
- **`src/e2e/e2e-hooks.spec.ts`** — Added Kiro generate + import e2e test cases
- **`docs/reference/file-formats.md`** — Added Kiro to event matrix and narrative
- **`docs/reference/supported-tools.md`** — Marked hooks as supported in Kiro row

## Behavior

- Output: `.kiro/agents/default.json` (merges `hooks` field with existing agent config)
- Events: `sessionStart`→`agentSpawn`, `sessionEnd`/stop→`stop`, `beforeSubmitPrompt`→`userPromptSubmit`, `preToolUse`/postToolUse` (passthrough)
- Only `command`-type hooks; `prompt`-type are silently skipped
- `timeout` ↔ `timeout_ms` mapping for Kiro CLI compatibility
- `isDeletable()` = false (shared config file)
- Project-level only (no global mode), supports import

Closes #1674