### PR TITLE
fix(codexcli-mcp): remove dead logger parameter in convertToCodexFormat

### DIFF
--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -65,10 +65,7 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   return result;
 }
 
-function convertToCodexFormat(
-  mcpServers: McpServers,
-  logger?: import("../../utils/logger.js").Logger,
-): Record<string, unknown> {
+function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   const result: Record<string, Record<string, unknown>> = {};
 
   for (const [name, config] of Object.entries(mcpServers)) {
@@ -88,7 +85,7 @@ function convertToCodexFormat(
             converted[mappedKey] = value;
           } else {
             warnWithFallback(
-              logger,
+              undefined,
               `[CodexCliMcp] Skipping invalid value type for mapped key '${key}': expected string array, got ${typeof value}`,
             );
           }
@@ -197,7 +194,7 @@ export class CodexcliMcp extends ToolMcp {
         ];
       }),
     );
-    const converted = convertToCodexFormat(mcpServersWithCodexFields, undefined);
+    const converted = convertToCodexFormat(mcpServersWithCodexFields);
     const filteredMcpServers = this.removeEmptyEntries(converted);
 
     for (const name of Object.keys(converted)) {


### PR DESCRIPTION
## Summary

PR #1637 added a `logger` parameter to `convertToCodexFormat` in `src/features/mcp/codexcli-mcp.ts`, but the sole caller in `fromRulesyncMcp` always passed `undefined`, making the parameter dead code. The inbound counterpart `convertFromCodexFormat` already hard-codes `undefined` in its `warnWithFallback` call, so the two directional converters were inconsistent.

This applies Option A from the issue: remove the parameter entirely and call `warnWithFallback` with `undefined` directly, matching `convertFromCodexFormat`. This also removes the inline `import("../../utils/logger.js").Logger` type annotation, aligning with the codebase's top-level static-import convention.

## Changes

- Remove the `logger?` parameter from `convertToCodexFormat`.
- Call `warnWithFallback(undefined, ...)` inside the converter, consistent with `convertFromCodexFormat`.
- Update the sole call site in `fromRulesyncMcp` to drop the `undefined` argument.

## Verification

- `pnpm cicheck` passes (format, lint, typecheck, 6049 tests, content checks).

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
