### PR TITLE
docs(readme): restructure the support matrix into a presence overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,42 +70,47 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 
 ## Supported Tools and Features
 
-| Tool                   | --targets       | rules | ignore |   mcp    | commands | subagents | skills | hooks | permissions |
-| ---------------------- | --------------- | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
-| AGENTS.md              | agentsmd        |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
-| AgentsSkills           | agentsskills    |       |        |          |          |           |   ✅   |       |             |
-| Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Gemini CLI ⚠️          | geminicli       | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Goose                  | goose           | ✅ 🌏 |   ✅   |          |          |           |        |       |             |
-| GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
-| GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   |        | ✅ 🌏 |             |
-| Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| deepagents-cli         | deepagents      |  ✅   |        |  ✅ 🌏   |          |    ✅     |   ✅   |  🌏   |             |
-| Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
-| OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Cline                  | cline           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |
-| Kilo Code              | kilo            | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
-| Roo Code               | roo             |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
-| Rovodev (Atlassian)    | rovodev         | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
-| Takt                   | takt            | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
-| Qwen Code              | qwencode        |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
-| Kiro                   | kiro            |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     |   ✅   |       |     ✅      |
-| Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |             |
-| Google Antigravity CLI | antigravity-cli | ✅ 🌏 |        | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
-| Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
-| JetBrains Junie        | junie           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
-| AugmentCode            | augmentcode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
-| Windsurf               | windsurf        |  ✅   |   ✅   |          |          |           | ✅ 🌏  |       |             |
-| Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
-| Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
-| Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
-| Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
+The tables below show whether each tool supports a given feature (✅ = supported, blank = not supported). For each tool's `--targets` value and mode details (project / global / simulated), see the [Supported Tools reference](https://rulesync.dyoshikawa.com/reference/supported-tools).
 
-- ✅: Supports project mode
-- 🌏: Supports global mode
-- 🎮: Supports simulated commands/subagents/skills (Project mode only)
-- 🔧: Supports MCP tool config (`enabledTools`/`disabledTools`)
+### AI Coding Tools
+
+| Tool                   | rules | ignore | mcp | commands | subagents | skills | hooks | permissions |
+| ---------------------- | :---: | :----: | :-: | :------: | :-------: | :----: | :---: | :---------: |
+| Claude Code            |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Codex CLI              |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Gemini CLI ⚠️          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Goose                  |  ✅   |   ✅   |     |          |           |        |       |             |
+| GitHub Copilot         |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
+| GitHub Copilot CLI     |  ✅   |        | ✅  |          |    ✅     |        |  ✅   |             |
+| Cursor                 |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| deepagents-cli         |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |             |
+| Factory Droid          |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
+| OpenCode               |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Cline                  |  ✅   |   ✅   | ✅  |    ✅    |           |   ✅   |       |     ✅      |
+| Kilo Code              |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Roo Code               |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |       |             |
+| Rovodev (Atlassian)    |  ✅   |        | ✅  |          |    ✅     |   ✅   |       |             |
+| Takt                   |  ✅   |        |     |    ✅    |    ✅     |   ✅   |       |             |
+| Qwen Code              |  ✅   |   ✅   |     |          |           |        |       |     ✅      |
+| Kiro                   |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
+| Google Antigravity IDE |  ✅   |        | ✅  |    ✅    |           |   ✅   |  ✅   |             |
+| Google Antigravity CLI |  ✅   |        | ✅  |          |           |   ✅   |  ✅   |     ✅      |
+| Google Antigravity ⚠️  |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
+| JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |       |             |
+| AugmentCode            |  ✅   |   ✅   |     |          |           |        |       |     ✅      |
+| Windsurf               |  ✅   |   ✅   |     |          |           |   ✅   |       |             |
+| Warp                   |  ✅   |        |     |          |           |        |       |             |
+| Replit                 |  ✅   |        |     |          |           |   ✅   |       |             |
+| Pi Coding Agent        |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
+| Zed                    |  ✅   |   ✅   | ✅  |          |           |   ✅   |       |             |
+
+### Open Standards
+
+| Standard     | rules | ignore | mcp | commands | subagents | skills | hooks | permissions |
+| ------------ | :---: | :----: | :-: | :------: | :-------: | :----: | :---: | :---------: |
+| AGENTS.md    |  ✅   |        |     |    ✅    |    ✅     |   ✅   |       |             |
+| Agent Skills |       |        |     |          |           |   ✅   |       |             |
+
 - ⚠️: Deprecated — still supported, but see the note below
 
 ### Deprecation notes

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -16,7 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |
-| Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
+| Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Roo Code               | roo             |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian)    | rovodev         | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                   | takt            | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -16,7 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |
-| Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  |       |    ✅ 🌏    |
+| Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Roo Code               | roo             |  ✅   |   ✅   |    ✅    |    ✅    |    🎮     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian)    | rovodev         | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Takt                   | takt            | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |


### PR DESCRIPTION
## Summary

The single dense matrix was hard to read, so I tried restructuring it. Sharing as a proposal — please judge whether it's worth merging.

- Reduced it to a **presence overview** (✅ / blank): readers first want to know "is my tool supported?", not the full scope breakdown.
- Split **AI Coding Tools** from **Open Standards** (AGENTS.md, Agent Skills).
- Moved `--targets` values and mode details (project / global / simulated) to the [Supported Tools reference](https://rulesync.dyoshikawa.com/reference/supported-tools), which already has that table.
- Kept the `⚠️` Deprecated markers and the Deprecation notes section as-is.

## Note

The matrix was missing 3 entries the code already supports. Synced both `README.md` and `docs/reference/supported-tools.md` to the implementation: `kilo` × subagents/hooks, `kiro` × hooks.

> If this table is updated by any automated/agentic flow when adding a tool, let me know — I'd like to avoid breaking that.

## Test plan

- [x] Overview matches the feature → tool registries in `src/features/*/` (29 targets incl. open standards)
- [x] `oxfmt --check` / `cspell`
