### PR TITLE
feat: Agent Skills global scope + frontmatter, Copilot excludeAgent value + skill allowed-tools

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -315,6 +315,16 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     agent-skills: ">=1.0.0"
   metadata: # (optional) free-form metadata
     author: rulesync
+agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata (max 500 chars)
+    agent-skills: ">=1.0.0"
+  metadata: # (optional) free-form metadata (spec-recommended place for skill versioning)
+    version: "1.0.0"
+  allowed-tools: "shell" # (optional, experimental) space-separated string or list
+copilot: # for GitHub Copilot-specific parameters (optional)
+  license: MIT # (optional)
+  allowed-tools: "shell" # (optional) tools pre-approved without per-use confirmation
 zed: # for Zed-specific parameters (optional)
   disable-model-invocation: true # (optional) prevent the model from auto-invoking this skill
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -5,7 +5,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Tool                   | --targets       | rules | ignore |   mcp    | commands | subagents | skills | hooks | permissions |
 | ---------------------- | --------------- | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md              | agentsmd        |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
-| AgentsSkills           | agentsskills    |       |        |          |          |           |   ✅   |       |             |
+| AgentsSkills           | agentsskills    |       |        |          |          |           | ✅ 🌏  |       |             |
 | Amp                    | amp             |       |        |  ✅ 🌏   |          |           |        |       |             |
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -315,6 +315,16 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     agent-skills: ">=1.0.0"
   metadata: # (optional) free-form metadata
     author: rulesync
+agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata (max 500 chars)
+    agent-skills: ">=1.0.0"
+  metadata: # (optional) free-form metadata (spec-recommended place for skill versioning)
+    version: "1.0.0"
+  allowed-tools: "shell" # (optional, experimental) space-separated string or list
+copilot: # for GitHub Copilot-specific parameters (optional)
+  license: MIT # (optional)
+  allowed-tools: "shell" # (optional) tools pre-approved without per-use confirmation
 zed: # for Zed-specific parameters (optional)
   disable-model-invocation: true # (optional) prevent the model from auto-invoking this skill
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -5,7 +5,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Tool                   | --targets       | rules | ignore |   mcp    | commands | subagents | skills | hooks | permissions |
 | ---------------------- | --------------- | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md              | agentsmd        |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
-| AgentsSkills           | agentsskills    |       |        |          |          |           |   ✅   |       |             |
+| AgentsSkills           | agentsskills    |       |        |          |          |           | ✅ 🌏  |       |             |
 | Amp                    | amp             |       |        |  ✅ 🌏   |          |           |        |       |             |
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -274,6 +274,10 @@ describe("E2E: skills (global mode)", () => {
       outputPath: join(".config", "opencode", "skills", "test-skill", "SKILL.md"),
     },
     {
+      target: "agentsskills",
+      outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
+    },
+    {
       target: "codexcli",
       outputPath: join(".codex", "skills", "test-skill", "SKILL.md"),
     },

--- a/src/features/rules/copilot-rule.test.ts
+++ b/src/features/rules/copilot-rule.test.ts
@@ -1122,6 +1122,14 @@ description: "Test trimming"
       }
     });
 
