### PR TITLE
release: v8.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.28.0",
+  "version": "8.28.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.28.0";
+const getVersion = () => "8.28.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v8.28.1.

### What's Changed

#### Bug Fixes
- Correct the Zed web search tool name to `search_web` in generated permissions (#1853)

#### Internal
- Prepend an AI-generated summary to the security scan email in the internal CI tooling (#1849)

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v8.28.0...v8.28.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)