### PR TITLE
feat(kilo): model skills config key, SKILL.md license/compatibility/metadata, and object subagent permissions

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -296,22 +296,22 @@ Attention, again, you are just the planner, so though you can read any files and
 
 Besides `mode`, the `kilo` subagent block accepts these optional fields (all preserved on round-trip):
 
-| Field         | Type            | Notes                                |
-| ------------- | --------------- | ------------------------------------ |
-| `displayName` | string          | Human-friendly name shown in pickers |
-| `model`       | string          | Model id                             |
-| `variant`     | string          | Model variant                        |
-| `temperature` | number          | Sampling temperature                 |
-| `top_p`       | number          | Nucleus-sampling parameter           |
-| `permission`  | string          | Permission profile                   |
-| `prompt`      | string          | Inline system prompt                 |
-| `color`       | string          | UI color                             |
-| `native`      | boolean         | Native (built-in) agent flag         |
-| `hidden`      | boolean         | Hide from top-level picker           |
-| `disable`     | boolean         | Disable the agent                    |
-| `deprecated`  | boolean         | Mark as deprecated                   |
-| `steps`       | array of object | Ordered step definitions             |
-| `options`     | object          | Free-form key/value options          |
+| Field         | Type             | Notes                                                                            |
+| ------------- | ---------------- | -------------------------------------------------------------------------------- |
+| `displayName` | string           | Human-friendly name shown in pickers                                             |
+| `model`       | string           | Model id                                                                         |
+| `variant`     | string           | Model variant                                                                    |
+| `temperature` | number           | Sampling temperature                                                             |
+| `top_p`       | number           | Nucleus-sampling parameter                                                       |
+| `permission`  | string \| object | Permission profile name, or a per-tool `{ <tool>: { allow, deny, ask } }` object |
+| `prompt`      | string           | Inline system prompt                                                             |
+| `color`       | string           | UI color                                                                         |
+| `native`      | boolean          | Native (built-in) agent flag                                                     |
+| `hidden`      | boolean          | Hide from top-level picker                                                       |
+| `disable`     | boolean          | Disable the agent                                                                |
+| `deprecated`  | boolean          | Mark as deprecated                                                               |
+| `steps`       | array of object  | Ordered step definitions                                                         |
+| `options`     | object           | Free-form key/value options                                                      |
 
 ## `.rulesync/skills/*/SKILL.md`
 
@@ -380,6 +380,15 @@ opencode: # for OpenCode-specific parameters (optional)
   metadata: # (optional) free-form metadata
     author: rulesync
   allowed-tools: # (optional) Anthropic-spec passthrough; OpenCode ignores unknown fields
+    - "Bash"
+    - "Read"
+kilo: # for Kilo Code-specific parameters (optional)
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    kilo-version: ">=7.0.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
+  allowed-tools: # (optional) backward-compat passthrough; not part of Kilo's official SKILL.md frontmatter
     - "Bash"
     - "Read"
 agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
@@ -481,7 +490,7 @@ Rulesync provides a JSON Schema for editor validation and autocompletion. Add th
 
 The `type` (and the equivalent `transport`) field accepts `local`, `stdio`, `sse`, `http`, `ws`, and `streamable-http`. `streamable-http` is the MCP specification's name for the HTTP transport and is accepted as an alias of `http`, so configurations copied from a server's documentation work unchanged. `ws` is the WebSocket transport (a persistent bidirectional connection) and accepts the same `url`/`headers`/`headersHelper`/`timeout` fields as `http`. Tools that do not recognize a given transport keep it on round-trip but may ignore it at runtime.
 
