### PR TITLE
test(generate): add regression tests for execution-order constraints on shared output files

### DIFF
--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -608,6 +608,72 @@ describe("generate", () => {
     });
   });
 
+  describe("execution order constraints", () => {
+    it("should run ignore before permissions to prevent shared settings.json data loss", async () => {
+      mockConfig.getFeatures.mockReturnValue(["ignore", "permissions"]);
+
+      const ignoreWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
+      const permissionsWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
+
+      vi.mocked(IgnoreProcessor).mockImplementation(function () {
+        return {
+          loadToolFiles: vi.fn().mockResolvedValue([]),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
+          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
+          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
+          writeAiFiles: ignoreWriteAiFiles,
+        } as unknown as IgnoreProcessor;
+      });
+      vi.mocked(PermissionsProcessor).mockImplementation(function () {
+        return {
+          loadToolFiles: vi.fn().mockResolvedValue([]),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
+          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
+          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
+          writeAiFiles: permissionsWriteAiFiles,
+        } as unknown as PermissionsProcessor;
+      });
+
+      await generate({ logger, config: mockConfig as never });
+
+      const ignoreCall = ignoreWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      const permissionsCall = permissionsWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      expect(ignoreCall).toBeLessThan(permissionsCall);
+    });
+
+    it("should run mcp before rules to prevent shared kilo.jsonc data loss", async () => {
+      mockConfig.getFeatures.mockReturnValue(["mcp", "rules"]);
+
+      const mcpWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
+      const rulesWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
+
+      vi.mocked(McpProcessor).mockImplementation(function () {
+        return {
+          loadToolFiles: vi.fn().mockResolvedValue([]),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
+          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
+          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
+          writeAiFiles: mcpWriteAiFiles,
+        } as unknown as McpProcessor;
+      });
+      vi.mocked(RulesProcessor).mockImplementation(function () {
+        return {
+          loadToolFiles: vi.fn().mockResolvedValue([]),
+          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
+          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
+          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
+          writeAiFiles: rulesWriteAiFiles,
+        } as unknown as RulesProcessor;
+      });
+
+      await generate({ logger, config: mockConfig as never });
+
+      const mcpCall = mcpWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      const rulesCall = rulesWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      expect(mcpCall).toBeLessThan(rulesCall);
+    });
+  });
+
   describe("all features combined", () => {
     it("should generate all features when all are enabled", async () => {
       mockConfig.getFeatures.mockReturnValue([

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -636,9 +636,11 @@ describe("generate", () => {
 
       await generate({ logger, config: mockConfig as never });
 
-      const ignoreCall = ignoreWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
-      const permissionsCall = permissionsWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
-      expect(ignoreCall).toBeLessThan(permissionsCall);
+      expect(ignoreWriteAiFiles).toHaveBeenCalled();
+      expect(permissionsWriteAiFiles).toHaveBeenCalled();
+      const ignoreCall = ignoreWriteAiFiles.mock.invocationCallOrder[0];
+      const permissionsCall = permissionsWriteAiFiles.mock.invocationCallOrder[0];
+      expect(ignoreCall).toBeLessThan(permissionsCall!);
     });
 
     it("should run mcp before rules to prevent shared kilo.jsonc data loss", async () => {
@@ -668,9 +670,11 @@ describe("generate", () => {
 
       await generate({ logger, config: mockConfig as never });
 
-      const mcpCall = mcpWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
-      const rulesCall = rulesWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
-      expect(mcpCall).toBeLessThan(rulesCall);
+      expect(mcpWriteAiFiles).toHaveBeenCalled();
+      expect(rulesWriteAiFiles).toHaveBeenCalled();
+      const mcpCall = mcpWriteAiFiles.mock.invocationCallOrder[0];
+      const rulesCall = rulesWriteAiFiles.mock.invocationCallOrder[0];
+      expect(mcpCall).toBeLessThan(rulesCall!);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add two regression tests to `generate.test.ts` that pin the implicit execution-order constraints documented in `generate.ts:188-204`
- `IgnoreProcessor` must run before `PermissionsProcessor` — both write to `.claude/settings.json` and reversing the order silently drops ignore-generated `deny` entries
- `McpProcessor` must run before `RulesProcessor` — both write to `kilo.jsonc` and reversing the order silently drops the `mcp`/`tools` block
- Each test asserts that both `writeAiFiles` mocks are actually invoked (`toHaveBeenCalled`), then compares `invocationCallOrder` to catch any reordering or parallelization regression

## References

- `src/lib/generate.ts` lines 188–204 — existing NOTEs that describe the constraint in prose

## Test plan

- [x] `pnpm test` — 53 tests pass (2 new)