### PR TITLE
fix(test): correct stale skill path in codexcli openai.yaml import test

### DIFF
--- a/src/features/skills/codexcli-skill.test.ts
+++ b/src/features/skills/codexcli-skill.test.ts
@@ -530,7 +530,9 @@ This is the body of the codex cli skill.`;
     });
 
     it("should read agents/openai.yaml back into the codexcli section on import", async () => {
-      const skillDir = join(testDir, ".codex", "skills", "test-skill");
+      // Codex CLI skills live under `.agents/skills/` (see getSettablePaths), which is
+      // where `fromDir` reads from; the skill fixture must be written to that path.
+      const skillDir = join(testDir, ".agents", "skills", "test-skill");
       await ensureDir(join(skillDir, "agents"));
       await writeFileContent(
         join(skillDir, SKILL_FILE_NAME),


### PR DESCRIPTION
## Summary

Fixes a stale test that left CI red on `main`.

The Codex CLI skills location moved to `.agents/skills/` (commit `54174c4d`), and `CodexCliSkill.getSettablePaths()` / `fromDir` now read from `.agents/skills/`. However, the `agents/openai.yaml` import round-trip test still wrote its fixture to the old `.codex/skills/` path, so `fromDir` could not find `SKILL.md` and the test failed:

```
Error: SKILL.md not found in .../.agents/skills/test-skill
```

This made the `CI` workflow fail on `main` (e.g. commit `9ffbd6fe`).

## Change

- Write the test fixture to `.agents/skills/test-skill` to match the implementation's read path.

This is a test-only change; no production behavior is affected. `pnpm cicheck` is fully green after the fix (6201 tests passing).
