### PR TITLE
ci(e2e): drop unsupported macos-15-intel runner and set fail-fast: false

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -58,8 +58,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build
     strategy:
+      # Keep every platform leg running even if one fails, so a single
+      # platform-specific breakage does not mask the others' results.
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -86,9 +89,8 @@ jobs:
             chmod +x dist-bun/rulesync-darwin-arm64
             BINARY_PATH=dist-bun/rulesync-darwin-arm64
           else
-            # macos-15-intel is Intel (x64)
-            chmod +x dist-bun/rulesync-darwin-x64
-            BINARY_PATH=dist-bun/rulesync-darwin-x64
+            echo "Unexpected matrix OS for Unix binary selection: $MATRIX_OS" >&2
+            exit 1
           fi
           echo "BINARY_PATH=$BINARY_PATH" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

The `macos-15-intel` (Intel macOS) E2E leg in `e2e-binaries.yml` fails at the **Setup mise** step, before any test runs:

```
mise ERROR Failed to install aqua:pnpm/pnpm@latest: unsupported env: darwin/amd64
(supported: ["linux", "windows", "darwin/arm64"])
```

`mise` resolves `pnpm` through the aqua backend (`aqua:pnpm/pnpm`), which no longer publishes a `darwin/amd64` build. This is an upstream toolchain limitation outside this project's control, and it currently breaks the E2E workflow on **`main` and every PR** (e.g. the latest `main` commit `3e1b0c06`).

Because the matrix used the default `fail-fast: true`, this single platform failure also **cancelled** the `ubuntu-latest` / `macos-latest` / `windows-latest` legs, masking their otherwise-passing results.

## Changes

- Remove `macos-15-intel` from the E2E matrix, since GitHub-hosted Intel macOS runners can no longer bootstrap the toolchain.
- Add `fail-fast: false` so a future single-platform breakage no longer cancels (and hides) the other legs.
- Replace the now-unreachable Intel branch in the Unix binary-path selector with an explicit error, so a newly added Unix platform cannot silently fall through to testing the wrong binary.

## Trade-off

The `dist-bun/rulesync-darwin-x64` binary is still built, but it is no longer smoke-tested natively (this leg was its only native runner). If Intel macOS coverage must be retained, `pnpm` would need to be installed off the aqua backend instead — e.g. `npm:pnpm` in `mise.toml`, or `corepack`. I kept this PR to the minimal, guaranteed-green fix; happy to switch to the coverage-preserving approach if you prefer.

## Why this PR is separate / not auto-merged

This change touches a GitHub Actions workflow (high-risk per the autonomous scrap-issue flow), so it is intentionally opened for manual review and merge rather than auto-merged. It unblocks CI so the in-flight scrap-issue PRs (starting with #1779) can go green and merge.

## Verification

- `pnpm cicheck` passes locally (format, lint, typecheck, 6049 tests, content checks).
- This PR's own E2E run exercises the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
