### PR TITLE
feat(amp): add native rules (AGENTS.md) and permissions (amp.tools.disable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,7 @@ rulesync.local.jsonc
 **/AGENTS.local.md
 **/AGENTS.md
 **/.agents/
+**/.agents/memories/
 **/.agents/skills/
 **/.agents/rules/
 **/GEMINI.md
@@ -316,7 +317,6 @@ rulesync.local.jsonc
 **/.opencode/plugins/
 **/.opencode/memories/
 **/.opencode/package-lock.json
-**/.agents/memories/
 **/.pi/prompts/
 **/.pi/skills/
 **/QWEN.md

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 
 | Tool                   | rules | ignore | mcp | commands | subagents | skills | hooks | permissions |
 | ---------------------- | :---: | :----: | :-: | :------: | :-------: | :----: | :---: | :---------: |
-| Amp                    |       |        | ✅  |          |           |   ✅   |       |             |
+| Amp                    |  ✅   |        | ✅  |          |           |   ✅   |       |     ✅      |
 | Claude Code            |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Codex CLI              |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Gemini CLI ⚠️          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |

--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,7 @@
     "agentsignore",
     "agentsmd",
     "agentsskills",
+    "ampcode",
     "aiexclude",
     "aiglobal",
     "aiignore",

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -6,7 +6,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | ---------------------- | --------------- | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md              | agentsmd        |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills           | agentsskills    |       |        |          |          |           | ✅ 🌏  |       |             |
-| Amp                    | amp             |       |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
+| Amp                    | amp             | ✅ 🌏 |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |    ✅ 🌏    |
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI ⚠️          | geminicli       | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -6,7 +6,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | ---------------------- | --------------- | :---: | :----: | :------: | :------: | :-------: | :----: | :---: | :---------: |
 | AGENTS.md              | agentsmd        |  ✅   |        |          |    🎮    |    🎮     |   🎮   |       |             |
 | AgentsSkills           | agentsskills    |       |        |          |          |           | ✅ 🌏  |       |             |
-| Amp                    | amp             |       |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
+| Amp                    | amp             | ✅ 🌏 |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |    ✅ 🌏    |
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI ⚠️          | geminicli       | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |    ✅     | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -38,11 +38,16 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "common", feature: "general", entry: "**/AGENTS.local.md" },
 
   // AGENTS.md
-  { target: ["agentsmd", "pi", "warp"], feature: "rules", entry: "**/AGENTS.md" },
+  { target: ["agentsmd", "amp", "pi", "warp"], feature: "rules", entry: "**/AGENTS.md" },
   { target: "agentsmd", feature: "rules", entry: "**/.agents/" },
 
   // Amp
-  // Amp reads Agent Skills from the shared `.agents/skills/` project tree.
+  // Amp reads project rules from a root `AGENTS.md` (handled by the shared
+  // AGENTS.md entry above) plus `.agents/memories/*.md` non-root rules. Agent
+  // Skills come from the shared `.agents/skills/` project tree. The
+  // `.amp/settings.json` permissions file is a user-managed file (like other
+  // tools' settings.json), so it is intentionally not gitignored.
+  { target: "amp", feature: "rules", entry: "**/.agents/memories/" },
   { target: "amp", feature: "skills", entry: "**/.agents/skills/" },
 
   // Antigravity (IDE + CLI, Antigravity 2.0)

--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -68,6 +68,32 @@ describe("E2E: permissions", () => {
     expect(tools.read_file.always_deny).toEqual([{ pattern: ".env", case_sensitive: false }]);
   });
 
