### PR TITLE
feat(junie): add hooks adapter and global MCP scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,7 +296,7 @@ rulesync.local.jsonc
 **/.copilot/agents/
 **/.copilot/hooks/
 **/.junie/guidelines.md
-**/.junie/mcp.json
+**/.junie/mcp/mcp.json
 **/.junie/skills/
 **/.junie/agents/
 **/.kilo/rules/

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | Google Antigravity IDE |  ✅   |        | ✅  |    ✅    |           |   ✅   |  ✅   |             |
 | Google Antigravity CLI |  ✅   |        | ✅  |          |           |   ✅   |  ✅   |     ✅      |
 | Google Antigravity ⚠️  |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
-| JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |       |             |
+| JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | AugmentCode            |  ✅   |   ✅   |     |    ✅    |           |        |  ✅   |     ✅      |
 | Devin Desktop          |  ✅   |   ✅   | ✅  |    ✅    |           |   ✅   |  ✅   |             |
 | Warp                   |  ✅   |        | ✅  |          |           |   ✅   |       |             |

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -27,7 +27,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |             |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |        | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
-| JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
+| JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |          |  ✅ 🌏   |           |        | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |             |
 | Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -27,7 +27,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |             |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |        | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
-| JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |    ✅    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
+| JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |          |  ✅ 🌏   |           |        | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |             |
 | Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -217,7 +217,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
 
   // Junie
   { target: "junie", feature: "rules", entry: "**/.junie/guidelines.md" },
-  { target: "junie", feature: "mcp", entry: "**/.junie/mcp.json" },
+  { target: "junie", feature: "mcp", entry: "**/.junie/mcp/mcp.json" },
   { target: "junie", feature: "skills", entry: "**/.junie/skills/" },
   { target: "junie", feature: "subagents", entry: "**/.junie/agents/" },
 

