### PR TITLE
fix: correct Zed web search tool name to search_web

### DIFF
--- a/src/features/permissions/zed-permissions.test.ts
+++ b/src/features/permissions/zed-permissions.test.ts
@@ -226,6 +226,28 @@ describe("ZedPermissions", () => {
       expect(json.permission.webfetch).toEqual({ "domain:github.com": "allow" });
     });
 
+    it("should round-trip websearch via Zed's search_web tool name", async () => {
+      const rulesyncPermissions = createRulesyncPermissions({
+        websearch: { "*": "allow" },
+      });
+
+      const generated = await ZedPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+
+      // `websearch` must map to Zed's built-in `search_web` tool, not `web_search`.
+      const generatedJson = JSON.parse(generated.getFileContent());
+      expect(generatedJson.agent.tool_permissions.tools.search_web.default).toBe("allow");
+      expect(generatedJson.agent.tool_permissions.tools.web_search).toBeUndefined();
+
+      await writeFileContent(join(testDir, ".zed", "settings.json"), generated.getFileContent());
+      const imported = await ZedPermissions.fromFile({ outputRoot: testDir });
+      const json = JSON.parse(imported.toRulesyncPermissions().getFileContent());
+
+      expect(json.permission.websearch).toEqual({ "*": "allow" });
+    });
+
     it("should pass through non-canonical mcp tool keys across generate → import", async () => {
       const rulesyncPermissions = createRulesyncPermissions({
         "mcp:context7:get-docs": { "*": "allow", secret: "deny" },

--- a/src/features/permissions/zed-permissions.ts
+++ b/src/features/permissions/zed-permissions.ts
@@ -53,7 +53,7 @@ const CANONICAL_TO_ZED_TOOL_NAMES: Record<string, string> = {
   read: "read_file",
   edit: "edit_file",
   webfetch: "fetch",
-  websearch: "web_search",
+  websearch: "search_web",
 };
 
 const ZED_TO_CANONICAL_TOOL_NAMES: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Summary

Zed's built-in web-search tool is named `search_web`, not `web_search`. The Zed permissions adapter mapped the canonical `websearch` category to `web_search`, so:

- a generated `agent.tool_permissions.tools.web_search` entry was silently ignored by Zed, and
- a real `search_web` entry did not round-trip back to `websearch` on reverse parse.

This changes the mapping in `src/features/permissions/zed-permissions.ts` to `websearch: "search_web"`. The reverse map is derived automatically, so no other code change is needed.

## Verification

Tool name confirmed against Zed's authoritative docs:
- https://github.com/zed-industries/zed/blob/main/docs/src/ai/tools.md (built-in tool list includes `search_web`)
- https://zed.dev/docs/ai/tool-permissions

The other mappings (`bash→terminal`, `read→read_file`, `edit→edit_file`, `webfetch→fetch`) were verified correct and left unchanged.

## Test

Added a round-trip test asserting `websearch ⇄ search_web` in `zed-permissions.test.ts`.

Closes #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)