### PR TITLE
test(generate): add real data-loss regression tests for shared output files

### DIFF
--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -74,6 +74,22 @@ const createMockAiFile = (filePath: string, content: string) => ({
   getFileContent: () => content,
 });
 
+/**
+ * Build a minimal processor mock whose `writeAiFiles` is the supplied spy, used
+ * by the execution-order tests to observe invocation order on a shared output
+ * file. `convertRulesyncFilesToToolFiles` returns an empty array because these
+ * tests only assert call order, not generated content; `writeAiFiles` is invoked
+ * unconditionally in `processFeatureGeneration` (see generate.ts), so the empty
+ * array does not skip the write.
+ */
+const createMockProcessorWith = (writeAiFiles: ReturnType<typeof vi.fn>) => ({
+  loadToolFiles: vi.fn().mockResolvedValue([]),
+  removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
+  loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
+  convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
+  writeAiFiles,
+});
+
 describe("generate", () => {
   let mockConfig: {
     getVerbose: ReturnType<typeof vi.fn>;
@@ -616,31 +632,19 @@ describe("generate", () => {
       const permissionsWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
 
       vi.mocked(IgnoreProcessor).mockImplementation(function () {
-        return {
-          loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
-          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
-          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: ignoreWriteAiFiles,
-        } as unknown as IgnoreProcessor;
+        return createMockProcessorWith(ignoreWriteAiFiles) as unknown as IgnoreProcessor;
       });
       vi.mocked(PermissionsProcessor).mockImplementation(function () {
-        return {
-          loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
-          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
-          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: permissionsWriteAiFiles,
-        } as unknown as PermissionsProcessor;
+        return createMockProcessorWith(permissionsWriteAiFiles) as unknown as PermissionsProcessor;
       });
 
       await generate({ logger, config: mockConfig as never });
 
       expect(ignoreWriteAiFiles).toHaveBeenCalled();
       expect(permissionsWriteAiFiles).toHaveBeenCalled();
-      const ignoreCall = ignoreWriteAiFiles.mock.invocationCallOrder[0];
-      const permissionsCall = permissionsWriteAiFiles.mock.invocationCallOrder[0];
-      expect(ignoreCall).toBeLessThan(permissionsCall!);
+      const ignoreCall = ignoreWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      const permissionsCall = permissionsWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      expect(ignoreCall).toBeLessThan(permissionsCall);
     });
 
     it("should run mcp before rules to prevent shared kilo.jsonc data loss", async () => {
@@ -650,31 +654,19 @@ describe("generate", () => {
       const rulesWriteAiFiles = vi.fn().mockResolvedValue({ count: 1, paths: [] });
 
       vi.mocked(McpProcessor).mockImplementation(function () {
-        return {
-          loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
-          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
-          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: mcpWriteAiFiles,
-        } as unknown as McpProcessor;
+        return createMockProcessorWith(mcpWriteAiFiles) as unknown as McpProcessor;
       });
       vi.mocked(RulesProcessor).mockImplementation(function () {
-        return {
-          loadToolFiles: vi.fn().mockResolvedValue([]),
-          removeOrphanAiFiles: vi.fn().mockResolvedValue(0),
-          loadRulesyncFiles: vi.fn().mockResolvedValue([{ file: "test" }]),
-          convertRulesyncFilesToToolFiles: vi.fn().mockResolvedValue([]),
-          writeAiFiles: rulesWriteAiFiles,
-        } as unknown as RulesProcessor;
+        return createMockProcessorWith(rulesWriteAiFiles) as unknown as RulesProcessor;
       });
 
       await generate({ logger, config: mockConfig as never });
 
       expect(mcpWriteAiFiles).toHaveBeenCalled();
       expect(rulesWriteAiFiles).toHaveBeenCalled();
-      const mcpCall = mcpWriteAiFiles.mock.invocationCallOrder[0];
-      const rulesCall = rulesWriteAiFiles.mock.invocationCallOrder[0];
-      expect(mcpCall).toBeLessThan(rulesCall!);
+      const mcpCall = mcpWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      const rulesCall = rulesWriteAiFiles.mock.invocationCallOrder[0] ?? 0;
+      expect(mcpCall).toBeLessThan(rulesCall);
     });
   });
 

--- a/src/lib/shared-file-data-loss.test.ts
+++ b/src/lib/shared-file-data-loss.test.ts
@@ -82,7 +82,9 @@ describe("shared output file data-loss regressions", () => {
 
   describe("kilo.jsonc (mcp before rules)", () => {
     it("preserves the mcp/tools block when rules registers instructions afterward", async () => {
-      // 1. mcp feature writes the `mcp` block to kilo.jsonc.
+      // 1. mcp feature writes the `mcp` (and `tools`) block to kilo.jsonc.
+      //    `enabledTools` produces a top-level `tools` map so we can assert it is
+      //    preserved too, not just the `mcp` block.
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: ".mcp.json",
@@ -91,6 +93,7 @@ describe("shared output file data-loss regressions", () => {
             "test-server": {
               command: "node",
               args: ["server.js"],
+              enabledTools: ["search"],
             },
           },
         }),
@@ -106,11 +109,13 @@ describe("shared output file data-loss regressions", () => {
       });
       await writeFileContent(rules.getFilePath(), rules.getFileContent());
 
-      // 3. The on-disk file must contain BOTH the mcp block and the instructions.
+      // 3. The on-disk file must contain BOTH the mcp/tools block and the
+      //    instructions.
       const finalContent = await readFileContent(join(testDir, "kilo.jsonc"));
       const kilo = JSON.parse(finalContent);
-      expect(kilo.mcp).toBeDefined();
       expect(kilo.mcp["test-server"]).toBeDefined();
+      expect(kilo.mcp["test-server"].type).toBe("local");
+      expect(kilo.tools["test-server_search"]).toBe(true);
       expect(kilo.instructions).toContain(join(".kilo", "rules", "coding.md"));
     });
   });

--- a/src/lib/shared-file-data-loss.test.ts
+++ b/src/lib/shared-file-data-loss.test.ts
@@ -1,0 +1,117 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+  RULESYNC_PERMISSIONS_FILE_NAME,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+import { ClaudecodeIgnore } from "../features/ignore/claudecode-ignore.js";
+import { RulesyncIgnore } from "../features/ignore/rulesync-ignore.js";
+import { KiloMcp } from "../features/mcp/kilo-mcp.js";
+import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
+import { ClaudecodePermissions } from "../features/permissions/claudecode-permissions.js";
+import { RulesyncPermissions } from "../features/permissions/rulesync-permissions.js";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import { readFileContent, writeFileContent } from "../utils/file.js";
+
+/**
+ * Integration regression tests for the execution-order constraints documented in
+ * `generate.ts`. Unlike the orchestration-order tests in `generate.test.ts` —
+ * which mock the processors and only assert `invocationCallOrder` — these tests
+ * exercise the *real* tool-file read-modify-write logic against a temp dir, so
+ * they actually fail if a writer drops the other feature's data from the shared
+ * file. They are the genuine data-loss guards the order tests stand in for.
+ */
+describe("shared output file data-loss regressions", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe(".claude/settings.json (ignore before permissions)", () => {
+    it("preserves ignore-written Read deny entries when permissions writes afterward", async () => {
+      // 1. ignore feature writes its Read(...) deny entries to settings.json.
+      const rulesyncIgnore = new RulesyncIgnore({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+        fileContent: ".env\nsecrets/**",
+      });
+      const ignore = await ClaudecodeIgnore.fromRulesyncIgnore({
+        outputRoot: testDir,
+        rulesyncIgnore,
+        options: {},
+      });
+      await writeFileContent(ignore.getFilePath(), ignore.getFileContent());
+
+      // 2. permissions feature reads that same settings.json and merges in its
+      //    own (Bash) entries. "Read" is NOT managed by this config, so the
+      //    ignore-written Read deny entries must survive.
+      const rulesyncPermissions = new RulesyncPermissions({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+        fileContent: JSON.stringify({
+          permission: {
+            bash: { "rm *": "deny" },
+          },
+        }),
+      });
+      const permissions = await ClaudecodePermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions,
+      });
+      await writeFileContent(permissions.getFilePath(), permissions.getFileContent());
+
+      // 3. The on-disk file must contain BOTH features' data.
+      const finalContent = await readFileContent(join(testDir, ".claude", "settings.json"));
+      const settings = JSON.parse(finalContent);
+      expect(settings.permissions.deny).toContain("Read(.env)");
+      expect(settings.permissions.deny).toContain("Read(secrets/**)");
+      expect(settings.permissions.deny).toContain("Bash(rm *)");
+    });
+  });
+
+  describe("kilo.jsonc (mcp before rules)", () => {
+    it("preserves the mcp/tools block when rules registers instructions afterward", async () => {
+      // 1. mcp feature writes the `mcp` block to kilo.jsonc.
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            "test-server": {
+              command: "node",
+              args: ["server.js"],
+            },
+          },
+        }),
+      });
+      const mcp = await KiloMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      await writeFileContent(mcp.getFilePath(), mcp.getFileContent());
+
+      // 2. rules feature registers non-root rules in the `instructions` key of the
+      //    same kilo.jsonc. This read-modify-write must preserve the mcp block.
+      const rules = await KiloMcp.fromInstructions({
+        outputRoot: testDir,
+        instructions: [join(".kilo", "rules", "coding.md")],
+      });
+      await writeFileContent(rules.getFilePath(), rules.getFileContent());
+
+      // 3. The on-disk file must contain BOTH the mcp block and the instructions.
+      const finalContent = await readFileContent(join(testDir, "kilo.jsonc"));
+      const kilo = JSON.parse(finalContent);
+      expect(kilo.mcp).toBeDefined();
+      expect(kilo.mcp["test-server"]).toBeDefined();
+      expect(kilo.instructions).toContain(join(".kilo", "rules", "coding.md"));
+    });
+  });
+});