--- a/src/e2e/e2e-hooks.spec.ts
+++ b/src/e2e/e2e-hooks.spec.ts
@@ -391,6 +391,7 @@ describe("E2E: hooks (global mode)", () => {
     { target: "opencode", outputPath: join(".config", "opencode", "plugins", "rulesync-hooks.js") },
     { target: "factorydroid", outputPath: join(".factory", "settings.json") },
     { target: "deepagents", outputPath: join(".deepagents", "hooks.json") },
+    { target: "junie", outputPath: join(".junie", "config.json") },
     { target: "cursor", outputPath: join(".cursor", "hooks.json") },
     { target: "copilotcli", outputPath: join(".copilot", "hooks", "copilot-hooks.json") },
     { target: "antigravity-ide", outputPath: join(".gemini", "config", "hooks.json") },
@@ -431,6 +432,12 @@ describe("E2E: hooks (global mode)", () => {
       // intentionally dropped during generation.
       const parsed = JSON.parse(generatedContent);
       expect(parsed.hooks.sessionStart).toBeDefined();
+      expect(JSON.stringify(parsed.hooks)).toContain(".rulesync/hooks/session-start.sh");
+    } else if (target === "junie") {
+      // Junie CLI only supports the `sessionStart` event (PascalCase
+      // SessionStart), so `stop` (audit.sh) is dropped during generation.
+      const parsed = JSON.parse(generatedContent);
+      expect(parsed.hooks.SessionStart).toBeDefined();
       expect(JSON.stringify(parsed.hooks)).toContain(".rulesync/hooks/session-start.sh");
     } else if (target === "antigravity-ide" || target === "antigravity-cli") {
       // Antigravity nests the event map under a generated `rulesync` hook name

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -301,6 +301,7 @@ describe("E2E: mcp (global mode)", () => {
     { target: "factorydroid", outputPath: join(".factory", "mcp.json") },
     { target: "rovodev", outputPath: join(".rovodev", "mcp.json") },
     { target: "kilo", outputPath: join(".config", "kilo", "kilo.jsonc") },
+    { target: "junie", outputPath: join(".junie", "mcp", "mcp.json") },
     { target: "amp", outputPath: join(".config", "amp", "settings.jsonc") },
     {
       target: "antigravity-ide",

--- a/src/features/commands/junie-command.ts
+++ b/src/features/commands/junie-command.ts
@@ -52,9 +52,9 @@ export class JunieCommand extends ToolCommand {
   }
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolCommandSettablePaths {
-    // JetBrains Junie (AI Assistant) currently stores commands in the project's .junie directory.
-    // If a future version of Junie introduces a global-scope directory (e.g., under user home),
-    // this method should branch based on the global option.
+    // JetBrains Junie stores commands under `.junie/commands` for both project
+    // and user scope. The relative path is identical in either mode; in global
+    // mode the same path is resolved under the user home (`~/.junie/commands`).
     return {
       relativeDirPath: join(".junie", "commands"),
     };

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -519,6 +519,7 @@ describe("HooksProcessor", () => {
         "deepagents",
         "devin",
         "augmentcode",
+        "junie",
       ]);
     });
 
@@ -556,6 +557,7 @@ describe("HooksProcessor", () => {
         "deepagents",
         "devin",
         "augmentcode",
+        "junie",
       ]);
     });
   });

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -13,6 +13,7 @@ import {
   FACTORYDROID_HOOK_EVENTS,
   GEMINICLI_HOOK_EVENTS,
   GOOSE_HOOK_EVENTS,
+  JUNIE_HOOK_EVENTS,
   KILO_HOOK_EVENTS,
   KIRO_HOOK_EVENTS,
   OPENCODE_HOOK_EVENTS,
@@ -36,6 +37,7 @@ import { DEVIN_HOOK_EVENTS, DevinHooks } from "./devin-hooks.js";
 import { FactorydroidHooks } from "./factorydroid-hooks.js";
 import { GeminicliHooks } from "./geminicli-hooks.js";
 import { GooseHooks } from "./goose-hooks.js";
+import { JunieHooks } from "./junie-hooks.js";
 import { KiloHooks } from "./kilo-hooks.js";
 import { KiroHooks } from "./kiro-hooks.js";
 import { OpencodeHooks } from "./opencode-hooks.js";
@@ -64,6 +66,7 @@ const hooksProcessorToolTargetTuple = [
   "kiro",
   "devin",
   "augmentcode",
+  "junie",
 ] as const;
 
 export type HooksProcessorToolTarget = (typeof hooksProcessorToolTargetTuple)[number];
@@ -325,6 +328,23 @@ const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFactory>([
         supportsImport: true,
       },
       supportedEvents: AUGMENTCODE_HOOK_EVENTS,
+      supportedHookTypes: ["command"],
+      supportsMatcher: true,
+    },
+  ],
+  [
+    "junie",
+    {
+      class: JunieHooks,
+      meta: {
+        // Junie CLI only runs user-scope hooks (~/.junie/config.json); project
+        // hooks in .junie/config.json are ignored by default for safety, so
+        // rulesync treats Junie hooks as global-only.
+        supportsProject: false,
+        supportsGlobal: true,
+        supportsImport: true,
+      },
+      supportedEvents: JUNIE_HOOK_EVENTS,
       supportedHookTypes: ["command"],
       supportsMatcher: true,
     },

--- a/src/features/hooks/junie-hooks.test.ts
+++ b/src/features/hooks/junie-hooks.test.ts
@@ -1,0 +1,212 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { JunieHooks } from "./junie-hooks.js";
+import { RulesyncHooks } from "./rulesync-hooks.js";
+
+describe("JunieHooks", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .junie and config.json for project mode", () => {
+      const paths = JunieHooks.getSettablePaths({ global: false });
+      expect(paths).toEqual({ relativeDirPath: ".junie", relativeFilePath: "config.json" });
+    });
+
+    it("should return .junie and config.json for global mode", () => {
+      const paths = JunieHooks.getSettablePaths({ global: true });
+      expect(paths).toEqual({ relativeDirPath: ".junie", relativeFilePath: "config.json" });
+    });
+  });
+
+  describe("fromRulesyncHooks", () => {
+    it("should emit hooks.SessionStart from a canonical sessionStart hook and drop unsupported events", async () => {
+      await ensureDir(join(testDir, ".junie"));
+      await writeFileContent(join(testDir, ".junie", "config.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
+          stop: [{ command: ".rulesync/hooks/audit.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const junieHooks = await JunieHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(junieHooks.getFileContent());
+      expect(parsed.hooks.SessionStart).toBeDefined();
+      expect(JSON.stringify(parsed.hooks.SessionStart)).toContain(
+        ".rulesync/hooks/session-start.sh",
+      );
+      // Junie supports only sessionStart, so `stop` is dropped.
+      expect(parsed.hooks.Stop).toBeUndefined();
+    });
+
+    it("should preserve a pre-existing unrelated key in config.json", async () => {
+      await ensureDir(join(testDir, ".junie"));
+      await writeFileContent(
+        join(testDir, ".junie", "config.json"),
+        JSON.stringify({ otherKey: "preserved" }),
+      );
+
+      const config = {
+        version: 1,
+        hooks: { sessionStart: [{ command: "echo" }] },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const junieHooks = await JunieHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(junieHooks.getFileContent());
+      expect(parsed.otherKey).toBe("preserved");
+      expect(parsed.hooks.SessionStart).toBeDefined();
+    });
+
+    it("should throw error with descriptive message when existing config.json contains invalid JSON", async () => {
+      await ensureDir(join(testDir, ".junie"));
+      await writeFileContent(join(testDir, ".junie", "config.json"), "invalid json {");
+
+      const config = { version: 1, hooks: {} };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      await expect(
+        JunieHooks.fromRulesyncHooks({
+          outputRoot: testDir,
+          rulesyncHooks,
+          validate: false,
+        }),
+      ).rejects.toThrow(/Failed to parse existing Junie config/);
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should load from .junie/config.json when it exists", async () => {
+      await ensureDir(join(testDir, ".junie"));
+      await writeFileContent(
+        join(testDir, ".junie", "config.json"),
+        JSON.stringify({ hooks: { SessionStart: [] } }),
+      );
+
+      const junieHooks = await JunieHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(junieHooks).toBeInstanceOf(JunieHooks);
+      const parsed = JSON.parse(junieHooks.getFileContent());
+      expect(parsed.hooks.SessionStart).toEqual([]);
+    });
+
+    it("should initialize empty hooks when .junie/config.json does not exist", async () => {
+      const junieHooks = await JunieHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(junieHooks).toBeInstanceOf(JunieHooks);
+      const parsed = JSON.parse(junieHooks.getFileContent());
+      expect(parsed.hooks).toEqual({});
+    });
+  });
+
+  describe("toRulesyncHooks", () => {
+    it("should convert Junie PascalCase hooks to canonical camelCase (round-trip)", () => {
+      const junieHooks = new JunieHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".junie",
+        relativeFilePath: "config.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [{ hooks: [{ type: "command", command: "session-start.sh" }] }],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = junieHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart).toHaveLength(1);
+      expect(json.hooks.sessionStart?.[0]?.command).toContain("session-start.sh");
+    });
+
+    it("should throw error with descriptive message when content contains invalid JSON", () => {
+      const junieHooks = new JunieHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".junie",
+        relativeFilePath: "config.json",
+        fileContent: "invalid json {",
+        validate: false,
+      });
+
+      expect(() => junieHooks.toRulesyncHooks()).toThrow(/Failed to parse Junie hooks content/);
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("should return false", () => {
+      const hooks = new JunieHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".junie",
+        relativeFilePath: "config.json",
+        fileContent: "{}",
+        validate: false,
+      });
+      expect(hooks.isDeletable()).toBe(false);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should return JunieHooks instance with empty hooks for deletion path", () => {
+      const hooks = JunieHooks.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".junie",
+        relativeFilePath: "config.json",
+      });
+      expect(hooks).toBeInstanceOf(JunieHooks);
+      const parsed = JSON.parse(hooks.getFileContent());
+      expect(parsed.hooks).toEqual({});
+    });
+  });
+});

