### PR TITLE
docs(rules): add playwright-cli fallback rule for unfetchable pages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,3 +38,4 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
 - The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.
 - Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.
+- When researching topics, if the built-in webfetch tool cannot retrieve a page's content (e.g., because the page is a SPA), use the `playwright-cli` skill instead.

--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -34,3 +34,4 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - Do not modify the root `skills/` directory unless you intend to change the official skills distributed to users.
 - The contents of `docs/` and `skills/rulesync/` are automatically synchronized by `scripts/sync-skill-docs.ts`. Be aware that their content may overlap.
 - Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.
+- When researching topics, if the built-in webfetch tool cannot retrieve a page's content (e.g., because the page is a SPA), use the `playwright-cli` skill instead.


### PR DESCRIPTION
## Summary

Adds a guideline to the project overview rule (`.rulesync/rules/overview.md`) instructing the use of the `playwright-cli` skill when the built-in webfetch tool cannot retrieve a page's content (e.g. SPA pages) during research.

The change is propagated to the generated `.github/copilot-instructions.md` via `rulesync generate`. Other generated targets (`CLAUDE.md`, `AGENTS.md`, `.takt/`) are gitignored and therefore not part of the diff.

## Test plan
- `pnpm cicheck` passes (format, lint, typecheck, 5613 tests, sync-skill-docs, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)