### PR TITLE
feat: prepend AI-generated summary to security scan email

### DIFF
--- a/scripts/security-scan-lib.test.ts
+++ b/scripts/security-scan-lib.test.ts
@@ -7,8 +7,10 @@ import { setupTestDirectory } from "../src/test-utils/test-directories.js";
 import type { OpenRouterClient, SecurityScanResult } from "./security-scan-lib.js";
 import {
   SecurityScanResultSchema,
+  buildSummaryInput,
   countHighSeverityVulnerabilities,
   formatEmailBody,
+  generateOverallSummary,
   getToonFiles,
   runSecurityScan,
   sendEmail,
@@ -269,6 +271,108 @@ describe("formatEmailBody", () => {
     const body = formatEmailBody({ results });
     expect(body).toContain("# Security Scan Report");
     expect(body).not.toContain("## ");
+  });
+
+  it("should prepend the AI summary when provided", () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("app.toon", {
+      vulnerabilities: [
+        { severity: "high", reason: "SQL injection", filePath: "src/db.ts", line: "L42" },
+      ],
+      summary: "Issues found",
+    });
+
+    const body = formatEmailBody({ results, overallSummary: "Overall the codebase is risky." });
+    expect(body).toContain("## AI Summary");
+    expect(body).toContain("Overall the codebase is risky.");
+    // Summary must appear before the per-file sections.
+    expect(body.indexOf("## AI Summary")).toBeLessThan(body.indexOf("## app.toon"));
+  });
+
+  it("should not render an AI Summary section for empty or whitespace summary", () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("app.toon", {
+      vulnerabilities: [
+        { severity: "high", reason: "SQL injection", filePath: "src/db.ts", line: "L42" },
+      ],
+      summary: "Issues found",
+    });
+
+    expect(formatEmailBody({ results, overallSummary: "" })).not.toContain("## AI Summary");
+    expect(formatEmailBody({ results, overallSummary: "   " })).not.toContain("## AI Summary");
+  });
+});
+
+describe("buildSummaryInput", () => {
+  it("should serialize files with their vulnerabilities", () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("app.toon", {
+      vulnerabilities: [
+        { severity: "high", reason: "SQL injection", filePath: "src/db.ts", line: "L42" },
+      ],
+      summary: "Issues found",
+    });
+
+    const input = buildSummaryInput({ results });
+    expect(input).toContain("File: app.toon");
+    expect(input).toContain("Summary: Issues found");
+    expect(input).toContain("- [high] src/db.ts L42: SQL injection");
+  });
+
+  it("should mark files with no vulnerabilities", () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("clean.toon", {
+      vulnerabilities: [],
+      summary: "Clean",
+    });
+
+    const input = buildSummaryInput({ results });
+    expect(input).toContain("File: clean.toon");
+    expect(input).toContain("- No vulnerabilities found");
+  });
+});
+
+describe("generateOverallSummary", () => {
+  it("should return the trimmed summary text from OpenRouter", async () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("app.toon", {
+      vulnerabilities: [
+        { severity: "critical", reason: "RCE", filePath: "src/exec.ts", line: "L10" },
+      ],
+      summary: "Critical issue",
+    });
+
+    const mockClient: OpenRouterClient = {
+      chat: {
+        send: vi.fn().mockResolvedValue({
+          choices: [{ message: { content: "  重大な脆弱性が見つかりました。  " } }],
+        }),
+      },
+    };
+
+    const summary = await generateOverallSummary({
+      client: mockClient,
+      model: "test-model",
+      results,
+    });
+
+    expect(summary).toBe("重大な脆弱性が見つかりました。");
+    expect(mockClient.chat.send).toHaveBeenCalledOnce();
+  });
+
+  it("should throw when no content returned", async () => {
+    const results = new Map<string, SecurityScanResult>();
+    results.set("app.toon", { vulnerabilities: [], summary: "Clean" });
+
+    const mockClient: OpenRouterClient = {
+      chat: {
+        send: vi.fn().mockResolvedValue({ choices: [{ message: { content: null } }] }),
+      },
+    };
+
+    await expect(
+      generateOverallSummary({ client: mockClient, model: "test-model", results }),
+    ).rejects.toThrow("No content returned from OpenRouter");
   });
 });
 