-> **Kilo Code note:** Kilo's MCP config uses its own native shape in `kilo.jsonc` (`type: "local" | "remote"`, `environment`, `enabled`, `command` as an array). Rulesync maps `stdio`/`local` ⇄ Kilo `local` and `http`/`sse` ⇄ Kilo `remote`; on import, Kilo `remote` is normalized to the canonical `http` transport (the deprecated `sse` is no longer emitted). The Kilo-specific `timeout` (local + remote, a positive integer in milliseconds) and `oauth` (remote only — either an OAuth-config object or `false` to disable auto-detection) fields are preserved on round-trip.
+> **Kilo Code note:** Kilo's MCP config uses its own native shape in `kilo.jsonc` (`type: "local" | "remote"`, `environment`, `enabled`, `command` as an array). Rulesync maps `stdio`/`local` ⇄ Kilo `local` and `http`/`sse` ⇄ Kilo `remote`; on import, Kilo `remote` is normalized to the canonical `http` transport (the deprecated `sse` is no longer emitted). The Kilo-specific `timeout` (local + remote, a positive integer in milliseconds) and `oauth` (remote only — either an OAuth-config object or `false` to disable auto-detection) fields are preserved on round-trip. The `kilo.jsonc` `skills` config key (`skills.paths` for extra skill locations and `skills.urls` for remote skill manifests) is likewise preserved when Rulesync writes the file.
 
 ### MCP Tool Config (`enabledTools` / `disabledTools`)
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -296,22 +296,22 @@ Attention, again, you are just the planner, so though you can read any files and
 
 Besides `mode`, the `kilo` subagent block accepts these optional fields (all preserved on round-trip):
 
-| Field         | Type            | Notes                                |
-| ------------- | --------------- | ------------------------------------ |
-| `displayName` | string          | Human-friendly name shown in pickers |
-| `model`       | string          | Model id                             |
-| `variant`     | string          | Model variant                        |
-| `temperature` | number          | Sampling temperature                 |
-| `top_p`       | number          | Nucleus-sampling parameter           |
-| `permission`  | string          | Permission profile                   |
-| `prompt`      | string          | Inline system prompt                 |
-| `color`       | string          | UI color                             |
-| `native`      | boolean         | Native (built-in) agent flag         |
-| `hidden`      | boolean         | Hide from top-level picker           |
-| `disable`     | boolean         | Disable the agent                    |
-| `deprecated`  | boolean         | Mark as deprecated                   |
-| `steps`       | array of object | Ordered step definitions             |
-| `options`     | object          | Free-form key/value options          |
+| Field         | Type             | Notes                                                                            |
+| ------------- | ---------------- | -------------------------------------------------------------------------------- |
+| `displayName` | string           | Human-friendly name shown in pickers                                             |
+| `model`       | string           | Model id                                                                         |
+| `variant`     | string           | Model variant                                                                    |
+| `temperature` | number           | Sampling temperature                                                             |
+| `top_p`       | number           | Nucleus-sampling parameter                                                       |
+| `permission`  | string \| object | Permission profile name, or a per-tool `{ <tool>: { allow, deny, ask } }` object |
+| `prompt`      | string           | Inline system prompt                                                             |
+| `color`       | string           | UI color                                                                         |
+| `native`      | boolean          | Native (built-in) agent flag                                                     |
+| `hidden`      | boolean          | Hide from top-level picker                                                       |
+| `disable`     | boolean          | Disable the agent                                                                |
+| `deprecated`  | boolean          | Mark as deprecated                                                               |
+| `steps`       | array of object  | Ordered step definitions                                                         |
+| `options`     | object           | Free-form key/value options                                                      |
 
 ## `.rulesync/skills/*/SKILL.md`
 
@@ -380,6 +380,15 @@ opencode: # for OpenCode-specific parameters (optional)
   metadata: # (optional) free-form metadata
     author: rulesync
   allowed-tools: # (optional) Anthropic-spec passthrough; OpenCode ignores unknown fields
+    - "Bash"
+    - "Read"
+kilo: # for Kilo Code-specific parameters (optional)
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    kilo-version: ">=7.0.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
+  allowed-tools: # (optional) backward-compat passthrough; not part of Kilo's official SKILL.md frontmatter
     - "Bash"
     - "Read"
 agentsskills: # for the Agent Skills standard target (optional; supports project + global ~/.agents/skills/)
