### PR TITLE
test: extend processor schema-vs-factory parity checks to all processors

### DIFF
--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -99,7 +99,7 @@ export const CommandsProcessorToolTargetSchema = z.enum(commandsProcessorToolTar
  * Factory Map mapping tool targets to their command factories.
  * Using Map to preserve insertion order for consistent iteration.
  */
-const toolCommandFactories = new Map<CommandsProcessorToolTarget, ToolCommandFactory>([
+export const toolCommandFactories = new Map<CommandsProcessorToolTarget, ToolCommandFactory>([
   [
     "agentsmd",
     {

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -101,7 +101,7 @@ type ToolHooksFactory = {
   supportsMatcher: boolean;
 };
 
-const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFactory>([
+export const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFactory>([
   [
     "antigravity-cli",
     {

--- a/src/features/ignore/ignore-processor.ts
+++ b/src/features/ignore/ignore-processor.ts
@@ -65,7 +65,7 @@ type ToolIgnoreFactory = {
   };
 };
 
-const toolIgnoreFactories = new Map<IgnoreProcessorToolTarget, ToolIgnoreFactory>([
+export const toolIgnoreFactories = new Map<IgnoreProcessorToolTarget, ToolIgnoreFactory>([
   ["antigravity-cli", { class: AntigravityCliIgnore }],
   ["augmentcode", { class: AugmentcodeIgnore }],
   ["claudecode", { class: ClaudecodeIgnore }],

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -104,7 +104,7 @@ type ToolMcpFactory = {
  * Factory Map mapping tool targets to their MCP factories.
  * Using Map to preserve insertion order for consistent iteration.
  */
-const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
+export const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>([
   [
     "amp",
     {

--- a/src/features/permissions/permissions-processor.ts
+++ b/src/features/permissions/permissions-processor.ts
@@ -71,7 +71,10 @@ type ToolPermissionsFactory = {
   };
 };
 
-const toolPermissionsFactories = new Map<PermissionsProcessorToolTarget, ToolPermissionsFactory>([
+export const toolPermissionsFactories = new Map<
+  PermissionsProcessorToolTarget,
+  ToolPermissionsFactory
+>([
   [
     "amp",
     {

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -114,7 +114,7 @@ export const SkillsProcessorToolTargetSchema = z.enum(skillsProcessorToolTargetT
  * Factory Map mapping tool targets to their skill factories.
  * Using Map to preserve insertion order for consistent iteration.
  */
-const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>([
+export const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFactory>([
   [
     "agentsmd",
     {

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -94,7 +94,7 @@ export const SubagentsProcessorToolTargetSchema = z.enum(subagentsProcessorToolT
  * Factory Map mapping tool targets to their subagent factories.
  * Using Map to preserve insertion order for consistent iteration.
  */
-const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolSubagentFactory>([
+export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolSubagentFactory>([
   [
     "agentsmd",
     {

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -1,16 +1,34 @@
 import { describe, expect, it } from "vitest";
 
-import { CommandsProcessorToolTargetSchema } from "../features/commands/commands-processor.js";
-import { HooksProcessorToolTargetSchema } from "../features/hooks/hooks-processor.js";
-import { IgnoreProcessorToolTargetSchema } from "../features/ignore/ignore-processor.js";
-import { McpProcessorToolTargetSchema } from "../features/mcp/mcp-processor.js";
-import { PermissionsProcessorToolTargetSchema } from "../features/permissions/permissions-processor.js";
+import {
+  CommandsProcessorToolTargetSchema,
+  toolCommandFactories,
+} from "../features/commands/commands-processor.js";
+import {
+  HooksProcessorToolTargetSchema,
+  toolHooksFactories,
+} from "../features/hooks/hooks-processor.js";
+import {
+  IgnoreProcessorToolTargetSchema,
+  toolIgnoreFactories,
+} from "../features/ignore/ignore-processor.js";
+import { McpProcessorToolTargetSchema, toolMcpFactories } from "../features/mcp/mcp-processor.js";
+import {
+  PermissionsProcessorToolTargetSchema,
+  toolPermissionsFactories,
+} from "../features/permissions/permissions-processor.js";
 import {
   RulesProcessorToolTargetSchema,
   toolRuleFactories,
 } from "../features/rules/rules-processor.js";
-import { SkillsProcessorToolTargetSchema } from "../features/skills/skills-processor.js";
-import { SubagentsProcessorToolTargetSchema } from "../features/subagents/subagents-processor.js";
+import {
+  SkillsProcessorToolTargetSchema,
+  toolSkillFactories,
+} from "../features/skills/skills-processor.js";
+import {
+  SubagentsProcessorToolTargetSchema,
+  toolSubagentFactories,
+} from "../features/subagents/subagents-processor.js";
 import {
   ALL_TOOL_TARGETS,
   ALL_TOOL_TARGETS_WITH_WILDCARD,
@@ -245,28 +263,72 @@ describe("tool targets", () => {
   describe("processor tool target consistency", () => {
     const allTargetSet = new Set<string>(ALL_TOOL_TARGETS);
 
+    // This list is hand-maintained: a 9th processor added later must be appended
+    // here (and given a `factory` entry) or it will silently escape these checks,
+    // reintroducing the "scattered list drift" these tests guard against. There is
+    // no central processor registry to derive it from yet; keep it in sync by hand.
     const processors = [
-      { name: "RulesProcessor", schema: RulesProcessorToolTargetSchema },
-      { name: "CommandsProcessor", schema: CommandsProcessorToolTargetSchema },
-      { name: "HooksProcessor", schema: HooksProcessorToolTargetSchema },
-      { name: "IgnoreProcessor", schema: IgnoreProcessorToolTargetSchema },
-      { name: "McpProcessor", schema: McpProcessorToolTargetSchema },
-      { name: "PermissionsProcessor", schema: PermissionsProcessorToolTargetSchema },
-      { name: "SkillsProcessor", schema: SkillsProcessorToolTargetSchema },
-      { name: "SubagentsProcessor", schema: SubagentsProcessorToolTargetSchema },
+      {
+        name: "RulesProcessor",
+        schema: RulesProcessorToolTargetSchema,
+        factory: toolRuleFactories,
+      },
+      {
+        name: "CommandsProcessor",
+        schema: CommandsProcessorToolTargetSchema,
+        factory: toolCommandFactories,
+      },
+      {
+        name: "HooksProcessor",
+        schema: HooksProcessorToolTargetSchema,
+        factory: toolHooksFactories,
+      },
+      {
+        name: "IgnoreProcessor",
+        schema: IgnoreProcessorToolTargetSchema,
+        factory: toolIgnoreFactories,
+      },
+      { name: "McpProcessor", schema: McpProcessorToolTargetSchema, factory: toolMcpFactories },
+      {
+        name: "PermissionsProcessor",
+        schema: PermissionsProcessorToolTargetSchema,
+        factory: toolPermissionsFactories,
+      },
+      {
+        name: "SkillsProcessor",
+        schema: SkillsProcessorToolTargetSchema,
+        factory: toolSkillFactories,
+      },
+      {
+        name: "SubagentsProcessor",
+        schema: SubagentsProcessorToolTargetSchema,
+        factory: toolSubagentFactories,
+      },
     ];
 
     for (const { name, schema } of processors) {
+      // Direction asserted: every target a processor declares must exist in
+      // ALL_TOOL_TARGETS (catches a typo'd or stale target inside a processor).
+      // The reverse (every ALL_TOOL_TARGETS entry must appear in every processor)
+      // is intentionally NOT asserted, because not every tool supports every
+      // feature. Adding a tool to ALL_TOOL_TARGETS without wiring it into a given
+      // processor is therefore legitimate and is not caught here by design.
       it(`${name}: all tool targets must be a subset of ALL_TOOL_TARGETS`, () => {
         const unknownTargets = schema.options.filter((target: string) => !allTargetSet.has(target));
         expect(unknownTargets).toEqual([]);
       });
     }
 
-    it("RulesProcessor: schema options must match toolRuleFactories keys", () => {
-      const schemaTargets = [...RulesProcessorToolTargetSchema.options].toSorted();
-      const factoryTargets = [...toolRuleFactories.keys()].toSorted();
-      expect(schemaTargets).toEqual(factoryTargets);
-    });
+    // Stronger, bidirectional guarantee: a processor's schema enum must set-equal
+    // the keys of its factory Map. This catches drift in either direction within a
+    // single processor (a target in the schema but missing a factory, or a factory
+    // for a target the schema rejects). Applied to every processor, not just rules.
+    for (const { name, schema, factory } of processors) {
+      it(`${name}: schema options must match factory map keys`, () => {
+        const schemaTargets = [...schema.options].toSorted();
+        const factoryTargets = [...factory.keys()].toSorted();
+        expect(schemaTargets).toEqual(factoryTargets);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Background

Follow-ups from PR #1859, which added consistency checks for processor tool target schemas. That PR applied the strong schema-vs-factory parity check to `RulesProcessor` only and left low-severity clarity/coverage items for later. This PR addresses them.

## Changes

- **Extend parity check to every processor (item 2).** Export the seven remaining `tool*Factories` maps (commands, hooks, ignore, mcp, permissions, skills, subagents) — matching the visibility already given to `toolRuleFactories` — and assert that each processor's schema enum set-equals its factory `Map` keys. This catches drift in either direction (a target in the schema with no factory, or a factory for a target the schema rejects) uniformly across all 8 processors, not just rules.
- **Clarify the subset guarantee (item 1).** Document in comments that the subset check intentionally guards only the "a target declared by a processor must exist in `ALL_TOOL_TARGETS`" direction; the reverse is deliberately not asserted because not every tool supports every feature.
- **Note the hand-maintained list footgun (item 4).** Add a comment that the `processors` list must be kept in sync until a central processor registry exists.

Item 3 (`.toSorted()` requiring ES2023) needs no action: `.toSorted()` is already the dominant sorting idiom across `src` (45 occurrences), so this is consistent with the codebase.

The only production change is widening the visibility of existing `const` factory maps to `export`; there is no behavioral change. All checks pass via `pnpm cicheck`.

Closes #1866