### PR TITLE
feat(junie): model the full subagent frontmatter field set

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -316,6 +316,7 @@
     "withoptions",
     "moonshotai",
     "kimi",
+    "writerside",
     "wrappy",
     "wscript",
     "XVCJ",

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -282,6 +282,15 @@ opencode: # for OpenCode-specific parameters
       "git diff": allow
 kilo: # for Kilo-specific parameters
   mode: all # (optional, defaults to "all") use "subagent" for hidden/subagent-only agents
+junie: # for JetBrains Junie CLI specific parameters (.junie/agents/*.md)
+  tools: ["Read", "Grep", "Edit"] # allowed tools
+  disallowedTools: ["Bash", "WebSearch"] # disallowed tools
+  mcpServers: ["github"] # MCP servers the subagent may use
+  model: sonnet # model id
+  reasoningLevel: high # low | medium | high
+  maxTurns: 20 # max agentic turns
+  skills: ["kotlin", "writerside"] # Agent Skills to utilize
+  allowPromptArgument: true # whether the subagent accepts a prompt argument
 takt: # takt specific parameters (optional; emitted under .takt/facets/personas/)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
 ---

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -282,6 +282,15 @@ opencode: # for OpenCode-specific parameters
       "git diff": allow
 kilo: # for Kilo-specific parameters
   mode: all # (optional, defaults to "all") use "subagent" for hidden/subagent-only agents
+junie: # for JetBrains Junie CLI specific parameters (.junie/agents/*.md)
+  tools: ["Read", "Grep", "Edit"] # allowed tools
+  disallowedTools: ["Bash", "WebSearch"] # disallowed tools
+  mcpServers: ["github"] # MCP servers the subagent may use
+  model: sonnet # model id
+  reasoningLevel: high # low | medium | high
+  maxTurns: 20 # max agentic turns
+  skills: ["kotlin", "writerside"] # Agent Skills to utilize
+  allowPromptArgument: true # whether the subagent accepts a prompt argument
 takt: # takt specific parameters (optional; emitted under .takt/facets/personas/)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
 ---

--- a/src/features/subagents/junie-subagent.test.ts
+++ b/src/features/subagents/junie-subagent.test.ts
@@ -43,6 +43,37 @@ describe("JunieSubagentFrontmatterSchema", () => {
     const invalidName = { name: 123, description: "A test agent" };
     expect(() => JunieSubagentFrontmatterSchema.parse(invalidName)).toThrow();
   });
