### PR TITLE
chore(devcontainer): source ~/.bashrc in init.sh

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. ~/.bashrc
+
 # Ensure node_modules and pnpm-store volumes have correct ownership for non-root user
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
 sudo chown -R node:node /home/node/.pnpm-store 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Source `~/.bashrc` at the beginning of `.devcontainer/init.sh` so that the user shell configuration (PATH and tool shims such as mise/pnpm) is loaded before the subsequent setup commands run.
- This prevents `command not found` style failures during container initialization when the init script relies on tools provisioned via the shell rc.

## Test plan

- `pnpm cicheck` passes (lint, format, typecheck, 6049 tests, content checks).
- Rebuild the devcontainer and confirm `init.sh` completes without missing-command errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)