### PR TITLE
feat(zed): skills, rules, mcp + git-transport root-path follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
-| Zed                    | zed             |       |   ✅   |          |          |           |        |       |             |
+| Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
 
 - ✅: Supports project mode
 - 🌏: Supports global mode

--- a/docs/guide/declarative-sources.md
+++ b/docs/guide/declarative-sources.md
@@ -31,19 +31,28 @@ Add a `sources` array to your `rulesync.jsonc`:
 
     // Git transport with a local repository
     { "source": "file:///path/to/local/repo", "transport": "git" },
+
+    // Git transport against a single-skill repo whose SKILL.md is at the root
+    {
+      "source": "https://github.com/feature-sliced/skills",
+      "transport": "git",
+      "path": ".",
+    },
   ],
 }
 ```
 
 Each entry in `sources` accepts:
 
-| Property    | Type       | Description                                                                                                                      |
-| ----------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `source`    | `string`   | Repository source. For GitHub transport: `owner/repo` or `owner/repo@ref:path`. For git transport: a full git URL.               |
-| `skills`    | `string[]` | Optional list of skill names to fetch. If omitted, all skills are fetched.                                                       |
-| `transport` | `string`   | `"github"` (default) uses the GitHub REST API. `"git"` uses git CLI and works with any git remote.                               |
-| `ref`       | `string`   | Branch, tag, or ref to fetch from. Defaults to the remote's default branch. For GitHub transport, use the `@ref` source syntax.  |
-| `path`      | `string`   | Path to the skills directory within the repository. Defaults to `"skills"`. For GitHub transport, use the `:path` source syntax. |
+| Property    | Type       | Description                                                                                                                                                                                                           |
+| ----------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`    | `string`   | Repository source. For GitHub transport: `owner/repo` or `owner/repo@ref:path`. For git transport: a full git URL.                                                                                                    |
+| `skills`    | `string[]` | Optional list of skill names to fetch. If omitted, all skills are fetched.                                                                                                                                            |
+| `transport` | `string`   | `"github"` (default) uses the GitHub REST API. `"git"` uses git CLI and works with any git remote.                                                                                                                    |
+| `ref`       | `string`   | Branch, tag, or ref to fetch from. Defaults to the remote's default branch. For GitHub transport, use the `@ref` source syntax.                                                                                       |
+| `path`      | `string`   | Path to the skills directory within the repository. Defaults to `"skills"`. Set to `""`, `"."`, or `"./"` to target the entire repository root (see note below). For GitHub transport, use the `:path` source syntax. |
+
+> **Repository-root paths (`path: "."`):** When `path` is `""`, `"."`, or `"./"` (with the `git` transport), rulesync disables sparse-checkout and fetches the **entire** repository tree, then groups each top-level directory as a skill. This is useful for single-skill repositories whose `SKILL.md` lives at the repo root (`<repo>/SKILL.md`) rather than under a `skills/` container. Because the whole tree is fetched, prefer a narrower `path` for large repositories; the fetch is still bounded by rulesync's file-count, total-size, and depth limits.
 
 ## How It Works
 

--- a/docs/guide/geminicli-to-antigravity-cli.md
+++ b/docs/guide/geminicli-to-antigravity-cli.md
@@ -53,10 +53,15 @@ transition.
   **global mode only**. The canonical `bash` tool maps to Antigravity's
   `command` tool name.
 - **Commands / subagents**: These are intentionally out of scope for
-  `antigravity-cli` today. Antigravity surfaces slash commands through skills,
-  and CLI subagents are only definable through plugin bundles or the
-  `define_subagent` tool — neither maps cleanly onto rulesync's per-feature
-  model. Keep generating them with `geminicli` if you still rely on them.
+  `antigravity-cli` today. Antigravity surfaces slash commands through skills.
+  CLI subagents are defined and managed at runtime (the interactive `/agents`
+  panel and the orchestrator's `invoke_subagent` / `define_subagent` tools), and
+  the only file-based way to ship one is bundled inside a plugin (a namespaced
+  package of skills + subagents + rules + MCP + hooks). There is no standalone,
+  declarative per-agent file (analogous to `geminicli`'s `.gemini/agents/`) that
+  rulesync could generate, and the plugin bundle does not map cleanly onto
+  rulesync's per-feature model. Keep generating subagents with `geminicli` if
+  you still rely on them.
 
 ## Updating `rulesync.jsonc`
 

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -31,7 +31,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
-| Zed                    | zed             |       |   ✅   |          |          |           |        |       |             |
+| Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
 
 - ✅: Supports project mode
 - 🌏: Supports global mode

--- a/skills/rulesync/declarative-sources.md
+++ b/skills/rulesync/declarative-sources.md
@@ -31,19 +31,28 @@ Add a `sources` array to your `rulesync.jsonc`:
 
     // Git transport with a local repository
     { "source": "file:///path/to/local/repo", "transport": "git" },
+
+    // Git transport against a single-skill repo whose SKILL.md is at the root
+    {
+      "source": "https://github.com/feature-sliced/skills",
+      "transport": "git",
+      "path": ".",
+    },
   ],
 }
 ```
 
 Each entry in `sources` accepts:
 
-| Property    | Type       | Description                                                                                                                      |
-| ----------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `source`    | `string`   | Repository source. For GitHub transport: `owner/repo` or `owner/repo@ref:path`. For git transport: a full git URL.               |
-| `skills`    | `string[]` | Optional list of skill names to fetch. If omitted, all skills are fetched.                                                       |
-| `transport` | `string`   | `"github"` (default) uses the GitHub REST API. `"git"` uses git CLI and works with any git remote.                               |
-| `ref`       | `string`   | Branch, tag, or ref to fetch from. Defaults to the remote's default branch. For GitHub transport, use the `@ref` source syntax.  |
-| `path`      | `string`   | Path to the skills directory within the repository. Defaults to `"skills"`. For GitHub transport, use the `:path` source syntax. |
+| Property    | Type       | Description                                                                                                                                                                                                           |
+| ----------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`    | `string`   | Repository source. For GitHub transport: `owner/repo` or `owner/repo@ref:path`. For git transport: a full git URL.                                                                                                    |
+| `skills`    | `string[]` | Optional list of skill names to fetch. If omitted, all skills are fetched.                                                                                                                                            |
+| `transport` | `string`   | `"github"` (default) uses the GitHub REST API. `"git"` uses git CLI and works with any git remote.                                                                                                                    |
+| `ref`       | `string`   | Branch, tag, or ref to fetch from. Defaults to the remote's default branch. For GitHub transport, use the `@ref` source syntax.                                                                                       |
+| `path`      | `string`   | Path to the skills directory within the repository. Defaults to `"skills"`. Set to `""`, `"."`, or `"./"` to target the entire repository root (see note below). For GitHub transport, use the `:path` source syntax. |
+
+> **Repository-root paths (`path: "."`):** When `path` is `""`, `"."`, or `"./"` (with the `git` transport), rulesync disables sparse-checkout and fetches the **entire** repository tree, then groups each top-level directory as a skill. This is useful for single-skill repositories whose `SKILL.md` lives at the repo root (`<repo>/SKILL.md`) rather than under a `skills/` container. Because the whole tree is fetched, prefer a narrower `path` for large repositories; the fetch is still bounded by rulesync's file-count, total-size, and depth limits.
 
 ## How It Works
 