+
+  it("should accept the full documented field set", () => {
+    const frontmatter = {
+      description: "Review a change and propose a safe patch",
+      name: "code-review-helper",
+      tools: ["Read", "Grep", "Edit"],
+      disallowedTools: ["Bash", "WebSearch"],
+      mcpServers: ["github"],
+      model: "sonnet",
+      reasoningLevel: "high",
+      maxTurns: 20,
+      skills: ["kotlin", "writerside"],
+      allowPromptArgument: true,
+    };
+
+    expect(() => JunieSubagentFrontmatterSchema.parse(frontmatter)).not.toThrow();
+    const result = JunieSubagentFrontmatterSchema.parse(frontmatter);
+    expect(result.tools).toEqual(["Read", "Grep", "Edit"]);
+    expect(result.maxTurns).toBe(20);
+    expect(result.allowPromptArgument).toBe(true);
+    expect(result.reasoningLevel).toBe("high");
+  });
+
+  it("should reject a non-numeric maxTurns and non-boolean allowPromptArgument", () => {
+    expect(() =>
+      JunieSubagentFrontmatterSchema.parse({ description: "x", maxTurns: "twenty" }),
+    ).toThrow();
+    expect(() =>
+      JunieSubagentFrontmatterSchema.parse({ description: "x", allowPromptArgument: "yes" }),
+    ).toThrow();
+  });
 });
 
 describe("JunieSubagent", () => {
@@ -192,6 +223,54 @@ describe("JunieSubagent", () => {
       expect(junieSubagent.getBody()).toBe(body);
       expect(junieSubagent.getRelativeDirPath()).toBe(join(".junie", "agents"));
       expect(junieSubagent.getRelativeFilePath()).toBe("test-agent.md");
+    });
+
+    it("round-trips the documented fields through the junie section", () => {
+      const rulesyncFrontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["junie"],
+        name: "code-review-helper",
+        description: "Review a change",
+        junie: {
+          tools: ["Read", "Grep"],
+          disallowedTools: ["Bash"],
+          mcpServers: ["github"],
+          model: "sonnet",
+          reasoningLevel: "high",
+          maxTurns: 20,
+          skills: ["kotlin"],
+          allowPromptArgument: true,
+        },
+      };
+
+      const rulesyncSubagent = new RulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "code-review-helper.md",
+        frontmatter: rulesyncFrontmatter,
+        body: "body",
+      });
+
+      const junieSubagent = JunieSubagent.fromRulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: JunieSubagent.getSettablePaths().relativeDirPath,
+        rulesyncSubagent,
+        validate: true,
+      }) as JunieSubagent;
+
+      const fm = junieSubagent.getFrontmatter();
+      expect(fm.tools).toEqual(["Read", "Grep"]);
+      expect(fm.mcpServers).toEqual(["github"]);
+      expect(fm.reasoningLevel).toBe("high");
+      expect(fm.maxTurns).toBe(20);
+      expect(fm.allowPromptArgument).toBe(true);
+
+      // Round-trips back into the rulesync junie section.
+      const back = junieSubagent.toRulesyncSubagent().getFrontmatter().junie as Record<
+        string,
+        unknown
+      >;
+      expect(back.tools).toEqual(["Read", "Grep"]);
+      expect(back.maxTurns).toBe(20);
     });
 
     it("should not allow junie section to overwrite top-level name and description", () => {

--- a/src/features/subagents/junie-subagent.ts
+++ b/src/features/subagents/junie-subagent.ts
@@ -16,9 +16,29 @@ import {
   ToolSubagentSettablePaths,
 } from "./tool-subagent.js";
 
+/**
+ * Frontmatter for Junie CLI custom subagents (`.junie/agents/*.md`). Junie
+ * documents these fields; the schema stays loose (and the list fields accept a
+ * single string or an array) for forward compatibility.
+ *
+ * @see https://junie.jetbrains.com/docs/junie-cli-subagents.html
+ */
 export const JunieSubagentFrontmatterSchema = z.looseObject({
   name: z.optional(z.string()),
   description: z.string(),
+  // Tool access controls.
+  tools: z.optional(z.union([z.string(), z.array(z.string())])),
+  disallowedTools: z.optional(z.union([z.string(), z.array(z.string())])),
+  // MCP servers the subagent may use.
+  mcpServers: z.optional(z.union([z.string(), z.array(z.string())])),
+  // Model and reasoning controls (`reasoningLevel`: low | medium | high).
+  model: z.optional(z.string()),
+  reasoningLevel: z.optional(z.string()),
+  maxTurns: z.optional(z.number()),
+  // Agent Skills the subagent should utilize.
+  skills: z.optional(z.union([z.string(), z.array(z.string())])),
+  // Whether the subagent accepts a prompt argument.
+  allowPromptArgument: z.optional(z.boolean()),
 });
 
 export type JunieSubagentFrontmatter = z.infer<typeof JunieSubagentFrontmatterSchema>;


### PR DESCRIPTION
## Summary

First-classes the full documented frontmatter field set for Junie CLI custom subagents. rulesync's `junie-subagent.ts` declared only `name`/`description`; the other documented fields rode through the loose object untyped.

This addresses the subagent half of #1821. The command half is resolved by **confirmation** (see below).

## Subagent frontmatter

Per [Junie's docs](https://junie.jetbrains.com/docs/junie-cli-subagents.html), the supported fields are: `name`, `description`, `tools`, `disallowedTools`, `mcpServers`, `model`, `reasoningLevel` (low/medium/high), `maxTurns`, `skills`, `allowPromptArgument`. These are now first-class and typed (e.g. `maxTurns` is a number, `allowPromptArgument` a boolean), mirroring the claudecode adapter. The schema stays loose for forward compatibility, and list fields accept a string or an array. The fields round-trip through the rulesync `junie:` section.

## Command frontmatter — confirmed, no change needed

The maintainer flagged the command fields (`argument-hint`/`model`/`allowed-tools`) as needing confirmation. I verified against [Junie's custom slash commands docs](https://junie.jetbrains.com/docs/custom-slash-commands.html): command frontmatter supports **only `description`** (arguments are passed via `$argumentName` keywords in the body, not a frontmatter field). So `junie-command.ts` (already `{ description? }`) needs no change — the inferred fields are not real.

## Deferred

The additional subagent discovery roots — `.agents/` (project) and `~/.junie/agents/`, `~/.agents/` (user) — are a separate follow-up: the subagents processor scans a single directory per tool (`getSettablePaths`), so multi-root import discovery needs processor-level support. Noted on #1821.

## Changes

- Expanded `JunieSubagentFrontmatterSchema` + unit tests (full field set, type rejection, round-trip).
- `docs/reference/file-formats.md` subagent example gains a `junie:` block (skill docs synced).

## Verification

- `pnpm cicheck:code` passes (254 files, 6291 tests).

Part of #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
