### PR TITLE
chore: source bashrc before mise in gtr postCreate hook

### DIFF
--- a/.gtrconfig
+++ b/.gtrconfig
@@ -3,7 +3,7 @@
     includeDirs = .rulesync
 
 [hooks]
-    postCreate = mise trust && mise install && pnpm i
+    postCreate = source ~/.bashrc && mise trust && mise install && pnpm i
     postCd = source ~/.bashrc
 
 [defaults]


### PR DESCRIPTION
## Summary

- gtr (git-worktree-runner) の `postCreate` フックで `mise install` / `pnpm i` を実行する前に `source ~/.bashrc` を追加
- これにより、worktree 作成直後の非インタラクティブシェルでも mise などのツールが PATH に乗った状態でフックが実行される

## Test plan

- `.gtrconfig` のみの変更（ツール設定ファイル）でアプリのコード・生成ロジックには影響なし
- 新規 worktree 作成時に `postCreate` フックが正常に完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)