--- a/skills/rulesync/geminicli-to-antigravity-cli.md
+++ b/skills/rulesync/geminicli-to-antigravity-cli.md
@@ -53,10 +53,15 @@ transition.
   **global mode only**. The canonical `bash` tool maps to Antigravity's
   `command` tool name.
 - **Commands / subagents**: These are intentionally out of scope for
-  `antigravity-cli` today. Antigravity surfaces slash commands through skills,
-  and CLI subagents are only definable through plugin bundles or the
-  `define_subagent` tool — neither maps cleanly onto rulesync's per-feature
-  model. Keep generating them with `geminicli` if you still rely on them.
+  `antigravity-cli` today. Antigravity surfaces slash commands through skills.
+  CLI subagents are defined and managed at runtime (the interactive `/agents`
+  panel and the orchestrator's `invoke_subagent` / `define_subagent` tools), and
+  the only file-based way to ship one is bundled inside a plugin (a namespaced
+  package of skills + subagents + rules + MCP + hooks). There is no standalone,
+  declarative per-agent file (analogous to `geminicli`'s `.gemini/agents/`) that
+  rulesync could generate, and the plugin bundle does not map cleanly onto
+  rulesync's per-feature model. Keep generating subagents with `geminicli` if
+  you still rely on them.
 
 ## Updating `rulesync.jsonc`
 

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -31,7 +31,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
-| Zed                    | zed             |       |   ✅   |          |          |           |        |       |             |
+| Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
 
 - ✅: Supports project mode
 - 🌏: Supports global mode

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -18,7 +18,6 @@ const TARGETS_WITHOUT_GITIGNORE_ENTRIES = new Set([
   "antigravity",
   "augmentcode-legacy",
   "claudecode-legacy",
-  "zed",
 ]);
 
 describe("GITIGNORE_ENTRY_REGISTRY", () => {

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -299,6 +299,15 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   // Warp
   { target: "warp", feature: "rules", entry: "**/.warp/" },
   { target: "warp", feature: "rules", entry: "**/WARP.md" },
+
+  // Zed
+  // `.rules` is the project rules file. `.agents/skills/` is shared with the
+  // antigravity targets (already registered above); re-tagging it for `zed`
+  // ensures target-filtered gitignore runs still include it.
+  // No entry for `.zed/settings.json` (MCP / ignore): it is a user-managed
+  // file, like other tools' settings.json, so it is intentionally not ignored.
+  { target: "zed", feature: "rules", entry: "**/.rules" },
+  { target: "zed", feature: "skills", entry: "**/.agents/skills/" },
 ] as const;
 
 export const ALL_GITIGNORE_ENTRIES: ReadonlyArray<string> = (() => {

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -35,6 +35,7 @@ describe("E2E: mcp", () => {
     { target: "junie", outputPath: join(".junie", "mcp", "mcp.json") },
     { target: "antigravity-ide", outputPath: join(".agents", "mcp_config.json") },
     { target: "antigravity-cli", outputPath: join(".agents", "mcp_config.json") },
+    { target: "zed", outputPath: join(".zed", "settings.json") },
   ])("should generate $target mcp", async ({ target, outputPath }) => {
     const testDir = getTestDir();
 
@@ -219,6 +220,30 @@ describe("E2E: mcp (import)", () => {
     const importedContent = await readFileContent(join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH));
     expect(importedContent).toContain("test-server");
   });
+
+  // Zed stores MCP servers under `context_servers` (not `mcpServers`) inside a
+  // shared settings.json, so it needs a bespoke source rather than the generic
+  // `mcpServers`-seeded import case above.
+  it("should import zed mcp from context_servers", async () => {
+    const testDir = getTestDir();
+
+    const settingsContent = JSON.stringify(
+      {
+        private_files: ["**/.env"],
+        context_servers: {
+          "test-server": { command: "echo", args: ["hello"] },
+        },
+      },
+      null,
+      2,
+    );
+    await writeFileContent(join(testDir, ".zed", "settings.json"), settingsContent);
+
+    await runImport({ target: "zed", features: "mcp" });
+
+    const importedContent = await readFileContent(join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH));
+    expect(importedContent).toContain("test-server");
+  });
 });
 
 describe("E2E: mcp (global mode)", () => {
@@ -243,6 +268,7 @@ describe("E2E: mcp (global mode)", () => {
       target: "antigravity-cli",
       outputPath: join(".gemini", "antigravity-cli", "mcp_config.json"),
     },
+    { target: "zed", outputPath: join(".config", "zed", "settings.json") },
   ])("should generate $target mcp in home directory", async ({ target, outputPath }) => {
     const projectDir = getProjectDir();
     const homeDir = getHomeDir();

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -38,6 +38,7 @@ describe("E2E: rules", () => {
     { target: "warp", outputPath: "WARP.md" },
     { target: "replit", outputPath: "replit.md" },
     { target: "pi", outputPath: "AGENTS.md" },
+    { target: "zed", outputPath: ".rules" },
   ])("should generate $target rules", async ({ target, outputPath }) => {
     const testDir = getTestDir();
 
@@ -246,6 +247,7 @@ describe("E2E: rules (import)", () => {
       sourcePath: join(".windsurf", "rules", "overview.md"),
       importedFileName: "overview.md",
     },
+    { target: "zed", sourcePath: ".rules", importedFileName: "overview.md" },
   ])("should import $target rules", async ({ target, sourcePath, importedFileName }) => {
     const testDir = getTestDir();
 
@@ -281,6 +283,7 @@ describe("E2E: rules (global mode)", () => {
     { target: "rovodev", outputPath: join(".rovodev", "AGENTS.md") },
     { target: "takt", outputPath: join(".takt", "facets", "policies", "overview.md") },
     { target: "pi", outputPath: join(".pi", "agent", "AGENTS.md") },
+    { target: "zed", outputPath: join(".config", "zed", "AGENTS.md") },
   ])("should generate $target rules in home directory", async ({ target, outputPath }) => {
     const projectDir = getProjectDir();
     const homeDir = getHomeDir();

--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -95,6 +95,10 @@ describe("E2E: skills", () => {
       target: "pi",
       outputPath: join(".pi", "skills", "test-skill", "SKILL.md"),
     },
+    {
+      target: "zed",
+      outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
+    },
   ])("should generate $target skills", async ({ target, outputPath }) => {
     const testDir = getTestDir();
 
@@ -175,6 +179,7 @@ This is the test skill body content.
     { target: "replit", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
     { target: "agentsskills", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
     { target: "pi", orphanPath: join(".pi", "skills", "orphan-skill", "SKILL.md") },
+    { target: "zed", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
   ])(
     "should fail in check mode when delete would remove an orphan $target skill file",
     async ({ target, orphanPath }) => {
@@ -226,6 +231,7 @@ describe("E2E: skills (import)", () => {
     { target: "junie", sourcePath: join(".junie", "skills", "test-skill", "SKILL.md") },
     { target: "replit", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
     { target: "pi", sourcePath: join(".pi", "skills", "test-skill", "SKILL.md") },
+    { target: "zed", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
   ])("should import $target skills", async ({ target, sourcePath }) => {
     const testDir = getTestDir();
 
@@ -308,6 +314,10 @@ describe("E2E: skills (global mode)", () => {
     {
       target: "pi",
       outputPath: join(".pi", "agent", "skills", "test-skill", "SKILL.md"),
+    },
+    {
+      target: "zed",
+      outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
     },
   ])("should generate $target skills in home directory", async ({ target, outputPath }) => {
     const projectDir = getProjectDir();

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -32,6 +32,7 @@ import {
   ToolMcpFromRulesyncMcpParams,
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
+import { ZedMcp } from "./zed-mcp.js";
 
 /**
  * Supported tool targets for McpProcessor.
@@ -56,6 +57,7 @@ const mcpProcessorToolTargetTuple = [
   "opencode",
   "roo",
   "rovodev",
+  "zed",
 ] as const;
 
 export type McpProcessorToolTarget = (typeof mcpProcessorToolTargetTuple)[number];
@@ -309,6 +311,18 @@ const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
       class: RovodevMcp,
       meta: {
         supportsProject: false,
+        supportsGlobal: true,
+        supportsEnabledTools: false,
+        supportsDisabledTools: false,
+      },
+    },
+  ],
+  [
+    "zed",
+    {
+      class: ZedMcp,
+      meta: {
+        supportsProject: true,
         supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,

--- a/src/features/mcp/zed-mcp.test.ts
+++ b/src/features/mcp/zed-mcp.test.ts
@@ -1,0 +1,217 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_MCP_SCHEMA_URL,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, readFileContent, writeFileContent } from "../../utils/file.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+import { ZedMcp } from "./zed-mcp.js";
+
+describe("ZedMcp", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .zed/settings.json for project mode", () => {
+      const paths = ZedMcp.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(".zed");
+      expect(paths.relativeFilePath).toBe("settings.json");
+    });
+
+    it("should return ~/.config/zed/settings.json for global mode", () => {
+      const paths = ZedMcp.getSettablePaths({ global: true });
+      expect(paths.relativeDirPath).toBe(join(".config", "zed"));
+      expect(paths.relativeFilePath).toBe("settings.json");
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("should always return false because settings.json is shared/user-managed", () => {
+      const mcp = new ZedMcp({
+        relativeDirPath: ".zed",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({ context_servers: {} }),
+      });
+      expect(mcp.isDeletable()).toBe(false);
+
+      const forDeletion = ZedMcp.forDeletion({
+        relativeDirPath: ".zed",
+        relativeFilePath: "settings.json",
+      });
+      expect(forDeletion.isDeletable()).toBe(false);
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should initialize empty context_servers if file does not exist", async () => {
+      const mcp = await ZedMcp.fromFile({ outputRoot: testDir });
+      expect(mcp.getJson()).toEqual({ context_servers: {} });
+    });
+
+    it("should preserve unrelated keys (e.g. private_files) from existing settings.json", async () => {
+      const existing = {
+        private_files: ["**/.env"],
+        context_servers: {
+          local: { command: "node", args: ["server.js"] },
+        },
+      };
+      await ensureDir(join(testDir, ".zed"));
+      await writeFileContent(
+        join(testDir, ".zed", "settings.json"),
+        JSON.stringify(existing, null, 2),
+      );
+
+      const mcp = await ZedMcp.fromFile({ outputRoot: testDir });
+      const json = mcp.getJson() as Record<string, unknown>;
+      expect(json.private_files).toEqual(["**/.env"]);
+      expect(json.context_servers).toEqual({
+        local: { command: "node", args: ["server.js"] },
+      });
+    });
+  });
+
+  describe("fromRulesyncMcp", () => {
+    it("should write servers under the context_servers key", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            local: { command: "node", args: ["server.js"], env: { FOO: "${BAR}" } },
+          },
+        }),
+      });
+
+      const mcp = await ZedMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const json = mcp.getJson() as Record<string, unknown>;
+      expect(json.context_servers).toEqual({
+        local: { command: "node", args: ["server.js"], env: { FOO: "${BAR}" } },
+      });
+      expect(json.mcpServers).toBeUndefined();
+    });
+
+    it("should preserve existing private_files when writing MCP servers", async () => {
+      const existing = { private_files: ["**/.env", "secrets.txt"] };
+      await ensureDir(join(testDir, ".zed"));
+      await writeFileContent(
+        join(testDir, ".zed", "settings.json"),
+        JSON.stringify(existing, null, 2),
+      );
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { remote: { url: "https://mcp.example.com/mcp" } },
+        }),
+      });
+
+      const mcp = await ZedMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const json = mcp.getJson() as Record<string, unknown>;
+      expect(json.private_files).toEqual(["**/.env", "secrets.txt"]);
+      expect(json.context_servers).toEqual({
+        remote: { url: "https://mcp.example.com/mcp" },
+      });
+    });
+
+    it("should strip codex-only envVars from output", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            pal: { command: "uvx", args: ["pal-mcp-server"], envVars: ["OPENAI_API_KEY"] },
+          },
+        }),
+      });
+
+      const mcp = await ZedMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const json = mcp.getJson() as { context_servers: Record<string, Record<string, unknown>> };
+      expect(json.context_servers.pal?.envVars).toBeUndefined();
+      expect(json.context_servers.pal?.command).toBe("uvx");
+    });
+
+    it("should write to ~/.config/zed/settings.json in global mode", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: { local: { command: "node" } } }),
+      });
+
+      const mcp = await ZedMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp, global: true });
+      expect(mcp.getFilePath()).toBe(join(testDir, ".config", "zed", "settings.json"));
+    });
+  });
+
+  describe("toRulesyncMcp", () => {
+    it("should map context_servers back to mcpServers", () => {
+      const mcp = new ZedMcp({
+        relativeDirPath: ".zed",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          private_files: ["**/.env"],
+          context_servers: { local: { command: "node", args: ["server.js"] } },
+        }),
+      });
+
+      const rulesyncMcp = mcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+      expect(exported).toEqual({
+        $schema: RULESYNC_MCP_SCHEMA_URL,
+        mcpServers: { local: { command: "node", args: ["server.js"] } },
+      });
+      // private_files must not leak into the rulesync MCP output.
+      expect(exported.private_files).toBeUndefined();
+      expect(exported.context_servers).toBeUndefined();
+    });
+
+    it("should produce empty mcpServers when no context_servers are present", () => {
+      const mcp = new ZedMcp({
+        relativeDirPath: ".zed",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({ private_files: ["**/.env"] }),
+      });
+
+      const exported = JSON.parse(mcp.toRulesyncMcp().getFileContent());
+      expect(exported.mcpServers).toEqual({});
+    });
+  });
+
+  describe("integration", () => {
+    it("should round-trip while preserving private_files on disk", async () => {
+      const existing = { private_files: ["**/.env"] };
+      await ensureDir(join(testDir, ".zed"));
+      await writeFileContent(
+        join(testDir, ".zed", "settings.json"),
+        JSON.stringify(existing, null, 2),
+      );
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: { local: { command: "node" } } }),
+      });
+
+      const mcp = await ZedMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      await writeFileContent(mcp.getFilePath(), mcp.getFileContent());
+
+      const onDisk = JSON.parse(await readFileContent(join(testDir, ".zed", "settings.json")));
+      expect(onDisk.private_files).toEqual(["**/.env"]);
+      expect(onDisk.context_servers).toEqual({ local: { command: "node" } });
+    });
+  });
+});

