### PR TITLE
fix(opencode): loosen MCP per-server schemas to preserve extra fields (timeout/oauth)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -292,6 +292,7 @@
     "typer",
     "typetest",
     "üñíçødé",
+    "unmodeled",
     "unpipe",
     "USERPROFILE",
     "uvicorn",

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -2012,6 +2012,55 @@ describe("OpencodeMcp", () => {
       });
     });
 
+    it("should round-trip documented-but-unmodeled per-server fields (timeout/oauth) back to OpenCode", async () => {
+      // Start with OpenCode format carrying OpenCode-supported extras
+      const originalJsonData = {
+        mcp: {
+          "local-server": {
+            type: "local",
+            command: ["node", "server.js"],
+            enabled: true,
+            timeout: 120000,
+          },
+          "remote-server": {
+            type: "remote",
+            url: "https://mcp.example.com/mcp",
+            enabled: true,
+            timeout: 60000,
+            oauth: { clientId: "abc" },
+          },
+        },
+      };
+      await writeFileContent(
+        join(testDir, "opencode.json"),
+        JSON.stringify(originalJsonData, null, 2),
+      );
+
+      const originalOpencodeMcp = await OpencodeMcp.fromFile({ outputRoot: testDir });
+      const rulesyncMcp = originalOpencodeMcp.toRulesyncMcp();
+
+      // Convert back to OpenCode format and verify the extras survive the export leg
+      const newOpencodeMcp = await OpencodeMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+      });
+
+      const { mcp } = newOpencodeMcp.getJson();
+      expect(mcp?.["local-server"]).toEqual({
+        type: "local",
+        command: ["node", "server.js"],
+        enabled: true,
+        timeout: 120000,
+      });
+      expect(mcp?.["remote-server"]).toEqual({
+        type: "remote",
+        url: "https://mcp.example.com/mcp",
+        enabled: true,
+        timeout: 60000,
+        oauth: { clientId: "abc" },
+      });
+    });
+
     it("should round-trip enabledTools/disabledTools from rulesync format", async () => {
       // Start with rulesync format
       const rulesyncData = {

--- a/src/features/mcp/opencode-mcp.test.ts
+++ b/src/features/mcp/opencode-mcp.test.ts
@@ -1176,6 +1176,36 @@ describe("OpencodeMcp", () => {
       expect(rulesyncMcp.getRelativeFilePath()).toBe("mcp.json");
     });
 
+    it("should preserve documented-but-unmodeled per-server fields (timeout/oauth) on import", () => {
+      const jsonData = {
+        mcp: {
+          "local-server": {
+            type: "local",
+            command: ["node", "server.js"],
+            enabled: true,
+            timeout: 120000,
+          },
+          "remote-server": {
+            type: "remote",
+            url: "https://mcp.example.com/mcp",
+            enabled: true,
+            timeout: 60000,
+            oauth: { clientId: "abc" },
+          },
+        },
+      };
+      const opencodeMcp = new OpencodeMcp({
+        relativeDirPath: ".",
+        relativeFilePath: "opencode.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const servers = JSON.parse(opencodeMcp.toRulesyncMcp().getFileContent()).mcpServers;
+      expect(servers["local-server"].timeout).toBe(120000);
+      expect(servers["remote-server"].timeout).toBe(60000);
+      expect(servers["remote-server"].oauth).toEqual({ clientId: "abc" });
+    });
+
     it("should convert environment to env and preserve outputRoot", () => {
       const jsonData = {
         mcp: {

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -77,6 +77,12 @@ type OpencodeMcpServer = z.infer<typeof OpencodeMcpServerSchema>;
 // OpenCode per-server keys that this converter transforms explicitly. Any other
 // key (e.g. `timeout`, `oauth`, future additions) is passed through verbatim so it
 // survives import — see https://opencode.ai/docs/mcp-servers
+//
+// `enabledTools`/`disabledTools` are also listed here: although OpenCode encodes
+// them in the top-level `tools` map (not on the server object), including them
+// guards against a stray same-named key on an OpenCode server object being passed
+// through as an "extra" field and colliding with the values this converter derives
+// from the `tools` map.
 const OPENCODE_KNOWN_SERVER_KEYS = new Set([
   "type",
   "command",
@@ -85,6 +91,8 @@ const OPENCODE_KNOWN_SERVER_KEYS = new Set([
   "cwd",
   "url",
   "headers",
+  "enabledTools",
+  "disabledTools",
 ]);
 
 function convertFromOpencodeFormat(
@@ -120,13 +128,15 @@ function convertFromOpencodeFormat(
         return [
           serverName,
           {
+            // Spread extras first so converter-derived fields below always win
+            // on any key collision.
+            ...extraFields,
             type: "sse" as const,
             url: serverConfig.url,
             ...(serverConfig.enabled === false && { disabled: true }),
             ...(serverConfig.headers && { headers: serverConfig.headers }),
             ...(enabledTools.length > 0 && { enabledTools }),
             ...(disabledTools.length > 0 && { disabledTools }),
-            ...extraFields,
           },
         ];
       }
@@ -139,6 +149,9 @@ function convertFromOpencodeFormat(
       return [
         serverName,
         {
+          // Spread extras first so converter-derived fields below always win
+          // on any key collision.
+          ...extraFields,
           type: "stdio" as const,
           command,
           ...(args.length > 0 && { args }),
@@ -147,12 +160,21 @@ function convertFromOpencodeFormat(
           ...(serverConfig.cwd && { cwd: serverConfig.cwd }),
           ...(enabledTools.length > 0 && { enabledTools }),
           ...(disabledTools.length > 0 && { disabledTools }),
-          ...extraFields,
         },
       ];
     }),
   );
 }
+
+// OpenCode-supported per-server fields that rulesync does not map explicitly.
+// On export these are copied verbatim so an OpenCode -> rulesync -> OpenCode
+// round-trip preserves them. Unlike the import side — whose source is OpenCode's
+// own format, where any unknown key is by definition an OpenCode field — the
+// rulesync `mcp.json` is a multi-tool superset, so export uses an explicit
+// allow-list to avoid leaking other tools' keys (e.g. `kiroAutoApprove`,
+// `alwaysAllow`, `trust`) into `opencode.json`.
+// https://opencode.ai/docs/mcp-servers
+const OPENCODE_PASSTHROUGH_SERVER_FIELDS = ["timeout", "oauth"] as const;
 
 /**
  * Convert standard MCP format to OpenCode native format
@@ -161,6 +183,7 @@ function convertFromOpencodeFormat(
  * - env -> environment
  * - disabled -> enabled (inverted)
  * - enabledTools/disabledTools -> top-level tools map (with server name prefix)
+ * - OpenCode-supported extras (timeout, oauth) -> passed through verbatim
  */
 function convertToOpencodeFormat(mcpServers: McpServers): {
   mcp: Record<string, OpencodeMcpServer>;
@@ -185,8 +208,19 @@ function convertToOpencodeFormat(mcpServers: McpServers): {
         }
       }
 
+      // Preserve OpenCode-supported extras (e.g. timeout, oauth) on export so a
+      // round-trip keeps them. Spread first so derived fields below always win.
+      const serverRecord = serverConfig as Record<string, unknown>;
+      const passthrough: Record<string, unknown> = {};
+      for (const key of OPENCODE_PASSTHROUGH_SERVER_FIELDS) {
+        if (serverRecord[key] !== undefined) {
+          passthrough[key] = serverRecord[key];
+        }
+      }
+
       if (isRemote) {
         const remoteServer: OpencodeMcpServer = {
+          ...passthrough,
           type: "remote",
           url: serverConfig.url ?? serverConfig.httpUrl ?? "",
           enabled: serverConfig.disabled !== undefined ? !serverConfig.disabled : true,
@@ -209,6 +243,7 @@ function convertToOpencodeFormat(mcpServers: McpServers): {
       }
 
       const localServer: OpencodeMcpServer = {
+        ...passthrough,
         type: "local",
         command: commandArray,
         enabled: serverConfig.disabled !== undefined ? !serverConfig.disabled : true,

--- a/src/features/mcp/opencode-mcp.ts
+++ b/src/features/mcp/opencode-mcp.ts
@@ -27,8 +27,11 @@ const OPENCODE_ENV_VAR_PATTERN = /(?<!\$)\{env:([^}:]+)\}/g;
 // OpenCode uses "local"/"remote" instead of "stdio"/"sse"/"http",
 // "environment" instead of "env", and "enabled" instead of "disabled"
 
-// OpenCode native format for local servers
-const OpencodeMcpLocalServerSchema = z.object({
+// OpenCode native format for local servers.
+// looseObject preserves documented-but-unmodeled per-server fields (e.g. `timeout`)
+// and future additions on round-trip, matching the project's frequently-changing
+// tool-config convention. https://opencode.ai/docs/mcp-servers
+const OpencodeMcpLocalServerSchema = z.looseObject({
   type: z.literal("local"),
   command: z.array(z.string()),
   environment: z.optional(z.record(z.string(), z.string())),
@@ -36,8 +39,10 @@ const OpencodeMcpLocalServerSchema = z.object({
   cwd: z.optional(z.string()),
 });
 
-// OpenCode native format for remote servers
-const OpencodeMcpRemoteServerSchema = z.object({
+// OpenCode native format for remote servers.
+// looseObject preserves documented-but-unmodeled per-server fields (e.g. `timeout`,
+// `oauth`) and future additions on round-trip. https://opencode.ai/docs/mcp-servers
+const OpencodeMcpRemoteServerSchema = z.looseObject({
   type: z.literal("remote"),
   url: z.string(),
   headers: z.optional(z.record(z.string(), z.string())),
@@ -69,12 +74,30 @@ type OpencodeMcpServer = z.infer<typeof OpencodeMcpServerSchema>;
  * - enabled -> disabled (inverted)
  * - top-level tools map -> per-server enabledTools/disabledTools (strip server prefix)
  */
+// OpenCode per-server keys that this converter transforms explicitly. Any other
+// key (e.g. `timeout`, `oauth`, future additions) is passed through verbatim so it
+// survives import — see https://opencode.ai/docs/mcp-servers
+const OPENCODE_KNOWN_SERVER_KEYS = new Set([
+  "type",
+  "command",
+  "environment",
+  "enabled",
+  "cwd",
+  "url",
+  "headers",
+]);
+
 function convertFromOpencodeFormat(
   opencodeMcp: Record<string, OpencodeMcpServer>,
   tools?: Record<string, boolean>,
 ): McpServers {
   return Object.fromEntries(
     Object.entries(opencodeMcp).map(([serverName, serverConfig]) => {
+      // Preserve documented-but-unmodeled fields (e.g. `timeout`, `oauth`) on import.
+      const extraFields = Object.fromEntries(
+        Object.entries(serverConfig).filter(([key]) => !OPENCODE_KNOWN_SERVER_KEYS.has(key)),
+      );
+
       // Extract enabledTools and disabledTools from top-level tools map
       const enabledTools: string[] = [];
       const disabledTools: string[] = [];
@@ -103,6 +126,7 @@ function convertFromOpencodeFormat(
             ...(serverConfig.headers && { headers: serverConfig.headers }),
             ...(enabledTools.length > 0 && { enabledTools }),
             ...(disabledTools.length > 0 && { disabledTools }),
+            ...extraFields,
           },
         ];
       }
@@ -123,6 +147,7 @@ function convertFromOpencodeFormat(
           ...(serverConfig.cwd && { cwd: serverConfig.cwd }),
           ...(enabledTools.length > 0 && { enabledTools }),
           ...(disabledTools.length > 0 && { disabledTools }),
+          ...extraFields,
         },
       ];
     }),


### PR DESCRIPTION
## Summary

### #1692 — OpenCode: loosen MCP per-server schemas (`timeout` / `oauth`)

`OpencodeMcpLocalServerSchema` / `OpencodeMcpRemoteServerSchema` were strict `z.object`, so documented per-server fields like `timeout` and `oauth` were stripped when importing an OpenCode config. This change:

- Switches both schemas to **`z.looseObject`** (matching the project guideline favoring loose objects for frequently-changing tool config), so unknown/extra fields are no longer dropped at parse time.
- Passes those extra fields through `convertFromOpencodeFormat` (the schema change alone is not enough — the converter explicitly picks fields) so `timeout`, `oauth`, and future additions actually **survive import**.

## Validation evidence

- OpenCode per-server fields (incl. `timeout`, `oauth`): https://opencode.ai/docs/mcp-servers

## Test plan

- `pnpm cicheck` — green (fmt, oxlint, typecheck, 5988 unit tests, sync-skill-docs, cspell, secretlint).
- New unit test: an OpenCode config with `timeout`/`oauth` on local and remote servers round-trips those fields into the rulesync MCP output.
- E2E `e2e-mcp` (opencode) passes.

## Linked issues

- Closes #1692

## Note on the other two newest scrap issues

This batch resolves only #1692 because the other two newest open scrap issues are larger, dedicated efforts rather than bounded fixes (details posted as comments on each):

- **#1693 (Cline Hooks)** — Cline hooks are **executable scripts** named by hook type (e.g. `PreToolUse`) under `.clinerules/hooks/` (project) / `~/Documents/Cline/Rules/Hooks/` (global), each reading JSON on stdin and returning JSON — not the single JSON-config shape every existing rulesync hooks adapter emits. A correct adapter needs multi-file emission + executable bits, so it warrants its own design.
- **#1691 (Goose `AGENTS.md` + global `.gooseignore`)** — the global `.gooseignore` (`~/.config/goose/.gooseignore`, confirmed) requires global-ignore plumbing that does not exist (`IgnoreProcessor` currently throws on global mode), and the `AGENTS.md`-for-Goose part overlaps the `agentsmd` target and needs a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
