### PR TITLE
chore: release v8.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.28.1",
+  "version": "8.29.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.28.1";
+const getVersion = () => "8.29.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Release v8.29.0

This PR bumps the version to 8.29.0 in preparation for the release.

### Highlights

- feat: add Vibe Code (vibe) as a supported tool target (#1861)
- feat(copilotcli): add agent skills adapter (#1872)
- fix(warp): correct Windows permissions path and fold non-root rules into AGENTS.md (#1873, #1870)
- Centralize and prune per-tool path constants (#1869)
- Data-loss and processor-parity regression tests (#1868, #1867)

See the draft release notes for the full changelog.