### PR TITLE
feat(ignore): generate brand-aligned .devinignore for Devin Desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,6 +345,7 @@ rulesync.local.jsonc
 **/.takt/config.yaml
 **/.devin/rules/
 **/.devin/workflows/
+**/.devinignore
 **/.windsurf/mcp_config.json
 **/.windsurf/hooks.json
 **/.devin/skills/

--- a/cspell.json
+++ b/cspell.json
@@ -83,6 +83,7 @@
     "deepview",
     "deepwiki",
     "depd",
+    "devinignore",
     "dnsutils",
     "donotpresent",
     "dotenv",

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -320,6 +320,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   // `.devin/` paths and the global skills path is unchanged.
   { target: "devin", feature: "rules", entry: "**/.devin/rules/" },
   { target: "devin", feature: "commands", entry: "**/.devin/workflows/" },
+  { target: "devin", feature: "ignore", entry: "**/.devinignore" },
   { target: "devin", feature: "mcp", entry: "**/.windsurf/mcp_config.json" },
   { target: "devin", feature: "hooks", entry: "**/.windsurf/hooks.json" },
   { target: "devin", feature: "skills", entry: "**/.devin/skills/" },

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -25,7 +25,7 @@ describe("E2E: ignore", () => {
     { target: "kiro", outputPath: ".aiignore", format: "plaintext" as const },
     { target: "junie", outputPath: ".aiignore", format: "plaintext" as const },
     { target: "augmentcode", outputPath: ".augmentignore", format: "plaintext" as const },
-    { target: "devin", outputPath: ".codeiumignore", format: "plaintext" as const },
+    { target: "devin", outputPath: ".devinignore", format: "plaintext" as const },
     {
       target: "zed",
       outputPath: join(".zed", "settings.json"),
@@ -78,7 +78,7 @@ credentials/
     { target: "kiro", orphanPath: ".aiignore" },
     { target: "junie", orphanPath: ".aiignore" },
     { target: "augmentcode", orphanPath: ".augmentignore" },
-    { target: "devin", orphanPath: ".codeiumignore" },
+    { target: "devin", orphanPath: ".devinignore" },
     // zed ignore uses .zed/settings.json which is not deletable by rulesync
   ])(
     "should fail in check mode when delete would remove an orphan $target ignore file",
@@ -142,7 +142,7 @@ describe("E2E: ignore (import)", () => {
     { target: "kiro", sourcePath: ".aiignore" },
     { target: "junie", sourcePath: ".aiignore" },
     { target: "augmentcode", sourcePath: ".augmentignore" },
-    { target: "devin", sourcePath: ".codeiumignore" },
+    { target: "devin", sourcePath: ".devinignore" },
   ])("should import $target ignore", async ({ target, sourcePath }) => {
     const testDir = getTestDir();
 

--- a/src/features/ignore/devin-ignore.test.ts
+++ b/src/features/ignore/devin-ignore.test.ts
@@ -184,7 +184,7 @@ desktop.ini`;
       expect(devinIgnore.getFileContent()).toBe(fileContent);
       expect(devinIgnore.getOutputRoot()).toBe("/test/project");
       expect(devinIgnore.getRelativeDirPath()).toBe(".");
-      expect(devinIgnore.getRelativeFilePath()).toBe(".codeiumignore");
+      expect(devinIgnore.getRelativeFilePath()).toBe(".devinignore");
     });
 
     it("should use default outputRoot when not provided", () => {
@@ -266,7 +266,32 @@ Thumbs.db`;
   });
 
   describe("fromFile", () => {
-    it("should read .codeiumignore file from current directory", async () => {
+    it("should read .devinignore file from current directory", async () => {
+      const fileContent = "*.log\nnode_modules/\n.env";
+      await writeFileContent(join(testDir, ".devinignore"), fileContent);
+
+      const devinIgnore = await DevinIgnore.fromFile({
+        outputRoot: testDir,
+      });
+
+      expect(devinIgnore).toBeInstanceOf(DevinIgnore);
+      expect(devinIgnore.getRelativeFilePath()).toBe(".devinignore");
+      expect(devinIgnore.getFileContent()).toBe(fileContent);
+    });
+
+    it("should prefer .devinignore over legacy .codeiumignore when both exist", async () => {
+      await writeFileContent(join(testDir, ".devinignore"), "from-devinignore");
+      await writeFileContent(join(testDir, ".codeiumignore"), "from-codeiumignore");
+
+      const devinIgnore = await DevinIgnore.fromFile({
+        outputRoot: testDir,
+      });
+
+      expect(devinIgnore.getRelativeFilePath()).toBe(".devinignore");
+      expect(devinIgnore.getFileContent()).toBe("from-devinignore");
+    });
+
+    it("should fall back to legacy .codeiumignore file from current directory", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
       const codeiumIgnorePath = join(testDir, ".codeiumignore");
       await writeFileContent(codeiumIgnorePath, fileContent);
@@ -407,7 +432,7 @@ jspm_packages/
       expect(devinIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should throw error when .codeiumignore file does not exist", async () => {
+    it("should throw error when neither .devinignore nor .codeiumignore exists", async () => {
       await expect(DevinIgnore.fromFile({ outputRoot: testDir })).rejects.toThrow();
     });
 
@@ -607,14 +632,8 @@ dist/
   });
 
   describe("DevinIgnore-specific behavior", () => {
-    it("should use .codeiumignore as the filename", () => {
-      const devinIgnore = new DevinIgnore({
-        relativeDirPath: ".",
-        relativeFilePath: ".codeiumignore",
-        fileContent: "*.log",
-      });
-
-      expect(devinIgnore.getRelativeFilePath()).toBe(".codeiumignore");
+    it("should use .devinignore as the default generated filename", () => {
+      expect(DevinIgnore.getSettablePaths().relativeFilePath).toBe(".devinignore");
     });
 
     it("should work as a Devin AI ignore file", () => {

--- a/src/features/ignore/devin-ignore.ts
+++ b/src/features/ignore/devin-ignore.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { readFileContent } from "../../utils/file.js";
+import { fileExists, readFileContent } from "../../utils/file.js";
 import { RulesyncIgnore } from "./rulesync-ignore.js";
 import type {
   ToolIgnoreForDeletionParams,
@@ -11,15 +11,36 @@ import type {
 import { ToolIgnore } from "./tool-ignore.js";
 
 /**
- * Devin AI code editor ignore file implementation
- * Uses .codeiumignore file with gitignore-compatible syntax
- * Automatically respects .gitignore patterns and has built-in defaults for node_modules/ and hidden files
+ * Brand-aligned Devin Desktop ignore filename, added in Devin Desktop v3.1.7
+ * (2026-06-10). This matches how rules/commands/skills already prefer `.devin/`
+ * since the Windsurf/Cascade rebrand.
+ */
+const DEVIN_IGNORE_FILE_NAME = ".devinignore";
+
+/**
+ * Legacy Codeium-era ignore filename. Devin Desktop still honors it (alongside
+ * `.windsurfignore`), so it is read on import for round-trip compatibility with
+ * projects generated before the rebrand.
+ */
+const DEVIN_LEGACY_IGNORE_FILE_NAME = ".codeiumignore";
+
+/**
+ * Devin Desktop (the Windsurf/Cascade rebrand) ignore file implementation.
+ *
+ * Generates the brand-aligned `.devinignore` file with gitignore-compatible
+ * syntax. Devin automatically respects `.gitignore` patterns and has built-in
+ * defaults for node_modules/ and hidden files. On import, the legacy
+ * `.codeiumignore` filename is read as a fallback so existing projects still
+ * round-trip.
+ *
+ * @see https://docs.devin.ai/desktop/changelog — v3.1.7 added `.devinignore`
+ *   alongside `.windsurfignore` and `.codeiumignore`.
  */
 export class DevinIgnore extends ToolIgnore {
   static getSettablePaths(): ToolIgnoreSettablePaths {
     return {
       relativeDirPath: ".",
-      relativeFilePath: ".codeiumignore",
+      relativeFilePath: DEVIN_IGNORE_FILE_NAME,
     };
   }
 
@@ -43,18 +64,21 @@ export class DevinIgnore extends ToolIgnore {
     outputRoot = process.cwd(),
     validate = true,
   }: ToolIgnoreFromFileParams): Promise<DevinIgnore> {
-    const fileContent = await readFileContent(
-      join(
-        outputRoot,
-        this.getSettablePaths().relativeDirPath,
-        this.getSettablePaths().relativeFilePath,
-      ),
-    );
+    const { relativeDirPath, relativeFilePath } = this.getSettablePaths();
+    const primaryPath = join(outputRoot, relativeDirPath, relativeFilePath);
+    const legacyPath = join(outputRoot, relativeDirPath, DEVIN_LEGACY_IGNORE_FILE_NAME);
+
+    // Prefer the brand-aligned `.devinignore`; fall back to the legacy
+    // `.codeiumignore` only when `.devinignore` is absent so projects generated
+    // before the rebrand still round-trip on import.
+    const useLegacy = !(await fileExists(primaryPath)) && (await fileExists(legacyPath));
+    const resolvedFilePath = useLegacy ? DEVIN_LEGACY_IGNORE_FILE_NAME : relativeFilePath;
+    const fileContent = await readFileContent(join(outputRoot, relativeDirPath, resolvedFilePath));
 
     return new DevinIgnore({
       outputRoot,
-      relativeDirPath: this.getSettablePaths().relativeDirPath,
-      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      relativeDirPath,
+      relativeFilePath: resolvedFilePath,
       fileContent,
       validate,
     });

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -279,7 +279,7 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should load DevinIgnore for devin target", async () => {
-      await writeFileContent(join(testDir, ".codeiumignore"), "*.log\nnode_modules/");
+      await writeFileContent(join(testDir, ".devinignore"), "*.log\nnode_modules/");
 
       const processor = new IgnoreProcessor({
         logger,
@@ -674,14 +674,14 @@ describe("IgnoreProcessor", () => {
       const mockDevinIgnore = new DevinIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".codeiumignore",
+        relativeFilePath: ".devinignore",
         fileContent: "*.log\n\n\n",
       });
 
       // Write the file using writeAiFiles
       await processor.writeAiFiles([mockDevinIgnore]);
 
-      const devinIgnorePath = join(testDir, ".codeiumignore");
+      const devinIgnorePath = join(testDir, ".devinignore");
       const content = await readFileContent(devinIgnorePath);
 
       // Should have exactly one trailing newline


### PR DESCRIPTION
## Summary

Devin Desktop added `.devinignore` in v3.1.7 (2026-06-10) alongside `.windsurfignore` and `.codeiumignore`. rulesync still emitted only the oldest Codeium-era `.codeiumignore`, even though the `devin` rules/commands/skills adapters already prefer the brand-aligned `.devin/` paths since the Windsurf/Cascade rebrand.

## Changes

- `devin-ignore.ts`: generate `.devinignore` as the primary ignore file. On import, fall back to the legacy `.codeiumignore` only when `.devinignore` is absent, so projects generated before the rebrand still round-trip.
- Updated unit, processor, and e2e ignore tests; added coverage for the `.devinignore` preference and the `.codeiumignore` legacy fallback.
- Added `devinignore` to the cspell dictionary.

## Out of scope

The issue also proposes evaluating `AGENTS.md` as a Devin rules output/import. That is a broader cross-tool maintainer-stance decision (AGENTS.md duplication across tools) and is intentionally deferred to a separate follow-up; this PR covers the concrete, primary ignore-filename gap.

## Verification

- `pnpm cicheck` passes (code + content).

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)