### PR TITLE
feat(cursor): add first-class model, readonly, is_background subagent frontmatter fields

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -286,6 +286,10 @@ opencode: # for OpenCode-specific parameters
       "git diff": allow
 kilo: # for Kilo-specific parameters
   mode: all # (optional, defaults to "all") use "subagent" for hidden/subagent-only agents
+cursor: # for Cursor-specific parameters (generated to .cursor/agents/*.md)
+  model: inherit # (optional, defaults to "inherit") model id, or "inherit" to use the parent's model
+  readonly: false # (optional, defaults to false) restrict the subagent to read-only tools
+  is_background: false # (optional, defaults to false) run the subagent as a background agent
 junie: # for JetBrains Junie CLI specific parameters (generated to .junie/agents/*.md; also imported from .agents/*.md)
   tools: ["Read", "Grep", "Edit"] # allowed tools
   disallowedTools: ["Bash", "WebSearch"] # disallowed tools

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -286,6 +286,10 @@ opencode: # for OpenCode-specific parameters
       "git diff": allow
 kilo: # for Kilo-specific parameters
   mode: all # (optional, defaults to "all") use "subagent" for hidden/subagent-only agents
+cursor: # for Cursor-specific parameters (generated to .cursor/agents/*.md)
+  model: inherit # (optional, defaults to "inherit") model id, or "inherit" to use the parent's model
+  readonly: false # (optional, defaults to false) restrict the subagent to read-only tools
+  is_background: false # (optional, defaults to false) run the subagent as a background agent
 junie: # for JetBrains Junie CLI specific parameters (generated to .junie/agents/*.md; also imported from .agents/*.md)
   tools: ["Read", "Grep", "Edit"] # allowed tools
   disallowedTools: ["Bash", "WebSearch"] # disallowed tools

--- a/src/features/subagents/cursor-subagent.test.ts
+++ b/src/features/subagents/cursor-subagent.test.ts
@@ -304,6 +304,95 @@ Body content`;
     });
   });
 
+  describe("cursor-specific frontmatter fields", () => {
+    it("should parse model, readonly and is_background as first-class fields from file", async () => {
+      const subagentsDir = join(testDir, ".cursor", "agents");
+      const filePath = join(subagentsDir, "cursor-fields-agent.md");
+      const fileContent = `---
+name: Cursor Fields Agent
+description: Agent exercising cursor-specific fields
+model: inherit
+readonly: true
+is_background: false
+---
+
+Body content`;
+      await writeFileContent(filePath, fileContent);
+
+      const subagent = await CursorSubagent.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "cursor-fields-agent.md",
+        validate: true,
+      });
+
+      expect(subagent.getFrontmatter()).toEqual({
+        name: "Cursor Fields Agent",
+        description: "Agent exercising cursor-specific fields",
+        model: "inherit",
+        readonly: true,
+        is_background: false,
+      });
+    });
+
+    it("should round-trip model, readonly and is_background through the cursor section", () => {
+      const sourceFrontmatter = {
+        name: "Round Trip Agent",
+        description: "Round trip description",
+        model: "inherit",
+        readonly: true,
+        is_background: true,
+      };
+      const cursorSubagent = new CursorSubagent({
+        outputRoot: testDir,
+        relativeDirPath: ".cursor/agents",
+        relativeFilePath: "round-trip-agent.md",
+        frontmatter: sourceFrontmatter,
+        body: "Round trip body",
+        fileContent: stringifyFrontmatter("Round trip body", sourceFrontmatter),
+        validate: true,
+      });
+
+      // Export: cursor-specific fields land in the namespaced `cursor` section.
+      const rulesyncSubagent = cursorSubagent.toRulesyncSubagent();
+      expect(rulesyncSubagent.getFrontmatter().cursor).toEqual({
+        model: "inherit",
+        readonly: true,
+        is_background: true,
+      });
+
+      // Import: cursor section is re-applied as first-class frontmatter fields.
+      const roundTripped = CursorSubagent.fromRulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: ".cursor/agents",
+        rulesyncSubagent,
+        validate: true,
+      }) as CursorSubagent;
+
+      expect(roundTripped.getFrontmatter()).toEqual(sourceFrontmatter);
+    });
+
+    it("should reject invalid types for cursor-specific fields", () => {
+      const frontmatter = {
+        name: "Invalid Types Agent",
+        description: "Invalid types",
+        readonly: "yes",
+      } as any;
+
+      expect(
+        () =>
+          new CursorSubagent({
+            outputRoot: testDir,
+            relativeDirPath: ".cursor/agents",
+            relativeFilePath: "invalid-types-agent.md",
+            frontmatter,
+            body: "Body",
+            fileContent: stringifyFrontmatter("Body", frontmatter),
+            validate: true,
+          }),
+      ).toThrow();
+    });
+  });
+
   describe("fromFile", () => {
     it("should load CursorSubagent from file", async () => {
       const subagentsDir = join(testDir, ".cursor", "agents");

--- a/src/features/subagents/cursor-subagent.ts
+++ b/src/features/subagents/cursor-subagent.ts
@@ -20,6 +20,9 @@ import {
 const CursorSubagentFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.optional(z.string()),
+  model: z.optional(z.string()),
+  readonly: z.optional(z.boolean()),
+  is_background: z.optional(z.boolean()),
 });
 
 type CursorSubagentFrontmatter = z.infer<typeof CursorSubagentFrontmatterSchema>;


### PR DESCRIPTION
## Summary

Follow up Cursor upstream updates by promoting the documented Cursor subagent frontmatter fields to first-class, typed optional fields on `CursorSubagentFrontmatterSchema`:

- `model` (`string`, default `inherit`)
- `readonly` (`boolean`, default `false`)
- `is_background` (`boolean`, default `false`)

Previously these three fields already round-tripped through the `cursor:` section via `z.looseObject` passthrough, so there was no data-loss bug — this change makes them first-class so they are explicitly typed and validated (e.g. wrong types like `readonly: "yes"` are now rejected).

The schema keeps `z.looseObject`, and `toRulesyncSubagent`/`fromRulesyncSubagent` continue to spread the fields into/out of the namespaced `cursor:` section, so no processor wiring change was needed. Cursor subagents remain project-scope only (`.cursor/agents/`); no global scope was added.

## Out of scope (intentional)

The issue also mentions a canonical top-level `model` mapping. This is intentionally skipped: rulesync has no canonical top-level subagent `model`, and each tool keeps `model` in its own namespaced section (e.g. `claudecode.model`, `opencode.model`, `kilo.model`). Adding a canonical mapping would contradict that existing convention.

## Evidence

- https://cursor.com/docs/agent/subagents
- https://cursor.com/changelog/2-4

## Changes

- `src/features/subagents/cursor-subagent.ts`: extend schema with `model`, `readonly`, `is_background`.
- `src/features/subagents/cursor-subagent.test.ts`: add happy-path tests for parsing the fields as first-class and round-tripping them through the `cursor:` section (file import + generate), plus an invalid-type rejection test.
- `docs/reference/file-formats.md` and `skills/rulesync/file-formats.md` (auto-synced): document the `cursor:` subagent block.

## Verification

`pnpm cicheck` is fully green (code: fmt/oxlint/typecheck/267 test files, 6422 tests passing; content: skill-docs sync, cspell, secretlint all passing).

Closes #1882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
