### PR TITLE
Release v8.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.24.1",
+  "version": "8.25.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.24.1";
+const getVersion = () => "8.25.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Release v8.25.0

This PR bumps the version to 8.25.0 for release.

### Highlights

- New tool support: Windsurf (commands/hooks/MCP), Augment Code (commands), Zed (permissions/skills), Warp (skills)
- OpenCode plural feature directories
- Antigravity IDE global MCP/skills relocated to ~/.gemini/config; Cline global rules
- Bug fixes for MCP generate no-op result, Antigravity hooks import, and Takt upstream URL
- Tooling: ESLint removed in favor of oxlint

See the draft release notes for the full changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)