### PR TITLE
refactor: delegate draft-release workflow prompt to skill

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -64,27 +64,4 @@ jobs:
           use_github_token: "true"
           share: false
           prompt: |
-            Let's work on the following steps.
-
-            1. Confirm that you are currently on the main branch and pull the latest changes. If not on main branch, switch to main branch.
-            2. Compare code changes between the previous version tag and the latest commit to prepare the release description.
-
-            - Write in English.
-            - Do not include confidential information.
-            - Sections, `What's Changed`, `Contributors` and `Full Changelog` are needed.
-            - `./tmp/release-notes/*.md` will be used as the release notes.
-
-            Then, check the environment variable $INPUT_NEW_VERSION. If it is not empty, use that value (without v prefix) as $new_version. For example, if $INPUT_NEW_VERSION is "1.0.0", the new version is "1.0.0".
-
-            If $INPUT_NEW_VERSION is empty, determine the new version automatically by performing the  release-dry-run skill.
-
-            Let's resume the release process.
-
-            3. Run `git pull`.
-            4. Run `git checkout -b release/v${new_version}`.
-            5. Update `getVersion()` function to return the ${new_version} in `src/cli/index.ts`, and run `pnpm cicheck`. If the checks fail, fix the code until pass. Then, execute `git add`, `git commit` and `git push`.
-            6. Update the version with `pnpm version ${new_version} --no-git-tag-version`.
-            7. Since `package.json` will be modified, execute `git commit` and `git push`.
-            8. As a precaution, verify that `getVersion()` in `src/cli/index.ts` is updated to the ${new_version}.
-            9. Run `gh pr create` to the main branch.
-            10. Create a **draft** release using `gh release create v${new_version} --draft --title v${new_version} --notes-file ./tmp/release-notes/*.md` command on the `github.com/dyoshikawa/rulesync` repository. This creates a draft release so that the publish-assets workflow can upload assets later.
+            Run the `draft-release` skill. Use the value of the `$INPUT_NEW_VERSION` environment variable as the skill's argument (it may be empty, in which case the skill will determine the new version automatically).


### PR DESCRIPTION
## Summary
- Shrink the inline prompt in `.github/workflows/draft-release.yml` down to a single sentence that delegates to the existing `draft-release` skill.
- The 10-step release procedure already lives in `.rulesync/skills/draft-release/SKILL.md` (and is mirrored to `.opencode/skill/draft-release/SKILL.md` by `pnpm generate`), so duplicating it in the workflow was redundant.
- The skill receives the workflow input via the existing `INPUT_NEW_VERSION` env var as its `$ARGUMENTS`; when empty, the skill falls back to the `release-dry-run` skill for automatic version determination.

## Test plan
- [x] `pnpm cicheck` passes locally
- [ ] Trigger the `Draft Release` workflow on this branch via `workflow_dispatch` (with and without `new_version`) before merging to verify OpenCode still produces the expected draft release PR and GitHub draft release