### PR DESCRIPTION
## Background

Follow-ups from PR #1858, which added execution-order regression tests for the shared output files `.claude/settings.json` (ignore before permissions) and `kilo.jsonc` (mcp before rules).

As noted in the review, those tests mock every processor and only assert `invocationCallOrder` of a mocked `writeAiFiles`. Because the processors are fully mocked, the tests still pass even if the real read-modify-write merge/preserve logic were broken — they are orchestration-order tests, not the data-loss guards the PR description framed them as.

## Changes

- **Add genuine data-loss regression tests** (`src/lib/shared-file-data-loss.test.ts`). These exercise the *real* tool-file writers against a temp dir, in the documented order, and assert both features' data survives the shared file:
  - **ignore → permissions**: `ClaudecodeIgnore` writes `Read(...)` deny entries, then `ClaudecodePermissions` merges in its `Bash` entries. Asserts the ignore-written Read entries are preserved alongside the new Bash entry (the deny-entry data-loss the description claims to guard).
  - **mcp → rules**: `KiloMcp.fromRulesyncMcp` writes the `mcp` block, then `KiloMcp.fromInstructions` (the rules feature's kilo.jsonc registration) adds `instructions`. Asserts the mcp block is preserved alongside the instructions (the mcp-block data-loss).
- **Remove the duplicated inline processor mocks (item 4 / DRY).** Extract a module-level `createMockProcessorWith(writeAiFiles)` helper in `generate.test.ts`, used by both order tests, and document why returning an empty `convertRulesyncFilesToToolFiles` is safe (`writeAiFiles` runs unconditionally in `processFeatureGeneration`).
- **Consistent assertions (item 3).** Replace the lone non-null assertion (`permissionsCall!`) with the `?? 0` idiom already used elsewhere in the file.

Item 2 (the order constraint being minimally pinned) needs no change — the minimal invariant is the correct one, as the review itself noted.

All checks pass via `pnpm cicheck`.

Closes #1865