+  it("should generate amp permissions into .amp/settings.json", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            edit_file: { "*": "deny" },
+            "builtin:Bash": { "*": "deny" },
+            read_file: { "*": "allow" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({ target: "amp", features: "permissions" });
+
+    const content = JSON.parse(await readFileContent(join(testDir, ".amp", "settings.json")));
+    // deny rules map to disabled tool names verbatim (including `builtin:` prefix);
+    // allow rules are skipped because Amp can only disable tools.
+    expect(content["amp.tools.disable"]).toEqual(["builtin:Bash", "edit_file"]);
+  });
+
   it("should generate codexcli permissions into .codex/config.toml", async () => {
     const testDir = getTestDir();
 
@@ -424,6 +450,32 @@ describe("E2E: permissions (import)", () => {
     expect(content.permission.bash["*"]).toBe("ask");
     expect(content.permission.bash["npm *"]).toBe("allow");
     expect(content.permission.read[".env"]).toBe("deny");
+  });
+
+  it("should import amp permissions into .rulesync/permissions.json", async () => {
+    const testDir = getTestDir();
+
+    await writeFileContent(
+      join(testDir, ".amp", "settings.json"),
+      JSON.stringify(
+        {
+          "amp.tools.disable": ["edit_file", "builtin:Bash", "*"],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runImport({ target: "amp", features: "permissions" });
+
+    const content = JSON.parse(
+      await readFileContent(join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH)),
+    );
+    // Each disabled tool name becomes a category with `{ "*": "deny" }`,
+    // preserving `builtin:` prefixes and the `*` glob verbatim.
+    expect(content.permission.edit_file["*"]).toBe("deny");
+    expect(content.permission["builtin:Bash"]["*"]).toBe("deny");
+    expect(content.permission["*"]["*"]).toBe("deny");
   });
 
   it("should import codexcli permissions into .rulesync/permissions.json", async () => {
@@ -1027,6 +1079,52 @@ describe("E2E: permissions (global mode)", () => {
     // Unrelated user settings preserved by the non-destructive merge.
     expect(generated.theme).toBe("One Dark");
     expect(generated.context_servers.my_server.command).toBe("x");
+  });
+
+  it("should generate amp permissions in home directory with --global", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+
+    await writeFileContent(
+      join(projectDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          permission: {
+            edit_file: { "*": "deny" },
+            "builtin:Bash": { "*": "deny" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Pre-seed the shared global settings with unrelated config (e.g. MCP) to
+    // verify the non-destructive merge into `~/.config/amp/settings.json`.
+    await writeFileContent(
+      join(homeDir, ".config", "amp", "settings.json"),
+      JSON.stringify(
+        {
+          "amp.mcpServers": { my_server: { command: "x" } },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await runGenerate({
+      target: "amp",
+      features: "permissions",
+      global: true,
+      env: { HOME_DIR: homeDir },
+    });
+
+    const generated = JSON.parse(
+      await readFileContent(join(homeDir, ".config", "amp", "settings.json")),
+    );
+    expect(generated["amp.tools.disable"]).toEqual(["builtin:Bash", "edit_file"]);
+    // Unrelated user settings preserved by the non-destructive merge.
+    expect(generated["amp.mcpServers"].my_server.command).toBe("x");
   });
 });
 

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -21,6 +21,7 @@ describe("E2E: rules", () => {
   it.each([
     { target: "claudecode", outputPath: "CLAUDE.md" },
     { target: "cursor", outputPath: join(".cursor", "rules", "overview.mdc") },
+    { target: "amp", outputPath: "AGENTS.md" },
     { target: "codexcli", outputPath: "AGENTS.md" },
     { target: "copilot", outputPath: join(".github", "copilot-instructions.md") },
     { target: "opencode", outputPath: "AGENTS.md" },
@@ -171,6 +172,7 @@ describe("E2E: rules (import)", () => {
       sourcePath: join(".cursor", "rules", "overview.mdc"),
       importedFileName: "overview.md",
     },
+    { target: "amp", sourcePath: "AGENTS.md", importedFileName: "overview.md" },
     { target: "codexcli", sourcePath: "AGENTS.md", importedFileName: "overview.md" },
     {
       target: "copilot",
@@ -273,6 +275,7 @@ describe("E2E: rules (global mode)", () => {
     { target: "copilot", outputPath: join(".copilot", "copilot-instructions.md") },
     { target: "opencode", outputPath: join(".config", "opencode", "AGENTS.md") },
     { target: "codexcli", outputPath: join(".codex", "AGENTS.md") },
+    { target: "amp", outputPath: join(".config", "amp", "AGENTS.md") },
     { target: "cline", outputPath: join(".agents", "AGENTS.md") },
     { target: "geminicli", outputPath: join(".gemini", "GEMINI.md") },
     { target: "antigravity-ide", outputPath: join(".gemini", "GEMINI.md") },

--- a/src/features/permissions/amp-permissions.test.ts
+++ b/src/features/permissions/amp-permissions.test.ts
@@ -1,0 +1,190 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_PERMISSIONS_FILE_NAME,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { writeFileContent } from "../../utils/file.js";
+import { AmpPermissions } from "./amp-permissions.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+
+const makeRulesyncPermissions = (testDir: string, permission: unknown): RulesyncPermissions =>
+  new RulesyncPermissions({
+    outputRoot: testDir,
+    relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+    relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+    fileContent: JSON.stringify({ permission }),
+  });
+
+describe("AmpPermissions", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("resolves project and global settings.json paths", () => {
+      expect(AmpPermissions.getSettablePaths()).toEqual({
+        relativeDirPath: ".amp",
+        relativeFilePath: "settings.json",
+      });
+      expect(AmpPermissions.getSettablePaths({ global: true })).toEqual({
+        relativeDirPath: join(".config", "amp"),
+        relativeFilePath: "settings.json",
+      });
+    });
+  });
+
+  describe("fromRulesyncPermissions", () => {
+    it("maps deny rules to amp.tools.disable, skipping allow/ask", async () => {
+      const rulesyncPermissions = makeRulesyncPermissions(testDir, {
+        edit_file: { "*": "deny" },
+        read_file: { "*": "allow" },
+        web: { "*": "ask" },
+      });
+
+      const instance = await AmpPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+      const json = JSON.parse(instance.getFileContent());
+
+      expect(json["amp.tools.disable"]).toEqual(["edit_file"]);
+    });
+
+    it("preserves builtin: prefixes and the * glob verbatim, sorted and deduped", async () => {
+      const rulesyncPermissions = makeRulesyncPermissions(testDir, {
+        edit_file: { "*": "deny" },
+        "builtin:Bash": { "*": "deny" },
+        "*": { "*": "deny" },
+      });
+
+      const instance = await AmpPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+      const json = JSON.parse(instance.getFileContent());
+
+      expect(json["amp.tools.disable"]).toEqual(["*", "builtin:Bash", "edit_file"]);
+    });
+
+    it("merges into an existing settings file, preserving other keys", async () => {
+      await writeFileContent(
+        join(testDir, ".amp", "settings.json"),
+        JSON.stringify({ "amp.mcpServers": { srv: { command: "x" } } }),
+      );
+      const rulesyncPermissions = makeRulesyncPermissions(testDir, {
+        edit_file: { "*": "deny" },
+      });
+
+      const instance = await AmpPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+      const json = JSON.parse(instance.getFileContent());
+
+      expect(json["amp.mcpServers"]).toEqual({ srv: { command: "x" } });
+      expect(json["amp.tools.disable"]).toEqual(["edit_file"]);
+    });
+
+    it("prefers an existing settings.jsonc file", async () => {
+      await writeFileContent(join(testDir, ".amp", "settings.jsonc"), "{}");
+      const rulesyncPermissions = makeRulesyncPermissions(testDir, {
+        edit_file: { "*": "deny" },
+      });
+
+      const instance = await AmpPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+
+      expect(instance.getRelativeFilePath()).toBe("settings.jsonc");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("initializes amp.tools.disable when absent", async () => {
+      await writeFileContent(join(testDir, ".amp", "settings.json"), JSON.stringify({ other: 1 }));
+
+      const instance = await AmpPermissions.fromFile({ outputRoot: testDir });
+      const json = JSON.parse(instance.getFileContent());
+
+      expect(json["amp.tools.disable"]).toEqual([]);
+      expect(json.other).toBe(1);
+    });
+  });
+
+  describe("toRulesyncPermissions", () => {
+    it("maps each disabled tool name to a category with { '*': 'deny' }", async () => {
+      await writeFileContent(
+        join(testDir, ".amp", "settings.json"),
+        JSON.stringify({ "amp.tools.disable": ["edit_file", "builtin:Bash", "*"] }),
+      );
+
+      const instance = await AmpPermissions.fromFile({ outputRoot: testDir });
+      const rulesync = instance.toRulesyncPermissions();
+      const config = JSON.parse(rulesync.getFileContent());
+
+      expect(config.permission.edit_file).toEqual({ "*": "deny" });
+      expect(config.permission["builtin:Bash"]).toEqual({ "*": "deny" });
+      expect(config.permission["*"]).toEqual({ "*": "deny" });
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("is never deletable because the settings file is shared", () => {
+      const instance = new AmpPermissions({
+        outputRoot: testDir,
+        relativeDirPath: ".amp",
+        relativeFilePath: "settings.json",
+        fileContent: "{}",
+      });
+      expect(instance.isDeletable()).toBe(false);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("produces an empty amp.tools.disable list", () => {
+      const instance = AmpPermissions.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".amp",
+        relativeFilePath: "settings.json",
+      });
+      const json = JSON.parse(instance.getFileContent());
+      expect(json["amp.tools.disable"]).toEqual([]);
+    });
+  });
+
+  describe("validate", () => {
+    it("rejects a non-array amp.tools.disable", () => {
+      const instance = new AmpPermissions({
+        outputRoot: testDir,
+        relativeDirPath: ".amp",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({ "amp.tools.disable": "nope" }),
+      });
+      expect(instance.validate().success).toBe(false);
+    });
+
+    it("accepts a valid array", () => {
+      const instance = new AmpPermissions({
+        outputRoot: testDir,
+        relativeDirPath: ".amp",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({ "amp.tools.disable": ["edit_file"] }),
+      });
+      expect(instance.validate().success).toBe(true);
+    });
+  });
+});

--- a/src/features/permissions/amp-permissions.ts
+++ b/src/features/permissions/amp-permissions.ts
@@ -1,0 +1,248 @@
+import { join } from "node:path";
+
+import { uniq } from "es-toolkit";
+import { parse as parseJsonc, type ParseError, printParseErrorCode } from "jsonc-parser";
+
+import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import type { PermissionAction, PermissionsConfig } from "../../types/permissions.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import { isRecord } from "../../utils/type-guards.js";
+import { RulesyncPermissions } from "./rulesync-permissions.js";
+import {
+  ToolPermissions,
+  type ToolPermissionsForDeletionParams,
+  type ToolPermissionsFromFileParams,
+  type ToolPermissionsFromRulesyncPermissionsParams,
+  type ToolPermissionsSettablePaths,
+} from "./tool-permissions.js";
+
+/**
+ * Amp's `"amp.tools.disable"` setting disables tools by name. It accepts a glob
+ * `*` (disable everything) and a `builtin:<tool>` prefix (disable only the
+ * builtin of that name). It lives in the shared Amp settings file:
+ * `.amp/settings.json` (project) and `~/.config/amp/settings.json` (global).
+ *
+ * Reference: https://ampcode.com/manual ("amp.tools.disable").
+ */
+const AMP_TOOLS_DISABLE_KEY = "amp.tools.disable";
+
+function parseAmpSettings(fileContent: string): Record<string, unknown> {
+  const errors: ParseError[] = [];
+  const parsed: unknown = parseJsonc(fileContent || "{}", errors, { allowTrailingComma: true });
+
+  if (errors.length > 0) {
+    const details = errors
+      .map((error) => `${printParseErrorCode(error.error)} at offset ${error.offset}`)
+      .join(", ");
+    throw new Error(`Failed to parse Amp settings: ${details}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Amp settings must be a JSON object");
+  }
+
+  return parsed;
+}
+
+function toDisableList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Permissions generator for Amp (ampcode).
+ *
+ * Amp only supports disabling tools (there is no allow/ask surface for the
+ * tools list), so rulesync `deny` rules are mapped onto the
+ * `"amp.tools.disable"` array. Each disabled tool name is modeled as a rulesync
+ * category with a single `{ "*": "deny" }` rule, so glob (`*`) entries and
+ * `builtin:` prefixes round-trip verbatim. `allow`/`ask` rules are skipped with
+ * a warning since Amp's tools list cannot represent them.
+ *
+ * The settings file is shared with the MCP feature (`amp.mcpServers`), so reads
+ * and writes merge into the existing JSON rather than overwriting it, and the
+ * file is never deleted.
+ */
+export class AmpPermissions extends ToolPermissions {
+  constructor(params: AiFileParams) {
+    super({
+      ...params,
+      fileContent: params.fileContent ?? "{}",
+    });
+  }
+
+  /**
+   * The settings file may carry other Amp settings (e.g. `amp.mcpServers`), so
+   * we never delete it; only the managed `amp.tools.disable` key is rewritten.
+   */
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static getSettablePaths({
+    global = false,
+  }: { global?: boolean } = {}): ToolPermissionsSettablePaths {
+    return global
+      ? { relativeDirPath: join(".config", "amp"), relativeFilePath: "settings.json" }
+      : { relativeDirPath: ".amp", relativeFilePath: "settings.json" };
+  }
+
+  /**
+   * Probe `<jsonDir>/settings.jsonc` first, falling back to `settings.json`, so
+   * an existing user file is read-modified-written in place instead of a fresh
+   * sibling being created next to a hand-authored `.jsonc`. Defaults to
+   * `settings.json` when neither file exists.
+   */
+  private static async resolveSettingsFile(
+    jsonDir: string,
+  ): Promise<{ fileContent: string | null; relativeFilePath: string }> {
+    const jsoncContent = await readFileContentOrNull(join(jsonDir, "settings.jsonc"));
+    if (jsoncContent !== null) {
+      return { fileContent: jsoncContent, relativeFilePath: "settings.jsonc" };
+    }
+    const jsonContent = await readFileContentOrNull(join(jsonDir, "settings.json"));
+    if (jsonContent !== null) {
+      return { fileContent: jsonContent, relativeFilePath: "settings.json" };
+    }
+    return { fileContent: null, relativeFilePath: "settings.json" };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolPermissionsFromFileParams): Promise<AmpPermissions> {
+    const basePaths = AmpPermissions.getSettablePaths({ global });
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
+    const { fileContent, relativeFilePath } = await this.resolveSettingsFile(jsonDir);
+
+    const json = fileContent ? parseAmpSettings(fileContent) : {};
+    const newJson = {
+      ...json,
+      [AMP_TOOLS_DISABLE_KEY]: toDisableList(json[AMP_TOOLS_DISABLE_KEY]),
+    };
+
+    return new AmpPermissions({
+      outputRoot,
+      relativeDirPath: basePaths.relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify(newJson, null, 2),
+      validate,
+    });
+  }
+
+  static async fromRulesyncPermissions({
+    outputRoot = process.cwd(),
+    rulesyncPermissions,
+    global = false,
+    logger,
+  }: ToolPermissionsFromRulesyncPermissionsParams): Promise<AmpPermissions> {
+    const basePaths = AmpPermissions.getSettablePaths({ global });
+    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
+    const { fileContent, relativeFilePath } = await this.resolveSettingsFile(jsonDir);
+
+    const json = fileContent ? parseAmpSettings(fileContent) : {};
+
+    const config = rulesyncPermissions.getJson();
+    const disable = convertRulesyncToAmpDisable(config, logger);
+
+    const newJson = { ...json, [AMP_TOOLS_DISABLE_KEY]: disable };
+
+    return new AmpPermissions({
+      outputRoot,
+      relativeDirPath: basePaths.relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify(newJson, null, 2),
+      validate: true,
+    });
+  }
+
+  toRulesyncPermissions(): RulesyncPermissions {
+    const json = parseAmpSettings(this.getFileContent());
+    const config = convertAmpDisableToRulesync(toDisableList(json[AMP_TOOLS_DISABLE_KEY]));
+
+    return this.toRulesyncPermissionsDefault({
+      fileContent: JSON.stringify(config, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    try {
+      const json = parseAmpSettings(this.fileContent);
+      const disable = json[AMP_TOOLS_DISABLE_KEY];
+      if (disable !== undefined && !Array.isArray(disable)) {
+        return {
+          success: false,
+          error: new Error(`"${AMP_TOOLS_DISABLE_KEY}" must be a JSON array of strings`),
+        };
+      }
+      return { success: true, error: null };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error : new Error(formatError(error)),
+      };
+    }
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolPermissionsForDeletionParams): AmpPermissions {
+    return new AmpPermissions({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({ [AMP_TOOLS_DISABLE_KEY]: [] }, null, 2),
+      validate: false,
+    });
+  }
+}
+
+/**
+ * Convert a rulesync permissions config into Amp's `amp.tools.disable` array.
+ *
+ * Each tool category is treated as a tool name; a `deny` rule disables it. The
+ * category name (including any `builtin:` prefix or `*` glob) is preserved
+ * verbatim. `allow`/`ask` rules are skipped with a warning since Amp's tools
+ * list can only express "disabled".
+ */
+function convertRulesyncToAmpDisable(
+  config: PermissionsConfig,
+  logger?: ToolPermissionsFromRulesyncPermissionsParams["logger"],
+): string[] {
+  const disable: string[] = [];
+
+  for (const [category, rules] of Object.entries(config.permission)) {
+    for (const [pattern, action] of Object.entries(rules)) {
+      if (action !== "deny") {
+        logger?.warn(
+          `Amp's "${AMP_TOOLS_DISABLE_KEY}" only supports disabling tools (deny). ` +
+            `Skipping ${action} rule for tool "${category}" (pattern "${pattern}").`,
+        );
+        continue;
+      }
+      // The tool name is the category; the `*` pattern means "disable the whole
+      // tool". Any non-`*` pattern is forwarded as-is onto the category name so
+      // it round-trips, but Amp itself matches on tool name only.
+      disable.push(category);
+    }
+  }
+
+  return uniq(disable.toSorted());
+}
+
+/**
+ * Convert Amp's `amp.tools.disable` array back into a rulesync permissions
+ * config. Each disabled tool name becomes a category with a single
+ * `{ "*": "deny" }` rule.
+ */
+function convertAmpDisableToRulesync(disable: string[]): PermissionsConfig {
+  const permission: Record<string, Record<string, PermissionAction>> = {};
+  for (const tool of disable) {
+    permission[tool] = { "*": "deny" };
+  }
+  return { permission };
+}

--- a/src/features/permissions/permissions-processor.test.ts
+++ b/src/features/permissions/permissions-processor.test.ts
@@ -79,6 +79,7 @@ describe("PermissionsProcessor", () => {
     it("should return all permissions tool targets for project mode", () => {
       const targets = PermissionsProcessor.getToolTargets();
       expect(targets).toEqual([
+        "amp",
         "augmentcode",
         "claudecode",
         "cline",
@@ -96,6 +97,7 @@ describe("PermissionsProcessor", () => {
     it("should return targets that support global mode", () => {
       const targets = PermissionsProcessor.getToolTargets({ global: true });
       expect(targets).toEqual([
+        "amp",
         "antigravity-cli",
         "augmentcode",
         "claudecode",
@@ -112,6 +114,7 @@ describe("PermissionsProcessor", () => {
     it("should return importable targets", () => {
       const targets = PermissionsProcessor.getToolTargets({ importOnly: true });
       expect(targets).toEqual([
+        "amp",
         "augmentcode",
         "claudecode",
         "cline",

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -7,6 +7,7 @@ import type { ToolFile } from "../../types/tool-file.js";
 import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
+import { AmpPermissions } from "./amp-permissions.js";
 import { AntigravityCliPermissions } from "./antigravity-cli-permissions.js";
 import { AugmentcodePermissions } from "./augmentcode-permissions.js";
 import { ClaudecodePermissions } from "./claudecode-permissions.js";
@@ -29,6 +30,7 @@ import { ToolPermissions } from "./tool-permissions.js";
 import { ZedPermissions } from "./zed-permissions.js";
 
 const permissionsProcessorToolTargetTuple = [
+  "amp",
   "antigravity-cli",
   "augmentcode",
   "claudecode",
@@ -64,6 +66,20 @@ type ToolPermissionsFactory = {
 };
 
 const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPermissionsFactory>([
+  [
+    "amp",
+    {
+      class: AmpPermissions,
+      meta: {
+        // Amp maps `deny` rules onto `amp.tools.disable` in the shared settings
+        // file: `.amp/settings.json` (project) and
+        // `~/.config/amp/settings.json` (global).
+        supportsProject: true,
+        supportsGlobal: true,
+        supportsImport: true,
+      },
+    },
+  ],
   [
     "antigravity-cli",
     {

--- a/src/features/rules/amp-rule.test.ts
+++ b/src/features/rules/amp-rule.test.ts
@@ -1,0 +1,233 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AmpRule } from "./amp-rule.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+
+describe("AmpRule", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("returns project root AGENTS.md and .agents/memories non-root paths", () => {
+      const paths = AmpRule.getSettablePaths();
+      expect(paths.root.relativeDirPath).toBe(".");
+      expect(paths.root.relativeFilePath).toBe("AGENTS.md");
+      expect(paths.nonRoot?.relativeDirPath).toBe(join(".agents", "memories"));
+    });
+
+    it("returns the global ~/.config/amp/AGENTS.md root path with no non-root", () => {
+      const paths = AmpRule.getSettablePaths({ global: true });
+      expect(paths.root.relativeDirPath).toBe(join(".config", "amp"));
+      expect(paths.root.relativeFilePath).toBe("AGENTS.md");
+      expect("nonRoot" in paths ? paths.nonRoot : undefined).toBeUndefined();
+    });
+  });
+
+  describe("fromFile", () => {
+    it("loads the root AGENTS.md file", async () => {
+      const content = "# Amp\n\nProject instructions.";
+      await writeFileContent(join(testDir, "AGENTS.md"), content);
+
+      const rule = await AmpRule.fromFile({ outputRoot: testDir, relativeFilePath: "AGENTS.md" });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.isRoot()).toBe(true);
+    });
+
+    it("loads a non-root rule from .agents/memories", async () => {
+      const memoriesDir = join(testDir, ".agents", "memories");
+      await ensureDir(memoriesDir);
+      const content = "# Memory\n\nDetail.";
+      await writeFileContent(join(memoriesDir, "detail.md"), content);
+
+      const rule = await AmpRule.fromFile({ outputRoot: testDir, relativeFilePath: "detail.md" });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.getRelativeFilePath()).toBe("detail.md");
+      expect(rule.getRelativeDirPath()).toBe(join(".agents", "memories"));
+      expect(rule.isRoot()).toBe(false);
+    });
+
+    it("loads the global root file from .config/amp/AGENTS.md", async () => {
+      const globalDir = join(testDir, ".config", "amp");
+      await ensureDir(globalDir);
+      const content = "# Global Amp";
+      await writeFileContent(join(globalDir, "AGENTS.md"), content);
+
+      const rule = await AmpRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "AGENTS.md",
+        global: true,
+      });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.getRelativeDirPath()).toBe(join(".config", "amp"));
+      expect(rule.isRoot()).toBe(true);
+    });
+  });
+
+  describe("fromRulesyncRule", () => {
+    it("generates the root AGENTS.md at the project root", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["*"], description: "Root", globs: ["**/*"] },
+        body: "# Root",
+      });
+
+      const rule = AmpRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getGlobs()).toEqual(["**/*"]);
+    });
+
+    it("generates a non-root rule under .agents/memories with globs preserved", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "ts.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "TS rule",
+          globs: ["src/**/*.ts"],
+        },
+        body: "# TS",
+      });
+
+      const rule = AmpRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+
+      expect(rule.getRelativeDirPath()).toBe(join(".agents", "memories"));
+      expect(rule.getRelativeFilePath()).toBe("ts.md");
+      expect(rule.isRoot()).toBe(false);
+      expect(rule.getGlobs()).toEqual(["src/**/*.ts"]);
+    });
+
+    it("uses the global root path when global=true", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["*"], description: "Root", globs: [] },
+        body: "# Root",
+      });
+
+      const rule = AmpRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule, global: true });
+
+      expect(rule.getRelativeDirPath()).toBe(join(".config", "amp"));
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+    });
+  });
+
+  describe("toRulesyncRule round-trip", () => {
+    it("preserves globs from a non-root rule", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "ts.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "TS rule",
+          globs: ["src/**/*.ts"],
+        },
+        body: "# TS",
+      });
+
+      const rule = AmpRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+      const roundTripped = rule.toRulesyncRule();
+
+      expect(roundTripped.getFrontmatter().globs).toEqual(["src/**/*.ts"]);
+      expect(roundTripped.getBody()).toBe("# TS");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("marks the root AGENTS.md as a root rule for deletion", () => {
+      const rule = AmpRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+      });
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getFileContent()).toBe("");
+    });
+
+    it("marks a non-root memory file as a non-root rule for deletion", () => {
+      const rule = AmpRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: join(".agents", "memories"),
+        relativeFilePath: "detail.md",
+      });
+      expect(rule.isRoot()).toBe(false);
+    });
+  });
+
+  describe("isTargetedByRulesyncRule", () => {
+    it("targets rules with the wildcard target", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["*"], description: "", globs: [] },
+        body: "x",
+      });
+      expect(AmpRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("targets rules that explicitly list amp", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["amp"], description: "", globs: [] },
+        body: "x",
+      });
+      expect(AmpRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("does not target rules that exclude amp", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["codexcli"], description: "", globs: [] },
+        body: "x",
+      });
+      expect(AmpRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(false);
+    });
+  });
+
+  describe("validate", () => {
+    it("always succeeds", () => {
+      const rule = new AmpRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "",
+        root: true,
+      });
+      expect(rule.validate().success).toBe(true);
+    });
+  });
+});

--- a/src/features/rules/amp-rule.ts
+++ b/src/features/rules/amp-rule.ts
@@ -1,0 +1,158 @@
+import { join } from "node:path";
+
+import { ValidationResult } from "../../types/ai-file.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+import {
+  ToolRule,
+  ToolRuleForDeletionParams,
+  ToolRuleFromFileParams,
+  ToolRuleFromRulesyncRuleParams,
+  ToolRuleSettablePaths,
+  ToolRuleSettablePathsGlobal,
+  buildToolPath,
+} from "./tool-rule.js";
+
+export type AmpRuleSettablePaths = ToolRuleSettablePaths & {
+  root: {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  };
+};
+
+export type AmpRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
+
+/**
+ * Rule generator for Amp (ampcode).
+ *
+ * Amp reads `AGENTS.md` at the project root (and parent directories / subtrees)
+ * plus the global `~/.config/amp/AGENTS.md`. Non-root rules are emitted under
+ * `.agents/memories/` and referenced from the root file in TOON format
+ * (`ruleDiscoveryMode: "toon"`), mapping rulesync per-rule `globs` to the
+ * `applyTo` field. Subtree AGENTS.md files additionally support `globs:`
+ * frontmatter and `@`-mention imports.
+ *
+ * In global mode, only the root `~/.config/amp/AGENTS.md` is emitted; non-root
+ * rules are not supported.
+ */
+export class AmpRule extends ToolRule {
+  static getSettablePaths({
+    global,
+    excludeToolDir,
+  }: {
+    global?: boolean;
+    excludeToolDir?: boolean;
+  } = {}): AmpRuleSettablePaths | AmpRuleSettablePathsGlobal {
+    if (global) {
+      return {
+        root: {
+          relativeDirPath: buildToolPath(join(".config", "amp"), ".", excludeToolDir),
+          relativeFilePath: "AGENTS.md",
+        },
+      };
+    }
+    return {
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+      },
+      nonRoot: {
+        relativeDirPath: buildToolPath(".agents", "memories", excludeToolDir),
+      },
+    };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    relativeFilePath,
+    validate = true,
+    global = false,
+  }: ToolRuleFromFileParams): Promise<AmpRule> {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    if (isRoot) {
+      const fileContent = await readFileContent(
+        join(outputRoot, paths.root.relativeDirPath, paths.root.relativeFilePath),
+      );
+
+      return new AmpRule({
+        outputRoot,
+        relativeDirPath: paths.root.relativeDirPath,
+        relativeFilePath: paths.root.relativeFilePath,
+        fileContent,
+        validate,
+        root: true,
+      });
+    }
+
+    if (!paths.nonRoot) {
+      throw new Error(`nonRoot path is not set for ${relativeFilePath}`);
+    }
+
+    const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
+    return new AmpRule({
+      outputRoot,
+      relativeDirPath: paths.nonRoot.relativeDirPath,
+      relativeFilePath,
+      fileContent,
+      validate,
+      root: false,
+    });
+  }
+
+  static fromRulesyncRule({
+    outputRoot = process.cwd(),
+    rulesyncRule,
+    validate = true,
+    global = false,
+  }: ToolRuleFromRulesyncRuleParams): AmpRule {
+    const paths = this.getSettablePaths({ global });
+    return new AmpRule(
+      this.buildToolRuleParamsAgentsmd({
+        outputRoot,
+        rulesyncRule,
+        validate,
+        rootPath: paths.root,
+        nonRootPath: paths.nonRoot,
+      }),
+    );
+  }
+
+  toRulesyncRule(): RulesyncRule {
+    return this.toRulesyncRuleDefault();
+  }
+
+  validate(): ValidationResult {
+    // Amp rules are plain markdown with optional `globs:` frontmatter, so any
+    // body content is considered valid (mirrors other AGENTS.md rule classes).
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolRuleForDeletionParams): AmpRule {
+    const paths = this.getSettablePaths({ global });
+    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+
+    return new AmpRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
+  }
+
+  static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {
+    return this.isTargetedByRulesyncRuleDefault({
+      rulesyncRule,
+      toolTarget: "amp",
+    });
+  }
+}

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -890,6 +890,7 @@ Content that would fail parsing`;
       const globalTargets = RulesProcessor.getToolTargets({ global: true });
 
       expect(globalTargets).toEqual([
+        "amp",
         "antigravity-cli",
         "antigravity-ide",
         "augmentcode",
@@ -930,6 +931,7 @@ Content that would fail parsing`;
       const globalTargets = RulesProcessor.getToolTargets({ global: true });
 
       // These are the targets that support global mode