--- a/scripts/security-scan-lib.ts
+++ b/scripts/security-scan-lib.ts
@@ -120,14 +120,81 @@ export const runSecurityScan = async ({
   return SecurityScanResultSchema.parse(JSON.parse(content));
 };
 
-const HIGH_SEVERITIES = new Set(["high", "critical"]);
+const OVERALL_SUMMARY_PROMPT = `\
+You are a security analyst. Below are the complete results of an automated security scan across \
+multiple files of a codebase. Write a concise executive summary in Japanese (3-5 sentences) that \
+describes the overall security posture, highlights the most critical findings, and recommends \
+priorities for remediation. Output only the summary text as plain prose, without any headings, \
+bullet points, or markdown formatting.`;
 
-export const formatEmailBody = ({
+export const buildSummaryInput = ({
   results,
 }: {
   results: Map<string, SecurityScanResult>;
 }): string => {
+  const sections: string[] = [];
+
+  for (const [filename, result] of results.entries()) {
+    const lines = [`File: ${filename}`, `Summary: ${result.summary}`];
+
+    if (result.vulnerabilities.length === 0) {
+      lines.push("- No vulnerabilities found");
+    } else {
+      for (const vuln of result.vulnerabilities) {
+        lines.push(`- [${vuln.severity}] ${vuln.filePath} ${vuln.line}: ${vuln.reason}`);
+      }
+    }
+
+    sections.push(lines.join("\n"));
+  }
+
+  return sections.join("\n\n");
+};
+
+export const generateOverallSummary = async ({
+  client,
+  model,
+  results,
+}: {
+  client: OpenRouterClient;
+  model: string;
+  results: Map<string, SecurityScanResult>;
+}): Promise<string> => {
+  const input = buildSummaryInput({ results });
+
+  const response = await client.chat.send({
+    chatGenerationParams: {
+      model,
+      messages: [{ role: "user", content: `${OVERALL_SUMMARY_PROMPT}\n\n${input}` }],
+      stream: false as const,
+    },
+    httpReferer: "https://github.com/dyoshikawa/rulesync",
+    xTitle: "rulesync security-scan",
+  });
+
+  const content = response.choices?.[0]?.message?.content;
+
+  if (!content || typeof content !== "string") {
+    throw new Error("No content returned from OpenRouter");
+  }
+
+  return content.trim();
+};
+
+const HIGH_SEVERITIES = new Set(["high", "critical"]);
+
+export const formatEmailBody = ({
+  results,
+  overallSummary,
+}: {
+  results: Map<string, SecurityScanResult>;
+  overallSummary?: string;
+}): string => {
   let body = "# Security Scan Report\n\n";
+
+  if (overallSummary && overallSummary.trim().length > 0) {
+    body += `## AI Summary\n\n${overallSummary.trim()}\n\n---\n\n`;
+  }
 
   for (const [filename, result] of results.entries()) {
     const filtered = result.vulnerabilities.filter((v) => HIGH_SEVERITIES.has(v.severity));

--- a/scripts/security-scan-toon.ts
+++ b/scripts/security-scan-toon.ts
@@ -10,6 +10,7 @@ import type { SecurityScanResult } from "./security-scan-lib.js";
 import {
   countHighSeverityVulnerabilities,
   formatEmailBody,
+  generateOverallSummary,
   getToonFiles,
   runSecurityScan,
   sendEmail,
@@ -124,7 +125,17 @@ const main = async (): Promise<void> => {
   const date = new Date().toISOString().split("T")[0];
   const subject = `Security Scan Report - ${date} (${totalHighVulnerabilities} high+ vulnerabilities found)`;
 
-  const emailBody = formatEmailBody({ results: highSeverityResults });
+  // Generate an AI summary from the full scan results to prepend to the email.
+  // Failure here must not block the notification, so fall back to no summary.
+  let overallSummary: string | undefined;
+  try {
+    overallSummary = await generateOverallSummary({ client, model, results });
+    console.log("Generated AI summary");
+  } catch (error: unknown) {
+    console.warn(`Failed to generate AI summary: ${formatError(error)}`);
+  }
+
+  const emailBody = formatEmailBody({ results: highSeverityResults, overallSummary });
   await sendEmail({
     apiKey: resendApiKey,
     from: resendFromEmail,


### PR DESCRIPTION
## Summary

The Security Scan GitHub Actions workflow (`security-scan.yml`) sends an email when high+ severity vulnerabilities are found. This PR adds an AI-generated executive summary to the top of that email so reviewers get an at-a-glance overview before the detailed per-file findings.

### Changes

- **`scripts/security-scan-lib.ts`**
  - `buildSummaryInput()` — serializes the **entire** scan result set (filename, summary, every vulnerability) into a prompt-friendly text block.
  - `generateOverallSummary()` — calls OpenRouter with the full results and returns a concise Japanese executive summary (mirrors `runSecurityScan`'s call style, including `httpReferer`/`xTitle`).
  - `formatEmailBody()` — accepts an optional `overallSummary` and renders it as a `## AI Summary` section at the very top of the email (skipped when empty/whitespace).
- **`scripts/security-scan-toon.ts`**
  - Generates the summary from the full `results` map (not just high+ findings) before sending.
  - Wraps generation in `try/catch`: a failure logs a warning and falls back to no summary, so it never blocks the notification.
- **`scripts/security-scan-lib.test.ts`**
  - Tests for `buildSummaryInput`, `generateOverallSummary`, and the summary-prepending behavior of `formatEmailBody`.

### Design notes

- The summary input uses **all** scanned results (not filtered to high+) so the model has full context, matching the "結果全体をinputにする" requirement.
- Summary generation is best-effort and non-fatal.

## Test plan

- [x] `pnpm cicheck` passes (fmt / oxlint / typecheck / 6301 tests / content checks)
- [ ] Verified end-to-end on the next `workflow_dispatch` run (requires `OPENROUTER_API_KEY` / `RESEND_*` / `SECURITY_SCAN_*` secrets, available only in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