--- a/src/features/mcp/zed-mcp.ts
+++ b/src/features/mcp/zed-mcp.ts
@@ -1,0 +1,131 @@
+import { join } from "node:path";
+
+import { ValidationResult } from "../../types/ai-file.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+import {
+  ToolMcp,
+  ToolMcpForDeletionParams,
+  ToolMcpFromFileParams,
+  ToolMcpFromRulesyncMcpParams,
+  ToolMcpParams,
+  ToolMcpSettablePaths,
+} from "./tool-mcp.js";
+
+/**
+ * MCP generator for the Zed editor.
+ *
+ * Zed configures MCP servers under the top-level `context_servers` key inside
+ * its settings file (`.zed/settings.json` for project, `~/.config/zed/settings.json`
+ * for global). That file is also where the ignore feature stores `private_files`,
+ * so reads and writes must merge into the existing JSON rather than overwrite it.
+ */
+export class ZedMcp extends ToolMcp {
+  private readonly json: Record<string, unknown>;
+
+  constructor(params: ToolMcpParams) {
+    super(params);
+    this.json = JSON.parse(this.fileContent || "{}");
+  }
+
+  getJson(): Record<string, unknown> {
+    return this.json;
+  }
+
+  static getSettablePaths({ global }: { global?: boolean } = {}): ToolMcpSettablePaths {
+    if (global) {
+      return {
+        relativeDirPath: join(".config", "zed"),
+        relativeFilePath: "settings.json",
+      };
+    }
+    return {
+      relativeDirPath: ".zed",
+      relativeFilePath: "settings.json",
+    };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolMcpFromFileParams): Promise<ZedMcp> {
+    const paths = this.getSettablePaths({ global });
+    const fileContent =
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? "{}";
+    const json = JSON.parse(fileContent);
+    const newJson = { ...json, context_servers: json.context_servers ?? {} };
+
+    return new ZedMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(newJson, null, 2),
+      validate,
+    });
+  }
+
+  static async fromRulesyncMcp({
+    outputRoot = process.cwd(),
+    rulesyncMcp,
+    validate = true,
+    global = false,
+  }: ToolMcpFromRulesyncMcpParams): Promise<ZedMcp> {
+    const paths = this.getSettablePaths({ global });
+
+    // Read and preserve any existing settings (e.g. `private_files` written by
+    // the ignore feature, or unrelated user settings) before writing MCP servers.
+    const fileContent = await readOrInitializeFileContent(
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      "{}",
+    );
+    const json = JSON.parse(fileContent);
+    // Use getMcpServers() so rulesync-only and codex-only fields are stripped.
+    // Zed reads `env`/`headers` as-is, so no env-var reference conversion is needed.
+    const newJson = { ...json, context_servers: rulesyncMcp.getMcpServers() };
+
+    return new ZedMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(newJson, null, 2),
+      validate,
+    });
+  }
+
+  toRulesyncMcp(): RulesyncMcp {
+    return this.toRulesyncMcpDefault({
+      fileContent: JSON.stringify({ mcpServers: this.json.context_servers ?? {} }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  /**
+   * settings.json is a user-managed file shared with other features
+   * (e.g. ignore's `private_files`), so it must not be deleted.
+   */
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolMcpForDeletionParams): ZedMcp {
+    return new ZedMcp({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -905,6 +905,7 @@ Content that would fail parsing`;
         "pi",
         "rovodev",
         "takt",
+        "zed",
       ]);
     });
 
@@ -940,7 +941,8 @@ Content that would fail parsing`;
       expect(globalTargets).toContain("pi");
       expect(globalTargets).toContain("rovodev");
       expect(globalTargets).toContain("takt");
-      expect(globalTargets.length).toBe(15);
+      expect(globalTargets).toContain("zed");
+      expect(globalTargets.length).toBe(16);
 
       // These targets should NOT be in global mode
       expect(globalTargets).not.toContain("cursor");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -69,6 +69,7 @@ import {
 } from "./tool-rule.js";
 import { WarpRule } from "./warp-rule.js";
 import { WindsurfRule } from "./windsurf-rule.js";
+import { ZedRule } from "./zed-rule.js";
 
 const rulesProcessorToolTargets: ToolTarget[] = [
   "agentsmd",
@@ -100,6 +101,7 @@ const rulesProcessorToolTargets: ToolTarget[] = [
   "takt",
   "warp",
   "windsurf",
+  "zed",
 ];
 export const RulesProcessorToolTargetSchema = z.enum(rulesProcessorToolTargets);
 export type RulesProcessorToolTarget = z.infer<typeof RulesProcessorToolTargetSchema>;
@@ -587,6 +589,20 @@ const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
         ruleDiscoveryMode: "auto",
         // No additionalConventions.skills needed: Windsurf Cascade auto-discovers
         // skills from .windsurf/skills/ and ~/.codeium/windsurf/skills/ directories.
+      },
+    },
+  ],
+  [
+    "zed",
+    {
+      class: ZedRule,
+      meta: {
+        // Zed reads a single project rules file (`.rules`) and a single global
+        // file (`~/.config/zed/AGENTS.md`). It is root-only with auto discovery,
+        // so there is no non-root location to render a conventions block into.
+        extension: "md",
+        supportsGlobal: true,
+        ruleDiscoveryMode: "auto",
       },
     },
   ],

--- a/src/features/rules/zed-rule.test.ts
+++ b/src/features/rules/zed-rule.test.ts
@@ -1,0 +1,196 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_OVERVIEW_FILE_NAME,
+  RULESYNC_RULES_RELATIVE_DIR_PATH,
+} from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { writeFileContent } from "../../utils/file.js";
+import { RulesyncRule, type RulesyncRuleFrontmatterInput } from "./rulesync-rule.js";
+import { ZedRule } from "./zed-rule.js";
+
+describe("ZedRule", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .rules as the project root file (no nonRoot)", () => {
+      const paths = ZedRule.getSettablePaths();
+      expect(paths.root).toEqual({ relativeDirPath: ".", relativeFilePath: ".rules" });
+      expect(paths.nonRoot).toBeUndefined();
+    });
+
+    it("should return ~/.config/zed/AGENTS.md for global mode", () => {
+      const paths = ZedRule.getSettablePaths({ global: true });
+      expect(paths.root).toEqual({
+        relativeDirPath: join(".config", "zed"),
+        relativeFilePath: "AGENTS.md",
+      });
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should create ZedRule from the root .rules file", async () => {
+      const content = "# Project Rules";
+      await writeFileContent(join(testDir, ".rules"), content);
+
+      const rule = await ZedRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: ".rules",
+      });
+
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getRelativeFilePath()).toBe(".rules");
+      expect(rule.getFileContent()).toBe(content);
+    });
+
+    it("should throw for non-root files", async () => {
+      await expect(
+        ZedRule.fromFile({ outputRoot: testDir, relativeFilePath: "other.md" }),
+      ).rejects.toThrow("ZedRule only supports root rules");
+    });
+
+    it("should read AGENTS.md in global mode", async () => {
+      const content = "# Global Rules";
+      await writeFileContent(join(testDir, ".config", "zed", "AGENTS.md"), content);
+
+      const rule = await ZedRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "AGENTS.md",
+        global: true,
+      });
+
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getFileContent()).toBe(content);
+    });
+  });
+
+  describe("fromRulesyncRule", () => {
+    it("should create ZedRule from a root RulesyncRule", () => {
+      const frontmatter: RulesyncRuleFrontmatterInput = {
+        description: "Test zed rule",
+        root: true,
+      };
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        frontmatter,
+        body: "# Test Rule",
+      });
+
+      const rule = ZedRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+      expect(rule).toBeInstanceOf(ZedRule);
+      expect(rule.getRelativeFilePath()).toBe(".rules");
+      expect(rule.isRoot()).toBe(true);
+    });
+
+    it("should write AGENTS.md in global mode", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        frontmatter: { root: true },
+        body: "# Global",
+      });
+
+      const rule = ZedRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule, global: true });
+      expect(rule.getRelativeDirPath()).toBe(join(".config", "zed"));
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+    });
+
+    it("should throw for non-root RulesyncRule", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: "memory.md",
+        frontmatter: { root: false },
+        body: "# Memory",
+      });
+
+      expect(() => ZedRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule })).toThrow(
+        "ZedRule only supports root rules",
+      );
+    });
+  });
+
+  describe("toRulesyncRule", () => {
+    it("should convert root ZedRule to RulesyncRule", () => {
+      const rule = new ZedRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        fileContent: "# Root Rule",
+        root: true,
+      });
+
+      const rulesyncRule = rule.toRulesyncRule();
+      expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
+      expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
+      expect(rulesyncRule.getRelativeFilePath()).toBe(RULESYNC_OVERVIEW_FILE_NAME);
+      expect(rulesyncRule.getFrontmatter().root).toBe(true);
+    });
+  });
+
+  describe("validate", () => {
+    it("should always return success", () => {
+      const rule = new ZedRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        fileContent: "# Test",
+        root: true,
+      });
+      expect(rule.validate()).toEqual({ success: true, error: null });
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a minimal root instance for deletion", () => {
+      const rule = ZedRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+      });
+      expect(rule).toBeInstanceOf(ZedRule);
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getFileContent()).toBe("");
+    });
+  });
+
+  describe("isTargetedByRulesyncRule", () => {
+    it("should target root rules for zed and wildcard", () => {
+      const zedRoot = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        frontmatter: { targets: ["zed"], root: true },
+        body: "Test",
+      });
+      const wildcardRoot = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+        frontmatter: { targets: ["*"], root: true },
+        body: "Test",
+      });
+      expect(ZedRule.isTargetedByRulesyncRule(zedRoot)).toBe(true);
+      expect(ZedRule.isTargetedByRulesyncRule(wildcardRoot)).toBe(true);
+    });
+
+    it("should not target non-root rules", () => {
+      const nonRoot = new RulesyncRule({
+        relativeDirPath: ".",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"], root: false },
+        body: "Test",
+      });
+      expect(ZedRule.isTargetedByRulesyncRule(nonRoot)).toBe(false);
+    });
+  });
+});

