### PR TITLE
feat: follow up Pi/Replit/Warp upstream updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 | JetBrains Junie        | junie           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode            | augmentcode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
 | Windsurf               | windsurf        |  ✅   |   ✅   |          |          |           | ✅ 🌏  |       |             |
-| Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
+| Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
 | Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -279,6 +279,25 @@ claudecode: # for claudecode-specific parameters
     - "test/**/*.ts"
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
+pi: # for Pi Coding Agent-specific parameters (optional)
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  disable-model-invocation: true # (optional) disable model invocation for this skill
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    pi-version: ">=0.75.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
+replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    agent-skills: ">=1.0.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
 ---

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -28,7 +28,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        | junie           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode            | augmentcode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
 | Windsurf               | windsurf        |  ✅   |   ✅   |          |          |           | ✅ 🌏  |       |             |
-| Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
+| Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
 | Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -279,6 +279,25 @@ claudecode: # for claudecode-specific parameters
     - "test/**/*.ts"
 codexcli: # for codexcli-specific parameters
   short-description: A brief user-facing description
+pi: # for Pi Coding Agent-specific parameters (optional)
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  disable-model-invocation: true # (optional) disable model invocation for this skill
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    pi-version: ">=0.75.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
+replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    agent-skills: ">=1.0.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
 ---

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -28,7 +28,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        | junie           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |    ✅     |   ✅   |       |             |
 | AugmentCode            | augmentcode     |  ✅   |   ✅   |          |          |           |        |       |    ✅ 🌏    |
 | Windsurf               | windsurf        |  ✅   |   ✅   |          |          |           | ✅ 🌏  |       |             |
-| Warp                   | warp            |  ✅   |        |          |          |           |        |       |             |
+| Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           |        |       |             |
 | Replit                 | replit          |  ✅   |        |          |          |           |   ✅   |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
 | Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -38,7 +38,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "common", feature: "general", entry: "**/AGENTS.local.md" },
 
   // AGENTS.md
-  { target: ["agentsmd", "pi"], feature: "rules", entry: "**/AGENTS.md" },
+  { target: ["agentsmd", "pi", "warp"], feature: "rules", entry: "**/AGENTS.md" },
   { target: "agentsmd", feature: "rules", entry: "**/.agents/" },
 
   // Antigravity (IDE + CLI, Antigravity 2.0)
@@ -297,8 +297,9 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "windsurf", feature: "skills", entry: "**/.codeium/windsurf/skills/" },
 
   // Warp
+  // `/init` now writes `AGENTS.md` (handled by the shared AGENTS.md entry above).
   { target: "warp", feature: "rules", entry: "**/.warp/" },
