### PR TITLE
refactor(skills): align Claude Code paths field order with schema and add tests

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -321,7 +321,9 @@ claudecode: # for claudecode-specific parameters
     - "WebFetch"
   disable-model-invocation: true # (optional) disable model invocation for this skill
   scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
-  paths: # (optional) glob patterns (string or list) limiting auto-activation
+  # paths (optional) limits auto-activation to matching globs. Accepts a
+  # comma-separated string, e.g. paths: "src/**/*.ts,test/**/*.ts", or a list:
+  paths:
     - "src/**/*.ts"
     - "test/**/*.ts"
 codexcli: # for codexcli-specific parameters

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -321,7 +321,9 @@ claudecode: # for claudecode-specific parameters
     - "WebFetch"
   disable-model-invocation: true # (optional) disable model invocation for this skill
   scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md
-  paths: # (optional) glob patterns (string or list) limiting auto-activation
+  # paths (optional) limits auto-activation to matching globs. Accepts a
+  # comma-separated string, e.g. paths: "src/**/*.ts,test/**/*.ts", or a list:
+  paths:
     - "src/**/*.ts"
     - "test/**/*.ts"
 codexcli: # for codexcli-specific parameters

--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -415,6 +415,42 @@ describe("ClaudecodeSkill", () => {
       });
     });
 
+    it("should preserve an empty-string paths value through a round-trip", () => {
+      const skill = new ClaudecodeSkill({
+        dirName: "empty-paths-string-skill",
+        frontmatter: {
+          name: "empty-paths-string-skill",
+          description: "Skill with an empty paths string",
+          paths: "",
+        },
+        body: "Empty paths string body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().claudecode).toEqual({ paths: "" });
+
+      const roundTripped = ClaudecodeSkill.fromRulesyncSkill({ rulesyncSkill });
+      expect(roundTripped.getFrontmatter().paths).toBe("");
+    });
+
+    it("should preserve an empty-array paths value through a round-trip", () => {
+      const skill = new ClaudecodeSkill({
+        dirName: "empty-paths-array-skill",
+        frontmatter: {
+          name: "empty-paths-array-skill",
+          description: "Skill with an empty paths list",
+          paths: [],
+        },
+        body: "Empty paths array body",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().claudecode).toEqual({ paths: [] });
+
+      const roundTripped = ClaudecodeSkill.fromRulesyncSkill({ rulesyncSkill });
+      expect(roundTripped.getFrontmatter().paths).toEqual([]);
+    });
+
     it("should preserve other files during conversion", () => {
       const frontmatter: ClaudecodeSkillFrontmatter = {
         name: "test-skill",
@@ -818,6 +854,52 @@ This skill uses a specific model.`;
       });
 
       expect(skill.getFrontmatter().model).toBe("sonnet");
+    });
+
+    it("should load skill with paths as a YAML list", async () => {
+      const skillDir = join(testDir, ".claude", "skills", "paths-list-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: paths-list-skill
+description: Skill scoped to paths
+paths:
+  - src/**/*.ts
+  - test/**/*.ts
+---
+
+This skill is scoped to matching files.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await ClaudecodeSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "paths-list-skill",
+      });
+
+      expect(skill.getFrontmatter().paths).toEqual(["src/**/*.ts", "test/**/*.ts"]);
+    });
+
+    it("should load skill with paths as a comma-separated string", async () => {
+      const skillDir = join(testDir, ".claude", "skills", "paths-string-skill");
+      await ensureDir(skillDir);
+
+      const content = `---
+name: paths-string-skill
+description: Skill scoped to paths
+paths: "src/**/*.ts,test/**/*.ts"
+---
+
+This skill is scoped to matching files.`;
+
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), content);
+
+      const skill = await ClaudecodeSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "paths-string-skill",
+      });
+
+      expect(skill.getFrontmatter().paths).toBe("src/**/*.ts,test/**/*.ts");
     });
 
     it("should load skill with other files", async () => {

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -131,8 +131,8 @@ export class ClaudecodeSkill extends ToolSkill {
       ...(frontmatter["disable-model-invocation"] !== undefined && {
         "disable-model-invocation": frontmatter["disable-model-invocation"],
       }),
-      ...(frontmatter.paths !== undefined && { paths: frontmatter.paths }),
       ...(this.relativeDirPath === CLAUDE_SCHEDULED_TASKS_DIR_PATH && { "scheduled-task": true }),
+      ...(frontmatter.paths !== undefined && { paths: frontmatter.paths }),
     };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,


### PR DESCRIPTION
## Summary

Addresses the review findings tracked in #1618 for the `paths` field support in Claude Code skills (PR #1604).

## Changes

- **[mid] Finding #4 — field order mismatch.** `ClaudecodeSkill.toRulesyncSkill` emitted `paths` before `scheduled-task`, while the canonical `RulesyncSkill` claudecode schema (`rulesync-skill.ts`) and the documented examples order them `disable-model-invocation` → `scheduled-task` → `paths`. The generator now emits `scheduled-task` before `paths`, so the produced frontmatter matches the schema and docs.
- **[low] Finding #1 — `fromDir` test gap.** Added `fromDir` tests that parse `paths` from a `SKILL.md` file in both the YAML list and the comma-separated string forms.
- **[low] Finding #2 — edge-case tests.** Added round-trip tests covering empty-string (`""`) and empty-array (`[]`) `paths` values.
- **[low] Finding #3 — docs example.** Documented the comma-separated string form of `paths` in `docs/reference/file-formats.md` (synced to `skills/rulesync/file-formats.md`).

Findings #5 (glob syntax validation) and #6 (per-field length limit) were intentionally left out: both are low-priority, behavior-affecting "consider" items not specific to this change, and `paths` values are not used in any filesystem or command-execution path within rulesync.

## Verification

- `pnpm cicheck` passes (format, lint, typecheck, tests, content + skill-docs sync).

Closes #1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