+      expect(globalTargets).toContain("amp");
       expect(globalTargets).toContain("antigravity-cli");
       expect(globalTargets).toContain("antigravity-ide");
       expect(globalTargets).toContain("augmentcode");
@@ -950,7 +952,7 @@ Content that would fail parsing`;
       expect(globalTargets).toContain("takt");
       expect(globalTargets).toContain("devin");
       expect(globalTargets).toContain("zed");
-      expect(globalTargets.length).toBe(20);
+      expect(globalTargets.length).toBe(21);
 
       // These targets should NOT be in global mode
       expect(globalTargets).not.toContain("cursor");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -29,6 +29,7 @@ import { RooSubagent } from "../subagents/roo-subagent.js";
 import { RovodevSubagent } from "../subagents/rovodev-subagent.js";
 import { SubagentsProcessor } from "../subagents/subagents-processor.js";
 import { AgentsMdRule } from "./agentsmd-rule.js";
+import { AmpRule } from "./amp-rule.js";
 import { AntigravityCliRule } from "./antigravity-cli-rule.js";
 import { AntigravityIdeRule } from "./antigravity-ide-rule.js";
 import { AntigravityRule } from "./antigravity-rule.js";
@@ -70,6 +71,7 @@ import { ZedRule } from "./zed-rule.js";
 
 const rulesProcessorToolTargets: ToolTarget[] = [
   "agentsmd",
+  "amp",
   "antigravity",
   "antigravity-cli",
   "antigravity-ide",
@@ -253,6 +255,20 @@ const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
           subagents: { subagentClass: AgentsmdSubagent },
           skills: { skillClass: AgentsmdSkill },
         },
+      },
+    },
+  ],
+  [
+    "amp",
+    {
+      class: AmpRule,
+      meta: {
+        // Amp reads a root `AGENTS.md` (project root or `~/.config/amp/AGENTS.md`
+        // global) and `.agents/memories/*.md` non-root files referenced via TOON.
+        // Subtree AGENTS.md files support `globs:` frontmatter and `@`-imports.
+        extension: "md",
+        supportsGlobal: true,
+        ruleDiscoveryMode: "toon",
       },
     },
   ],


### PR DESCRIPTION
## Summary

Adds the two missing native Amp ([ampcode](https://ampcode.com/manual)) surfaces, verified against the Amp Owner's Manual:

1. **rules — `AGENTS.md` (project + global).** New `AmpRule` emits `AGENTS.md` at the project root and `~/.config/amp/AGENTS.md` globally, with `.agents/memories/*.md` non-root rules referenced via TOON (`globs` -> `applyTo`). Subtree `AGENTS.md` files support `globs:` frontmatter and `@`-mention imports. Registered in `rules-processor.ts` with project + global support.
2. **permissions — `amp.tools.disable` (project + global).** New `AmpPermissions` maps rulesync `deny` rules onto the `amp.tools.disable` string array in `.amp/settings.json` (project) and `~/.config/amp/settings.json` (global). The merge is non-destructive (preserves other keys such as `amp.mcpServers`), and `builtin:` prefixes plus the `*` glob round-trip verbatim. `allow`/`ask` rules are skipped with a warning since Amp's tools list can only disable. Registered in `permissions-processor.ts` with project + global support.

The Amp "Code Review checks" (`.agents/checks/`) surface is intentionally **out of scope** (deferred by the maintainer).

## Key decisions

- **rules non-root path:** `.agents/memories/` — matching the dominant AGENTS.md convention (agentsmd, pi) and Amp's shared `.agents/` subtree.
- **deny -> amp.tools.disable mapping:** each tool category with a `deny` rule becomes a disabled tool-name entry; the category name (incl. `builtin:` / `*`) is preserved verbatim and round-trips back to `{ "*": "deny" }`.
- **gitignore:** added `amp` to the shared `**/AGENTS.md` tag and `**/.agents/memories/` (rules); `settings.json` is user-managed and intentionally NOT gitignored (matches zed/opencode). Global `~/.config/amp/...` paths are never gitignored.

## Tests

- Unit: `amp-rule.test.ts`, `amp-permissions.test.ts`.
- E2E: added `amp` to the rules and permissions Tool x Feature matrices (project + import + global).
- `pnpm cicheck` green; all amp-specific E2E cases pass.

Closes #1788
Issue: https://github.com/dyoshikawa/rulesync/issues/1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
