### PR TITLE
fix(cursor): emit schema-required cli config fields

### DIFF
--- a/src/features/permissions/cursor-permissions.test.ts
+++ b/src/features/permissions/cursor-permissions.test.ts
@@ -190,6 +190,61 @@ describe("CursorPermissions", () => {
       expect(parsed.version).toBe(1);
     });
 
+    it("should default-stamp editor.vimMode and keep allow as an empty array for deny-only configs", async () => {
+      const logger = createMockLogger();
+      const rulesyncPermissions = new RulesyncPermissions({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+        fileContent: JSON.stringify({
+          permission: {
+            bash: { "git push --force*": "deny" },
+          },
+        }),
+      });
+
+      const cursorPermissions = await CursorPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+        logger,
+      });
+
+      const parsed = JSON.parse(cursorPermissions.getFileContent());
+      expect(parsed.editor).toEqual({ vimMode: false });
+      expect(parsed.permissions.allow).toEqual([]);
+      expect(parsed.permissions.deny).toEqual(["Shell(git push --force*)"]);
+    });
+
+    it("should preserve a pre-existing editor.vimMode value", async () => {
+      const logger = createMockLogger();
+      const cursorDir = join(testDir, ".cursor");
+      await ensureDir(cursorDir);
+      await writeFileContent(
+        join(cursorDir, "cli.json"),
+        JSON.stringify({
+          version: 1,
+          editor: { vimMode: true, fontSize: 14 },
+          permissions: {},
+        }),
+      );
+
+      const rulesyncPermissions = new RulesyncPermissions({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+        fileContent: JSON.stringify({
+          permission: { bash: { "git *": "allow" } },
+        }),
+      });
+
+      const cursorPermissions = await CursorPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+        logger,
+      });
+
+      const parsed = JSON.parse(cursorPermissions.getFileContent());
+      expect(parsed.editor).toEqual({ vimMode: true, fontSize: 14 });
+    });
+
     it("should default-stamp version: 1 when generating from a fresh config (global)", async () => {
       const logger = createMockLogger();
       const rulesyncPermissions = new RulesyncPermissions({

--- a/src/features/permissions/cursor-permissions.ts
+++ b/src/features/permissions/cursor-permissions.ts
@@ -153,9 +153,14 @@ function buildCursorPermissionEntry(type: string, pattern: string): string {
 
 type CursorCliConfig = {
   version?: unknown;
+  editor?: {
+    vimMode?: unknown;
+    [key: string]: unknown;
+  };
   permissions?: {
     allow?: string[];
     deny?: string[];
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 };
@@ -288,6 +293,23 @@ export class CursorPermissions extends ToolPermissions {
       Object.keys(config.permission).map((category) => toCursorType(category)),
     );
 
+    const existingEditorRaw = settings.editor;
+    let existingEditor: Record<string, unknown>;
+    if (existingEditorRaw === undefined) {
+      existingEditor = {};
+    } else if (
+      existingEditorRaw !== null &&
+      typeof existingEditorRaw === "object" &&
+      !Array.isArray(existingEditorRaw)
+    ) {
+      existingEditor = existingEditorRaw;
+    } else {
+      logger?.warn(
+        `Cursor CLI config at ${filePath} has a non-object \`editor\` field; ignoring existing editor settings.`,
+      );
+      existingEditor = {};
+    }
+
     const existingPermissionsRaw = settings.permissions;
     let existingPermissions: Record<string, unknown>;
     if (existingPermissionsRaw === undefined) {
@@ -328,11 +350,7 @@ export class CursorPermissions extends ToolPermissions {
     const mergedAllow = uniq([...preservedAllow, ...allow].toSorted());
     const mergedDeny = uniq([...preservedDeny, ...deny].toSorted());
 
-    if (mergedAllow.length > 0) {
-      mergedPermissions.allow = mergedAllow;
-    } else {
-      delete mergedPermissions.allow;
-    }
+    mergedPermissions.allow = mergedAllow;
     if (mergedDeny.length > 0) {
       mergedPermissions.deny = mergedDeny;
     } else {
@@ -351,6 +369,10 @@ export class CursorPermissions extends ToolPermissions {
     const merged = {
       ...settings,
       version: settings.version ?? 1,
+      editor: {
+        ...existingEditor,
+        vimMode: existingEditor.vimMode ?? false,
+      },
       permissions: mergedPermissions,
     };
     const fileContent = JSON.stringify(merged, null, 2);


### PR DESCRIPTION
## Summary\n- default-stamp Cursor CLI `editor.vimMode` when missing\n- always emit `permissions.allow` as an array, even for deny-only configs\n- add regression coverage for deny-only generation and preserving existing editor settings\n\n## Testing\n- corepack pnpm exec vitest run src/features/permissions/cursor-permissions.test.ts --silent=true\n- corepack pnpm exec eslint src/features/permissions/cursor-permissions.ts src/features/permissions/cursor-permissions.test.ts\n\nCloses #1669