### PR TITLE
chore(release): v8.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.26.0",
+  "version": "8.27.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.26.0";
+const getVersion = () => "8.27.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v8.27.0.

- Bump `getVersion()` in `src/cli/index.ts` to 8.27.0
- Bump `package.json` version to 8.27.0

## Release Notes

See the draft release: https://github.com/dyoshikawa/rulesync/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)