--- a/src/features/hooks/junie-hooks.ts
+++ b/src/features/hooks/junie-hooks.ts
@@ -26,6 +26,9 @@ const JUNIE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   canonicalToToolEventNames: CANONICAL_TO_JUNIE_EVENT_NAMES,
   toolToCanonicalEventNames: JUNIE_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "",
+  // Junie CLI hooks only support `type: "command"`; drop any `prompt`-type
+  // hooks so generation matches the declared capability.
+  supportedHookTypes: new Set(["command"]),
 };
 
 export class JunieHooks extends ToolHooks {

--- a/src/features/hooks/junie-hooks.ts
+++ b/src/features/hooks/junie-hooks.ts
@@ -1,0 +1,152 @@
+import { join } from "node:path";
+
+import type { AiFileParams } from "../../types/ai-file.js";
+import type { ValidationResult } from "../../types/ai-file.js";
+import {
+  CANONICAL_TO_JUNIE_EVENT_NAMES,
+  JUNIE_HOOK_EVENTS,
+  JUNIE_TO_CANONICAL_EVENT_NAMES,
+} from "../../types/hooks.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
+import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  ToolHooks,
+  type ToolHooksForDeletionParams,
+  type ToolHooksFromFileParams,
+  type ToolHooksFromRulesyncHooksParams,
+  type ToolHooksSettablePaths,
+} from "./tool-hooks.js";
+
+const JUNIE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
+  supportedEvents: JUNIE_HOOK_EVENTS,
+  canonicalToToolEventNames: CANONICAL_TO_JUNIE_EVENT_NAMES,
+  toolToCanonicalEventNames: JUNIE_TO_CANONICAL_EVENT_NAMES,
+  projectDirVar: "",
+};
+
+export class JunieHooks extends ToolHooks {
+  constructor(params: AiFileParams) {
+    super({
+      ...params,
+      fileContent: params.fileContent ?? "{}",
+    });
+  }
+
+  override isDeletable(): boolean {
+    // ~/.junie/config.json is the user's primary Junie CLI config and holds
+    // other user settings besides hooks; it must never be deleted.
+    return false;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
+    // Junie CLI only runs user-scope hooks, so generation always targets
+    // `~/.junie/config.json`. In global mode the same relative path is
+    // resolved under the user home; project hooks are ignored by Junie.
+    return { relativeDirPath: ".junie", relativeFilePath: "config.json" };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolHooksFromFileParams): Promise<JunieHooks> {
+    const paths = JunieHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
+    return new JunieHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncHooks({
+    outputRoot = process.cwd(),
+    rulesyncHooks,
+    validate = true,
+    global = false,
+    logger,
+  }: ToolHooksFromRulesyncHooksParams & {
+    global?: boolean;
+    logger?: Logger;
+  }): Promise<JunieHooks> {
+    const paths = JunieHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = await readOrInitializeFileContent(
+      filePath,
+      JSON.stringify({}, null, 2),
+    );
+    let settings: Record<string, unknown>;
+    try {
+      settings = JSON.parse(existingContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse existing Junie config at ${filePath}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+    const config = rulesyncHooks.getJson();
+    const junieHooks = canonicalToToolHooks({
+      config,
+      toolOverrideHooks: config.junie?.hooks,
+      converterConfig: JUNIE_CONVERTER_CONFIG,
+      logger,
+    });
+    const merged = { ...settings, hooks: junieHooks };
+    const fileContent = JSON.stringify(merged, null, 2);
+    return new JunieHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  toRulesyncHooks(): RulesyncHooks {
+    let settings: { hooks?: unknown };
+    try {
+      settings = JSON.parse(this.getFileContent());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Junie hooks content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    const hooks = toolHooksToCanonical({
+      hooks: settings.hooks,
+      converterConfig: JUNIE_CONVERTER_CONFIG,
+    });
+    return this.toRulesyncHooksDefault({
+      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolHooksForDeletionParams): JunieHooks {
+    // Kept for interface parity with other ToolHooks implementations even
+    // though isDeletable() returns false (config.json is never deleted).
+    return new JunieHooks({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({ hooks: {} }, null, 2),
+      validate: false,
+    });
+  }
+}

--- a/src/features/mcp/junie-mcp.test.ts
+++ b/src/features/mcp/junie-mcp.test.ts
@@ -62,6 +62,16 @@ describe("JunieMcp", () => {
     });
   });
 
+  describe("getSettablePaths", () => {
+    it("returns the same .junie/mcp/mcp.json path for project and global mode", () => {
+      const projectPaths = JunieMcp.getSettablePaths({ global: false });
+      const globalPaths = JunieMcp.getSettablePaths({ global: true });
+      const expected = { relativeDirPath: join(".junie", "mcp"), relativeFilePath: "mcp.json" };
+      expect(projectPaths).toEqual(expected);
+      expect(globalPaths).toEqual(expected);
+    });
+  });
+
   describe("fromRulesyncMcp", () => {
     it("copies content from .rulesync/.mcp.json", async () => {
       const rulesyncContent = JSON.stringify(

--- a/src/features/mcp/junie-mcp.ts
+++ b/src/features/mcp/junie-mcp.ts
@@ -24,7 +24,9 @@ export class JunieMcp extends ToolMcp {
     return this.json;
   }
 
-  static getSettablePaths(): ToolMcpSettablePaths {
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolMcpSettablePaths {
+    // The relative path is identical for both project and user scope. In global
+    // mode the same path is resolved under the user home (`~/.junie/mcp/mcp.json`).
     return {
       relativeDirPath: join(".junie", "mcp"),
       relativeFilePath: "mcp.json",
@@ -34,21 +36,20 @@ export class JunieMcp extends ToolMcp {
   static async fromFile({
     outputRoot = process.cwd(),
     validate = true,
+    global = false,
   }: ToolMcpFromFileParams): Promise<JunieMcp> {
+    const paths = this.getSettablePaths({ global });
     const fileContent = await readFileContent(
-      join(
-        outputRoot,
-        this.getSettablePaths().relativeDirPath,
-        this.getSettablePaths().relativeFilePath,
-      ),
+      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
     );
 
     return new JunieMcp({
       outputRoot,
-      relativeDirPath: this.getSettablePaths().relativeDirPath,
-      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
       fileContent,
       validate,
+      global,
     });
   }
 
@@ -56,7 +57,10 @@ export class JunieMcp extends ToolMcp {
     outputRoot = process.cwd(),
     rulesyncMcp,
     validate = true,
+    global = false,
   }: ToolMcpFromRulesyncMcpParams): JunieMcp {
+    const paths = this.getSettablePaths({ global });
+
     // Preserve top-level fields ($schema, etc.) from the source JSON, but
     // use getMcpServers() (not getJson().mcpServers) so rulesync-only
     // fields and codex-only fields (`envVars`) are stripped before
@@ -70,10 +74,11 @@ export class JunieMcp extends ToolMcp {
 
     return new JunieMcp({
       outputRoot,
-      relativeDirPath: this.getSettablePaths().relativeDirPath,
-      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
       fileContent,
       validate,
+      global,
     });
   }
 
@@ -89,6 +94,7 @@ export class JunieMcp extends ToolMcp {
     outputRoot = process.cwd(),
     relativeDirPath,
     relativeFilePath,
+    global = false,
   }: ToolMcpForDeletionParams): JunieMcp {
     return new JunieMcp({
       outputRoot,
@@ -96,6 +102,7 @@ export class JunieMcp extends ToolMcp {
       relativeFilePath,
       fileContent: "{}",
       validate: false,
+      global,
     });
   }
 }

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -293,7 +293,7 @@ const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
       class: JunieMcp,
       meta: {
         supportsProject: true,
-        supportsGlobal: false,
+        supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,
       },

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -280,6 +280,15 @@ export const AUGMENTCODE_HOOK_EVENTS: readonly HookEvent[] = [
   "stop",
 ];
 
+/**
+ * Hook events supported by JetBrains Junie CLI.
+ * Junie CLI currently exposes only the SessionStart lifecycle event
+ * (matchers `startup` / `resume`), defined under the `"hooks"` key of
+ * `~/.junie/config.json`. Project-local hooks are ignored for safety.
+ * @see https://junie.jetbrains.com/docs/junie-cli-hooks.html
+ */
+export const JUNIE_HOOK_EVENTS: readonly HookEvent[] = ["sessionStart"];
+
 const hooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema));
 
 /**
@@ -304,6 +313,7 @@ export const HooksConfigSchema = z.looseObject({
   augmentcode: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   "antigravity-ide": z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   "antigravity-cli": z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
+  junie: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
 });
 
 export type HooksConfig = z.infer<typeof HooksConfigSchema>;
@@ -579,4 +589,19 @@ export const CANONICAL_TO_KIRO_EVENT_NAMES: Record<string, string> = {
  */
 export const KIRO_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
   Object.entries(CANONICAL_TO_KIRO_EVENT_NAMES).map(([k, v]) => [v, k]),
+);
+
+/**
+ * Map canonical camelCase event names to Junie PascalCase.
+ * Junie reuses the same PascalCase names as Claude for the events it supports.
+ */
+export const CANONICAL_TO_JUNIE_EVENT_NAMES: Record<string, string> = {
+  sessionStart: "SessionStart",
+};
+
+/**
+ * Map Junie PascalCase event names to canonical camelCase.
+ */
+export const JUNIE_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_JUNIE_EVENT_NAMES).map(([k, v]) => [v, k]),
 );


### PR DESCRIPTION
## Summary

Adds two JetBrains Junie CLI capabilities to rulesync, per #1793:

1. **Hooks** — a new `JunieHooks` adapter that writes a `"hooks"` block into `~/.junie/config.json` (global/user scope only). Junie ignores project-local hooks for safety, so rulesync treats Junie hooks as global-only. The adapter is modeled on `ClaudecodeHooks`: the hooks JSON is Claude-Code-shaped and is merged into the existing `config.json`, preserving the user's other settings. `config.json` is never deleted (`isDeletable()` returns `false`). Junie currently exposes only the `SessionStart` lifecycle event.
2. **Global MCP scope** — Junie MCP now supports user/global scope at `~/.junie/mcp/mcp.json` (the same relative path as project scope, resolved under home in global mode).

Both facts were verified against the official Junie CLI docs (`junie-cli-hooks.html`, `junie-cli-mcp-configuration.html`).

## Changes

- `src/types/hooks.ts`: add `JUNIE_HOOK_EVENTS`, `CANONICAL_TO_JUNIE_EVENT_NAMES` / `JUNIE_TO_CANONICAL_EVENT_NAMES`, and a `junie` override key in `HooksConfigSchema`.
- `src/features/hooks/junie-hooks.ts`: new `JunieHooks` adapter.
- `src/features/hooks/hooks-processor.ts`: register `junie` (global-only, importable, command hooks, matcher supported).
- `src/features/mcp/mcp-processor.ts`: flip Junie MCP `supportsGlobal` to `true`.
- `src/features/mcp/junie-mcp.ts`: thread `global` through to support global generation (path identical in both scopes).
- `src/features/commands/junie-command.ts`: replace the stale comment about unsupported global commands (behavior unchanged).
- `README.md` / `docs/reference/supported-tools.md` / `skills/rulesync/supported-tools.md`: update the support matrix (Junie hooks ✅/🌏, MCP global 🌏).
- Tests: new `junie-hooks.test.ts`, updated `junie-mcp.test.ts`, processor test expectations, and e2e global-mode coverage for hooks and MCP.

## Verification

`pnpm cicheck` passes (lint, format, types, 6071 unit tests, content/spell/secret checks). E2E hooks and MCP global-mode suites pass.

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