--- a/src/features/rules/zed-rule.ts
+++ b/src/features/rules/zed-rule.ts
@@ -1,0 +1,149 @@
+import { join } from "node:path";
+
+import { ValidationResult } from "../../types/ai-file.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+import {
+  ToolRule,
+  ToolRuleForDeletionParams,
+  ToolRuleFromFileParams,
+  ToolRuleFromRulesyncRuleParams,
+  ToolRuleSettablePaths,
+  ToolRuleSettablePathsGlobal,
+  buildToolPath,
+} from "./tool-rule.js";
+
+export type ZedRuleSettablePaths = Pick<ToolRuleSettablePaths, "root"> & {
+  root: {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  };
+  nonRoot?: undefined;
+};
+
+export type ZedRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
+
+/**
+ * Rule generator for the Zed editor.
+ *
+ * Zed reads a single project rules file (the first match in its priority list,
+ * of which `.rules` is the highest-priority, Zed-specific entry) and a single
+ * global rules file at `~/.config/zed/AGENTS.md`. Because Zed loads exactly one
+ * file, only root rules are supported; non-root rules cannot be represented.
+ */
+export class ZedRule extends ToolRule {
+  static getSettablePaths({
+    global,
+    excludeToolDir,
+  }: {
+    global?: boolean;
+    excludeToolDir?: boolean;
+  } = {}): ZedRuleSettablePaths | ZedRuleSettablePathsGlobal {
+    if (global) {
+      return {
+        root: {
+          relativeDirPath: buildToolPath(join(".config", "zed"), ".", excludeToolDir),
+          relativeFilePath: "AGENTS.md",
+        },
+      };
+    }
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: ".rules",
+      },
+    };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    relativeFilePath,
+    validate = true,
+    global = false,
+  }: ToolRuleFromFileParams): Promise<ZedRule> {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    if (!isRoot) {
+      throw new Error(`ZedRule only supports root rules: ${relativeFilePath}`);
+    }
+
+    const fileContent = await readFileContent(
+      join(outputRoot, paths.root.relativeDirPath, paths.root.relativeFilePath),
+    );
+
+    return new ZedRule({
+      outputRoot,
+      relativeDirPath: paths.root.relativeDirPath,
+      relativeFilePath: paths.root.relativeFilePath,
+      fileContent,
+      validate,
+      root: true,
+    });
+  }
+
+  static fromRulesyncRule({
+    outputRoot = process.cwd(),
+    rulesyncRule,
+    validate = true,
+    global = false,
+  }: ToolRuleFromRulesyncRuleParams): ZedRule {
+    const paths = this.getSettablePaths({ global });
+
+    const isRoot = rulesyncRule.getFrontmatter().root ?? false;
+    if (!isRoot) {
+      throw new Error(`ZedRule only supports root rules: ${rulesyncRule.getRelativeFilePath()}`);
+    }
+
+    return new ZedRule(
+      this.buildToolRuleParamsDefault({
+        outputRoot,
+        rulesyncRule,
+        validate,
+        rootPath: paths.root,
+        nonRootPath: undefined,
+      }),
+    );
+  }
+
+  toRulesyncRule(): RulesyncRule {
+    return this.toRulesyncRuleDefault();
+  }
+
+  validate(): ValidationResult {
+    // Zed rules are plain markdown without frontmatter requirements.
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): ZedRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new ZedRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
+  }
+
+  static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {
+    // Only root rules are targeted; Zed reads a single rules file.
+    const isRoot = rulesyncRule.getFrontmatter().root ?? false;
+    if (!isRoot) {
+      return false;
+    }
+
+    return this.isTargetedByRulesyncRuleDefault({
+      rulesyncRule,
+      toolTarget: "zed",
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -842,6 +842,7 @@ Content that would fail parsing`;
           "rovodev",
           "takt",
           "windsurf",
+          "zed",
         ]),
       );
     });
@@ -874,6 +875,7 @@ Content that would fail parsing`;
           "rovodev",
           "takt",
           "windsurf",
+          "zed",
         ]),
       );
     });
