### PR TITLE
test: add consistency checks for processor tool target schemas

### DIFF
--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -243,7 +243,7 @@ type ToolRuleFactory = {
  * Factory Map mapping tool targets to their rule factories.
  * Using Map to preserve insertion order for consistent iteration.
  */
-const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
+export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFactory>([
   [
     "agentsmd",
     {

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import { CommandsProcessorToolTargetSchema } from "../features/commands/commands-processor.js";
+import { HooksProcessorToolTargetSchema } from "../features/hooks/hooks-processor.js";
+import { IgnoreProcessorToolTargetSchema } from "../features/ignore/ignore-processor.js";
+import { McpProcessorToolTargetSchema } from "../features/mcp/mcp-processor.js";
+import { PermissionsProcessorToolTargetSchema } from "../features/permissions/permissions-processor.js";
+import { RulesProcessorToolTargetSchema } from "../features/rules/rules-processor.js";
+import { SkillsProcessorToolTargetSchema } from "../features/skills/skills-processor.js";
+import { SubagentsProcessorToolTargetSchema } from "../features/subagents/subagents-processor.js";
 import {
   ALL_TOOL_TARGETS,
   ALL_TOOL_TARGETS_WITH_WILDCARD,
@@ -229,5 +237,29 @@ describe("tool targets", () => {
       expect(() => ToolTargetsSchema.parse(validToolTargets)).not.toThrow();
       expect(() => RulesyncTargetsSchema.parse(validToolTargets)).not.toThrow();
     });
+  });
+
+  describe("processor tool target consistency", () => {
+    const allTargetSet = new Set<string>(ALL_TOOL_TARGETS);
+
+    const processors = [
+      { name: "RulesProcessor", schema: RulesProcessorToolTargetSchema },
+      { name: "CommandsProcessor", schema: CommandsProcessorToolTargetSchema },
+      { name: "HooksProcessor", schema: HooksProcessorToolTargetSchema },
+      { name: "IgnoreProcessor", schema: IgnoreProcessorToolTargetSchema },
+      { name: "McpProcessor", schema: McpProcessorToolTargetSchema },
+      { name: "PermissionsProcessor", schema: PermissionsProcessorToolTargetSchema },
+      { name: "SkillsProcessor", schema: SkillsProcessorToolTargetSchema },
+      { name: "SubagentsProcessor", schema: SubagentsProcessorToolTargetSchema },
+    ];
+
+    for (const { name, schema } of processors) {
+      it(`${name}: all tool targets must be a subset of ALL_TOOL_TARGETS`, () => {
+        const unknownTargets = schema.options.filter(
+          (target: string) => !allTargetSet.has(target),
+        );
+        expect(unknownTargets).toEqual([]);
+      });
+    }
   });
 });

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -5,7 +5,10 @@ import { HooksProcessorToolTargetSchema } from "../features/hooks/hooks-processo
 import { IgnoreProcessorToolTargetSchema } from "../features/ignore/ignore-processor.js";
 import { McpProcessorToolTargetSchema } from "../features/mcp/mcp-processor.js";
 import { PermissionsProcessorToolTargetSchema } from "../features/permissions/permissions-processor.js";
-import { RulesProcessorToolTargetSchema } from "../features/rules/rules-processor.js";
+import {
+  RulesProcessorToolTargetSchema,
+  toolRuleFactories,
+} from "../features/rules/rules-processor.js";
 import { SkillsProcessorToolTargetSchema } from "../features/skills/skills-processor.js";
 import { SubagentsProcessorToolTargetSchema } from "../features/subagents/subagents-processor.js";
 import {
@@ -255,11 +258,15 @@ describe("tool targets", () => {
 
     for (const { name, schema } of processors) {
       it(`${name}: all tool targets must be a subset of ALL_TOOL_TARGETS`, () => {
-        const unknownTargets = schema.options.filter(
-          (target: string) => !allTargetSet.has(target),
-        );
+        const unknownTargets = schema.options.filter((target: string) => !allTargetSet.has(target));
         expect(unknownTargets).toEqual([]);
       });
     }
+
+    it("RulesProcessor: schema options must match toolRuleFactories keys", () => {
+      const schemaTargets = [...RulesProcessorToolTargetSchema.options].toSorted();
+      const factoryTargets = [...toolRuleFactories.keys()].toSorted();
+      expect(schemaTargets).toEqual(factoryTargets);
+    });
   });
 });


### PR DESCRIPTION
## Background

The knowledge of which tools are supported by which processor feature is scattered across multiple places: each processor's hardcoded tool list (e.g. \`rulesProcessorToolTargets\` in \`rules-processor.ts\`), each processor's factory \`Map\`, and \`ALL_TOOL_TARGETS\` in \`src/types/tool-targets.ts\`. There was no runtime or test-time check that these lists stay in sync.

A concrete failure mode: adding a new tool to \`ALL_TOOL_TARGETS\` without updating a processor's schema list produces no type error and no test failure — the tool silently generates nothing for that feature.

## Changes

- Add a \`"processor tool target consistency"\` describe block to \`src/types/tool-targets.test.ts\` that verifies all 8 processor \`*ProcessorToolTargetSchema.options\` are subsets of \`ALL_TOOL_TARGETS\`
- Export \`toolRuleFactories\` from \`rules-processor.ts\` and add a parity test that \`RulesProcessorToolTargetSchema.options\` and \`toolRuleFactories\` keys are equal sets — catching drift between the hardcoded enum array and the factory Map at runtime

No production behavior changes. Test-only addition (plus one \`export\` keyword on an existing constant).

## Test plan

- [x] \`pnpm test\` — 9 new tests pass
- [x] \`pnpm oxlint\` — clean
- [x] \`pnpm fmt\` — applied
- [x] \`pnpm typecheck\` — clean (pre-existing errors in \`scripts/\` unrelated to this change)