@@ -481,7 +490,7 @@ Rulesync provides a JSON Schema for editor validation and autocompletion. Add th
 
 The `type` (and the equivalent `transport`) field accepts `local`, `stdio`, `sse`, `http`, `ws`, and `streamable-http`. `streamable-http` is the MCP specification's name for the HTTP transport and is accepted as an alias of `http`, so configurations copied from a server's documentation work unchanged. `ws` is the WebSocket transport (a persistent bidirectional connection) and accepts the same `url`/`headers`/`headersHelper`/`timeout` fields as `http`. Tools that do not recognize a given transport keep it on round-trip but may ignore it at runtime.
 
-> **Kilo Code note:** Kilo's MCP config uses its own native shape in `kilo.jsonc` (`type: "local" | "remote"`, `environment`, `enabled`, `command` as an array). Rulesync maps `stdio`/`local` ⇄ Kilo `local` and `http`/`sse` ⇄ Kilo `remote`; on import, Kilo `remote` is normalized to the canonical `http` transport (the deprecated `sse` is no longer emitted). The Kilo-specific `timeout` (local + remote, a positive integer in milliseconds) and `oauth` (remote only — either an OAuth-config object or `false` to disable auto-detection) fields are preserved on round-trip.
+> **Kilo Code note:** Kilo's MCP config uses its own native shape in `kilo.jsonc` (`type: "local" | "remote"`, `environment`, `enabled`, `command` as an array). Rulesync maps `stdio`/`local` ⇄ Kilo `local` and `http`/`sse` ⇄ Kilo `remote`; on import, Kilo `remote` is normalized to the canonical `http` transport (the deprecated `sse` is no longer emitted). The Kilo-specific `timeout` (local + remote, a positive integer in milliseconds) and `oauth` (remote only — either an OAuth-config object or `false` to disable auto-detection) fields are preserved on round-trip. The `kilo.jsonc` `skills` config key (`skills.paths` for extra skill locations and `skills.urls` for remote skill manifests) is likewise preserved when Rulesync writes the file.
 
 ### MCP Tool Config (`enabledTools` / `disabledTools`)
 

--- a/src/features/mcp/kilo-mcp.test.ts
+++ b/src/features/mcp/kilo-mcp.test.ts
@@ -2314,6 +2314,33 @@ describe("KiloMcp", () => {
         },
       });
     });
+
+    it("should preserve an existing skills config key when writing mcp", async () => {
+      const existingConfig = {
+        skills: {
+          paths: ["~/my-skills", "relative/skills"],
+          urls: ["https://example.com/.well-known/skills/"],
+        },
+      };
+      await writeFileContent(join(testDir, "kilo.jsonc"), JSON.stringify(existingConfig, null, 2));
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            "new-server": { command: "node", args: ["server.js"] },
+          },
+        }),
+      });
+
+      const kiloMcp = await KiloMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+
+      expect((kiloMcp.getJson() as { skills?: unknown }).skills).toEqual({
+        paths: ["~/my-skills", "relative/skills"],
+        urls: ["https://example.com/.well-known/skills/"],
+      });
+    });
   });
 
   describe("error handling", () => {

--- a/src/features/mcp/kilo-mcp.ts
+++ b/src/features/mcp/kilo-mcp.ts
@@ -64,6 +64,15 @@ const KiloConfigSchema = z.looseObject({
   // Project rule files/globs that Kilo auto-loads. Shared with the rules
   // feature (see kilo-rule.ts); preserved here so writing MCP never drops it.
   instructions: z.optional(z.array(z.string())),
+  // Extra skill locations and remote skill manifest URLs configurable in
+  // `kilo.jsonc`. Preserved here so writing MCP never drops them.
+  // https://kilo.ai/docs/customize/skills
+  skills: z.optional(
+    z.looseObject({
+      paths: z.optional(z.array(z.string())),
+      urls: z.optional(z.array(z.string())),
+    }),
+  ),
 });
 
 type KiloConfig = z.infer<typeof KiloConfigSchema>;

--- a/src/features/skills/kilo-skill.test.ts
+++ b/src/features/skills/kilo-skill.test.ts
@@ -114,6 +114,35 @@ describe("KiloSkill", () => {
         "allowed-tools": ["Bash", "Read"],
       });
     });
