### PR TITLE
fix(mcp): clarify generate no-op result so zero count is not read as failure

### DIFF
--- a/src/e2e/e2e-mcp-server.spec.ts
+++ b/src/e2e/e2e-mcp-server.spec.ts
@@ -211,6 +211,64 @@ describe("E2E: mcp server (daemon over stdio JSON-RPC)", () => {
   });
 
   it(
+    "should generate output files through the daemon and report a no-op on re-run",
+    { timeout: 30_000 },
+    async () => {
+      const testDir = getTestDir();
+
+      const connection = await connectRulesyncMcpServer(testDir);
+      close = connection.close;
+      const { client } = connection;
+
+      // Seed a rule via the MCP tool so generate has something to work with.
+      const putRule = await client.callTool({
+        name: "rulesyncTool",
+        arguments: {
+          feature: "rule",
+          operation: "put",
+          targetPathFromCwd: ".rulesync/rules/overview.md",
+          frontmatter: { root: true, targets: ["*"], description: "Overview" },
+          body: "# Overview",
+        },
+      });
+      expect(putRule.isError).not.toBe(true);
+
+      // First generate: writes the cursor rule file.
+      const firstGenerate = await client.callTool({
+        name: "rulesyncTool",
+        arguments: {
+          feature: "generate",
+          operation: "run",
+          generateOptions: { targets: ["cursor"], features: ["rules"] },
+        },
+      });
+      expect(firstGenerate.isError).not.toBe(true);
+      const firstPayload = JSON.parse(resultText(firstGenerate));
+      expect(firstPayload.success).toBe(true);
+      expect(firstPayload.result.totalCount).toBeGreaterThan(0);
+      expect(firstPayload.message).toContain("Generated");
+
+      // The output file must actually exist on disk.
+      expect(await fileExists(join(testDir, ".cursor", "rules", "overview.mdc"))).toBe(true);
+
+      // Second generate: nothing changed, so it is a successful no-op.
+      const secondGenerate = await client.callTool({
+        name: "rulesyncTool",
+        arguments: {
+          feature: "generate",
+          operation: "run",
+          generateOptions: { targets: ["cursor"], features: ["rules"] },
+        },
+      });
+      expect(secondGenerate.isError).not.toBe(true);
+      const secondPayload = JSON.parse(resultText(secondGenerate));
+      expect(secondPayload.success).toBe(true);
+      expect(secondPayload.result.totalCount).toBe(0);
+      expect(secondPayload.message).toContain("already up to date");
+    },
+  );
+
+  it(
     "should return an error when permissions put is called without content",
     { timeout: 30_000 },
     async () => {

--- a/src/mcp/generate.test.ts
+++ b/src/mcp/generate.test.ts
@@ -55,6 +55,51 @@ description: "Test rule"
       expect(result.config).toBeDefined();
     });
 
