### PR TITLE
feat(kiro): map rule globs to steering inclusion frontmatter

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -40,7 +40,7 @@ augmentcode: # augmentcode specific parameters
   description: "When to apply this rule" # (optional) used with "agent_requested" type
 kiro: # kiro specific parameters (steering inclusion)
   inclusion: "fileMatch" # always, fileMatch, or manual
-  fileMatchPattern: "src/components/**/*.tsx" # (optional) single glob used when inclusion is "fileMatch"
+  fileMatchPattern: ["src/components/**/*.tsx"] # (optional) glob string or array of globs, used when inclusion is "fileMatch"
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -54,7 +54,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 ...
 ```
 
-> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (so the rule applies only to matching files instead of always); otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -38,6 +38,9 @@ devin: # devin (Devin Desktop, formerly Windsurf) specific parameters
 augmentcode: # augmentcode specific parameters
   type: "always_apply" # always_apply, manual, or agent_requested
   description: "When to apply this rule" # (optional) used with "agent_requested" type
+kiro: # kiro specific parameters (steering inclusion)
+  inclusion: "fileMatch" # always, fileMatch, or manual
+  fileMatchPattern: "src/components/**/*.tsx" # (optional) single glob used when inclusion is "fileMatch"
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -50,6 +53,8 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 
 ...
 ```
+
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (so the rule applies only to matching files instead of always); otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -40,7 +40,7 @@ augmentcode: # augmentcode specific parameters
   description: "When to apply this rule" # (optional) used with "agent_requested" type
 kiro: # kiro specific parameters (steering inclusion)
   inclusion: "fileMatch" # always, fileMatch, or manual
-  fileMatchPattern: "src/components/**/*.tsx" # (optional) single glob used when inclusion is "fileMatch"
+  fileMatchPattern: ["src/components/**/*.tsx"] # (optional) glob string or array of globs, used when inclusion is "fileMatch"
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -54,7 +54,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 ...
 ```
 
-> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (so the rule applies only to matching files instead of always); otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -38,6 +38,9 @@ devin: # devin (Devin Desktop, formerly Windsurf) specific parameters
 augmentcode: # augmentcode specific parameters
   type: "always_apply" # always_apply, manual, or agent_requested
   description: "When to apply this rule" # (optional) used with "agent_requested" type
+kiro: # kiro specific parameters (steering inclusion)
+  inclusion: "fileMatch" # always, fileMatch, or manual
+  fileMatchPattern: "src/components/**/*.tsx" # (optional) single glob used when inclusion is "fileMatch"
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -50,6 +53,8 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 
 ...
 ```
+
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (so the rule applies only to matching files instead of always); otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -23,14 +23,17 @@ describe("deriveKiroInclusion", () => {
     expect(deriveKiroInclusion({ globs: ["*", "**"] })).toBeUndefined();
   });
 
