### PR TITLE
Release v8.28.0

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -67,5 +67,11 @@
       "environment": {}
     }
   },
-  "share": "disabled"
+  "share": "disabled",
+  "instructions": [
+    ".github/workflows/AGENTS.md",
+    ".opencode/memories/coding-guidelines.md",
+    ".opencode/memories/feature-change-guidelines.md",
+    ".opencode/memories/testing-guidelines.md"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.27.0",
+  "version": "8.28.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.27.0";
+const getVersion = () => "8.28.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v8.28.0

See the draft release notes for details.

## Highlights
- New permission adapters: Warp, Antigravity IDE, Factory Droid
- New MCP adapters: Goose, OpenCode
- New ignore adapters: Antigravity CLI (.geminiignore), Devin (.devinignore)
- Hook event expansions for Copilot CLI, Codex CLI, Deep Agents
- Various bug fixes for Codex CLI permissions and symlink handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)