### PR TITLE
fix(mcp): allow trailing commas in Amp JSONC parsing

### DIFF
--- a/src/features/mcp/amp-mcp.test.ts
+++ b/src/features/mcp/amp-mcp.test.ts
@@ -420,6 +420,31 @@ describe("AmpMcp", () => {
       expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.jsonc"));
     });
 
+    it("should parse settings.jsonc with trailing commas", async () => {
+      const jsoncContent = `{
+  // Amp settings with trailing commas
+  "amp.mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+    },
+  },
+}`;
+      await ensureDir(join(testDir, ".amp"));
+      await writeFileContent(join(testDir, ".amp", "settings.jsonc"), jsoncContent);
+
+      const ampMcp = await AmpMcp.fromFile({ outputRoot: testDir });
+
+      expect(ampMcp.getJson()).toEqual({
+        "amp.mcpServers": {
+          context7: {
+            type: "http",
+            url: "https://mcp.context7.com/mcp",
+          },
+        },
+      });
+    });
+
     it("should fall back to settings.json if settings.jsonc does not exist", async () => {
       const jsonData = {
         "amp.mcpServers": {

--- a/src/features/mcp/amp-mcp.ts
+++ b/src/features/mcp/amp-mcp.ts
@@ -20,7 +20,7 @@ const AMP_MCP_SERVERS_KEY = "amp.mcpServers";
 
 function parseAmpSettingsJsonc(fileContent: string): Record<string, unknown> {
   const errors: ParseError[] = [];
-  const parsed: unknown = parseJsonc(fileContent || "{}", errors);
+  const parsed: unknown = parseJsonc(fileContent || "{}", errors, { allowTrailingComma: true });
 
   if (errors.length > 0) {
     const details = errors


### PR DESCRIPTION
Fixes #1728

## What changed

Pass `{ allowTrailingComma: true }` as the third argument to `jsonc-parser`'s `parse()` in `parseAmpSettingsJsonc()`, so that valid JSONC files with trailing commas are accepted instead of rejected.

Amp's primary config format is `settings.jsonc` -- a format whose whole point is to tolerate JSON-with-comments and trailing commas. The current parser rejected perfectly legal JSONC that uses trailing commas, which is exactly the kind of file a human would hand-author.

**Files changed:**
- `src/features/mcp/amp-mcp.ts` -- one-line fix: add `{ allowTrailingComma: true }` option to `parseJsonc()` call
- `src/features/mcp/amp-mcp.test.ts` -- add regression test for JSONC with trailing commas in the existing `JSONC support` describe block

## Pattern reference

This matches the existing pattern in `src/features/permissions/kilo-permissions.ts` line 43:
```ts
const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
```

## Verification

```
pnpm test     # 233 files, 5840 tests passed
pnpm check    # format, oxlint, eslint, typecheck all passed
```
