### PR TITLE
fix(codexcli): emit workspace root permissions

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -515,11 +515,11 @@ For OpenCode, this generates the `permission` object in `opencode.json` / `openc
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 
 - `bash`: generates one `prefix_rule(...)` per command pattern in `.codex/rules/rulesync.rules` (`allow` → `allow`, `ask` → `prompt`, `deny` → `forbidden`)
-- `read`: `allow` → `read`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
-- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `read`: `allow` → `read`, `ask`/`deny` → `deny` in `permissions.<profile>.filesystem`
+- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `deny` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
-Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":project_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated project-root rules contain unbounded `**` patterns.
+Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":workspace_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated workspace-root rules contain unbounded `**` patterns.
 
 For Gemini CLI, this generates a Policy Engine file at `.gemini/policies/rulesync.toml` (project mode) or `~/.gemini/policies/rulesync.toml` (global mode). Gemini CLI auto-discovers any `*.toml` file under the `policies/` directory, so no `settings.json` modification is required:
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -515,11 +515,11 @@ For OpenCode, this generates the `permission` object in `opencode.json` / `openc
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 
 - `bash`: generates one `prefix_rule(...)` per command pattern in `.codex/rules/rulesync.rules` (`allow` → `allow`, `ask` → `prompt`, `deny` → `forbidden`)
-- `read`: `allow` → `read`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
-- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `none` in `permissions.<profile>.filesystem`
+- `read`: `allow` → `read`, `ask`/`deny` → `deny` in `permissions.<profile>.filesystem`
+- `edit` / `write`: `allow` → `write`, `ask`/`deny` → `deny` in `permissions.<profile>.filesystem`
 - `webfetch`: `allow`/`deny` map to `permissions.<profile>.network.domains` (Codex does not support `ask` for domain rules)
 
-Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":project_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated project-root rules contain unbounded `**` patterns.
+Relative filesystem globs such as `src/**` or `**/*.tf` are emitted under `permissions.<profile>.filesystem.":workspace_roots"` instead of the top-level filesystem table, because Codex expects top-level filesystem keys to be absolute paths, `~/...`, or named roots. Rulesync also sets `glob_scan_max_depth = 8` when generated workspace-root rules contain unbounded `**` patterns.
 
 For Gemini CLI, this generates a Policy Engine file at `.gemini/policies/rulesync.toml` (project mode) or `~/.gemini/policies/rulesync.toml` (global mode). Gemini CLI auto-discovers any `*.toml` file under the `policies/` directory, so no `settings.json` modification is required:
 

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -73,13 +73,13 @@ describe("E2E: permissions", () => {
     const filesystem = toTable(rulesyncProfile.filesystem);
     const network = toTable(rulesyncProfile.network);
     const domains = toTable(network.domains);
-    const projectRoots = toTable(filesystem[":project_roots"]);
+    const workspaceRoots = toTable(filesystem[":workspace_roots"]);
     expect(filesystem["/workspace/project/**"]).toBe("read");
     expect(filesystem["/workspace/project/src/**"]).toBe("write");
     expect(filesystem.glob_scan_max_depth).toBe(8);
-    expect(projectRoots["**/*.tf"]).toBe("none");
-    expect(projectRoots["src/**"]).toBe("read");
-    expect(projectRoots["docs/**"]).toBe("write");
+    expect(workspaceRoots["**/*.tf"]).toBe("deny");
+    expect(workspaceRoots["src/**"]).toBe("read");
+    expect(workspaceRoots["docs/**"]).toBe("write");
     expect(domains["github.com"]).toBe("allow");
 
     const rulesContent = await readFileContent(join(testDir, ".codex", "rules", "rulesync.rules"));
@@ -371,7 +371,7 @@ default_permissions = "rulesync"
 [permissions.rulesync.filesystem]
 "/workspace/project/**" = "read"
 "/workspace/project/src/**" = "write"
-"/workspace/project/.env" = "none"
+"/workspace/project/.env" = "deny"
 
 [permissions.rulesync.network.domains]
 "github.com" = "allow"

--- a/src/features/permissions/codexcli-permissions.test.ts
+++ b/src/features/permissions/codexcli-permissions.test.ts
@@ -47,14 +47,14 @@ describe("CodexcliPermissions", () => {
     expect(fileContent).toContain('default_permissions = "rulesync"');
     expect(fileContent).toContain("[permissions.rulesync.filesystem]");
     expect(fileContent).toContain('"/workspace/project/**" = "read"');
-    expect(fileContent).toContain('"/workspace/project/.env" = "none"');
+    expect(fileContent).toContain('"/workspace/project/.env" = "deny"');
     expect(fileContent).toContain('"/workspace/project/src/**" = "write"');
     expect(fileContent).toContain("[permissions.rulesync.network.domains]");
     expect(fileContent).toContain('"github.com" = "allow"');
     expect(fileContent).toContain('"example.com" = "deny"');
   });
 
-  it("should place relative filesystem globs under the Codex project root table", async () => {
+  it("should place relative filesystem globs under the Codex workspace roots table", async () => {
     const logger = createMockLogger();
     const rulesyncPermissions = new RulesyncPermissions({
       outputRoot: testDir,
@@ -84,8 +84,8 @@ describe("CodexcliPermissions", () => {
     expect(fileContent).toContain("[permissions.rulesync.filesystem]");
     expect(fileContent).toContain("glob_scan_max_depth = 8");
     expect(fileContent).toContain('"/workspace/project/**" = "read"');
-    expect(fileContent).toContain('[permissions.rulesync.filesystem.":project_roots"]');
-    expect(fileContent).toContain('"**/*.tf" = "none"');
+    expect(fileContent).toContain('[permissions.rulesync.filesystem.":workspace_roots"]');
+    expect(fileContent).toContain('"**/*.tf" = "deny"');
     expect(fileContent).toContain('"src/**" = "read"');
     expect(fileContent).toContain('"docs/**" = "write"');
   });
@@ -101,7 +101,7 @@ default_permissions = "rulesync"
 [permissions.rulesync.filesystem]
 "/workspace/project/**" = "read"
 "/workspace/project/src/**" = "write"
-"/workspace/project/.env" = "none"
+"/workspace/project/.env" = "deny"
 
 [permissions.rulesync.network.domains]
 "github.com" = "allow"
@@ -119,7 +119,7 @@ default_permissions = "rulesync"
     expect(json.permission.webfetch?.["example.com"]).toBe("deny");
   });
 
-  it("should not set glob_scan_max_depth when project-root globs contain only single-level wildcards", async () => {
+  it("should not set glob_scan_max_depth when workspace-root globs contain only single-level wildcards", async () => {
     const logger = createMockLogger();
     const rulesyncPermissions = new RulesyncPermissions({
       outputRoot: testDir,
@@ -144,13 +144,13 @@ default_permissions = "rulesync"
     });
 
     const fileContent = codexPermissions.getFileContent();
-    expect(fileContent).toContain('[permissions.rulesync.filesystem.":project_roots"]');
+    expect(fileContent).toContain('[permissions.rulesync.filesystem.":workspace_roots"]');
     expect(fileContent).toContain('"src/*" = "read"');
     expect(fileContent).toContain('"docs/*" = "write"');
     expect(fileContent).not.toContain("glob_scan_max_depth");
   });
 
-  it("should import nested Codex project root filesystem rules", () => {
+  it("should import nested Codex workspace root filesystem rules", () => {
     const codexPermissions = new CodexcliPermissions({
       outputRoot: testDir,
       relativeDirPath: ".codex",
@@ -162,8 +162,8 @@ default_permissions = "rulesync"
 glob_scan_max_depth = 8
 "/workspace/project/**" = "read"
 
-[permissions.rulesync.filesystem.":project_roots"]
-"**/*.tf" = "none"
+[permissions.rulesync.filesystem.":workspace_roots"]
+"**/*.tf" = "deny"
 "src/**" = "read"
 "docs/**" = "write"
 `,
@@ -179,7 +179,27 @@ glob_scan_max_depth = 8
     expect(json.permission.edit?.["docs/**"]).toBe("allow");
   });
 
-  it("should warn when :project_roots is set as a direct string access rule", async () => {
+  it("should import legacy nested Codex project root filesystem rules", () => {
+    const codexPermissions = new CodexcliPermissions({
+      outputRoot: testDir,
+      relativeDirPath: ".codex",
+      relativeFilePath: "config.toml",
+      fileContent: `
+default_permissions = "rulesync"
+
+[permissions.rulesync.filesystem.":project_roots"]
+"**/*.tf" = "none"
+`,
+    });
+
+    const rulesyncPermissions = codexPermissions.toRulesyncPermissions();
+    const json = rulesyncPermissions.getJson();
+
+    expect(json.permission.read?.["**/*.tf"]).toBe("deny");
+    expect(json.permission.edit?.["**/*.tf"]).toBe("deny");
+  });
+
+  it("should warn when :workspace_roots is set as a direct string access rule", async () => {
     const logger = createMockLogger();
     const rulesyncPermissions = new RulesyncPermissions({
       outputRoot: testDir,
@@ -188,7 +208,7 @@ glob_scan_max_depth = 8
       fileContent: JSON.stringify({
         permission: {
           read: {
-            ":project_roots": "deny",
+            ":workspace_roots": "deny",
             "src/**": "allow",
           },
         },
@@ -202,7 +222,7 @@ glob_scan_max_depth = 8
     });
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('":project_roots" is set as a direct filesystem access rule'),
+      expect.stringContaining('":workspace_roots" is set as a direct filesystem access rule'),
     );
   });
 

--- a/src/features/permissions/codexcli-permissions.ts
+++ b/src/features/permissions/codexcli-permissions.ts
@@ -18,10 +18,11 @@ import {
 
 const RULESYNC_PROFILE_NAME = "rulesync";
 const RULESYNC_BASH_RULES_FILE_NAME = "rulesync.rules";
-const CODEX_PROJECT_ROOTS_KEY = ":project_roots";
+const CODEX_WORKSPACE_ROOTS_KEY = ":workspace_roots";
 const CODEX_GLOB_SCAN_MAX_DEPTH = 8; // Matches Codex CLI default glob_scan_max_depth
 
-type CodexFilesystemAccess = "read" | "write" | "none";
+// `none` is accepted on import for configs generated before Codex CLI v0.131.0.
+type CodexFilesystemAccess = "read" | "write" | "deny" | "none";
 type CodexFilesystemRuleTable = Record<string, CodexFilesystemAccess>;
 type CodexFilesystem = Record<string, CodexFilesystemAccess | CodexFilesystemRuleTable | number>;
 
@@ -169,7 +170,7 @@ function convertRulesyncToCodexProfile({
   logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
 }): CodexPermissionProfile {
   const filesystem: CodexFilesystem = {};
-  const projectRootFilesystem: CodexFilesystemRuleTable = {};
+  const workspaceRootFilesystem: CodexFilesystemRuleTable = {};
   const domains: Record<string, "allow" | "deny"> = {};
 
   for (const [toolName, rules] of Object.entries(config.permission)) {
@@ -177,7 +178,7 @@ function convertRulesyncToCodexProfile({
       for (const [pattern, action] of Object.entries(rules)) {
         addFilesystemRule({
           filesystem,
-          projectRootFilesystem,
+          workspaceRootFilesystem,
           pattern,
           access: mapReadAction(action),
           logger,
@@ -190,7 +191,7 @@ function convertRulesyncToCodexProfile({
       for (const [pattern, action] of Object.entries(rules)) {
         addFilesystemRule({
           filesystem,
-          projectRootFilesystem,
+          workspaceRootFilesystem,
           pattern,
           access: mapWriteAction(action),
           logger,
@@ -217,16 +218,16 @@ function convertRulesyncToCodexProfile({
     );
   }
 
-  if (Object.keys(projectRootFilesystem).length > 0) {
-    if (typeof filesystem[CODEX_PROJECT_ROOTS_KEY] === "string") {
+  if (Object.keys(workspaceRootFilesystem).length > 0) {
+    if (typeof filesystem[CODEX_WORKSPACE_ROOTS_KEY] === "string") {
       logger?.warn(
-        `"${CODEX_PROJECT_ROOTS_KEY}" is set as a direct filesystem access rule in the permissions, but it will be overwritten by project-root rules. Consider removing the direct "${CODEX_PROJECT_ROOTS_KEY}" entry.`,
+        `"${CODEX_WORKSPACE_ROOTS_KEY}" is set as a direct filesystem access rule in the permissions, but it will be overwritten by workspace-root rules. Consider removing the direct "${CODEX_WORKSPACE_ROOTS_KEY}" entry.`,
       );
     }
-    if (Object.keys(projectRootFilesystem).some((pattern) => pattern.includes("**"))) {
+    if (Object.keys(workspaceRootFilesystem).some((pattern) => pattern.includes("**"))) {
       filesystem.glob_scan_max_depth = CODEX_GLOB_SCAN_MAX_DEPTH;
     }
-    filesystem[CODEX_PROJECT_ROOTS_KEY] = projectRootFilesystem;
+    filesystem[CODEX_WORKSPACE_ROOTS_KEY] = workspaceRootFilesystem;
   }
 
   return {
@@ -279,13 +280,13 @@ function toCodexProfile(value: unknown): CodexPermissionProfile | undefined {
 
 function addFilesystemRule({
   filesystem,
-  projectRootFilesystem,
+  workspaceRootFilesystem,
   pattern,
   access,
   logger,
 }: {
   filesystem: CodexFilesystem;
-  projectRootFilesystem: CodexFilesystemRuleTable;
+  workspaceRootFilesystem: CodexFilesystemRuleTable;
   pattern: string;
   access: CodexFilesystemAccess;
   logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"];
@@ -300,7 +301,7 @@ function addFilesystemRule({
     return;
   }
 
-  projectRootFilesystem[pattern] = access;
+  workspaceRootFilesystem[pattern] = access;
 }
 
 function canBeCodexFilesystemRoot(pattern: string): boolean {
@@ -318,7 +319,7 @@ function addRulesyncFilesystemRule(
   pattern: string,
   access: CodexFilesystemAccess,
 ): void {
-  if (access === "none") {
+  if (access === "deny" || access === "none") {
     permission.read ??= {};
     permission.edit ??= {};
     permission.read[pattern] = "deny";
@@ -362,7 +363,7 @@ function toFilesystemRecord(value: unknown): CodexFilesystem | undefined {
 }
 
 function isCodexFilesystemAccess(value: unknown): value is CodexFilesystemAccess {
-  return value === "read" || value === "write" || value === "none";
+  return value === "read" || value === "write" || value === "deny" || value === "none";
 }
 
 function isCodexFilesystemRuleTable(value: unknown): value is CodexFilesystemRuleTable {
@@ -392,12 +393,12 @@ function toDomainRecord(value: unknown): Record<string, "allow" | "deny"> | unde
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function mapReadAction(action: PermissionAction): "read" | "none" {
-  return action === "allow" ? "read" : "none";
+function mapReadAction(action: PermissionAction): "read" | "deny" {
+  return action === "allow" ? "read" : "deny";
 }
 
-function mapWriteAction(action: PermissionAction): "write" | "none" {
-  return action === "allow" ? "write" : "none";
+function mapWriteAction(action: PermissionAction): "write" | "deny" {
+  return action === "allow" ? "write" : "deny";
 }
 
 function buildCodexBashRulesContent(config: PermissionsConfig): string {


### PR DESCRIPTION
## Summary

- emit Codex CLI relative filesystem rules under `:workspace_roots` instead of deprecated `:project_roots`
- emit `deny` instead of `none` for denied/ask Codex filesystem rules
- keep import compatibility for legacy `:project_roots` / `none` configs
- update Codex permissions docs and e2e expectations

Closes #1716.

## Context

Codex CLI renamed `:project_roots` to `:workspace_roots` and removed old parsing support in openai/codex#22624, released in `rust-v0.131.0`.

## Tests

- `./node_modules/.bin/vitest run src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts --silent=true`
- `./node_modules/.bin/vitest run --config vitest.e2e.config.ts src/e2e/e2e-permissions.spec.ts --silent=true`
- `./node_modules/.bin/vitest run --silent=true`
- `./node_modules/.bin/tsgo --noEmit`
- `./node_modules/.bin/oxfmt --check src/features/permissions/codexcli-permissions.ts src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts docs/reference/file-formats.md`
- `./node_modules/.bin/oxlint src/features/permissions/codexcli-permissions.ts src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts --max-warnings 0`
- `./node_modules/.bin/eslint src/features/permissions/codexcli-permissions.ts src/features/permissions/codexcli-permissions.test.ts src/e2e/e2e-permissions.spec.ts --max-warnings 0`