+    it("should accept the documented cloud-agent excludeAgent value", () => {
+      const result = CopilotRuleFrontmatterSchema.safeParse({ excludeAgent: "cloud-agent" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.excludeAgent).toBe("cloud-agent");
+      }
+    });
+
     it("should reject invalid excludeAgent", () => {
       const invalidFrontmatter = {
         excludeAgent: "invalid-agent",

--- a/src/features/rules/copilot-rule.ts
+++ b/src/features/rules/copilot-rule.ts
@@ -22,7 +22,12 @@ import {
 export const CopilotRuleFrontmatterSchema = z.object({
   description: z.optional(z.string()),
   applyTo: z.optional(z.string()),
-  excludeAgent: z.optional(z.union([z.literal("code-review"), z.literal("coding-agent")])),
+  // Documented values are `code-review` and `cloud-agent`; `coding-agent` is kept
+  // as a deprecated alias so existing configs still import.
+  // https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions
+  excludeAgent: z.optional(
+    z.union([z.literal("code-review"), z.literal("cloud-agent"), z.literal("coding-agent")]),
+  ),
 });
 
 export type CopilotRuleFrontmatter = z.infer<typeof CopilotRuleFrontmatterSchema>;

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -45,7 +45,10 @@ export const RulesyncRuleFrontmatterSchema = z.object({
   ),
   copilot: z.optional(
     z.looseObject({
-      excludeAgent: z.optional(z.union([z.literal("code-review"), z.literal("coding-agent")])),
+      // `cloud-agent` is the current documented value; `coding-agent` is a deprecated alias.
+      excludeAgent: z.optional(
+        z.union([z.literal("code-review"), z.literal("cloud-agent"), z.literal("coding-agent")]),
+      ),
     }),
   ),
   antigravity: z.optional(

--- a/src/features/skills/agentsskills-skill.test.ts
+++ b/src/features/skills/agentsskills-skill.test.ts
@@ -31,10 +31,41 @@ describe("AgentsSkillsSkill", () => {
       expect(paths.relativeDirPath).toBe(join(".agents", "skills"));
     });
 
-    it("should throw error when global is true", () => {
-      expect(() => AgentsSkillsSkill.getSettablePaths({ global: true })).toThrow(
-        "AgentsSkillsSkill does not support global mode.",
-      );
+    it("should return the same .agents/skills path in global mode (resolved under home)", () => {
+      // The Agent Skills standard defines `~/.agents/skills/` as the personal location.
+      const paths = AgentsSkillsSkill.getSettablePaths({ global: true });
+      expect(paths.relativeDirPath).toBe(join(".agents", "skills"));
+    });
+
+    it("should carry standard optional frontmatter through the agentsskills section", () => {
+      const skill = new AgentsSkillsSkill({
+        outputRoot: testDir,
+        dirName: "std-skill",
+        frontmatter: {
+          name: "std-skill",
+          description: "Standard",
+          license: "MIT",
+          compatibility: { "agent-skills": ">=1.0.0" },
+          metadata: { version: "1.2.3" },
+          "allowed-tools": "shell",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().agentsskills).toEqual({
+        license: "MIT",
+        compatibility: { "agent-skills": ">=1.0.0" },
+        metadata: { version: "1.2.3" },
+        "allowed-tools": "shell",
+      });
+
+      const roundTripped = AgentsSkillsSkill.fromRulesyncSkill({ rulesyncSkill });
+      const fm = roundTripped.getFrontmatter();
+      expect(fm.license).toBe("MIT");
+      expect(fm["allowed-tools"]).toBe("shell");
+      expect(fm.metadata).toEqual({ version: "1.2.3" });
     });
   });
 

--- a/src/features/skills/agentsskills-skill.ts
+++ b/src/features/skills/agentsskills-skill.ts
@@ -18,6 +18,11 @@ import {
 export const AgentsSkillsSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  // Optional Agent Skills standard frontmatter. https://agentskills.io/specification
+  license: z.optional(z.string()),
+  compatibility: z.optional(z.looseObject({})),
+  metadata: z.optional(z.looseObject({})),
+  "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
 });
 
 export type AgentsSkillsSkillFrontmatter = z.infer<typeof AgentsSkillsSkillFrontmatterSchema>;
@@ -70,10 +75,11 @@ export class AgentsSkillsSkill extends ToolSkill {
     }
   }
 
-  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
-    if (options?.global) {
-      throw new Error("AgentsSkillsSkill does not support global mode.");
-    }
+  static getSettablePaths(_options?: { global?: boolean }): ToolSkillSettablePaths {
+    // The Agent Skills standard defines `.agents/skills/` (project) and
+    // `~/.agents/skills/` (personal/global). The relative path is the same; the
+    // resolution root (cwd vs. home) is supplied via outputRoot by the processor.
+    // https://agentskills.io/specification
     return {
       relativeDirPath: join(".agents", "skills"),
     };
@@ -111,10 +117,19 @@ export class AgentsSkillsSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const agentsskillsSection = {
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && { compatibility: frontmatter.compatibility }),
+      ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
+      ...(frontmatter["allowed-tools"] !== undefined && {
+        "allowed-tools": frontmatter["allowed-tools"],
+      }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
+      ...(Object.keys(agentsskillsSection).length > 0 && { agentsskills: agentsskillsSection }),
     };
 
     return new RulesyncSkill({
@@ -137,10 +152,21 @@ export class AgentsSkillsSkill extends ToolSkill {
   }: ToolSkillFromRulesyncSkillParams): AgentsSkillsSkill {
     const settablePaths = AgentsSkillsSkill.getSettablePaths({ global });
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+    const agentsskillsSection = rulesyncFrontmatter.agentsskills;
 
     const agentsSkillsFrontmatter: AgentsSkillsSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
+      ...(agentsskillsSection?.license !== undefined && { license: agentsskillsSection.license }),
+      ...(agentsskillsSection?.compatibility !== undefined && {
+        compatibility: agentsskillsSection.compatibility,
+      }),
+      ...(agentsskillsSection?.metadata !== undefined && {
+        metadata: agentsskillsSection.metadata,
+      }),
+      ...(agentsskillsSection?.["allowed-tools"] !== undefined && {
+        "allowed-tools": agentsskillsSection["allowed-tools"],
+      }),
     };
 
     return new AgentsSkillsSkill({

--- a/src/features/skills/copilot-skill.test.ts
+++ b/src/features/skills/copilot-skill.test.ts
@@ -197,6 +197,24 @@ Skill content goes here.`,
       });
       expect(copilotSkill.getBody()).toBe("Follow the testing plan");
     });
+
+    it("should round-trip the allowed-tools skill frontmatter", () => {
+      const skill = new CopilotSkill({
+        dirName: "shell-skill",
+        frontmatter: {
+          name: "shell-skill",
+          description: "Runs shell",
+          "allowed-tools": "shell",
+        },
+        body: "body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().copilot).toEqual({ "allowed-tools": "shell" });
+
+      const roundTripped = CopilotSkill.fromRulesyncSkill({ rulesyncSkill });
+      expect(roundTripped.getFrontmatter()["allowed-tools"]).toBe("shell");
+    });
   });
 
   describe("isTargetedByRulesyncSkill", () => {

--- a/src/features/skills/copilot-skill.ts
+++ b/src/features/skills/copilot-skill.ts
@@ -19,6 +19,9 @@ export const CopilotSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
   license: z.optional(z.string()),
+  // Pre-approved tools the agent may run without per-use confirmation.
+  // https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills
+  "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
 });
 
 export type CopilotSkillFrontmatter = z.infer<typeof CopilotSkillFrontmatterSchema>;
@@ -111,15 +114,17 @@ export class CopilotSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const copilotSection = {
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter["allowed-tools"] !== undefined && {
+        "allowed-tools": frontmatter["allowed-tools"],
+      }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
-      ...(frontmatter.license && {
-        copilot: {
-          license: frontmatter.license,
-        },
-      }),
+      ...(Object.keys(copilotSection).length > 0 && { copilot: copilotSection }),
     };
 
     return new RulesyncSkill({
@@ -146,7 +151,12 @@ export class CopilotSkill extends ToolSkill {
     const copilotFrontmatter: CopilotSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
-      license: rulesyncFrontmatter.copilot?.license,
+      ...(rulesyncFrontmatter.copilot?.license !== undefined && {
+        license: rulesyncFrontmatter.copilot.license,
+      }),
+      ...(rulesyncFrontmatter.copilot?.["allowed-tools"] !== undefined && {
+        "allowed-tools": rulesyncFrontmatter.copilot["allowed-tools"],
+      }),
     };
 
     return new CopilotSkill({

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -46,6 +46,7 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   copilot: z.optional(
     z.looseObject({
       license: z.optional(z.string()),
+      "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
     }),
   ),
   pi: z.optional(
@@ -72,6 +73,14 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   ),
   cline: z.optional(z.looseObject({})),
   roo: z.optional(z.looseObject({})),
+  agentsskills: z.optional(
+    z.looseObject({
+      license: z.optional(z.string()),
+      compatibility: z.optional(z.looseObject({})),
+      metadata: z.optional(z.looseObject({})),
+      "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
+    }),
+  ),
   takt: z.optional(
     z.looseObject({
       // Rename the emitted file stem (e.g. "test-skill.md" → "{name}.md").
@@ -109,6 +118,7 @@ export type RulesyncSkillFrontmatterInput = {
   };
   copilot?: {
     license?: string;
+    "allowed-tools"?: string | string[];
   };
   pi?: {
     "allowed-tools"?: string[];
@@ -128,6 +138,12 @@ export type RulesyncSkillFrontmatterInput = {
   };
   roo?: Record<string, unknown>;
   cline?: Record<string, unknown>;
+  agentsskills?: {
+    license?: string;
+    compatibility?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    "allowed-tools"?: string | string[];
+  };
   takt?: {
     name?: string;
   };

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -930,6 +930,7 @@ Content that would fail parsing`;
     it("should return global targets in global mode", () => {
       const targets = SkillsProcessor.getToolTargetsGlobal();
       expect(targets).toEqual([
+        "agentsskills",
         "antigravity",
         "antigravity-cli",
         "antigravity-ide",
@@ -958,6 +959,7 @@ Content that would fail parsing`;
     it("should return global targets when global option is true", () => {
       const targets = SkillsProcessor.getToolTargets({ global: true });
       expect(targets).toEqual([
+        "agentsskills",
         "antigravity",
         "antigravity-cli",
         "antigravity-ide",

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -121,8 +121,10 @@ const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>(
   [
     "agentsskills",
     {
+      // The Agent Skills standard defines `~/.agents/skills/` as the personal/global
+      // location in addition to project `.agents/skills/`. https://agentskills.io/specification
       class: AgentsSkillsSkill,
-      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: false },
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
     },
   ],
   [


### PR DESCRIPTION
## Summary

Batch follow-up of maintainer-scrap upstream issues, all primary-source verified.

### #1684 — Agent Skills: global scope + optional standard frontmatter (fully resolved)

- **Global scope** — the `agentsskills` target now supports the standard personal/global location `~/.agents/skills/` (`supportsGlobal: true`; `getSettablePaths` no longer throws on global; the relative path is the same and the resolution root is supplied by the processor).
- **Standard optional frontmatter** — `license`, `compatibility`, `metadata`, and `allowed-tools` are now passed through generation/import via a new rulesync `agentsskills` skill section, instead of being dropped.

### #1686 — GitHub Copilot: `excludeAgent` value + skill `allowed-tools` (partial)

- **`excludeAgent` value drift** — the documented values are `code-review` and `cloud-agent`, but the schema only accepted `coding-agent`. Now accepts `cloud-agent` (the current value) while keeping `coding-agent` as a deprecated alias so existing configs still import.
- **Skill `allowed-tools`** — added the optional `allowed-tools` frontmatter to the `copilot` skill namespace (`CopilotSkill` + the rulesync `copilot` skill section), mirroring the sibling skill blocks.

> Remaining #1686 follow-ups: the missing hook events (`agentStop`/`subagentStop`), and global scope for subagents (`~/.copilot/agents`) and skills (`~/.copilot/skills`). This PR does **not** close #1686.

## Validation evidence (primary sources)

- Agent Skills standard (`~/.agents/skills/`, `license`/`compatibility`/`metadata`/`allowed-tools`): https://agentskills.io/specification
- Copilot `excludeAgent` values: https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions
- Copilot skill `allowed-tools`: https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills

## Test plan

- `pnpm cicheck` — green (fmt, oxlint, typecheck, 5990 unit tests, sync-skill-docs, cspell, secretlint).
- New unit tests: agentsskills global path + frontmatter round-trip; Copilot `cloud-agent` acceptance; Copilot skill `allowed-tools` round-trip.
- E2E: added `agentsskills` to the global-mode skills happy-path. `e2e-skills` passes in full. (Note: `e2e-rules` has one pre-existing, unrelated environmental flake — a test asserting `stderr === ""` that trips on a Node `DEP0205 module.register()` deprecation warning from tsx; it is independent of this change.)

## Note on the third newest issue (#1687, Copilot CLI)

Deferred: #1687 (Copilot CLI hooks `agentStop`/`cwd`/`env` + new `http`/`prompt` hook types + a new skills adapter) is a larger effort that extends the canonical hook model (new `http` type, per-hook `cwd`/`env`) and overlaps #1686 on the shared Copilot hook-event set, so it warrants a dedicated, coherent change rather than a partial here.

## Linked issues

- Closes #1684
- Addresses #1686 (excludeAgent value + skill allowed-tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
