### PR TITLE
Release v8.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.21.0",
+  "version": "8.22.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.21.0";
+const getVersion = () => "8.22.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v8.22.0.

## Highlights

### New Features
- feat(antigravity): split antigravity into antigravity-ide and antigravity-cli (Antigravity 2.0) (#1708)
  - The legacy `antigravity` target is kept as an alias for `antigravity-ide` and now emits a deprecation warning.

### Documentation
- docs(commands): always add maintainer-scrap label in research-tool-updates (#1712)

### Other Changes
- chore(claude): enable 1M context disable and raise autocompact threshold (#1683)

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v8.21.0...v8.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)