### PR TITLE
fix(skills): accept string compatibility for agentsskills (Agent Skills spec)

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -360,8 +360,7 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     author: rulesync
 agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
   license: MIT # (optional)
-  compatibility: # (optional) free-form compatibility metadata (max 500 chars)
-    agent-skills: ">=1.0.0"
+  compatibility: "Requires Python 3.14+ and uv" # (optional) free-form string, 1–500 chars (an object is also accepted for back-compat)
   metadata: # (optional) free-form metadata (spec-recommended place for skill versioning)
     version: "1.0.0"
   allowed-tools: "shell" # (optional, experimental) space-separated string or list

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -360,8 +360,7 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     author: rulesync
 agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
   license: MIT # (optional)
-  compatibility: # (optional) free-form compatibility metadata (max 500 chars)
-    agent-skills: ">=1.0.0"
+  compatibility: "Requires Python 3.14+ and uv" # (optional) free-form string, 1–500 chars (an object is also accepted for back-compat)
   metadata: # (optional) free-form metadata (spec-recommended place for skill versioning)
     version: "1.0.0"
   allowed-tools: "shell" # (optional, experimental) space-separated string or list

--- a/src/features/skills/agentsskills-skill.test.ts
+++ b/src/features/skills/agentsskills-skill.test.ts
@@ -67,6 +67,28 @@ describe("AgentsSkillsSkill", () => {
       expect(fm["allowed-tools"]).toBe("shell");
       expect(fm.metadata).toEqual({ version: "1.2.3" });
     });
+
+    it("should carry a string compatibility value through the agentsskills section", () => {
+      const skill = new AgentsSkillsSkill({
+        outputRoot: testDir,
+        dirName: "string-compat-skill",
+        frontmatter: {
+          name: "string-compat-skill",
+          description: "Standard",
+          compatibility: "Requires Python 3.14+ and uv",
+        },
+        body: "Body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().agentsskills).toEqual({
+        compatibility: "Requires Python 3.14+ and uv",
+      });
+
+      const roundTripped = AgentsSkillsSkill.fromRulesyncSkill({ rulesyncSkill });
+      expect(roundTripped.getFrontmatter().compatibility).toBe("Requires Python 3.14+ and uv");
+    });
   });
 
   describe("constructor", () => {
@@ -115,6 +137,26 @@ This is the body of the agent skill.`;
         name: "Test Skill",
         description: "Test skill description",
       });
+    });
+
+    it("should import a SKILL.md with a string compatibility value (Agent Skills spec form)", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "string-compat-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: string-compat-skill
+description: Spec-compliant skill
+compatibility: Requires Python 3.14+ and uv
+---
+
+Body.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await AgentsSkillsSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "string-compat-skill",
+      });
+
+      expect(skill.getFrontmatter().compatibility).toBe("Requires Python 3.14+ and uv");
     });
 
     it("should throw error when SKILL.md not found", async () => {

--- a/src/features/skills/agentsskills-skill.ts
+++ b/src/features/skills/agentsskills-skill.ts
@@ -20,7 +20,9 @@ export const AgentsSkillsSkillFrontmatterSchema = z.looseObject({
   description: z.string(),
   // Optional Agent Skills standard frontmatter. https://agentskills.io/specification
   license: z.optional(z.string()),
-  compatibility: z.optional(z.looseObject({})),
+  // The spec defines `compatibility` as a free-form string (1–500 chars). The
+  // object form is also accepted to stay permissive for existing inputs.
+  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
   metadata: z.optional(z.looseObject({})),
   "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
 });

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -123,7 +123,9 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   agentsskills: z.optional(
     z.looseObject({
       license: z.optional(z.string()),
-      compatibility: z.optional(z.looseObject({})),
+      // The Agent Skills spec defines `compatibility` as a free-form string
+      // (1–500 chars); the object form stays accepted for back-compat.
+      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
       metadata: z.optional(z.looseObject({})),
       "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
     }),
@@ -221,7 +223,7 @@ export type RulesyncSkillFrontmatterInput = {
   };
   agentsskills?: {
     license?: string;
-    compatibility?: Record<string, unknown>;
+    compatibility?: string | Record<string, unknown>;
     metadata?: Record<string, unknown>;
     "allowed-tools"?: string | string[];
   };


### PR DESCRIPTION
## Summary

The Agent Skills standard (agentskills.io) defines `compatibility` as a free-form **string** (1–500 chars, e.g. `compatibility: Requires Python 3.14+ and uv`), but rulesync modeled it as an **object** (`z.optional(z.looseObject({}))`) for the `agentsskills` target. As a result, a spec-compliant `SKILL.md` using a string `compatibility` was rejected on `fromDir` import (`Invalid input: expected object, received string`) and could not be generated or round-tripped.

## Changes

- Accept both the string and object forms via `z.union([z.string(), z.looseObject({})])` in:
  - `src/features/skills/agentsskills-skill.ts` (`AgentsSkillsSkillFrontmatterSchema`)
  - the `agentsskills` section of `src/features/skills/rulesync-skill.ts` (schema + generated type)
  The object form is kept for backward compatibility with existing inputs.
- Document `compatibility` as a string in `docs/reference/file-formats.md` (synced to `skills/rulesync/file-formats.md`).
- Add `fromDir` and round-trip tests covering the string form.

Scope is intentionally limited to `agentsskills`; the `pi`/`replit` sections keep their own object-shaped `compatibility` conventions.

## Verification

- `pnpm cicheck` passes (format, lint, typecheck, 6051 tests, content + skill-docs sync).

Closes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