@@ -904,6 +906,7 @@ Content that would fail parsing`;
           "rovodev",
           "takt",
           "windsurf",
+          "zed",
         ]),
       );
     });
@@ -940,6 +943,7 @@ Content that would fail parsing`;
         "rovodev",
         "takt",
         "windsurf",
+        "zed",
       ]);
       expect(targets).toEqual(skillsProcessorToolTargetsGlobal);
     });
@@ -965,6 +969,7 @@ Content that would fail parsing`;
         "rovodev",
         "takt",
         "windsurf",
+        "zed",
       ]);
       expect(targets).toEqual(skillsProcessorToolTargetsGlobal);
     });

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -43,6 +43,7 @@ import {
   toolSkillSearchRoots,
 } from "./tool-skill.js";
 import { WindsurfSkill } from "./windsurf-skill.js";
+import { ZedSkill } from "./zed-skill.js";
 
 /**
  * Factory entry for each tool skill class.
@@ -95,6 +96,7 @@ const skillsProcessorToolTargetTuple = [
   "rovodev",
   "takt",
   "windsurf",
+  "zed",
 ] as const;
 
 export type SkillsProcessorToolTarget = (typeof skillsProcessorToolTargetTuple)[number];
@@ -272,6 +274,13 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
     "windsurf",
     {
       class: WindsurfSkill,
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
+    },
+  ],
+  [
+    "zed",
+    {
+      class: ZedSkill,
       meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
     },
   ],

--- a/src/features/skills/zed-skill.test.ts
+++ b/src/features/skills/zed-skill.test.ts
@@ -1,0 +1,198 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+import { ZedSkill } from "./zed-skill.js";
+
+describe("ZedSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .agents/skills for both project and global modes", () => {
+      expect(ZedSkill.getSettablePaths().relativeDirPath).toBe(join(".agents", "skills"));
+      expect(ZedSkill.getSettablePaths({ global: true }).relativeDirPath).toBe(
+        join(".agents", "skills"),
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new ZedSkill({
+        outputRoot: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: { name: "test-skill", description: "Test skill description" },
+        body: "This is the body of the zed skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(ZedSkill);
+      expect(skill.getBody()).toBe("This is the body of the zed skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should accept the optional disable-model-invocation flag", () => {
+      const skill = new ZedSkill({
+        outputRoot: testDir,
+        dirName: "manual-skill",
+        frontmatter: {
+          name: "manual-skill",
+          description: "Manual only",
+          "disable-model-invocation": true,
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      expect(skill.getFrontmatter()["disable-model-invocation"]).toBe(true);
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from a valid skill directory", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: test-skill
+description: Test skill description
+---
+
+This is the body of the zed skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await ZedSkill.fromDir({ outputRoot: testDir, dirName: "test-skill" });
+
+      expect(skill).toBeInstanceOf(ZedSkill);
+      expect(skill.getBody()).toBe("This is the body of the zed skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        ZedSkill.fromDir({ outputRoot: testDir, dirName: "empty-skill" }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: { name: "test-skill", description: "Test skill description" },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const zedSkill = ZedSkill.fromRulesyncSkill({ rulesyncSkill, validate: true });
+
+      expect(zedSkill).toBeInstanceOf(ZedSkill);
+      expect(zedSkill.getRelativeDirPath()).toBe(join(".agents", "skills"));
+      expect(zedSkill.getBody()).toBe("Test body content");
+      expect(zedSkill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should target wildcard and zed", () => {
+      const wildcard = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "s",
+        frontmatter: { name: "s", description: "d", targets: ["*"] },
+        body: "b",
+        validate: true,
+      });
+      const zed = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "s",
+        frontmatter: { name: "s", description: "d", targets: ["zed"] },
+        body: "b",
+        validate: true,
+      });
+      expect(ZedSkill.isTargetedByRulesyncSkill(wildcard)).toBe(true);
+      expect(ZedSkill.isTargetedByRulesyncSkill(zed)).toBe(true);
+    });
+
+    it("should not target other tools", () => {
+      const other = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "s",
+        frontmatter: { name: "s", description: "d", targets: ["claudecode"] },
+        body: "b",
+        validate: true,
+      });
+      expect(ZedSkill.isTargetedByRulesyncSkill(other)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should convert to RulesyncSkill with wildcard targets", () => {
+      const skill = new ZedSkill({
+        outputRoot: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: { name: "test-skill", description: "Test description" },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill).toBeInstanceOf(RulesyncSkill);
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test description",
+        targets: ["*"],
+      });
+      expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a minimal instance for deletion", () => {
+      const skill = ZedSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: join(".agents", "skills"),
+      });
+
+      expect(skill).toBeInstanceOf(ZedSkill);
+      expect(skill.getDirName()).toBe("cleanup");
+      expect(skill.getRelativeDirPath()).toBe(join(".agents", "skills"));
+      expect(skill.getFrontmatter()).toEqual({ name: "", description: "" });
+      expect(skill.getBody()).toBe("");
+    });
+  });
+});

--- a/src/features/skills/zed-skill.ts
+++ b/src/features/skills/zed-skill.ts
@@ -1,0 +1,208 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { ValidationResult } from "../../types/ai-dir.js";
+import { formatError } from "../../utils/error.js";
+import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  ToolSkill,
+  ToolSkillForDeletionParams,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+export const ZedSkillFrontmatterSchema = z.looseObject({
+  name: z.string(),
+  description: z.string(),
+  "disable-model-invocation": z.optional(z.boolean()),
+});
+
+export type ZedSkillFrontmatter = z.infer<typeof ZedSkillFrontmatterSchema>;
+
+export type ZedSkillParams = {
+  outputRoot?: string;
+  relativeDirPath?: string;
+  dirName: string;
+  frontmatter: ZedSkillFrontmatter;
+  body: string;
+  otherFiles?: SkillFile[];
+  validate?: boolean;
+  global?: boolean;
+};
+
+/**
+ * Represents a Zed agent skill directory.
+ * Skills are stored under .agents/skills/ (project) or ~/.agents/skills/ (global)
+ * with SKILL.md files.
+ */
+export class ZedSkill extends ToolSkill {
+  constructor({
+    outputRoot = process.cwd(),
+    relativeDirPath = join(".agents", "skills"),
+    dirName,
+    frontmatter,
+    body,
+    otherFiles = [],
+    validate = true,
+    global = false,
+  }: ZedSkillParams) {
+    super({
+      outputRoot,
+      relativeDirPath,
+      dirName,
+      mainFile: {
+        name: SKILL_FILE_NAME,
+        body,
+        frontmatter: { ...frontmatter },
+      },
+      otherFiles,
+      global,
+    });
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static getSettablePaths(_options?: { global?: boolean }): ToolSkillSettablePaths {
+    // Zed skills use the same relative path for both project and global modes.
+    // The actual location differs based on outputRoot:
+    // - Project mode: {process.cwd()}/.agents/skills/
+    // - Global mode: {getHomeDirectory()}/.agents/skills/
+    return {
+      relativeDirPath: join(".agents", "skills"),
+    };
+  }
+
+  getFrontmatter(): ZedSkillFrontmatter {
+    return ZedSkillFrontmatterSchema.parse(this.requireMainFileFrontmatter());
+  }
+
+  getBody(): string {
+    return this.mainFile?.body ?? "";
+  }
+
+  validate(): ValidationResult {
+    if (!this.mainFile) {
+      return {
+        success: false,
+        error: new Error(`${this.getDirPath()}: ${SKILL_FILE_NAME} file does not exist`),
+      };
+    }
+
+    const result = ZedSkillFrontmatterSchema.safeParse(this.mainFile.frontmatter);
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${this.getDirPath()}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+
+    return { success: true, error: null };
+  }
+
+  toRulesyncSkill(): RulesyncSkill {
+    const frontmatter = this.getFrontmatter();
+    const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      targets: ["*"],
+    };
+
+    return new RulesyncSkill({
+      outputRoot: this.outputRoot,
+      relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+      dirName: this.getDirName(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.getBody(),
+      otherFiles: this.getOtherFiles(),
+      validate: true,
+      global: this.global,
+    });
+  }
+
+  static fromRulesyncSkill({
+    outputRoot = process.cwd(),
+    rulesyncSkill,
+    validate = true,
+    global = false,
+  }: ToolSkillFromRulesyncSkillParams): ZedSkill {
+    const settablePaths = ZedSkill.getSettablePaths({ global });
+    const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+    const zedFrontmatter: ZedSkillFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    return new ZedSkill({
+      outputRoot,
+      relativeDirPath: settablePaths.relativeDirPath,
+      dirName: rulesyncSkill.getDirName(),
+      frontmatter: zedFrontmatter,
+      body: rulesyncSkill.getBody(),
+      otherFiles: rulesyncSkill.getOtherFiles(),
+      validate,
+      global,
+    });
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    const targets = rulesyncSkill.getFrontmatter().targets;
+    return targets.includes("*") || targets.includes("zed");
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<ZedSkill> {
+    const loaded = await this.loadSkillDirContent({
+      ...params,
+      getSettablePaths: ZedSkill.getSettablePaths,
+    });
+
+    const result = ZedSkillFrontmatterSchema.safeParse(loaded.frontmatter);
+    if (!result.success) {
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
+      throw new Error(
+        `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
+      );
+    }
+
+    return new ZedSkill({
+      outputRoot: loaded.outputRoot,
+      relativeDirPath: loaded.relativeDirPath,
+      dirName: loaded.dirName,
+      frontmatter: result.data,
+      body: loaded.body,
+      otherFiles: loaded.otherFiles,
+      validate: true,
+      global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): ZedSkill {
+    const settablePaths = ZedSkill.getSettablePaths({ global });
+    return new ZedSkill({
+      outputRoot,
+      relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/lib/git-client.test.ts
+++ b/src/lib/git-client.test.ts
@@ -312,7 +312,7 @@ describe("git-client", () => {
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining("symlink"));
     });
 
-    it.each(["", ".", "./"])(
+    it.each(["", ".", "./", "./.", ".//", ".\\"])(
       "disables sparse-checkout when skillsPath is %j (repo root)",
       async (skillsPath) => {
         mockExecFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
@@ -362,9 +362,13 @@ describe("git-client", () => {
       });
 
       expect(files).toHaveLength(1);
+      // The clone root must be walked directly: a relative path computed against
+      // `<tmpDir>/.` would yield "./root-file.md" instead of "root-file.md".
       expect(files[0]?.relativePath).toBe("root-file.md");
-      // No `<tmpDir>/.` style path should be probed.
       expect(seenDirs).toContain("/tmp/test");
+      // The skills root must be `tmpDir` itself, never a naive `<tmpDir>/.`
+      // (which a string-concatenated `join(tmpDir, ".")` would produce).
+      expect(seenDirs).not.toContain("/tmp/test/.");
     });
 
     it("throws GitClientError at max directory depth", async () => {

--- a/src/lib/git-client.ts
+++ b/src/lib/git-client.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { isAbsolute, join, relative } from "node:path";
+import { isAbsolute, join, posix, relative } from "node:path";
 import { promisify } from "node:util";
 
 import { MAX_FILE_SIZE } from "../constants/rulesync-paths.js";
@@ -152,7 +152,10 @@ export async function fetchSkillFiles(params: {
   // instead. Otherwise repositories whose skills live directly at the root
   // (e.g. `<repo>/<skill-name>/SKILL.md` without a `skills/` container)
   // would only yield root-level files like README.md.
-  const isRootPath = skillsPath === "" || skillsPath === "." || skillsPath === "./";
+  // Normalize first so variants like "./.", ".//", or Windows ".\\" are also
+  // recognized as the root and don't fall back to the (buggy) sparse-checkout path.
+  const normalizedSkillsPath = posix.normalize(skillsPath.replace(/\\/g, "/")).replace(/\/+$/, "");
+  const isRootPath = normalizedSkillsPath === "" || normalizedSkillsPath === ".";
   try {
     await execFileAsync(
       "git",

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -1086,6 +1086,46 @@ describe("resolveAndFetchSources", () => {
     expect(writeFileContent).not.toHaveBeenCalled();
   });
 
+  it("should install each top-level directory as a skill for path '.' with wildcard filter", async () => {
+    const { resolveDefaultRef, fetchSkillFiles } = await import("./git-client.js");
+    vi.mocked(resolveDefaultRef).mockResolvedValue({ ref: "main", sha: "d".repeat(40) });
+    // Whole-repo fetch (path: ".") returns multiple top-level skill directories
+    // plus a root-level file that must be ignored under the wildcard filter.
+    vi.mocked(fetchSkillFiles).mockResolvedValue([
+      { relativePath: "README.md", content: "root docs", size: 20 },
+      { relativePath: "skill-a/SKILL.md", content: "# Skill A", size: 50 },
+      { relativePath: "skill-b/SKILL.md", content: "# Skill B", size: 50 },
+    ]);
+
+    const result = await resolveAndFetchSources({
+      logger,
+      sources: [
+        {
+          source: "https://dev.azure.com/org/_git/multi-skill-repo",
+          transport: "git",
+          path: ".",
+          skills: ["*"],
+        },
+      ],
+      projectRoot: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(2);
+    expect(writeFileContent).toHaveBeenCalledWith(
+      join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH, "skill-a", "SKILL.md"),
+      "# Skill A",
+    );
+    expect(writeFileContent).toHaveBeenCalledWith(
+      join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH, "skill-b", "SKILL.md"),
+      "# Skill B",
+    );
+    // The root-level README.md must not be installed as a skill.
+    expect(writeFileContent).not.toHaveBeenCalledWith(
+      expect.stringContaining(join("README.md")),
+      expect.anything(),
+    );
+  });
+
   it("should install single-skill repo with SKILL.md at path root via github transport", async () => {
     mockClientInstance.listDirectory.mockImplementation(
       async (_owner: string, _repo: string, path: string) => {


### PR DESCRIPTION
## Summary

This PR resolves three open `maintainer-scrap` issues together.

### Zed: skills, rules, and MCP (#1705)
The `zed` target previously supported only `ignore`. This adds:
- **skills** — `ZedSkill` writing `.agents/skills/<name>/SKILL.md` (project) and `~/.agents/skills/` (global).
- **rules** — `ZedRule` writing the project `.rules` file (first in Zed's priority list) and the global `~/.config/zed/AGENTS.md`. Root-only, since Zed reads exactly one rules file.
- **mcp** — `ZedMcp` writing the `context_servers` key in `.zed/settings.json` (project) / `~/.config/zed/settings.json` (global). Reads/writes merge into the existing JSON so the ignore feature's `private_files` (which shares the same file) is preserved. Env references pass through unchanged.

Registered all three in their processors, added gitignore entries, updated the README/`docs` support matrix, and added e2e happy-path cells (generate / import / global).

### git-transport root-path follow-ups (#1718)
Follow-ups from the PR #1711 review:
- Normalize `skillsPath` before the repo-root check so `"./."`, `".//"`, and Windows `".\\"` also disable sparse-checkout instead of re-triggering the original bug.
- Tighten the root-path regression test so it distinguishes fixed vs. unfixed behavior.
- Add a wildcard (`skills: ["*"]`) × repo-root (`path: "."`) integration test in `sources.test.ts`.
- Document that `path: ""` / `"."` / `"./"` fetches the whole repository root.

### antigravity-cli subagents (#1706)
Verified via the official Antigravity docs (rendered with `playwright-cli`) that CLI subagents are defined/managed only at runtime — the interactive `/agents` panel and the `invoke_subagent` / `define_subagent` tools — or bundled inside plugins. There is no standalone, declarative per-agent file (analogous to `geminicli`'s `.gemini/agents/`) that rulesync could generate, so subagents remain **out of scope**. Refined the migration guide to record this conclusion. No generator added.

## Related issues
- Closes #1705
- Closes #1718
- Closes #1706

## Test plan
- [x] `pnpm cicheck` (lint, types, format, 5799 unit/integration tests, content/spelling/secrets) — green
- [x] New unit tests: `zed-skill.test.ts`, `zed-rule.test.ts`, `zed-mcp.test.ts`
- [x] Updated `git-client.test.ts` and `sources.test.ts`
- [x] E2E: `e2e-skills`, `e2e-rules`, `e2e-mcp` pass with the new `zed` cells
- [x] `pnpm dev gitignore` produces no spurious diff
