### PR TITLE
docs(commands): always add maintainer-scrap label in research-tool-updates

### DIFF
--- a/.rulesync/commands/research-tool-updates.md
+++ b/.rulesync/commands/research-tool-updates.md
@@ -204,8 +204,9 @@ conversation language.
   ```
 
 - Labels: pick a small, precise set from the fetched vocabulary (do not invent
-  labels). Typically `enhancement` plus `considering`; add `codex` for the
-  Codex CLI, `security` only when relevant. Do not add `maintainer-scrap`.
+  labels). Always add `maintainer-scrap` (issues filed by this command are
+  maintainer scraps). Also add `enhancement` plus `considering`; add `codex`
+  for the Codex CLI, and `security` only when relevant.
 
 ```bash
 gh issue create --title "<title>" --body "<body>" --label "<label1>,<label2>"


### PR DESCRIPTION
## Summary

Updates the label guidance in the `research-tool-updates` command so that issues it files always include the `maintainer-scrap` label.

Issues created by this command are maintainer scraps, so the previous guidance ("Do not add `maintainer-scrap`") was incorrect. The label set is now:

- `maintainer-scrap` (always)
- `enhancement` plus `considering`
- `codex` for the Codex CLI
- `security` only when relevant

## Test Plan

- `pnpm cicheck` passes (lint, type check, tests, content/spelling/secrets checks).
- Documentation-only change to a command definition; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
