### PR TITLE
chore: release v8.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.19.0";
+const getVersion = () => "8.20.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v8.20.0

## Changes

- feat(opencode): add env variable format translation for MCP config
- fix(codexcli-mcp): prevent prototype pollution in map lookups
- fix(codexcli-mcp): tighten envVars handling
- fix: keep wildcard matcher change scoped
- fix: normalize wildcard hook matcher
- fix: avoid duplicate matcher regex declarations
- refactor: delegate draft-release workflow prompt to skill
- refactor(mcp): extract shared env var format conversion utility
- Various test and chore improvements

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v8.19.0...v8.20.0