### PR TITLE
fix: correct PNPM_HOME path for global packages in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -119,9 +119,8 @@ RUN curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/
 
 # Install global packages
 ENV PNPM_HOME=/home/node/.pnpm
-ENV PATH=$PATH:$PNPM_HOME
+ENV PATH=$PNPM_HOME/bin:$PATH
 RUN mkdir -p "$PNPM_HOME" && \
-    mise exec -- pnpm setup && \
     mise exec -- pnpm add -g \
     @openai/codex \
     @google/gemini-cli


### PR DESCRIPTION
## Summary

- Prepend `$PNPM_HOME/bin` to `PATH` instead of appending `$PNPM_HOME` so globally installed pnpm binaries resolve correctly.
- Remove the redundant `mise exec -- pnpm setup` step.

## Test plan

- Rebuild the devcontainer and confirm that globally installed CLIs (`@openai/codex`, `@google/gemini-cli`, etc.) are available on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)