-  it("maps specific globs to fileMatch with a comma-joined pattern", () => {
+  it("maps a single specific glob to fileMatch with a string pattern", () => {
     expect(deriveKiroInclusion({ globs: ["src/components/**/*.tsx"] })).toEqual({
       inclusion: "fileMatch",
       fileMatchPattern: "src/components/**/*.tsx",
     });
+  });
+
+  it("maps multiple specific globs to fileMatch with an array pattern (dropping wildcards)", () => {
     expect(deriveKiroInclusion({ globs: ["a/**", "b/**", "**/*"] })).toEqual({
       inclusion: "fileMatch",
-      fileMatchPattern: "a/**,b/**",
+      fileMatchPattern: ["a/**", "b/**"],
     });
   });
 
@@ -389,6 +392,54 @@ describe("KiroRule", () => {
         fileMatchPattern: "src/**/*.ts",
       });
       expect(roundTrip.getBody()).toContain("# Frontend body");
+    });
+
+    it("emits and round-trips an array fileMatchPattern for multiple globs", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "ts.md",
+        frontmatter: {
+          root: false,
+          targets: ["kiro"],
+          globs: ["**/*.ts", "**/*.tsx"],
+        },
+        body: "# TS body",
+      });
+
+      const generated = KiroRule.fromRulesyncRule({ rulesyncRule });
+      const content = generated.getFileContent();
+      expect(content).toContain("inclusion: fileMatch");
+      // YAML array form, not a comma-joined string.
+      expect(content).not.toContain("**/*.ts,**/*.tsx");
+
+      const roundTrip = generated.toRulesyncRule();
+      expect(roundTrip.getFrontmatter().globs).toEqual(["**/*.ts", "**/*.tsx"]);
+      expect(roundTrip.getFrontmatter().kiro).toEqual({
+        inclusion: "fileMatch",
+        fileMatchPattern: ["**/*.ts", "**/*.tsx"],
+      });
+    });
+
+    it("imports a hand-authored array fileMatchPattern steering file", async () => {
+      const steeringDir = join(testDir, ".kiro/steering");
+      await ensureDir(steeringDir);
+      await writeFileContent(
+        join(steeringDir, "authored.md"),
+        '---\ninclusion: fileMatch\nfileMatchPattern: ["**/*.ts", "**/*.tsx"]\n---\n# Authored\n',
+      );
+
+      const kiroRule = await KiroRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "authored.md",
+      });
+      const roundTrip = kiroRule.toRulesyncRule();
+
+      expect(roundTrip.getFrontmatter().globs).toEqual(["**/*.ts", "**/*.tsx"]);
+      expect(roundTrip.getFrontmatter().kiro).toEqual({
+        inclusion: "fileMatch",
+        fileMatchPattern: ["**/*.ts", "**/*.tsx"],
+      });
+      expect(roundTrip.getBody()).toContain("# Authored");
     });
 
     it("should use custom outputRoot", () => {

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -9,8 +9,52 @@ import {
 } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
-import { KiroRule } from "./kiro-rule.js";
+import { deriveKiroInclusion, KiroRule } from "./kiro-rule.js";
 import { RulesyncRule } from "./rulesync-rule.js";
+
+describe("deriveKiroInclusion", () => {
+  it("returns undefined when there are no globs (always-on, plain file)", () => {
+    expect(deriveKiroInclusion({ globs: [] })).toBeUndefined();
+    expect(deriveKiroInclusion({})).toBeUndefined();
+  });
+
+  it("treats wildcard globs as always-on (undefined)", () => {
+    expect(deriveKiroInclusion({ globs: ["**/*"] })).toBeUndefined();
+    expect(deriveKiroInclusion({ globs: ["*", "**"] })).toBeUndefined();
+  });
+
+  it("maps specific globs to fileMatch with a comma-joined pattern", () => {
+    expect(deriveKiroInclusion({ globs: ["src/components/**/*.tsx"] })).toEqual({
+      inclusion: "fileMatch",
+      fileMatchPattern: "src/components/**/*.tsx",
+    });
+    expect(deriveKiroInclusion({ globs: ["a/**", "b/**", "**/*"] })).toEqual({
+      inclusion: "fileMatch",
+      fileMatchPattern: "a/**,b/**",
+    });
+  });
+
+  it("honors an explicit kiro.inclusion block", () => {
+    expect(deriveKiroInclusion({ kiro: { inclusion: "manual" }, globs: ["x/**"] })).toEqual({
+      inclusion: "manual",
+    });
+    expect(deriveKiroInclusion({ kiro: { inclusion: "always" } })).toEqual({
+      inclusion: "always",
+    });
+  });
+
+  it("derives fileMatchPattern from globs when kiro.inclusion is fileMatch without a pattern", () => {
+    expect(
+      deriveKiroInclusion({ kiro: { inclusion: "fileMatch" }, globs: ["lib/**/*.ts"] }),
+    ).toEqual({ inclusion: "fileMatch", fileMatchPattern: "lib/**/*.ts" });
+    expect(
+      deriveKiroInclusion({
+        kiro: { inclusion: "fileMatch", fileMatchPattern: "explicit/**" },
+        globs: ["ignored/**"],
+      }),
+    ).toEqual({ inclusion: "fileMatch", fileMatchPattern: "explicit/**" });
+  });
+});
 
 describe("KiroRule", () => {
   let testDir: string;
@@ -283,6 +327,68 @@ describe("KiroRule", () => {
         "# Detail RulesyncRule\n\nContent from detail rulesync.",
       );
       expect(kiroRule.isRoot()).toBe(false);
+    });
+
+    it("emits fileMatch inclusion frontmatter for a non-root rule with specific globs", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "frontend.md",
+        frontmatter: {
+          root: false,
+          targets: ["kiro"],
+          description: "Frontend rule",
+          globs: ["src/components/**/*.tsx"],
+        },
+        body: "# Frontend\n\nUse functional components.",
+      });
+
+      const kiroRule = KiroRule.fromRulesyncRule({ rulesyncRule });
+      const content = kiroRule.getFileContent();
+
+      expect(content).toContain("inclusion: fileMatch");
+      expect(content).toContain("fileMatchPattern: src/components/**/*.tsx");
+      expect(content).toContain("# Frontend\n\nUse functional components.");
+    });
+
+    it("emits no frontmatter for a non-root rule without globs (always-on)", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "general.md",
+        frontmatter: {
+          root: false,
+          targets: ["kiro"],
+          description: "General rule",
+          globs: [],
+        },
+        body: "# General\n\nBe consistent.",
+      });
+
+      const kiroRule = KiroRule.fromRulesyncRule({ rulesyncRule });
+
+      expect(kiroRule.getFileContent()).toBe("# General\n\nBe consistent.");
+    });
+
+    it("round-trips a fileMatch rule through toRulesyncRule", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "frontend.md",
+        frontmatter: {
+          root: false,
+          targets: ["kiro"],
+          globs: ["src/**/*.ts"],
+        },
+        body: "# Frontend body",
+      });
+
+      const generated = KiroRule.fromRulesyncRule({ rulesyncRule });
+      const roundTrip = generated.toRulesyncRule();
+
+      expect(roundTrip.getFrontmatter().globs).toEqual(["src/**/*.ts"]);
+      expect(roundTrip.getFrontmatter().kiro).toEqual({
+        inclusion: "fileMatch",
+        fileMatchPattern: "src/**/*.ts",
+      });
+      expect(roundTrip.getBody()).toContain("# Frontend body");
     });
 
     it("should use custom outputRoot", () => {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
+import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -18,11 +19,71 @@ export type KiroRuleParams = ToolRuleParams;
 export type KiroRuleSettablePaths = Pick<ToolRuleSettablePaths, "nonRoot">;
 
 /**
+ * Steering `inclusion` frontmatter that Kiro reads at the top of each
+ * `.kiro/steering/*.md` file:
+ * - `always` — loaded into every interaction (Kiro's default when no frontmatter
+ *   is present, so rulesync omits the block in this case).
+ * - `fileMatch` — loaded only when the open file matches `fileMatchPattern`.
+ * - `manual` — loaded on demand via `#steering-file-name`.
+ *
+ * @see https://kiro.dev/docs/steering/
+ */
+export type KiroSteeringInclusion = {
+  inclusion: string;
+  fileMatchPattern?: string;
+};
+
+const WILDCARD_GLOBS = new Set(["**/*", "**", "*"]);
+
+/**
+ * Derives the Kiro steering `inclusion` frontmatter for a non-root rule from the
+ * rulesync rule frontmatter.
+ *
+ * Precedence:
+ * 1. An explicit `kiro.inclusion` block round-trips as-is (with `fileMatchPattern`
+ *    taken from the block, or derived from `globs` when omitted for `fileMatch`).
+ * 2. Otherwise specific (non-wildcard) globs map to `fileMatch`, scoping the rule
+ *    to matching files instead of leaving it implicitly always-on.
+ * 3. Otherwise the rule stays `always` — represented by omitting the block so the
+ *    emitted file matches Kiro's no-frontmatter default.
+ *
+ * Returns `undefined` when no frontmatter should be written (the `always` case).
+ */
+export function deriveKiroInclusion({
+  kiro,
+  globs,
+}: {
+  kiro?: { inclusion?: string; fileMatchPattern?: string };
+  globs?: string[];
+}): KiroSteeringInclusion | undefined {
+  const specificGlobs = (globs ?? []).filter((g) => !WILDCARD_GLOBS.has(g));
+
+  if (kiro?.inclusion) {
+    if (kiro.inclusion === "fileMatch") {
+      const fileMatchPattern = kiro.fileMatchPattern ?? (specificGlobs.join(",") || undefined);
+      return fileMatchPattern
+        ? { inclusion: "fileMatch", fileMatchPattern }
+        : { inclusion: "fileMatch" };
+    }
+    return { inclusion: kiro.inclusion };
+  }
+
+  if (specificGlobs.length > 0) {
+    return { inclusion: "fileMatch", fileMatchPattern: specificGlobs.join(",") };
+  }
+
+  return undefined;
+}
+
+/**
  * Rule generator for Kiro AI-powered IDE
  *
- * Generates steering documents for Kiro's spec-driven development approach.
- * Supports both root file (.kiro/guidelines.md) and steering documents
- * in the .kiro/steering/ directory (product.md, structure.md, tech.md).
+ * Generates steering documents for Kiro's spec-driven development approach in the
+ * `.kiro/steering/` directory (product.md, structure.md, tech.md, ...).
+ *
+ * Non-root steering files carry an `inclusion` frontmatter block derived from the
+ * rulesync rule's globs / `kiro` override (see {@link deriveKiroInclusion}); the
+ * root overview index stays plain so Kiro always loads it.
  */
 export class KiroRule extends ToolRule {
   static getSettablePaths(
@@ -43,13 +104,12 @@ export class KiroRule extends ToolRule {
     relativeFilePath,
     validate = true,
   }: ToolRuleFromFileParams): Promise<KiroRule> {
-    const fileContent = await readFileContent(
-      join(outputRoot, this.getSettablePaths().nonRoot.relativeDirPath, relativeFilePath),
-    );
+    const relativeDirPath = this.getSettablePaths().nonRoot.relativeDirPath;
+    const fileContent = await readFileContent(join(outputRoot, relativeDirPath, relativeFilePath));
 
     return new KiroRule({
       outputRoot,
-      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeDirPath,
       relativeFilePath: relativeFilePath,
       fileContent,
       validate,
@@ -62,18 +122,67 @@ export class KiroRule extends ToolRule {
     rulesyncRule,
     validate = true,
   }: ToolRuleFromRulesyncRuleParams): KiroRule {
-    return new KiroRule(
-      this.buildToolRuleParamsDefault({
-        outputRoot,
-        rulesyncRule,
-        validate,
-        nonRootPath: this.getSettablePaths().nonRoot,
-      }),
-    );
+    const params = this.buildToolRuleParamsDefault({
+      outputRoot,
+      rulesyncRule,
+      validate,
+      nonRootPath: this.getSettablePaths().nonRoot,
+    });
+
+    // The root overview index stays plain (Kiro always-loads a frontmatter-less
+    // steering file). Only non-root steering files carry inclusion frontmatter.
+    if (params.root) {
+      return new KiroRule(params);
+    }
+
+    const frontmatter = rulesyncRule.getFrontmatter();
+    const inclusion = deriveKiroInclusion({
+      kiro: frontmatter.kiro,
+      globs: frontmatter.globs,
+    });
+
+    if (!inclusion) {
+      return new KiroRule(params);
+    }
+
+    return new KiroRule({
+      ...params,
+      fileContent: stringifyFrontmatter(rulesyncRule.getBody(), inclusion),
+    });
   }
 
   toRulesyncRule(): RulesyncRule {
-    return this.toRulesyncRuleDefault();
+    // Round-trip steering inclusion frontmatter back into the rulesync `kiro`
+    // block (plus `globs` for fileMatch), so re-generating reproduces the file.
+    const { frontmatter, body } = parseFrontmatter(
+      this.getFileContent(),
+      this.getRelativeFilePath(),
+    );
+    const inclusion = typeof frontmatter.inclusion === "string" ? frontmatter.inclusion : undefined;
+
+    if (!inclusion) {
+      return this.toRulesyncRuleDefault();
+    }
+
+    const fileMatchPattern =
+      typeof frontmatter.fileMatchPattern === "string" ? frontmatter.fileMatchPattern : undefined;
+    const globs =
+      inclusion === "fileMatch" && fileMatchPattern
+        ? fileMatchPattern.split(",").map((g) => g.trim())
+        : [];
+
+    return new RulesyncRule({
+      outputRoot: process.cwd(),
+      relativeDirPath: RulesyncRule.getSettablePaths().recommended.relativeDirPath,
+      relativeFilePath: this.getRelativeFilePath(),
+      frontmatter: {
+        root: false,
+        targets: ["*"],
+        globs,
+        kiro: { inclusion, ...(fileMatchPattern ? { fileMatchPattern } : {}) },
+      },
+      body,
+    });
   }
 
   validate(): ValidationResult {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -30,10 +30,23 @@ export type KiroRuleSettablePaths = Pick<ToolRuleSettablePaths, "nonRoot">;
  */
 export type KiroSteeringInclusion = {
   inclusion: string;
-  fileMatchPattern?: string;
+  // A single glob is emitted as a string; multiple globs as a YAML array, both of
+  // which Kiro accepts for `fileMatchPattern`.
+  fileMatchPattern?: string | string[];
 };
 
 const WILDCARD_GLOBS = new Set(["**/*", "**", "*"]);
+
+/**
+ * Emits one glob as a string and several as an array, matching the two
+ * `fileMatchPattern` forms Kiro accepts.
+ */
+function toFileMatchPattern(globs: string[]): string | string[] | undefined {
+  if (globs.length === 0) {
+    return undefined;
+  }
+  return globs.length === 1 ? globs[0] : globs;
+}
 
 /**
  * Derives the Kiro steering `inclusion` frontmatter for a non-root rule from the
@@ -53,14 +66,14 @@ export function deriveKiroInclusion({
   kiro,
   globs,
 }: {
-  kiro?: { inclusion?: string; fileMatchPattern?: string };
+  kiro?: { inclusion?: string; fileMatchPattern?: string | string[] };
   globs?: string[];
 }): KiroSteeringInclusion | undefined {
   const specificGlobs = (globs ?? []).filter((g) => !WILDCARD_GLOBS.has(g));
 
   if (kiro?.inclusion) {
     if (kiro.inclusion === "fileMatch") {
-      const fileMatchPattern = kiro.fileMatchPattern ?? (specificGlobs.join(",") || undefined);
+      const fileMatchPattern = kiro.fileMatchPattern ?? toFileMatchPattern(specificGlobs);
       return fileMatchPattern
         ? { inclusion: "fileMatch", fileMatchPattern }
         : { inclusion: "fileMatch" };
@@ -68,8 +81,9 @@ export function deriveKiroInclusion({
     return { inclusion: kiro.inclusion };
   }
 
-  if (specificGlobs.length > 0) {
-    return { inclusion: "fileMatch", fileMatchPattern: specificGlobs.join(",") };
+  const fileMatchPattern = toFileMatchPattern(specificGlobs);
+  if (fileMatchPattern) {
+    return { inclusion: "fileMatch", fileMatchPattern };
   }
 
   return undefined;
@@ -164,12 +178,19 @@ export class KiroRule extends ToolRule {
       return this.toRulesyncRuleDefault();
     }
 
-    const fileMatchPattern =
-      typeof frontmatter.fileMatchPattern === "string" ? frontmatter.fileMatchPattern : undefined;
-    const globs =
-      inclusion === "fileMatch" && fileMatchPattern
-        ? fileMatchPattern.split(",").map((g) => g.trim())
-        : [];
+    const rawPattern = frontmatter.fileMatchPattern;
+    const fileMatchPattern: string | string[] | undefined = Array.isArray(rawPattern)
+      ? rawPattern.filter((p): p is string => typeof p === "string")
+      : typeof rawPattern === "string"
+        ? rawPattern
+        : undefined;
+    const patternGlobs =
+      fileMatchPattern === undefined
+        ? []
+        : Array.isArray(fileMatchPattern)
+          ? fileMatchPattern
+          : [fileMatchPattern];
+    const globs = inclusion === "fileMatch" ? patternGlobs : [];
 
     return new RulesyncRule({
       outputRoot: process.cwd(),
@@ -179,7 +200,7 @@ export class KiroRule extends ToolRule {
         root: false,
         targets: ["*"],
         globs,
-        kiro: { inclusion, ...(fileMatchPattern ? { fileMatchPattern } : {}) },
+        kiro: { inclusion, ...(fileMatchPattern !== undefined ? { fileMatchPattern } : {}) },
       },
       body,
     });

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -71,6 +71,14 @@ export const RulesyncRuleFrontmatterSchema = z.object({
       description: z.optional(z.string()),
     }),
   ),
+  kiro: z.optional(
+    z.looseObject({
+      // Steering inclusion mode: always | fileMatch | manual (string for forward compat).
+      inclusion: z.optional(z.string()),
+      // Single glob string used when `inclusion: fileMatch`.
+      fileMatchPattern: z.optional(z.string()),
+    }),
+  ),
   takt: z.optional(
     z.looseObject({
       // Rename the emitted file stem (e.g. "coder.md" → "{name}.md").

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -75,8 +75,9 @@ export const RulesyncRuleFrontmatterSchema = z.object({
     z.looseObject({
       // Steering inclusion mode: always | fileMatch | manual (string for forward compat).
       inclusion: z.optional(z.string()),
-      // Single glob string used when `inclusion: fileMatch`.
-      fileMatchPattern: z.optional(z.string()),
+      // Glob(s) used when `inclusion: fileMatch`. Kiro accepts a single string or
+      // a YAML array of globs.
+      fileMatchPattern: z.optional(z.union([z.string(), z.array(z.string())])),
     }),
   ),
   takt: z.optional(


### PR DESCRIPTION
## Summary

Maps rulesync rule frontmatter onto Kiro's steering `inclusion` modes so `.kiro/steering/*.md` files are no longer all implicitly always-on.

Kiro reads an `inclusion` frontmatter block at the top of each steering file (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`) to decide when it is loaded. Previously rulesync emitted every steering file without that block, so each was treated as `always`.

This is the self-contained slice of #1783 that does **not** depend on the IDE-vs-CLI framing decision. The other items (IDE Markdown subagents, `.kiro.hook` hooks, global scope, and the Powers bundle) remain a maintainer call and are intentionally **not** addressed here.

## Mapping

For non-root steering files (`deriveKiroInclusion`):
1. An explicit `kiro.inclusion` block round-trips as-is (with `fileMatchPattern` from the block, or derived from `globs` for `fileMatch`).
2. Otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` with a comma-joined `fileMatchPattern`, scoping the rule to matching files.
3. Otherwise the file stays `always` — written plain (no block), matching Kiro's no-frontmatter default.

The root overview index stays plain so Kiro always loads it.

## Changes

- `deriveKiroInclusion` + reworked `KiroRule.fromRulesyncRule` / `toRulesyncRule` (round-trips inclusion into the rulesync `kiro` block + `globs`).
- New `kiro` frontmatter block on the rulesync rule schema (`inclusion`, `fileMatchPattern`).
- Unit tests for `deriveKiroInclusion` and fromRulesyncRule/toRulesyncRule round-trip; docs updated (skill docs synced).

## Verification

- `pnpm cicheck:code` passes (251 files, 6259 tests).
- Manual generate confirmed: glob-scoped rules get `inclusion: fileMatch`; globless rules stay plain.

Part of #1783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