+
+    it("should round-trip license, compatibility, and metadata via the kilo section", () => {
+      const skill = new KiloSkill({
+        outputRoot: testDir,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "Test Skill",
+          description: "Test description",
+          license: "MIT",
+          compatibility: { network: "required" },
+          metadata: { author: "rulesync" },
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().kilo).toEqual({
+        license: "MIT",
+        compatibility: { network: "required" },
+        metadata: { author: "rulesync" },
+      });
+
+      const roundTripped = KiloSkill.fromRulesyncSkill({ rulesyncSkill });
+      const fm = roundTripped.getFrontmatter();
+      expect(fm.license).toBe("MIT");
+      expect(fm.compatibility).toEqual({ network: "required" });
+      expect(fm.metadata).toEqual({ author: "rulesync" });
+    });
   });
 
   describe("fromRulesyncSkill", () => {

--- a/src/features/skills/kilo-skill.ts
+++ b/src/features/skills/kilo-skill.ts
@@ -18,6 +18,13 @@ import {
 export const KiloSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  // Kilo's official SKILL.md frontmatter: `name`, `description`, `license`,
+  // `compatibility`, and `metadata`. https://kilo.ai/docs/customize/skills
+  license: z.optional(z.string()),
+  compatibility: z.optional(z.looseObject({})),
+  metadata: z.optional(z.looseObject({})),
+  // `allowed-tools` is NOT recognized by Kilo; it is retained for backward
+  // compatibility with existing rulesync skill files.
   "allowed-tools": z.optional(z.array(z.string())),
 });
 
@@ -105,15 +112,21 @@ export class KiloSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const kiloBlock = {
+      ...(frontmatter["allowed-tools"] !== undefined && {
+        "allowed-tools": frontmatter["allowed-tools"],
+      }),
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && {
+        compatibility: frontmatter.compatibility,
+      }),
+      ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
-      ...(frontmatter["allowed-tools"] && {
-        kilo: {
-          "allowed-tools": frontmatter["allowed-tools"],
-        },
-      }),
+      ...(Object.keys(kiloBlock).length > 0 && { kilo: kiloBlock }),
     };
 
     return new RulesyncSkill({
@@ -135,11 +148,19 @@ export class KiloSkill extends ToolSkill {
     global = false,
   }: ToolSkillFromRulesyncSkillParams): KiloSkill {
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+    const kiloSection = rulesyncFrontmatter.kilo;
 
     const kiloFrontmatter: KiloSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
-      "allowed-tools": rulesyncFrontmatter.kilo?.["allowed-tools"],
+      ...(kiloSection?.["allowed-tools"] !== undefined && {
+        "allowed-tools": kiloSection["allowed-tools"],
+      }),
+      ...(kiloSection?.license !== undefined && { license: kiloSection.license }),
+      ...(kiloSection?.compatibility !== undefined && {
+        compatibility: kiloSection.compatibility,
+      }),
+      ...(kiloSection?.metadata !== undefined && { metadata: kiloSection.metadata }),
     };
 
     const settablePaths = KiloSkill.getSettablePaths({ global });

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -71,7 +71,12 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   ),
   kilo: z.optional(
     z.looseObject({
+      // `allowed-tools` is not part of Kilo's official SKILL.md frontmatter; it is
+      // retained for backward compatibility with existing rulesync skill files.
       "allowed-tools": z.optional(z.array(z.string())),
+      license: z.optional(z.string()),
+      compatibility: z.optional(z.looseObject({})),
+      metadata: z.optional(z.looseObject({})),
     }),
   ),
   deepagents: z.optional(

--- a/src/features/subagents/kilo-subagent.test.ts
+++ b/src/features/subagents/kilo-subagent.test.ts
@@ -461,6 +461,29 @@ Agent body`,
     }
   });
 
+  it("should accept a per-tool permission object as well as a string", () => {
+    const stringResult = KiloSubagentFrontmatterSchema.safeParse({
+      name: "agent",
+      permission: "read-only",
+    });
+    expect(stringResult.success).toBe(true);
+
+    const objectResult = KiloSubagentFrontmatterSchema.safeParse({
+      name: "agent",
+      permission: {
+        bash: { allow: ["git *"], deny: ["rm -rf *"] },
+        edit: { ask: ["src/**"] },
+      },
+    });
+    expect(objectResult.success).toBe(true);
+    if (objectResult.success) {
+      expect(objectResult.data.permission).toEqual({
+        bash: { allow: ["git *"], deny: ["rm -rf *"] },
+        edit: { ask: ["src/**"] },
+      });
+    }
+  });
+
   it("should round-trip the options and steps fields via fromRulesyncSubagent", () => {
     const rulesyncSubagent = new RulesyncSubagent({
       outputRoot: testDir,

--- a/src/features/subagents/kilo-subagent.ts
+++ b/src/features/subagents/kilo-subagent.ts
@@ -31,7 +31,10 @@ export const KiloSubagentFrontmatterSchema = z.looseObject({
   top_p: z.optional(z.number()),
   temperature: z.optional(z.number()),
   color: z.optional(z.string()),
-  permission: z.optional(z.string()),
+  // Kilo custom modes accept a per-tool permission object (`{ <tool>: { allow,
+  // deny, ask } }`, glob-aware), in addition to a bare string. Accept both so an
+  // object value is no longer rejected. https://kilo.ai/docs/customize/custom-modes
+  permission: z.optional(z.union([z.string(), z.record(z.string(), z.unknown())])),
   model: z.optional(z.string()),
   variant: z.optional(z.string()),
   prompt: z.optional(z.string()),


### PR DESCRIPTION
## Summary

Aligns the Kilo Code adapters with Kilo's current upstream surface (verified against [Kilo skills docs](https://kilo.ai/docs/customize/skills) and [custom-modes docs](https://kilo.ai/docs/customize/custom-modes)). Three additive schema fixes:

1. **`kilo.jsonc` `skills` config key** — declare `skills` (`skills.paths` for extra skill locations, `skills.urls` for remote skill manifests) on `KiloConfigSchema` so it is preserved (not dropped) when Rulesync writes the shared `kilo.jsonc`.
2. **SKILL.md frontmatter drift** — Kilo's official SKILL.md frontmatter is `name`/`description`/`license`/`compatibility`/`metadata` (it does **not** recognize `allowed-tools`). Model `license`/`compatibility`/`metadata` on `KiloSkillFrontmatterSchema` and round-trip them via the `kilo` section, mirroring the OpenCode sibling. `allowed-tools` is **retained as a backward-compat passthrough** so existing rulesync skill files are not broken.
3. **Subagent permission type** — Kilo custom modes accept a per-tool `permission` object (`{ <tool>: { allow, deny, ask } }`, glob-aware), but `KiloSubagentFrontmatterSchema` declared `permission` as a bare string, which rejected object values. Widen it to `string | object`.

## Tests / docs
Round-trip tests for the new skill fields, a `skills`-key preservation test, and a subagent permission-object test. README/docs (`file-formats.md` Kilo MCP note, subagent field table, SKILL.md example, synced skill docs) updated. `pnpm cicheck` fully green.

Closes #1818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
