### PR TITLE
fix(hooks): wrap matcher handlers in block scope to avoid duplicate const __re

### DIFF
--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -330,6 +331,66 @@ describe("KiloHooks", () => {
       expect(content).toContain("format.sh");
       expect(content).toContain('new RegExp("Write")');
       expect(content).toContain('new RegExp("Edit")');
+    });
+
+    it("should generate valid block-scoped regex declarations for multiple matcher handlers", () => {
+      const config = {
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", command: "audit-read.sh", matcher: "Read" },
+            { type: "command", command: "audit-write.sh", matcher: "Write" },
+            { type: "command", command: "audit-edit.sh", matcher: "Edit" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const kiloHooks = KiloHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = kiloHooks.getFileContent();
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Read");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-read.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Write");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-write.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Edit");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-edit.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+
+      execFileSync("node", ["--input-type=module", "--check"], { input: content });
     });
 
     it("should throw on invalid regex in matcher", () => {

--- a/src/features/hooks/opencode-hooks.test.ts
+++ b/src/features/hooks/opencode-hooks.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -330,6 +331,66 @@ describe("OpencodeHooks", () => {
       expect(content).toContain("format.sh");
       expect(content).toContain('new RegExp("Write")');
       expect(content).toContain('new RegExp("Edit")');
+    });
+
+    it("should generate valid block-scoped regex declarations for multiple matcher handlers", () => {
+      const config = {
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", command: "audit-read.sh", matcher: "Read" },
+            { type: "command", command: "audit-write.sh", matcher: "Write" },
+            { type: "command", command: "audit-edit.sh", matcher: "Edit" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const opencodeHooks = OpencodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = opencodeHooks.getFileContent();
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Read");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-read.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Write");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-write.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+      expect(content).toContain(
+        [
+          "      {",
+          '        const __re = new RegExp("Edit");',
+          "        if (__re.test(input.tool)) {",
+          "          await $`audit-edit.sh`;",
+          "        }",
+          "      }",
+        ].join("\n"),
+      );
+
+      execFileSync("node", ["--input-type=module", "--check"], { input: content });
     });
 
     it("should throw on invalid regex in matcher", () => {

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -92,9 +92,11 @@ export function generateOpencodeStylePluginCode(
       const escapedCommand = escapeForTemplateLiteral(handler.command);
       if (handler.matcher) {
         const safeMatcher = validateAndSanitizeMatcher(handler.matcher);
-        lines.push(`      const __re = new RegExp("${safeMatcher}");`);
-        lines.push(`      if (__re.test(input.tool)) {`);
-        lines.push(`        await $\`${escapedCommand}\`;`);
+        lines.push("      {");
+        lines.push(`        const __re = new RegExp("${safeMatcher}");`);
+        lines.push(`        if (__re.test(input.tool)) {`);
+        lines.push(`          await $\`${escapedCommand}\`;`);
+        lines.push("        }");
         lines.push("      }");
       } else {
         lines.push(`      await $\`${escapedCommand}\`;`);


### PR DESCRIPTION
Fixes #1725

## What changed

The `generateOpencodeStylePluginCode` function in `opencode-style-generator.ts` emits `const __re = new RegExp(...)` once per handler in the same function scope. When multiple handlers with matchers exist for the same event (e.g., `postToolUse` with 3 matchers), the generated code has duplicate `const __re` declarations in the same scope, causing `SyntaxError: Identifier '__re' has already been declared`.

The fix wraps each matcher handler in its own block scope (`{ ... }`), so each `const __re` declaration lives in a separate scope. This affects both opencode and kilo targets since they share the same generator.

**Files changed:**
- `src/features/hooks/opencode-style-generator.ts` -- wrap matcher handlers in block scope
- `src/features/hooks/opencode-hooks.test.ts` -- add regression test with 3 matchers and `node --input-type=module --check`
- `src/features/hooks/kilo-hooks.test.ts` -- same regression test for kilo

## Verification

```
pnpm cicheck
```

All checks passed: format, oxlint, eslint, typecheck, 233 test files (5842 tests), cspell, secretlint.

DCO sign-off included.
