### PR TITLE
feat(augmentcode): declare argument-hint and model command frontmatter fields

### DIFF
--- a/src/features/commands/augmentcode-command.test.ts
+++ b/src/features/commands/augmentcode-command.test.ts
@@ -138,6 +138,36 @@ describe("AugmentcodeCommand", () => {
         augmentcode: { "argument-hint": "<file>", model: "gpt-5" },
       });
     });
+
+    it("should accept and validate the argument-hint and model frontmatter fields", () => {
+      expect(
+        () =>
+          new AugmentcodeCommand({
+            outputRoot: testDir,
+            relativeDirPath: join(".augment", "commands"),
+            relativeFilePath: "test.md",
+            frontmatter: {
+              description: "Test description",
+              "argument-hint": "<file>",
+              model: "gpt-5",
+            },
+            body: "Test body",
+            validate: true,
+          }),
+      ).not.toThrow();
+
+      expect(
+        () =>
+          new AugmentcodeCommand({
+            outputRoot: testDir,
+            relativeDirPath: join(".augment", "commands"),
+            relativeFilePath: "test.md",
+            frontmatter: { model: 123 as any },
+            body: "Test body",
+            validate: true,
+          }),
+      ).toThrow(/Invalid frontmatter/);
+    });
   });
 
   describe("fromRulesyncCommand", () => {

--- a/src/features/commands/augmentcode-command.ts
+++ b/src/features/commands/augmentcode-command.ts
@@ -18,6 +18,10 @@ import {
 // looseObject preserves unknown keys during parsing (like passthrough in Zod 3)
 export const AugmentcodeCommandFrontmatterSchema = z.looseObject({
   description: z.optional(z.string()),
+  // Augment Code custom commands also support `argument-hint` and `model`
+  // frontmatter fields. https://docs.augmentcode.com/cli/custom-commands
+  "argument-hint": z.optional(z.string()),
+  model: z.optional(z.string()),
 });
 
 export type AugmentcodeCommandFrontmatter = z.infer<typeof AugmentcodeCommandFrontmatterSchema>;


### PR DESCRIPTION
## Summary

Augment Code custom commands support three frontmatter fields — `description`, `argument-hint`, and `model` — per the [official docs](https://docs.augmentcode.com/cli/custom-commands), but `AugmentcodeCommandFrontmatterSchema` declared only `description`. The other two were preserved only through `looseObject` passthrough and were never validated as first-class fields, unlike the Claude Code command adapter which declares both.

## Change

- Declare `argument-hint` and `model` as optional string fields on `AugmentcodeCommandFrontmatterSchema` (keeping `z.looseObject` so future fields still pass through).
- Add a test asserting the two fields validate and that a wrong-typed `model` is rejected.

The round-trip logic is unchanged: `toRulesyncCommand` already preserves extra fields into the `augmentcode:` section, so the only behavioral change is that these two known fields are now type-checked.

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
