### PR TITLE
chore(release): v8.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.25.0",
+  "version": "8.26.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.25.0";
+const getVersion = () => "8.26.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release preparation for **v8.26.0**.

- Bump `getVersion()` in `src/cli/index.ts` to `8.26.0`
- Bump `package.json` version to `8.26.0`

## Highlights

- feat: rename `windsurf` target to `devin` (Devin Desktop) and add AugmentCode hooks
- feat: Agent Skills global scope + frontmatter, Copilot `excludeAgent`, skill `allowed-tools`
- feat: Cursor `workspaceOpen`/`failClosed`, Factory hook cleanup, DeepAgents `input.required`
- feat: Takt `extends`, Amp skills adapter, Qwen `.qwenignore` fix
- feat: follow upstream updates for Claude Code, Codex CLI, and Goose
- feat(commands): add `goal-pr` and `goal-all-scrap-issues` commands
- Multiple bug fixes (OpenCode MCP, Codex CLI MCP, Kilo/Roo/Rovo Dev, agentsskills)

Full changelog: https://github.com/dyoshikawa/rulesync/compare/v8.25.0...v8.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)