### PR TITLE
docs: unify README doc domain, add deepagents-cli reference row, clarify presence markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/qu
 
 ## Supported Tools and Features
 
-The tables below show whether each tool supports a given feature (✅ = supported, blank = not supported). For each tool's `--targets` value and mode details (project / global / simulated), see the [Supported Tools reference](https://rulesync.dyoshikawa.com/reference/supported-tools).
+The tables below show whether each tool supports a given feature (✅ = supported, blank = not supported). A ✅ means the feature is supported in at least one mode (project, global, or simulated) — for example, Codex CLI `commands` is global-only. For each tool's `--targets` value and full mode breakdown (project / global / simulated / MCP tool config), see the [Supported Tools reference](https://dyoshikawa.github.io/rulesync/reference/supported-tools).
 
 ### AI Coding Tools
 

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -14,6 +14,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   |        | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |          |          |           |        |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
+| deepagents-cli         | deepagents      |  ✅   |        |  ✅ 🌏   |          |    ✅     |   ✅   |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -14,6 +14,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   |        | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |          |          |           |        |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
+| deepagents-cli         | deepagents      |  ✅   |        |  ✅ 🌏   |          |    ✅     |   ✅   |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |    🎮    |    🎮     |   🎮   | ✅ 🌏 |             |
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           |  ✅   |   ✅   |    ✅    |  ✅ 🌏   |           | ✅ 🌏  |       |     ✅      |


### PR DESCRIPTION
## Summary

Resolves the actionable documentation follow-ups identified after PR #1710 (which restructured the "Supported Tools and Features" matrix into a presence overview), batched into one PR. Grouped by issue:

### #1727 — Docs follow-ups from PR #1710

- **Doc domain unified.** `README.md` had a single "Supported Tools" link using the `rulesync.dyoshikawa.com` host while every other README doc link uses `dyoshikawa.github.io/rulesync`. The outlier is switched to the majority convention.
- **`deepagents-cli` reference row added.** The README presence overview lists `deepagents-cli`, but `docs/reference/supported-tools.md` (and its synced copy `skills/rulesync/supported-tools.md`) had no row. Added one with markers **derived from the source-of-truth processors, not guessed**:
  - rules `✅` — `rules-processor.ts` (`supportsGlobal: false`)
  - mcp `✅ 🌏` — `mcp-processor.ts` (`supportsProject`/`supportsGlobal: true`; no `enabledTools`/`disabledTools` → no `🔧`)
  - subagents `✅`, skills `✅` — native, project-only (no simulated/global)
  - hooks `🌏` — `hooks-processor.ts` (`supportsProject: false, supportsGlobal: true` → global-only)
  - commands / ignore / permissions blank — no `deepagents` entry
- The optional legend note (sub-item 3) is folded into the #1724 mode-note below.

### #1724 — Review of PR #1710 (presence overview)

- **Presence-marker clarification.** The README intro now states that a single `✅` means "supported in at least one mode (project, global, or simulated)", with **Codex CLI `commands` (global-only)** as a concrete example, and links to the full mode breakdown in the reference. This addresses the review's main concern that the flat `✅` hides global-only / simulated-only support.
  - Ground truth for the example: `src/features/commands/codexcli-command.ts:18-21` throws unless `{ global: true }`; `docs/reference/supported-tools.md` lists Codex CLI commands as `🌏` only.
- The format divergence between the README (presence-only) and the reference (multi-marker) is intentional and adequately bridged by the summary→detail link; no separate change is needed.

## Not in scope (left open)

- **#1701 (Windsurf upstream follow-up)** — validation confirmed all the gaps are still real (Cascade hooks, workflows/commands, MCP, global rules, and the `manual`/`model_decision` trigger modes; none are implemented in rulesync today), but closing them is a large multi-feature buildout that needs maintainer scoping (priority/order, native-vs-simulated, project-vs-global coverage). It is intentionally **not** bundled into this docs PR and remains open.

## Validation evidence

- Codebase (markers / ground truth): `src/features/{rules,mcp,subagents,skills,hooks}/*-processor.ts` deepagents meta; `src/features/commands/codexcli-command.ts:18-21`.
- README link inventory: 1 occurrence of `rulesync.dyoshikawa.com` vs 6 of `dyoshikawa.github.io/rulesync` before the fix.
- `skills/rulesync/supported-tools.md` is kept byte-identical to `docs/reference/supported-tools.md` by `scripts/sync-skill-docs.ts`.

## Test plan

- `pnpm cicheck` — green: `fmt:check` / `oxlint` / `eslint` / `typecheck` pass; **5844 tests pass**; `check:sync-skill-docs`, `cspell` (0 issues), and `secretlint` pass.

Closes #1727
Closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
