### PR TITLE
refactor(mcp): unify env var regex patterns and harden format helpers

### DIFF
--- a/src/features/mcp/cursor-mcp.test.ts
+++ b/src/features/mcp/cursor-mcp.test.ts
@@ -54,6 +54,30 @@ describe("CursorMcp", () => {
       expect(exported.mcpServers["test-server"].env.DEBUG).toBe("true");
     });
 
+    it("should convert multiple Cursor env vars embedded in a single string (toRulesyncMcp)", () => {
+      const cursorConfig = {
+        mcpServers: {
+          "test-server": {
+            command: "node",
+            env: {
+              URL: "https://${env:HOST}:${env:PORT}/api",
+            },
+          },
+        },
+      };
+
+      const cursorMcp = new CursorMcp({
+        relativeDirPath: ".cursor",
+        relativeFilePath: "mcp.json",
+        fileContent: JSON.stringify(cursorConfig),
+      });
+
+      const rulesyncMcp = cursorMcp.toRulesyncMcp();
+      const exported = JSON.parse(rulesyncMcp.getFileContent());
+
+      expect(exported.mcpServers["test-server"].env.URL).toBe("https://${HOST}:${PORT}/api");
+    });
+
     it("should convert canonical env format ${VAR} to Cursor ${env:VAR} when exporting (fromRulesyncMcp)", async () => {
       const rulesyncConfig = {
         mcpServers: {

--- a/src/features/mcp/cursor-mcp.ts
+++ b/src/features/mcp/cursor-mcp.ts
@@ -18,7 +18,9 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
-const CURSOR_ENV_VAR_PATTERN = /\$\{env:([^}]+)\}/g;
+// Variable names exclude `:` (matching the canonical and OpenCode patterns);
+// environment variable names cannot contain `:` on any supported OS.
+const CURSOR_ENV_VAR_PATTERN = /\$\{env:([^}:]+)\}/g;
 
 export type CursorMcpParams = ToolMcpParams;
 

--- a/src/features/mcp/mcp-env-var-format.test.ts
+++ b/src/features/mcp/mcp-env-var-format.test.ts
@@ -81,6 +81,32 @@ describe("mcp-env-var-format", () => {
       expect(result["a"]?.env?.K).toBe("${A}");
       expect(result["b"]?.env?.K).toBe("${B}");
     });
+
+    it("should convert both env and headers on the same server entry", () => {
+      const mcpServers: McpServers = {
+        server: {
+          type: "http",
+          url: "https://example.com",
+          env: { KEY: "{tool:API_KEY}" },
+          headers: { Authorization: "Bearer {tool:TOKEN}" },
+        },
+      };
+
+      const result = convertEnvVarRefsFromToolFormat({ mcpServers, pattern: TOOL_PATTERN });
+
+      expect(result["server"]?.env?.KEY).toBe("${API_KEY}");
+      expect(result["server"]?.headers?.Authorization).toBe("Bearer ${TOKEN}");
+    });
+
+    it("should throw when the pattern lacks the global flag", () => {
+      const mcpServers: McpServers = {
+        server: { command: "node", env: { K: "{tool:A}" } },
+      };
+
+      expect(() =>
+        convertEnvVarRefsFromToolFormat({ mcpServers, pattern: /\{tool:([^}:]+)\}/ }),
+      ).toThrow(/global/);
+    });
   });
 
   describe("convertEnvVarRefsToToolFormat", () => {
@@ -112,6 +138,22 @@ describe("mcp-env-var-format", () => {
 
       const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
 
+      expect(result["server"]?.headers?.Authorization).toBe("Bearer {tool:TOKEN}");
+    });
+
+    it("should convert both env and headers on the same server entry", () => {
+      const mcpServers: McpServers = {
+        server: {
+          type: "http",
+          url: "https://example.com",
+          env: { KEY: "${API_KEY}" },
+          headers: { Authorization: "Bearer ${TOKEN}" },
+        },
+      };
+
+      const result = convertEnvVarRefsToToolFormat({ mcpServers, replacement: "{tool:$1}" });
+
+      expect(result["server"]?.env?.KEY).toBe("{tool:API_KEY}");
       expect(result["server"]?.headers?.Authorization).toBe("Bearer {tool:TOKEN}");
     });
 

--- a/src/features/mcp/mcp-env-var-format.ts
+++ b/src/features/mcp/mcp-env-var-format.ts
@@ -1,5 +1,11 @@
 import { McpServers } from "../../types/mcp.js";
 
+/**
+ * Canonical rulesync env var reference pattern: `${VAR}` (but not `${env:VAR}`,
+ * which is a tool-specific format). Variable names exclude `:` so they match the
+ * tool-specific patterns (e.g. OpenCode `{env:VAR}`, Cursor `${env:VAR}`). The
+ * `g` flag is required because callers may have multiple references per value.
+ */
 const CANONICAL_ENV_VAR_PATTERN = /\$\{(?!env:)([^}:]+)\}/g;
 
 function convertRecordValues({
@@ -16,6 +22,13 @@ function convertRecordValues({
   );
 }
 
+/**
+ * Convert tool-specific env var references (e.g. `{env:VAR}`) back to the
+ * canonical `${VAR}` format in each server's `env` and `headers` values.
+ *
+ * `pattern` must carry the `g` flag, otherwise only the first reference in each
+ * value would be converted.
+ */
 export function convertEnvVarRefsFromToolFormat({
   mcpServers,
   pattern,
@@ -23,6 +36,10 @@ export function convertEnvVarRefsFromToolFormat({
   mcpServers: McpServers;
   pattern: RegExp;
 }): McpServers {
+  if (!pattern.global) {
+    throw new Error("convertEnvVarRefsFromToolFormat requires a pattern with the global (g) flag");
+  }
+
   return Object.fromEntries(
     Object.entries(mcpServers).map(([name, config]) => [
       name,
@@ -39,6 +56,16 @@ export function convertEnvVarRefsFromToolFormat({
   );
 }
 
+/**
+ * Convert canonical `${VAR}` env var references to a tool-specific format in
+ * each server's `env` and `headers` values.
+ *
+ * `replacement` is passed directly to `String.prototype.replace`, so it may use
+ * capture-group references (`$1` is the variable name) and is subject to the
+ * special replacement patterns (`$$`, `$&`, `` $` ``, `$'`). Callers should pass
+ * a static template such as `"${env:$1}"` or `"{env:$1}"` and must not build it
+ * from untrusted input.
+ */
 export function convertEnvVarRefsToToolFormat({
   mcpServers,
   replacement,


### PR DESCRIPTION
## Summary

Addresses the review findings tracked in #1671 for the shared MCP env var format translation utility (`src/features/mcp/mcp-env-var-format.ts`) introduced by PR #1667.

## Changes

- **[mid] Finding #1 — regex capture-group asymmetry.** `CURSOR_ENV_VAR_PATTERN` used `[^}]+` while `CANONICAL_ENV_VAR_PATTERN` and `OPENCODE_ENV_VAR_PATTERN` used `[^}:]+`. Unified Cursor's pattern to `[^}:]+` and added a comment explaining the rationale (env var names cannot contain `:` on any supported OS).
- **[low] Finding #2 — missing `g`-flag guard.** `convertEnvVarRefsFromToolFormat` now throws if the supplied `pattern` lacks the global flag, since otherwise only the first reference per value would be converted.
- **[low] Finding #3 — replacement-string constraint undocumented.** Added JSDoc to `convertEnvVarRefsToToolFormat` documenting that `replacement` is passed to `String.prototype.replace` and is subject to special replacement patterns (`$$`, `$&`, etc.); callers must use a static template and never untrusted input.
- **[low] Finding #4 — `CANONICAL_ENV_VAR_PATTERN` undocumented.** Added JSDoc describing the canonical pattern and why variable names exclude `:`.
- **[low] Findings #6/#7 — test gaps.** Added tests for env+headers conversion on the same server entry (both directions), the new `g`-flag guard, and multiple Cursor env vars embedded in a single string at the `CursorMcp.toRulesyncMcp()` integration level.

Finding #5 (validation of extracted variable names) was intentionally left out: it would silently drop or alter values and the issue lists it as low-priority "consider"; the existing behavior is preserved.

## Verification

- `pnpm cicheck` passes (format, lint, typecheck, 6053 tests, content checks).

Closes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