+    it("should report a message describing how many files were generated", async () => {
+      const rulesDir = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
+      await ensureDir(rulesDir);
+
+      await writeFileContent(
+        join(rulesDir, "overview.md"),
+        `---
+root: true
+targets: ["*"]
+description: "Test rule"
+---
+# Test Rule`,
+      );
+
+      const result = await executeGenerate({ targets: ["cursor"], features: ["rules"] });
+
+      expect(result.success).toBe(true);
+      expect(result.result?.totalCount).toBeGreaterThan(0);
+      expect(result.message).toContain(`Generated ${result.result?.totalCount} file(s)`);
+    });
+
+    it("should report a no-op message when outputs are already up to date", async () => {
+      const rulesDir = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
+      await ensureDir(rulesDir);
+
+      await writeFileContent(
+        join(rulesDir, "overview.md"),
+        `---
+root: true
+targets: ["*"]
+description: "Test rule"
+---
+# Test Rule`,
+      );
+
+      // First run writes the files; the second run finds them already up to date.
+      await executeGenerate({ targets: ["cursor"], features: ["rules"] });
+      const result = await executeGenerate({ targets: ["cursor"], features: ["rules"] });
+
+      expect(result.success).toBe(true);
+      expect(result.result?.totalCount).toBe(0);
+      expect(result.message).toContain("already up to date");
+      expect(result.message).toContain("successful no-op");
+    });
+
     it("should use rulesync.jsonc settings when no options provided", async () => {
       // Create .rulesync directory
       const rulesyncDir = join(testDir, ".rulesync");

--- a/src/mcp/generate.ts
+++ b/src/mcp/generate.ts
@@ -32,6 +32,12 @@ export type GenerateOptions = z.infer<typeof generateOptionsSchema>;
 
 export type McpGenerateResult = {
   success: boolean;
+  /**
+   * Human-readable summary of the outcome. Clarifies that a `totalCount` of 0
+   * means "already up to date" (success with nothing to write) rather than a
+   * failure, since `generate` is idempotent and only writes changed files.
+   */
+  message?: string;
   result?: McpResultCounts;
   config?: {
     targets: string[];
@@ -92,6 +98,30 @@ export async function executeGenerate(options: GenerateOptions = {}): Promise<Mc
   }
 }
 
+/**
+ * Build a human-readable summary of a successful generation.
+ *
+ * `generate` is idempotent: `totalCount` reflects only files whose content
+ * actually changed on disk, so a count of 0 is a normal "nothing to update"
+ * outcome — not a failure. The message makes that explicit so MCP callers do
+ * not misread a zero count as a broken generate.
+ */
+function buildGenerateMessage(params: { totalCount: number; config: Config }): string {
+  const { totalCount, config } = params;
+  const targets = config.getTargets().join(", ");
+  const features = config.getFeatures().join(", ");
+
+  if (totalCount > 0) {
+    return `Generated ${totalCount} file(s) for targets [${targets}] and features [${features}].`;
+  }
+
+  return (
+    `No files needed updating for targets [${targets}] and features [${features}]. ` +
+    `'generate' only writes files whose content changed, so a totalCount of 0 means the ` +
+    `outputs are already up to date — this is a successful no-op, not a failure.`
+  );
+}
+
 function buildSuccessResponse(params: {
   generateResult: GenerateResult;
   config: Config;
@@ -102,6 +132,7 @@ function buildSuccessResponse(params: {
 
   return {
     success: true,
+    message: buildGenerateMessage({ totalCount, config }),
     result: {
       rulesCount: generateResult.rulesCount,
       ignoreCount: generateResult.ignoreCount,
@@ -133,7 +164,7 @@ export const generateTools = {
   executeGenerate: {
     name: "executeGenerate",
     description:
-      "Execute the rulesync generate command to create output files for AI tools. Uses rulesync.jsonc settings by default, but options can override them.",
+      "Execute the rulesync generate command to create output files for AI tools. Uses rulesync.jsonc settings by default, but options can override them. Idempotent: only files whose content changed are written, so a totalCount of 0 means the outputs are already up to date (a successful no-op), not a failure. See the 'message' field for a human-readable summary.",
     parameters: generateToolSchemas.executeGenerate,
     execute: async (options: GenerateOptions = {}): Promise<string> => {
       const result = await executeGenerate(options);


### PR DESCRIPTION
## Summary

A user reported that `generate` in the rulesync MCP server "wasn't working." Investigation showed that `generate` **does work** — it is idempotent. `writeAiFiles` (`src/types/feature-processor.ts`) only writes files whose content actually changed, so re-running it when outputs are already up to date returns `success: true` with `totalCount: 0`. Callers (especially LLM agents) misread that zero count as a silent failure.

This PR makes the no-op outcome explicit so a zero count is no longer mistaken for a broken generate.

## Changes

- **`src/mcp/generate.ts`**
  - Add a `message` field to `McpGenerateResult`.
  - `buildGenerateMessage` returns `Generated N file(s) ...` when files were written, and an explicit "already up to date — this is a successful no-op, not a failure" message when `totalCount` is 0.
  - Document the idempotent behavior in the `executeGenerate` tool description so agents interpret a zero count correctly.
- **`src/mcp/generate.test.ts`** — Unit tests for both the "generated" and "no-op" messages.
- **`src/e2e/e2e-mcp-server.spec.ts`** — Add daemon-level e2e coverage for `generate` (previously only `permissions`/`hooks` were covered): `rule put` → `generate` verifies the output file is written, and a second `generate` verifies the successful no-op.

## Test Plan

- [x] `pnpm cicheck` passes (fmt, oxlint, eslint, typecheck, 5846 unit tests, cspell, secretlint)
- [x] `pnpm test:e2e src/e2e/e2e-mcp-server.spec.ts` passes (4 tests, incl. new generate round-trip)
- [x] Verified the live MCP daemon (`pnpm dev mcp`) generates files for fresh targets and returns the new no-op message on re-run

## Note

No behavior change to the generated files themselves — this is purely a clarity/observability improvement to the MCP `generate` result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