-  { target: "warp", feature: "rules", entry: "**/WARP.md" },
+  { target: "warp", feature: "mcp", entry: "**/.warp/.mcp.json" },
 
   // Zed
   // `.rules` is the project rules file. `.agents/skills/` is shared with the

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -35,6 +35,7 @@ describe("E2E: mcp", () => {
     { target: "junie", outputPath: join(".junie", "mcp", "mcp.json") },
     { target: "antigravity-ide", outputPath: join(".agents", "mcp_config.json") },
     { target: "antigravity-cli", outputPath: join(".agents", "mcp_config.json") },
+    { target: "warp", outputPath: join(".warp", ".mcp.json") },
     { target: "zed", outputPath: join(".zed", "settings.json") },
   ])("should generate $target mcp", async ({ target, outputPath }) => {
     const testDir = getTestDir();
@@ -198,6 +199,7 @@ describe("E2E: mcp (import)", () => {
     { target: "junie", sourcePath: join(".junie", "mcp", "mcp.json") },
     { target: "antigravity-ide", sourcePath: join(".agents", "mcp_config.json") },
     { target: "antigravity-cli", sourcePath: join(".agents", "mcp_config.json") },
+    { target: "warp", sourcePath: join(".warp", ".mcp.json") },
   ])("should import $target mcp", async ({ target, sourcePath }) => {
     const testDir = getTestDir();
 
@@ -268,6 +270,7 @@ describe("E2E: mcp (global mode)", () => {
       target: "antigravity-cli",
       outputPath: join(".gemini", "antigravity-cli", "mcp_config.json"),
     },
+    { target: "warp", outputPath: join(".warp", ".mcp.json") },
     { target: "zed", outputPath: join(".config", "zed", "settings.json") },
   ])("should generate $target mcp in home directory", async ({ target, outputPath }) => {
     const projectDir = getProjectDir();

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -35,7 +35,7 @@ describe("E2E: rules", () => {
     { target: "rovodev", outputPath: join(".rovodev", "AGENTS.md") },
     { target: "qwencode", outputPath: "QWEN.md" },
     { target: "junie", outputPath: join(".junie", "guidelines.md") },
-    { target: "warp", outputPath: "WARP.md" },
+    { target: "warp", outputPath: "AGENTS.md" },
     { target: "replit", outputPath: "replit.md" },
     { target: "pi", outputPath: "AGENTS.md" },
     { target: "zed", outputPath: ".rules" },
@@ -204,7 +204,7 @@ describe("E2E: rules (import)", () => {
       sourcePath: join(".junie", "guidelines.md"),
       importedFileName: "overview.md",
     },
-    { target: "warp", sourcePath: "WARP.md", importedFileName: "overview.md" },
+    { target: "warp", sourcePath: "AGENTS.md", importedFileName: "overview.md" },
     { target: "replit", sourcePath: "replit.md", importedFileName: "overview.md" },
     { target: "pi", sourcePath: "AGENTS.md", importedFileName: "overview.md" },
     {

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -32,6 +32,7 @@ import {
   ToolMcpFromRulesyncMcpParams,
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
+import { WarpMcp } from "./warp-mcp.js";
 import { ZedMcp } from "./zed-mcp.js";
 
 /**
@@ -57,6 +58,7 @@ const mcpProcessorToolTargetTuple = [
   "opencode",
   "roo",
   "rovodev",
+  "warp",
   "zed",
 ] as const;
 
@@ -311,6 +313,18 @@ const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
       class: RovodevMcp,
       meta: {
         supportsProject: false,
+        supportsGlobal: true,
+        supportsEnabledTools: false,
+        supportsDisabledTools: false,
+      },
+    },
+  ],
+  [
+    "warp",
+    {
+      class: WarpMcp,
+      meta: {
+        supportsProject: true,
         supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,

--- a/src/features/mcp/warp-mcp.test.ts
+++ b/src/features/mcp/warp-mcp.test.ts
@@ -1,0 +1,241 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_MCP_SCHEMA_URL,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+import { WarpMcp } from "./warp-mcp.js";
+
+describe("WarpMcp", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .warp/.mcp.json for project scope", () => {
+      const paths = WarpMcp.getSettablePaths();
+
+      expect(paths).toEqual({
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+      });
+    });
+
+    it("should return .warp/.mcp.json for global scope", () => {
+      const paths = WarpMcp.getSettablePaths({ global: true });
+
+      expect(paths).toEqual({
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+      });
+    });
+  });
+
+  describe("constructor", () => {
+    it("should parse JSON content", () => {
+      const jsonData = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            args: ["server.js"],
+          },
+        },
+      };
+
+      const warpMcp = new WarpMcp({
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      expect(warpMcp.getJson()).toEqual(jsonData);
+    });
+
+    it("should throw on invalid JSON content", () => {
+      expect(() => {
+        const _instance = new WarpMcp({
+          relativeDirPath: ".warp",
+          relativeFilePath: ".mcp.json",
+          fileContent: "{ invalid json }",
+        });
+      }).toThrow("Failed to parse Warp MCP config at .warp/.mcp.json");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should read an existing project config", async () => {
+      const jsonData = {
+        mcpServers: {
+          "file-server": {
+            command: "node",
+            args: ["file-server.js"],
+          },
+        },
+      };
+      await ensureDir(join(testDir, ".warp"));
+      await writeFileContent(
+        join(testDir, ".warp", ".mcp.json"),
+        JSON.stringify(jsonData, null, 2),
+      );
+
+      const warpMcp = await WarpMcp.fromFile({ validate: true });
+
+      expect(warpMcp).toBeInstanceOf(WarpMcp);
+      expect(warpMcp.getJson()).toEqual(jsonData);
+      expect(warpMcp.getRelativeDirPath()).toBe(".warp");
+      expect(warpMcp.getRelativeFilePath()).toBe(".mcp.json");
+    });
+
+    it("should initialize empty mcpServers when the file does not exist", async () => {
+      const warpMcp = await WarpMcp.fromFile({ validate: true });
+
+      expect(warpMcp.getJson()).toEqual({ mcpServers: {} });
+    });
+
+    it("should read an existing global config", async () => {
+      const jsonData = {
+        mcpServers: {
+          "global-server": {
+            command: "node",
+            args: ["global-server.js"],
+          },
+        },
+      };
+      await ensureDir(join(testDir, ".warp"));
+      await writeFileContent(
+        join(testDir, ".warp", ".mcp.json"),
+        JSON.stringify(jsonData, null, 2),
+      );
+
+      const warpMcp = await WarpMcp.fromFile({
+        outputRoot: testDir,
+        validate: true,
+        global: true,
+      });
+
+      expect(warpMcp.getJson()).toEqual(jsonData);
+      expect(warpMcp.getFilePath()).toBe(join(testDir, ".warp", ".mcp.json"));
+    });
+  });
+
+  describe("fromRulesyncMcp", () => {
+    it("should write mcpServers from RulesyncMcp", async () => {
+      const rulesyncMcpData = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            args: ["server.js"],
+          },
+        },
+      };
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(rulesyncMcpData),
+      });
+
+      const warpMcp = await WarpMcp.fromRulesyncMcp({
+        rulesyncMcp,
+        validate: true,
+      });
+
+      expect(warpMcp.getJson()).toEqual({ mcpServers: rulesyncMcpData.mcpServers });
+      expect(warpMcp.getRelativeDirPath()).toBe(".warp");
+      expect(warpMcp.getRelativeFilePath()).toBe(".mcp.json");
+    });
+
+    it("should strip rulesync-only fields such as targets", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            "test-server": {
+              command: "node",
+              args: ["server.js"],
+              targets: ["warp"],
+            },
+          },
+        }),
+      });
+
+      const warpMcp = await WarpMcp.fromRulesyncMcp({ rulesyncMcp, validate: true });
+      const json = warpMcp.getJson() as {
+        mcpServers: Record<string, { targets?: unknown }>;
+      };
+
+      expect(json.mcpServers["test-server"]?.targets).toBeUndefined();
+    });
+  });
+
+  describe("toRulesyncMcp", () => {
+    it("should convert WarpMcp to RulesyncMcp", () => {
+      const warpMcpData = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            args: ["server.js"],
+          },
+        },
+      };
+
+      const warpMcp = new WarpMcp({
+        outputRoot: testDir,
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(warpMcpData),
+      });
+
+      const rulesyncMcp = warpMcp.toRulesyncMcp();
+
+      expect(rulesyncMcp).toBeInstanceOf(RulesyncMcp);
+      expect(JSON.parse(rulesyncMcp.getFileContent())).toEqual({
+        $schema: RULESYNC_MCP_SCHEMA_URL,
+        ...warpMcpData,
+      });
+    });
+  });
+
+  describe("validate", () => {
+    it("should always return success", () => {
+      const warpMcp = new WarpMcp({
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: {} }),
+        validate: false,
+      });
+
+      const result = warpMcp.validate();
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a deletable instance", () => {
+      const warpMcp = WarpMcp.forDeletion({
+        relativeDirPath: ".warp",
+        relativeFilePath: ".mcp.json",
+      });
+
+      expect(warpMcp).toBeInstanceOf(WarpMcp);
+      expect(warpMcp.getJson()).toEqual({});
+    });
+  });
+});

--- a/src/features/mcp/warp-mcp.ts
+++ b/src/features/mcp/warp-mcp.ts
@@ -28,22 +28,29 @@ export class WarpMcp extends ToolMcp {
 
   constructor(params: ToolMcpParams) {
     super(params);
-    if (this.fileContent !== undefined) {
-      try {
-        this.json = JSON.parse(this.fileContent);
-      } catch (error) {
-        throw new Error(
-          `Failed to parse Warp MCP config at ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(error)}`,
-          { cause: error },
-        );
-      }
-    } else {
-      this.json = {};
-    }
+    this.json =
+      this.fileContent !== undefined
+        ? WarpMcp.parseJsonOrThrow(this.fileContent, this.relativeDirPath, this.relativeFilePath)
+        : {};
   }
 
   getJson(): Record<string, unknown> {
     return this.json;
+  }
+
+  private static parseJsonOrThrow(
+    content: string,
+    relativeDirPath: string,
+    relativeFilePath: string,
+  ): Record<string, unknown> {
+    try {
+      return JSON.parse(content);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Warp MCP config at ${join(relativeDirPath, relativeFilePath)}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
   }
 
   static getSettablePaths(_options?: { global?: boolean }): ToolMcpSettablePaths {
@@ -61,15 +68,7 @@ export class WarpMcp extends ToolMcp {
     const paths = this.getSettablePaths({ global });
     const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const fileContent = (await readFileContentOrNull(filePath)) ?? '{"mcpServers":{}}';
-    let json: Record<string, unknown>;
-    try {
-      json = JSON.parse(fileContent);
-    } catch (error) {
-      throw new Error(
-        `Failed to parse Warp MCP config at ${join(paths.relativeDirPath, paths.relativeFilePath)}: ${formatError(error)}`,
-        { cause: error },
-      );
-    }
+    const json = this.parseJsonOrThrow(fileContent, paths.relativeDirPath, paths.relativeFilePath);
     const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
 
     return new WarpMcp({
@@ -94,15 +93,7 @@ export class WarpMcp extends ToolMcp {
       join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       JSON.stringify({ mcpServers: {} }, null, 2),
     );
-    let json: Record<string, unknown>;
-    try {
-      json = JSON.parse(fileContent);
-    } catch (error) {
-      throw new Error(
-        `Failed to parse Warp MCP config at ${join(paths.relativeDirPath, paths.relativeFilePath)}: ${formatError(error)}`,
-        { cause: error },
-      );
-    }
+    const json = this.parseJsonOrThrow(fileContent, paths.relativeDirPath, paths.relativeFilePath);
 
     const warpConfig = { ...json, mcpServers: rulesyncMcp.getMcpServers() };
 

--- a/src/features/mcp/warp-mcp.ts
+++ b/src/features/mcp/warp-mcp.ts
@@ -1,0 +1,144 @@
+import { join } from "node:path";
+
+import { ValidationResult } from "../../types/ai-file.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+import {
+  ToolMcp,
+  ToolMcpForDeletionParams,
+  ToolMcpFromFileParams,
+  ToolMcpFromRulesyncMcpParams,
+  ToolMcpParams,
+  ToolMcpSettablePaths,
+} from "./tool-mcp.js";
+
+/**
+ * MCP generator for Warp.
+ *
+ * Warp reads file-based MCP configuration from:
+ * - Project scope: `.warp/.mcp.json`
+ * - Global scope: `~/.warp/.mcp.json`
+ *
+ * Both scopes use the same relative path under `.warp`; only the
+ * `outputRoot` (project directory vs. home directory) differs.
+ */
+export class WarpMcp extends ToolMcp {
+  private readonly json: Record<string, unknown>;
+
+  constructor(params: ToolMcpParams) {
+    super(params);
+    if (this.fileContent !== undefined) {
+      try {
+        this.json = JSON.parse(this.fileContent);
+      } catch (error) {
+        throw new Error(
+          `Failed to parse Warp MCP config at ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(error)}`,
+          { cause: error },
+        );
+      }
+    } else {
+      this.json = {};
+    }
+  }
+
+  getJson(): Record<string, unknown> {
+    return this.json;
+  }
+
+  static getSettablePaths(_options?: { global?: boolean }): ToolMcpSettablePaths {
+    return {
+      relativeDirPath: ".warp",
+      relativeFilePath: ".mcp.json",
+    };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolMcpFromFileParams): Promise<WarpMcp> {
+    const paths = this.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"mcpServers":{}}';
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(fileContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Warp MCP config at ${join(paths.relativeDirPath, paths.relativeFilePath)}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+    const newJson = { ...json, mcpServers: json.mcpServers ?? {} };
+
+    return new WarpMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(newJson, null, 2),
+      validate,
+      global,
+    });
+  }
+
+  static async fromRulesyncMcp({
+    outputRoot = process.cwd(),
+    rulesyncMcp,
+    validate = true,
+    global = false,
+  }: ToolMcpFromRulesyncMcpParams): Promise<WarpMcp> {
+    const paths = this.getSettablePaths({ global });
+
+    const fileContent = await readOrInitializeFileContent(
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      JSON.stringify({ mcpServers: {} }, null, 2),
+    );
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(fileContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Warp MCP config at ${join(paths.relativeDirPath, paths.relativeFilePath)}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+
+    const warpConfig = { ...json, mcpServers: rulesyncMcp.getMcpServers() };
+
+    return new WarpMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: JSON.stringify(warpConfig, null, 2),
+      validate,
+      global,
+    });
+  }
+
+  toRulesyncMcp(): RulesyncMcp {
+    return this.toRulesyncMcpDefault({
+      fileContent: JSON.stringify({ mcpServers: this.json.mcpServers ?? {} }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolMcpForDeletionParams): WarpMcp {
+    return new WarpMcp({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "{}",
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/rules/warp-rule.test.ts
+++ b/src/features/rules/warp-rule.test.ts
@@ -45,7 +45,7 @@ describe("WarpRule", () => {
     it("should create a WarpRule with root parameter set to true", () => {
       const params: WarpRuleParams = {
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         fileContent: "# Root Warp Rule\n\nThis is a root warp rule.",
         root: true,
       };
@@ -53,7 +53,7 @@ describe("WarpRule", () => {
       const warpRule = new WarpRule(params);
 
       expect(warpRule.isRoot()).toBe(true);
-      expect(warpRule.getRelativeFilePath()).toBe("WARP.md");
+      expect(warpRule.getRelativeFilePath()).toBe("AGENTS.md");
     });
 
     it("should create a WarpRule with root parameter set to false", () => {
@@ -115,20 +115,20 @@ describe("WarpRule", () => {
   });
 
   describe("fromFile", () => {
-    it("should create WarpRule from root WARP.md file", async () => {
+    it("should create WarpRule from root AGENTS.md file", async () => {
       const warpContent = "# Main Warp File\n\nThis is the main warp configuration.";
-      await writeFileContent(join(testDir, "WARP.md"), warpContent);
+      await writeFileContent(join(testDir, "AGENTS.md"), warpContent);
 
       const warpRule = await WarpRule.fromFile({
         outputRoot: testDir,
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
       });
 
       expect(warpRule.isRoot()).toBe(true);
       expect(warpRule.getRelativeDirPath()).toBe(".");
-      expect(warpRule.getRelativeFilePath()).toBe("WARP.md");
+      expect(warpRule.getRelativeFilePath()).toBe("AGENTS.md");
       expect(warpRule.getFileContent()).toBe(warpContent);
-      expect(warpRule.getFilePath()).toBe(join(testDir, "WARP.md"));
+      expect(warpRule.getFilePath()).toBe(join(testDir, "AGENTS.md"));
     });
 
     it("should create WarpRule from memory file in .warp/memories", async () => {
@@ -151,10 +151,10 @@ describe("WarpRule", () => {
 
     it("should use default outputRoot (process.cwd()) when not provided", async () => {
       const warpContent = "# Default Test";
-      await writeFileContent(join(testDir, "WARP.md"), warpContent);
+      await writeFileContent(join(testDir, "AGENTS.md"), warpContent);
 
       const warpRule = await WarpRule.fromFile({
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
       });
 
       expect(warpRule.getOutputRoot()).toBe(testDir);
@@ -163,11 +163,11 @@ describe("WarpRule", () => {
 
     it("should handle validation parameter", async () => {
       const warpContent = "# Validation Test";
-      await writeFileContent(join(testDir, "WARP.md"), warpContent);
+      await writeFileContent(join(testDir, "AGENTS.md"), warpContent);
 
       const warpRule = await WarpRule.fromFile({
         outputRoot: testDir,
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         validate: false,
       });
 
@@ -193,7 +193,7 @@ describe("WarpRule", () => {
 
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         frontmatter,
         body: "# Test Rule\n\nContent",
       });
@@ -206,7 +206,7 @@ describe("WarpRule", () => {
       expect(warpRule).toBeInstanceOf(WarpRule);
       expect(warpRule.getOutputRoot()).toBe(testDir);
       expect(warpRule.getRelativeDirPath()).toBe(".");
-      expect(warpRule.getRelativeFilePath()).toBe("WARP.md");
+      expect(warpRule.getRelativeFilePath()).toBe("AGENTS.md");
       expect(warpRule.isRoot()).toBe(true);
     });
 
@@ -242,7 +242,7 @@ describe("WarpRule", () => {
 
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         frontmatter,
         body: "# Default",
       });
@@ -262,7 +262,7 @@ describe("WarpRule", () => {
 
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         frontmatter,
         body: "# Validation",
       });
@@ -295,7 +295,7 @@ describe("WarpRule", () => {
     it("should convert root WarpRule to RulesyncRule", () => {
       const warpRule = new WarpRule({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         fileContent: "# Root Rule\n\nRoot content",
         root: true,
       });
@@ -339,7 +339,7 @@ describe("WarpRule", () => {
     it("should return success true for root file", () => {
       const warpRule = new WarpRule({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
         fileContent: "# Root Content",
         root: true,
       });
@@ -352,13 +352,13 @@ describe("WarpRule", () => {
   });
 
   describe("file path handling", () => {
-    it("should correctly identify WARP.md as root file in fromFile", async () => {
+    it("should correctly identify AGENTS.md as root file in fromFile", async () => {
       const content = "# Root File";
-      await writeFileContent(join(testDir, "WARP.md"), content);
+      await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const warpRule = await WarpRule.fromFile({
         outputRoot: testDir,
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
       });
 
       expect(warpRule.isRoot()).toBe(true);
@@ -387,7 +387,7 @@ describe("WarpRule", () => {
 
       expect(paths.root).toEqual({
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
       });
 
       expect(paths.nonRoot).toEqual({

--- a/src/features/rules/warp-rule.ts
+++ b/src/features/rules/warp-rule.ts
@@ -44,7 +44,7 @@ export class WarpRule extends ToolRule {
     return {
       root: {
         relativeDirPath: ".",
-        relativeFilePath: "WARP.md",
+        relativeFilePath: "AGENTS.md",
       },
       nonRoot: {
         relativeDirPath: buildToolPath(".warp", "memories", _options.excludeToolDir),
@@ -79,7 +79,7 @@ export class WarpRule extends ToolRule {
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): WarpRule {
     return new WarpRule(
-      this.buildToolRuleParamsDefault({
+      this.buildToolRuleParamsAgentsmd({
         outputRoot,
         rulesyncRule,
         validate,

--- a/src/features/skills/pi-skill.test.ts
+++ b/src/features/skills/pi-skill.test.ts
@@ -226,6 +226,43 @@ Body`,
 
       expect(skill.getRelativeDirPath()).toBe(join(".pi", "agent", "skills"));
     });
+
+    it("should emit Pi-specific frontmatter from the pi block", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "demo",
+        frontmatter: {
+          name: "demo",
+          description: "Demo",
+          targets: ["*"],
+          pi: {
+            "allowed-tools": ["read", "write"],
+            "disable-model-invocation": true,
+            license: "MIT",
+            compatibility: { "pi-version": ">=0.75.0" },
+            metadata: { author: "rulesync" },
+          },
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      const skill = PiSkill.fromRulesyncSkill({
+        outputRoot: testDir,
+        rulesyncSkill,
+      });
+
+      expect(skill.getFrontmatter()).toEqual({
+        name: "demo",
+        description: "Demo",
+        "allowed-tools": ["read", "write"],
+        "disable-model-invocation": true,
+        license: "MIT",
+        compatibility: { "pi-version": ">=0.75.0" },
+        metadata: { author: "rulesync" },
+      });
+    });
   });
 
   describe("toRulesyncSkill", () => {
@@ -245,6 +282,38 @@ Body`,
         targets: ["*"],
       });
       expect(rulesyncSkill.getBody()).toBe("Body");
+    });
+
+    it("should carry Pi-specific frontmatter into the pi block", () => {
+      const skill = new PiSkill({
+        outputRoot: testDir,
+        relativeDirPath: join(".pi", "skills"),
+        dirName: "demo",
+        frontmatter: {
+          name: "demo",
+          description: "Demo",
+          "allowed-tools": ["read", "write"],
+          "disable-model-invocation": true,
+          license: "MIT",
+          compatibility: { "pi-version": ">=0.75.0" },
+          metadata: { author: "rulesync" },
+        },
+        body: "Body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "demo",
+        description: "Demo",
+        targets: ["*"],
+        pi: {
+          "allowed-tools": ["read", "write"],
+          "disable-model-invocation": true,
+          license: "MIT",
+          compatibility: { "pi-version": ">=0.75.0" },
+          metadata: { author: "rulesync" },
+        },
+      });
     });
   });
 

--- a/src/features/skills/pi-skill.ts
+++ b/src/features/skills/pi-skill.ts
@@ -25,6 +25,11 @@ import {
 export const PiSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  "allowed-tools": z.optional(z.array(z.string())),
+  "disable-model-invocation": z.optional(z.boolean()),
+  license: z.optional(z.string()),
+  compatibility: z.optional(z.looseObject({})),
+  metadata: z.optional(z.looseObject({})),
 });
 
 export type PiSkillFrontmatter = z.infer<typeof PiSkillFrontmatterSchema>;
@@ -122,10 +127,24 @@ export class PiSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const piBlock = {
+      ...(frontmatter["allowed-tools"] !== undefined && {
+        "allowed-tools": frontmatter["allowed-tools"],
+      }),
+      ...(frontmatter["disable-model-invocation"] !== undefined && {
+        "disable-model-invocation": frontmatter["disable-model-invocation"],
+      }),
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && {
+        compatibility: frontmatter.compatibility,
+      }),
+      ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
+      ...(Object.keys(piBlock).length > 0 && { pi: piBlock }),
     };
 
     return new RulesyncSkill({
@@ -152,6 +171,7 @@ export class PiSkill extends ToolSkill {
     const piFrontmatter: PiSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
+      ...rulesyncFrontmatter.pi,
     };
 
     return new PiSkill({

--- a/src/features/skills/replit-skill.test.ts
+++ b/src/features/skills/replit-skill.test.ts
@@ -125,6 +125,40 @@ This is the body of the replit skill.`;
         description: "Test skill description",
       });
     });
+
+    it("should emit standard optional frontmatter from the replit block", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test skill description",
+          replit: {
+            "allowed-tools": ["read", "write"],
+            license: "MIT",
+            compatibility: { "agent-skills": ">=1.0.0" },
+            metadata: { author: "rulesync" },
+          },
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const replitSkill = ReplitSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(replitSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test skill description",
+        "allowed-tools": ["read", "write"],
+        license: "MIT",
+        compatibility: { "agent-skills": ">=1.0.0" },
+        metadata: { author: "rulesync" },
+      });
+    });
   });
 
   describe("isTargetedByRulesyncSkill", () => {
@@ -203,6 +237,38 @@ This is the body of the replit skill.`;
         targets: ["*"],
       });
       expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+
+    it("should carry standard optional frontmatter into the replit block", () => {
+      const skill = new ReplitSkill({
+        outputRoot: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+          "allowed-tools": ["read", "write"],
+          license: "MIT",
+          compatibility: { "agent-skills": ">=1.0.0" },
+          metadata: { author: "rulesync" },
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "Test Skill",
+        description: "Test description",
+        targets: ["*"],
+        replit: {
+          "allowed-tools": ["read", "write"],
+          license: "MIT",
+          compatibility: { "agent-skills": ">=1.0.0" },
+          metadata: { author: "rulesync" },
+        },
+      });
     });
   });
 

--- a/src/features/skills/replit-skill.ts
+++ b/src/features/skills/replit-skill.ts
@@ -18,6 +18,10 @@ import {
 export const ReplitSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  "allowed-tools": z.optional(z.array(z.string())),
+  license: z.optional(z.string()),
+  compatibility: z.optional(z.looseObject({})),
+  metadata: z.optional(z.looseObject({})),
 });
 
 export type ReplitSkillFrontmatter = z.infer<typeof ReplitSkillFrontmatterSchema>;
@@ -111,10 +115,21 @@ export class ReplitSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const replitBlock = {
+      ...(frontmatter["allowed-tools"] !== undefined && {
+        "allowed-tools": frontmatter["allowed-tools"],
+      }),
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && {
+        compatibility: frontmatter.compatibility,
+      }),
+      ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
+      ...(Object.keys(replitBlock).length > 0 && { replit: replitBlock }),
     };
 
     return new RulesyncSkill({
@@ -141,6 +156,7 @@ export class ReplitSkill extends ToolSkill {
     const replitFrontmatter: ReplitSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
+      ...rulesyncFrontmatter.replit,
     };
 
     return new ReplitSkill({

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -48,6 +48,23 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
       license: z.optional(z.string()),
     }),
   ),
+  pi: z.optional(
+    z.looseObject({
+      "allowed-tools": z.optional(z.array(z.string())),
+      "disable-model-invocation": z.optional(z.boolean()),
+      license: z.optional(z.string()),
+      compatibility: z.optional(z.looseObject({})),
+      metadata: z.optional(z.looseObject({})),
+    }),
+  ),
+  replit: z.optional(
+    z.looseObject({
+      "allowed-tools": z.optional(z.array(z.string())),
+      license: z.optional(z.string()),
+      compatibility: z.optional(z.looseObject({})),
+      metadata: z.optional(z.looseObject({})),
+    }),
+  ),
   cline: z.optional(z.looseObject({})),
   roo: z.optional(z.looseObject({})),
   takt: z.optional(
@@ -87,6 +104,19 @@ export type RulesyncSkillFrontmatterInput = {
   };
   copilot?: {
     license?: string;
+  };
+  pi?: {
+    "allowed-tools"?: string[];
+    "disable-model-invocation"?: boolean;
+    license?: string;
+    compatibility?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  };
+  replit?: {
+    "allowed-tools"?: string[];
+    license?: string;
+    compatibility?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
   };
   roo?: Record<string, unknown>;
   cline?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Follow up on three upstream-update scrap issues, implemented together as one PR.

### Pi skills — add a `pi` skill frontmatter block (#1704)

Pi `SKILL.md` supports `allowed-tools`, `disable-model-invocation`, `license`, `compatibility`, and `metadata`, but `PiSkill` previously emitted only `name`/`description`.

- Added a `pi` block to `RulesyncSkillFrontmatterSchema`.
- Extended `PiSkillFrontmatterSchema` and round-tripped the fields through `PiSkill.toRulesyncSkill` / `fromRulesyncSkill`.

### Replit skills — pass through standard frontmatter (#1703)

Replit Agent skills follow the Agent Skills standard, but `ReplitSkill` dropped the standard optional fields.

- Added a `replit` block to `RulesyncSkillFrontmatterSchema` (`allowed-tools`, `license`, `compatibility`, `metadata`).
- Round-tripped the fields through `ReplitSkill`.

### Warp — `AGENTS.md` rules file and file-based MCP (#1702)

- **rules:** switched the Warp rules root file from `WARP.md` to `AGENTS.md` (Warp `/init` switched to `AGENTS.md` in release 2026.01.21). Uses the shared AGENTS.md builder, so `agentsmd.subprojectPath` is now honored for Warp too.
- **mcp:** added a new `WarpMcp` adapter emitting `.warp/.mcp.json` (project) and `~/.warp/.mcp.json` (global), registered in `McpProcessor` with project + global support.
- Updated gitignore entries (shared `AGENTS.md` entry now includes `warp`; added `.warp/.mcp.json` for the mcp feature; dropped the legacy `WARP.md` entry).

### Docs & tests

- Updated the Supported Tools matrix (Warp `mcp` → ✅ 🌏) and the skill frontmatter example in `docs/reference/file-formats.md`; re-synced `skills/rulesync/`.
- Added unit tests for the new passthrough fields and `WarpMcp`, and extended the Tool × Feature e2e happy-path matrices (warp rules → `AGENTS.md`, warp mcp generate/import for project and global).

### Migration note (Warp)

`WARP.md` is no longer emitted and is **not** kept as a deprecated alias; the Warp rules root file is now `AGENTS.md`. If you have an existing `WARP.md`, rename it to `AGENTS.md` (Warp `/init` already writes `AGENTS.md` since release 2026.01.21). `import --targets warp` reads `AGENTS.md` only.

### Post-review refactor

- Deduplicated the repeated `try/catch` JSON parsing in `WarpMcp` into a private `parseJsonOrThrow` helper (used by the constructor, `fromFile`, and `fromRulesyncMcp`), keeping the descriptive parse-error message.

Closes #1702
Closes #1703
Closes #1704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
