### PR TITLE
feat(roo): emit native .roomodes custom modes instead of inert .roo/subagents/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,7 +331,7 @@ rulesync.local.jsonc
 **/.roo/skills/
 **/.rooignore
 **/.roo/mcp.json
-**/.roo/subagents/
+**/.roomodes
 **/.rovodev/AGENTS.md
 **/.rovodev/subagents/
 **/.rovodev/skills/

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -317,6 +317,14 @@ junie: # for JetBrains Junie CLI specific parameters (generated to .junie/agents
   allowPromptArgument: true # whether the subagent accepts a prompt argument
 takt: # takt specific parameters (optional; emitted under .takt/facets/personas/)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
+roo: # for Roo Code specific parameters (optional; aggregated into the root .roomodes file)
+  slug: planner # (optional) custom mode slug (^[a-zA-Z0-9-]+$); defaults to the sanitized file name
+  whenToUse: "When planning a task" # (optional) guidance for automated mode selection
+  customInstructions: "Be concise." # (optional) extra behavioral guidelines
+  roleDefinition: "You are the planner." # (optional) overrides the body as the mode's roleDefinition
+  groups: # (optional, defaults to ["read", "edit", "command", "mcp"]) tool access
+    - read
+    - ["edit", { fileRegex: "\\.md$", description: "Markdown files" }]
 ---
 
 You are the planner for any tasks.
@@ -331,6 +339,8 @@ Attention, again, you are just the planner, so though you can read any files and
 > **Cline note:** Cline file-based agents are emitted as YAML files (`<name>.yaml`) into `.cline/agents/` (project) and `~/.cline/agents/` (global, via `--global`). The file is a YAML frontmatter block (`name` required, `description`) followed by the system prompt body, matching Cline's agent config loader.
 
 > **Devin note:** Devin Local custom subagent profiles are emitted as `AGENT.md` files in a **directory-per-agent** layout: `.devin/agents/<name>/AGENT.md` (project) and `~/.config/devin/agents/<name>/AGENT.md` (global, via `--global`). The directory name `<name>` is the profile id (derived from the rulesync subagent file name). The `AGENT.md` is a YAML frontmatter block followed by the subagent's system prompt. Besides the shared `name`/`description`, the `devin` subagent block accepts these optional fields (all preserved on round-trip): `model` (string, override the subagent LLM), `allowed-tools` (list of strings, restrict available tools), `permissions` (object with `allow`/`deny`/`ask` string lists, override tool permissions), and `max-nesting` (integer, enable nested subagent spawning up to the given depth). See the [Devin subagents docs](https://docs.devin.ai/cli/subagents).
+
+> **Roo note (as of 2026-06-16):** Roo Code reads project custom modes from a single aggregated `.roomodes` file at the workspace root (YAML; JSON also accepted). Rulesync therefore collapses every Roo-targeted subagent into that file's `customModes` array — each subagent becomes one mode whose `slug` is derived from the file name (sanitized to `^[a-zA-Z0-9-]+$`), `name`/`description` come from the shared frontmatter, and `roleDefinition` is the subagent body. The optional `roo:` block supplies `groups` (defaults to `["read", "edit", "command", "mcp"]`), `whenToUse`, `customInstructions`, an explicit `slug`, and a `roleDefinition` override. (Roo's previous `.roo/subagents/` output was inert — Roo Code never read it.) See the [Roo custom-modes docs](https://roocodeinc.github.io/Roo-Code/features/custom-modes).
 
 > **Kilo note (as of 2026-05-13):** Kilo's documented default for user-defined agents is `mode: all`, which makes the agent available both as a top-level pick and as a subagent. Set `kilo.mode: subagent` to opt into hidden/subagent-only behavior.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -317,6 +317,14 @@ junie: # for JetBrains Junie CLI specific parameters (generated to .junie/agents
   allowPromptArgument: true # whether the subagent accepts a prompt argument
 takt: # takt specific parameters (optional; emitted under .takt/facets/personas/)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
+roo: # for Roo Code specific parameters (optional; aggregated into the root .roomodes file)
+  slug: planner # (optional) custom mode slug (^[a-zA-Z0-9-]+$); defaults to the sanitized file name
+  whenToUse: "When planning a task" # (optional) guidance for automated mode selection
+  customInstructions: "Be concise." # (optional) extra behavioral guidelines
+  roleDefinition: "You are the planner." # (optional) overrides the body as the mode's roleDefinition
+  groups: # (optional, defaults to ["read", "edit", "command", "mcp"]) tool access
+    - read
+    - ["edit", { fileRegex: "\\.md$", description: "Markdown files" }]
 ---
 
 You are the planner for any tasks.
@@ -331,6 +339,8 @@ Attention, again, you are just the planner, so though you can read any files and
 > **Cline note:** Cline file-based agents are emitted as YAML files (`<name>.yaml`) into `.cline/agents/` (project) and `~/.cline/agents/` (global, via `--global`). The file is a YAML frontmatter block (`name` required, `description`) followed by the system prompt body, matching Cline's agent config loader.
 
 > **Devin note:** Devin Local custom subagent profiles are emitted as `AGENT.md` files in a **directory-per-agent** layout: `.devin/agents/<name>/AGENT.md` (project) and `~/.config/devin/agents/<name>/AGENT.md` (global, via `--global`). The directory name `<name>` is the profile id (derived from the rulesync subagent file name). The `AGENT.md` is a YAML frontmatter block followed by the subagent's system prompt. Besides the shared `name`/`description`, the `devin` subagent block accepts these optional fields (all preserved on round-trip): `model` (string, override the subagent LLM), `allowed-tools` (list of strings, restrict available tools), `permissions` (object with `allow`/`deny`/`ask` string lists, override tool permissions), and `max-nesting` (integer, enable nested subagent spawning up to the given depth). See the [Devin subagents docs](https://docs.devin.ai/cli/subagents).
+
+> **Roo note (as of 2026-06-16):** Roo Code reads project custom modes from a single aggregated `.roomodes` file at the workspace root (YAML; JSON also accepted). Rulesync therefore collapses every Roo-targeted subagent into that file's `customModes` array — each subagent becomes one mode whose `slug` is derived from the file name (sanitized to `^[a-zA-Z0-9-]+$`), `name`/`description` come from the shared frontmatter, and `roleDefinition` is the subagent body. The optional `roo:` block supplies `groups` (defaults to `["read", "edit", "command", "mcp"]`), `whenToUse`, `customInstructions`, an explicit `slug`, and a `roleDefinition` override. (Roo's previous `.roo/subagents/` output was inert — Roo Code never read it.) See the [Roo custom-modes docs](https://roocodeinc.github.io/Roo-Code/features/custom-modes).
 
 > **Kilo note (as of 2026-05-13):** Kilo's documented default for user-defined agents is `mode: all`, which makes the agent available both as a top-level pick and as a subagent. Set `kilo.mode: subagent` to opt into hidden/subagent-only behavior.
 

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -350,7 +350,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "roo", feature: "skills", entry: "**/.roo/skills/" },
   { target: "roo", feature: "ignore", entry: "**/.rooignore" },
   { target: "roo", feature: "mcp", entry: "**/.roo/mcp.json" },
-  { target: "roo", feature: "subagents", entry: "**/.roo/subagents/" },
+  { target: "roo", feature: "subagents", entry: "**/.roomodes" },
 
   // Rovodev
   {

--- a/src/constants/roo-paths.ts
+++ b/src/constants/roo-paths.ts
@@ -3,17 +3,13 @@ import { join } from "node:path";
 export const ROO_DIR = ".roo";
 export const ROO_COMMANDS_DIR_PATH = join(ROO_DIR, "commands");
 export const ROO_SKILLS_DIR_PATH = join(ROO_DIR, "skills");
-export const ROO_SUBAGENTS_DIR_PATH = join(ROO_DIR, "subagents");
 export const ROO_MCP_FILE_NAME = "mcp.json";
 export const ROO_IGNORE_FILE_NAME = ".rooignore";
 
 /**
  * Roo Code reads project-level custom modes from a single aggregated
- * `.roomodes` file at the workspace root (YAML; JSON also accepted).
- * Global-level custom modes live in `custom_modes.yaml` inside Roo's settings
- * directory (`~/.roo/`). rulesync emits the project-scope `.roomodes` file.
+ * `.roomodes` file at the workspace root (YAML; JSON also accepted). rulesync
+ * emits the project-scope `.roomodes` file.
  * @see https://roocodeinc.github.io/Roo-Code/features/custom-modes
  */
 export const ROO_MODES_FILE_NAME = ".roomodes";
-export const ROO_GLOBAL_MODES_DIR_PATH = ROO_DIR;
-export const ROO_GLOBAL_MODES_FILE_NAME = "custom_modes.yaml";

--- a/src/constants/roo-paths.ts
+++ b/src/constants/roo-paths.ts
@@ -6,3 +6,14 @@ export const ROO_SKILLS_DIR_PATH = join(ROO_DIR, "skills");
 export const ROO_SUBAGENTS_DIR_PATH = join(ROO_DIR, "subagents");
 export const ROO_MCP_FILE_NAME = "mcp.json";
 export const ROO_IGNORE_FILE_NAME = ".rooignore";
+
+/**
+ * Roo Code reads project-level custom modes from a single aggregated
+ * `.roomodes` file at the workspace root (YAML; JSON also accepted).
+ * Global-level custom modes live in `custom_modes.yaml` inside Roo's settings
+ * directory (`~/.roo/`). rulesync emits the project-scope `.roomodes` file.
+ * @see https://roocodeinc.github.io/Roo-Code/features/custom-modes
+ */
+export const ROO_MODES_FILE_NAME = ".roomodes";
+export const ROO_GLOBAL_MODES_DIR_PATH = ROO_DIR;
+export const ROO_GLOBAL_MODES_FILE_NAME = "custom_modes.yaml";

--- a/src/e2e/e2e-subagents.spec.ts
+++ b/src/e2e/e2e-subagents.spec.ts
@@ -87,6 +87,10 @@ describe("E2E: subagents", () => {
       target: "goose",
       outputPath: join(".goose", "recipes", "subagents", "planner.yaml"),
     },
+    {
+      target: "roo",
+      outputPath: ".roomodes",
+    },
   ])("should generate $target subagents", async ({ target, outputPath }) => {
     const testDir = getTestDir();
 
@@ -112,30 +116,30 @@ You are the planner. Analyze files and create a plan.
     expect(generatedContent).toContain("Analyze files and create a plan.");
   });
 
-  it.each([
-    { target: "agentsmd", outputPath: join(".agents", "subagents", "planner.md") },
-    { target: "roo", outputPath: join(".roo", "subagents", "planner.md") },
-  ])("should generate $target simulated subagents", async ({ target, outputPath }) => {
-    const testDir = getTestDir();
+  it.each([{ target: "agentsmd", outputPath: join(".agents", "subagents", "planner.md") }])(
+    "should generate $target simulated subagents",
+    async ({ target, outputPath }) => {
+      const testDir = getTestDir();
 
-    const subagentContent = `---
+      const subagentContent = `---
 name: planner
 targets: ["*"]
 description: "Plans implementation tasks"
 ---
 You are the planner. Analyze files and create a plan.
 `;
-    await writeFileContent(
-      join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
-      subagentContent,
-    );
+      await writeFileContent(
+        join(testDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
+        subagentContent,
+      );
 
-    await runGenerate({ target, features: "subagents", simulateSubagents: true });
+      await runGenerate({ target, features: "subagents", simulateSubagents: true });
 
-    const generatedContent = await readFileContent(join(testDir, outputPath));
-    expect(generatedContent).toContain("planner");
-    expect(generatedContent).toContain("Analyze files and create a plan.");
-  });
+      const generatedContent = await readFileContent(join(testDir, outputPath));
+      expect(generatedContent).toContain("planner");
+      expect(generatedContent).toContain("Analyze files and create a plan.");
+    },
+  );
 
   it("should preserve opencode.mode when generating OpenCode subagents", async () => {
     const testDir = getTestDir();

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -28,7 +28,6 @@ import { RulesyncSkill } from "../skills/rulesync-skill.js";
 import { SkillsProcessor } from "../skills/skills-processor.js";
 import { AgentsmdSubagent } from "../subagents/agentsmd-subagent.js";
 import { GeminiCliSubagent } from "../subagents/geminicli-subagent.js";
-import { RooSubagent } from "../subagents/roo-subagent.js";
 import { RovodevSubagent } from "../subagents/rovodev-subagent.js";
 import { SubagentsProcessor } from "../subagents/subagents-processor.js";
 import { AgentsMdRule } from "./agentsmd-rule.js";
@@ -574,15 +573,14 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
   [
     "roo",
     {
+      // Roo subagents are native now (aggregated into `.roomodes`), so no
+      // simulated `additionalConventions.subagents` block is needed — mirrors
+      // how native subagent tools like geminicli are wired.
       class: RooRule,
       meta: {
         extension: "md",
         supportsGlobal: false,
         ruleDiscoveryMode: "auto",
-        additionalConventions: {
-          subagents: { subagentClass: RooSubagent },
-        },
-        createsSeparateConventionsRule: true,
       },
     },
   ],

--- a/src/features/subagents/roo-subagent.test.ts
+++ b/src/features/subagents/roo-subagent.test.ts
@@ -1,42 +1,49 @@
 import { join } from "node:path";
 
+import { load } from "js-yaml";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { writeFileContent } from "../../utils/file.js";
-import { RooSubagent } from "./roo-subagent.js";
+import { RooMode, RooSubagent, sanitizeRooSlug } from "./roo-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
-import {
-  SimulatedSubagentFrontmatter,
-  SimulatedSubagentFrontmatterSchema,
-} from "./simulated-subagent.js";
+
+function makeRulesyncSubagent({
+  testDir,
+  relativeFilePath = "planner.md",
+  frontmatter,
+  body = "You are the planner.",
+}: {
+  testDir: string;
+  relativeFilePath?: string;
+  frontmatter: Record<string, unknown>;
+  body?: string;
+}): RulesyncSubagent {
+  return new RulesyncSubagent({
+    outputRoot: testDir,
+    relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+    relativeFilePath,
+    frontmatter: frontmatter as never,
+    body,
+    validate: true,
+  });
+}
+
+function parseModes(content: string): RooMode[] {
+  const parsed = load(content) as { customModes: RooMode[] };
+  return parsed.customModes;
+}
 
 describe("RooSubagent", () => {
   let testDir: string;
   let cleanup: () => Promise<void>;
 
-  const validMarkdownContent = `---
-name: Test Roo Agent
-description: Test roo agent description
----
-
-This is the body of the roo agent.
-It can be multiline.`;
-
-  const invalidMarkdownContent = `---
-# Missing required fields
-invalid: true
----
-
-Body content`;
-
-  const markdownWithoutFrontmatter = `This is just plain content without frontmatter.`;
-
   beforeEach(async () => {
     const testSetup = await setupTestDirectory();
     testDir = testSetup.testDir;
     cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
   });
 
   afterEach(async () => {
@@ -45,305 +52,235 @@ Body content`;
   });
 
   describe("getSettablePaths", () => {
-    it("should return correct paths for roo subagents", () => {
+    it("writes the aggregated .roomodes at the workspace root", () => {
       const paths = RooSubagent.getSettablePaths();
-      expect(paths).toEqual({
-        relativeDirPath: ".roo/subagents",
-      });
+      expect(paths).toEqual({ relativeDirPath: "." });
     });
   });
 
-  describe("constructor", () => {
-    it("should create instance with valid markdown content", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "Test Roo Agent",
-          description: "Test roo agent description",
-        },
-        body: "This is the body of the roo agent.\nIt can be multiline.",
-        validate: true,
-      });
-
-      expect(subagent).toBeInstanceOf(RooSubagent);
-      expect(subagent.getBody()).toBe("This is the body of the roo agent.\nIt can be multiline.");
-      expect(subagent.getFrontmatter()).toEqual({
-        name: "Test Roo Agent",
-        description: "Test roo agent description",
-      });
+  describe("sanitizeRooSlug", () => {
+    it("lowercases and collapses invalid characters into hyphens", () => {
+      expect(sanitizeRooSlug("My Cool Agent!")).toBe("my-cool-agent");
+      expect(sanitizeRooSlug("planner_v2")).toBe("planner-v2");
+      expect(sanitizeRooSlug("--Lead--")).toBe("lead");
     });
 
-    it("should create instance with empty name and description", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "",
-          description: "",
-        },
-        body: "This is a roo agent without name or description.",
-        validate: true,
-      });
-
-      expect(subagent.getBody()).toBe("This is a roo agent without name or description.");
-      expect(subagent.getFrontmatter()).toEqual({
-        name: "",
-        description: "",
-      });
-    });
-
-    it("should create instance without validation when validate is false", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test body",
-        validate: false,
-      });
-
-      expect(subagent).toBeInstanceOf(RooSubagent);
-    });
-
-    it("should throw error for invalid frontmatter when validation is enabled", () => {
-      expect(
-        () =>
-          new RooSubagent({
-            outputRoot: testDir,
-            relativeDirPath: ".roo/subagents",
-            relativeFilePath: "invalid-agent.md",
-            frontmatter: {
-              // Missing required fields
-            } as SimulatedSubagentFrontmatter,
-            body: "Body content",
-            validate: true,
-          }),
-      ).toThrow();
-    });
-  });
-
-  describe("getBody", () => {
-    it("should return the body content", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "This is the body content.\nWith multiple lines.",
-        validate: true,
-      });
-
-      expect(subagent.getBody()).toBe("This is the body content.\nWith multiple lines.");
-    });
-  });
-
-  describe("getFrontmatter", () => {
-    it("should return frontmatter with name and description", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "Test Roo Agent",
-          description: "Test roo agent",
-        },
-        body: "Test body",
-        validate: true,
-      });
-
-      const frontmatter = subagent.getFrontmatter();
-      expect(frontmatter).toEqual({
-        name: "Test Roo Agent",
-        description: "Test roo agent",
-      });
-    });
-  });
-
-  describe("toRulesyncSubagent", () => {
-    it("should throw error as it is a simulated file", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test body",
-        validate: true,
-      });
-
-      expect(() => subagent.toRulesyncSubagent()).toThrow(
-        "Not implemented because it is a SIMULATED file.",
-      );
+    it("falls back to 'mode' when nothing usable remains", () => {
+      expect(sanitizeRooSlug("!!!")).toBe("mode");
     });
   });
 
   describe("fromRulesyncSubagent", () => {
-    it("should create RooSubagent from RulesyncSubagent", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
+    it("maps a single subagent to one mode with default groups", () => {
+      const rulesyncSubagent = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "Planner Agent.md",
         frontmatter: {
           targets: ["roo"],
-          name: "Test Agent",
-          description: "Test description from rulesync",
+          name: "Planner",
+          description: "Plans tasks",
         },
-        body: "Test agent content",
-        validate: true,
+        body: "You are the planner.",
       });
 
-      const rooSubagent = RooSubagent.fromRulesyncSubagent({
+      const roo = RooSubagent.fromRulesyncSubagent({
         outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         rulesyncSubagent,
         validate: true,
       }) as RooSubagent;
 
-      expect(rooSubagent).toBeInstanceOf(RooSubagent);
-      expect(rooSubagent.getBody()).toBe("Test agent content");
-      expect(rooSubagent.getFrontmatter()).toEqual({
-        name: "Test Agent",
-        description: "Test description from rulesync",
-      });
-      expect(rooSubagent.getRelativeFilePath()).toBe("test-agent.md");
-      expect(rooSubagent.getRelativeDirPath()).toBe(".roo/subagents");
-    });
+      expect(roo).toBeInstanceOf(RooSubagent);
+      expect(roo.getRelativeFilePath()).toBe(".roomodes");
+      expect(roo.getRelativeDirPath()).toBe(".");
 
-    it("should handle RulesyncSubagent with different file extensions", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "complex-agent.txt",
-        frontmatter: {
-          targets: ["roo"],
-          name: "Complex Agent",
-          description: "Complex agent",
-        },
-        body: "Complex content",
-        validate: true,
-      });
-
-      const rooSubagent = RooSubagent.fromRulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        rulesyncSubagent,
-        validate: true,
-      }) as RooSubagent;
-
-      expect(rooSubagent.getRelativeFilePath()).toBe("complex-agent.txt");
-    });
-
-    it("should handle empty name and description", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: ["roo"],
-          name: "",
-          description: "",
-        },
-        body: "Test content",
-        validate: true,
-      });
-
-      const rooSubagent = RooSubagent.fromRulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        rulesyncSubagent,
-        validate: true,
-      }) as RooSubagent;
-
-      expect(rooSubagent.getFrontmatter()).toEqual({
-        name: "",
-        description: "",
+      const modes = parseModes(roo.getFileContent());
+      expect(modes).toHaveLength(1);
+      expect(modes[0]).toMatchObject({
+        slug: "planner-agent",
+        name: "Planner",
+        description: "Plans tasks",
+        roleDefinition: "You are the planner.",
+        groups: ["read", "edit", "command", "mcp"],
       });
     });
   });
 
-  describe("fromFile", () => {
-    it("should load RooSubagent from file", async () => {
-      const subagentsDir = join(testDir, ".roo", "subagents");
-      const filePath = join(subagentsDir, "test-file-agent.md");
+  describe("fromRulesyncSubagents", () => {
+    it("aggregates multiple subagents into one .roomodes file", () => {
+      const planner = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "planner.md",
+        frontmatter: { targets: ["roo"], name: "Planner", description: "Plans" },
+        body: "Planner role.",
+      });
+      const reviewer = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "reviewer.md",
+        frontmatter: { targets: ["roo"], name: "Reviewer", description: "Reviews" },
+        body: "Reviewer role.",
+      });
 
-      await writeFileContent(filePath, validMarkdownContent);
-
-      const subagent = await RooSubagent.fromFile({
+      const roo = RooSubagent.fromRulesyncSubagents({
         outputRoot: testDir,
-        relativeFilePath: "test-file-agent.md",
+        rulesyncSubagents: [planner, reviewer],
+      });
+
+      const modes = parseModes(roo.getFileContent());
+      expect(modes).toHaveLength(2);
+      expect(modes.map((m) => m.slug)).toEqual(["planner", "reviewer"]);
+    });
+
+    it("de-duplicates by slug so a later subagent wins", () => {
+      const first = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "planner.md",
+        frontmatter: { targets: ["roo"], name: "Planner", roo: { slug: "lead" } },
+        body: "First.",
+      });
+      const second = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "reviewer.md",
+        frontmatter: { targets: ["roo"], name: "Reviewer", roo: { slug: "lead" } },
+        body: "Second.",
+      });
+
+      const roo = RooSubagent.fromRulesyncSubagents({
+        outputRoot: testDir,
+        rulesyncSubagents: [first, second],
+      });
+
+      const modes = parseModes(roo.getFileContent());
+      expect(modes).toHaveLength(1);
+      expect(modes[0]?.slug).toBe("lead");
+      expect(modes[0]?.roleDefinition).toBe("Second.");
+    });
+
+    it("honors the roo: section for groups, whenToUse, customInstructions, and roleDefinition override", () => {
+      const rulesyncSubagent = makeRulesyncSubagent({
+        testDir,
+        relativeFilePath: "docs.md",
+        frontmatter: {
+          targets: ["roo"],
+          name: "Docs",
+          description: "Doc writer",
+          roo: {
+            groups: ["read", ["edit", { fileRegex: "\\.md$", description: "Markdown" }]],
+            whenToUse: "When editing docs",
+            customInstructions: "Be concise",
+            roleDefinition: "You only touch docs.",
+          },
+        },
+        body: "This body is overridden.",
+      });
+
+      const roo = RooSubagent.fromRulesyncSubagents({
+        outputRoot: testDir,
+        rulesyncSubagents: [rulesyncSubagent],
+      });
+
+      const modes = parseModes(roo.getFileContent());
+      expect(modes[0]).toMatchObject({
+        slug: "docs",
+        name: "Docs",
+        whenToUse: "When editing docs",
+        customInstructions: "Be concise",
+        roleDefinition: "You only touch docs.",
+      });
+      expect(modes[0]?.groups).toEqual([
+        "read",
+        ["edit", { fileRegex: "\\.md$", description: "Markdown" }],
+      ]);
+    });
+  });
+
+  describe("isTargetedByRulesyncSubagent", () => {
+    it("returns true when targets include roo", () => {
+      const rulesyncSubagent = makeRulesyncSubagent({
+        testDir,
+        frontmatter: { targets: ["roo"], name: "Planner" },
+      });
+      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
+    });
+
+    it("returns false when targets exclude roo", () => {
+      const rulesyncSubagent = makeRulesyncSubagent({
+        testDir,
+        frontmatter: { targets: ["copilot"], name: "Planner" },
+      });
+      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(false);
+    });
+  });
+
+  describe("fromFile and toRulesyncSubagents (import)", () => {
+    const roomodesContent = `customModes:
+  - slug: planner
+    name: Planner
+    description: Plans tasks
+    roleDefinition: You are the planner.
+    groups:
+      - read
+      - edit
+  - slug: reviewer
+    name: Reviewer
+    roleDefinition: You are the reviewer.
+    whenToUse: When reviewing code
+    customInstructions: Be thorough
+    groups:
+      - read
+`;
+
+    it("parses every custom mode from .roomodes", async () => {
+      await writeFileContent(join(testDir, ".roomodes"), roomodesContent);
+
+      const roo = await RooSubagent.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: ".roomodes",
         validate: true,
       });
 
-      expect(subagent).toBeInstanceOf(RooSubagent);
-      expect(subagent.getBody()).toBe("This is the body of the roo agent.\nIt can be multiline.");
-      expect(subagent.getFrontmatter()).toEqual({
-        name: "Test Roo Agent",
-        description: "Test roo agent description",
-      });
-      expect(subagent.getRelativeFilePath()).toBe("test-file-agent.md");
+      expect(roo).toBeInstanceOf(RooSubagent);
+      expect(roo.getModes()).toHaveLength(2);
     });
 
-    it("should handle file path with subdirectories", async () => {
-      const subagentsDir = join(testDir, ".roo", "subagents", "subdir");
-      const filePath = join(subagentsDir, "nested-agent.md");
+    it("fans out each mode into its own rulesync subagent", async () => {
+      await writeFileContent(join(testDir, ".roomodes"), roomodesContent);
 
-      await writeFileContent(filePath, validMarkdownContent);
-
-      const subagent = await RooSubagent.fromFile({
+      const roo = await RooSubagent.fromFile({
         outputRoot: testDir,
-        relativeFilePath: "subdir/nested-agent.md",
+        relativeFilePath: ".roomodes",
         validate: true,
       });
 
-      expect(subagent.getRelativeFilePath()).toBe("nested-agent.md");
+      const rulesyncSubagents = roo.toRulesyncSubagents();
+      expect(rulesyncSubagents).toHaveLength(2);
+
+      const planner = rulesyncSubagents[0];
+      expect(planner?.getRelativeFilePath()).toBe("planner.md");
+      expect(planner?.getBody()).toBe("You are the planner.");
+      expect(planner?.getFrontmatter()).toMatchObject({
+        targets: ["roo"],
+        name: "Planner",
+        description: "Plans tasks",
+      });
+
+      const reviewer = rulesyncSubagents[1];
+      expect(reviewer?.getFrontmatter()).toMatchObject({
+        name: "Reviewer",
+        roo: { whenToUse: "When reviewing code", customInstructions: "Be thorough" },
+      });
     });
 
-    it("should throw error when file does not exist", async () => {
-      await expect(
-        RooSubagent.fromFile({
-          outputRoot: testDir,
-          relativeFilePath: "non-existent-agent.md",
-          validate: true,
-        }),
-      ).rejects.toThrow();
-    });
-
-    it("should throw error when file contains invalid frontmatter", async () => {
-      const subagentsDir = join(testDir, ".roo", "subagents");
-      const filePath = join(subagentsDir, "invalid-agent.md");
-
-      await writeFileContent(filePath, invalidMarkdownContent);
-
-      await expect(
-        RooSubagent.fromFile({
-          outputRoot: testDir,
-          relativeFilePath: "invalid-agent.md",
-          validate: true,
-        }),
-      ).rejects.toThrow();
-    });
-
-    it("should handle file without frontmatter", async () => {
-      const subagentsDir = join(testDir, ".roo", "subagents");
-      const filePath = join(subagentsDir, "no-frontmatter.md");
-
-      await writeFileContent(filePath, markdownWithoutFrontmatter);
+    it("throws on invalid .roomodes", async () => {
+      await writeFileContent(
+        join(testDir, ".roomodes"),
+        "customModes:\n  - name: Missing slug and roleDefinition\n",
+      );
 
       await expect(
         RooSubagent.fromFile({
           outputRoot: testDir,
-          relativeFilePath: "no-frontmatter.md",
+          relativeFilePath: ".roomodes",
           validate: true,
         }),
       ).rejects.toThrow();
@@ -351,290 +288,40 @@ Body content`;
   });
 
   describe("validate", () => {
-    it("should return success for valid frontmatter", () => {
-      const subagent = new RooSubagent({
+    it("returns success for valid modes", () => {
+      const roo = new RooSubagent({
         outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "valid-agent.md",
-        frontmatter: {
-          name: "Valid Agent",
-          description: "Valid description",
-        },
-        body: "Valid body",
-        validate: false, // Skip validation in constructor to test validate method
-      });
-
-      const result = subagent.validate();
-      expect(result.success).toBe(true);
-      expect(result.error).toBeNull();
-    });
-
-    it("should handle frontmatter with additional properties", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "agent-with-extras.md",
-        frontmatter: {
-          name: "Agent",
-          description: "Agent with extra properties",
-          // Additional properties should be allowed but not validated
-          extra: "property",
-        } as any,
-        body: "Body content",
+        relativeDirPath: ".",
+        relativeFilePath: ".roomodes",
+        modes: [{ slug: "planner", name: "Planner", roleDefinition: "Role." }],
         validate: false,
       });
+      expect(roo.validate().success).toBe(true);
+    });
 
-      const result = subagent.validate();
-      // The validation should pass as long as required fields are present
-      expect(result.success).toBe(true);
+    it("throws in the constructor for an invalid mode when validation is enabled", () => {
+      expect(
+        () =>
+          new RooSubagent({
+            outputRoot: testDir,
+            relativeDirPath: ".",
+            relativeFilePath: ".roomodes",
+            modes: [{ slug: "planner" } as RooMode],
+            validate: true,
+          }),
+      ).toThrow();
     });
   });
 
-  describe("SimulatedSubagentFrontmatterSchema", () => {
-    it("should validate valid frontmatter with name and description", () => {
-      const validFrontmatter = {
-        name: "Test Agent",
-        description: "Test description",
-      };
-
-      const result = SimulatedSubagentFrontmatterSchema.parse(validFrontmatter);
-      expect(result).toEqual(validFrontmatter);
-    });
-
-    it("should throw error for frontmatter without name", () => {
-      const invalidFrontmatter = {
-        description: "Test description",
-      };
-
-      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
-    });
-
-    it("should accept frontmatter without description (description is optional)", () => {
-      const frontmatter = {
-        name: "Test Agent",
-      };
-
-      const result = SimulatedSubagentFrontmatterSchema.parse(frontmatter);
-      expect(result.name).toBe("Test Agent");
-      expect(result.description).toBeUndefined();
-    });
-
-    it("should throw error for frontmatter with invalid types", () => {
-      const invalidFrontmatter = {
-        name: 123, // Should be string
-        description: "Test",
-      };
-
-      expect(() => SimulatedSubagentFrontmatterSchema.parse(invalidFrontmatter)).toThrow();
-    });
-  });
-
-  describe("edge cases", () => {
-    it("should handle empty body content", () => {
-      const subagent = new RooSubagent({
+  describe("forDeletion", () => {
+    it("creates a minimal instance without parsing", () => {
+      const roo = RooSubagent.forDeletion({
         outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "empty-body.md",
-        frontmatter: {
-          name: "Empty Body Agent",
-          description: "Agent with empty body",
-        },
-        body: "",
-        validate: true,
+        relativeDirPath: ".",
+        relativeFilePath: ".roomodes",
       });
-
-      expect(subagent.getBody()).toBe("");
-      expect(subagent.getFrontmatter()).toEqual({
-        name: "Empty Body Agent",
-        description: "Agent with empty body",
-      });
-    });
-
-    it("should handle special characters in content", () => {
-      const specialContent =
-        "Special characters: @#$%^&*()\nUnicode: 你好世界 🌍\nQuotes: \"Hello 'World'\"";
-
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "special-char.md",
-        frontmatter: {
-          name: "Special Agent",
-          description: "Special characters test",
-        },
-        body: specialContent,
-        validate: true,
-      });
-
-      expect(subagent.getBody()).toBe(specialContent);
-      expect(subagent.getBody()).toContain("@#$%^&*()");
-      expect(subagent.getBody()).toContain("你好世界 🌍");
-      expect(subagent.getBody()).toContain("\"Hello 'World'\"");
-    });
-
-    it("should handle very long content", () => {
-      const longContent = "A".repeat(10000);
-
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "long-content.md",
-        frontmatter: {
-          name: "Long Agent",
-          description: "Long content test",
-        },
-        body: longContent,
-        validate: true,
-      });
-
-      expect(subagent.getBody()).toBe(longContent);
-      expect(subagent.getBody().length).toBe(10000);
-    });
-
-    it("should handle multi-line name and description", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "multiline-fields.md",
-        frontmatter: {
-          name: "Multi-line\nAgent Name",
-          description: "This is a multi-line\ndescription with\nmultiple lines",
-        },
-        body: "Test body",
-        validate: true,
-      });
-
-      expect(subagent.getFrontmatter()).toEqual({
-        name: "Multi-line\nAgent Name",
-        description: "This is a multi-line\ndescription with\nmultiple lines",
-      });
-    });
-
-    it("should handle Windows-style line endings", () => {
-      const windowsContent = "Line 1\r\nLine 2\r\nLine 3";
-
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "windows-lines.md",
-        frontmatter: {
-          name: "Windows Agent",
-          description: "Test with Windows line endings",
-        },
-        body: windowsContent,
-        validate: true,
-      });
-
-      expect(subagent.getBody()).toBe(windowsContent);
-    });
-  });
-
-  describe("inheritance", () => {
-    it("should inherit from SimulatedSubagent", () => {
-      const subagent = new RooSubagent({
-        outputRoot: testDir,
-        relativeDirPath: ".roo/subagents",
-        relativeFilePath: "test.md",
-        frontmatter: {
-          name: "Test",
-          description: "Test",
-        },
-        body: "Test",
-        validate: true,
-      });
-
-      expect(subagent).toBeInstanceOf(RooSubagent);
-      // Test that it inherits methods from parent class
-      expect(() => subagent.toRulesyncSubagent()).toThrow(
-        "Not implemented because it is a SIMULATED file.",
-      );
-    });
-  });
-
-  describe("isTargetedByRulesyncSubagent", () => {
-    it("should return true when targets includes roo", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: ["roo"],
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test content",
-        validate: true,
-      });
-
-      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
-    });
-
-    it("should return true when targets includes asterisk", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: ["*"],
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test content",
-        validate: true,
-      });
-
-      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
-    });
-
-    it("should return false when targets array is empty", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: [],
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test content",
-        validate: false, // Skip validation to allow empty targets array
-      });
-
-      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(false);
-    });
-
-    it("should return false when targets does not include roo", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: ["copilot", "cline"],
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test content",
-        validate: true,
-      });
-
-      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(false);
-    });
-
-    it("should return true when targets includes roo among other targets", () => {
-      const rulesyncSubagent = new RulesyncSubagent({
-        outputRoot: testDir,
-        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: "test-agent.md",
-        frontmatter: {
-          targets: ["copilot", "roo", "cline"],
-          name: "Test Agent",
-          description: "Test description",
-        },
-        body: "Test content",
-        validate: true,
-      });
-
-      expect(RooSubagent.isTargetedByRulesyncSubagent(rulesyncSubagent)).toBe(true);
+      expect(roo).toBeInstanceOf(RooSubagent);
+      expect(roo.getModes()).toEqual([]);
     });
   });
 });

--- a/src/features/subagents/roo-subagent.ts
+++ b/src/features/subagents/roo-subagent.ts
@@ -246,7 +246,10 @@ export class RooSubagent extends ToolSubagent {
         frontmatter: rulesyncFrontmatter,
         body: roleDefinition,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        relativeFilePath: `${slug}.md`,
+        // Re-sanitize the imported slug before using it as a filename so a
+        // crafted `.roomodes` cannot produce a traversing path (defense in depth
+        // on top of the central path-traversal guard).
+        relativeFilePath: `${sanitizeRooSlug(slug)}.md`,
         validate: true,
       });
     });

--- a/src/features/subagents/roo-subagent.ts
+++ b/src/features/subagents/roo-subagent.ts
@@ -1,6 +1,14 @@
-import { ROO_SUBAGENTS_DIR_PATH } from "../../constants/roo-paths.js";
-import { RulesyncSubagent } from "./rulesync-subagent.js";
-import { SimulatedSubagent } from "./simulated-subagent.js";
+import { basename, join } from "node:path";
+
+import { dump, load } from "js-yaml";
+import { z } from "zod/mini";
+
+import { ROO_MODES_FILE_NAME } from "../../constants/roo-paths.js";
+import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncSubagent, RulesyncSubagentFrontmatter } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
   ToolSubagentForDeletionParams,
@@ -9,21 +17,261 @@ import {
   ToolSubagentSettablePaths,
 } from "./tool-subagent.js";
 
-export class RooSubagent extends SimulatedSubagent {
-  static getSettablePaths(): ToolSubagentSettablePaths {
+/**
+ * Default tool groups assigned to a generated mode when the rulesync source
+ * does not specify a `roo.groups` override. Mirrors Roo's built-in code mode
+ * (full read/edit/command/mcp access; browser is opt-in).
+ */
+const DEFAULT_GROUPS = ["read", "edit", "command", "mcp"] as const;
+
+/**
+ * One entry of a mode's `groups` array. Either a bare toolset name
+ * (`"read"`, `"edit"`, `"command"`, `"mcp"`, `"browser"`) or a tuple pairing a
+ * toolset (in practice `"edit"`) with a file restriction object.
+ * @see https://roocodeinc.github.io/Roo-Code/features/custom-modes
+ */
+const RooModeGroupSchema = z.union([z.string(), z.tuple([z.string(), z.looseObject({})])]);
+
+/**
+ * A single custom mode inside the `customModes` array of `.roomodes`.
+ * @see https://roocodeinc.github.io/Roo-Code/features/custom-modes
+ */
+export const RooModeSchema = z.looseObject({
+  slug: z.string(),
+  name: z.string(),
+  description: z.optional(z.string()),
+  roleDefinition: z.string(),
+  whenToUse: z.optional(z.string()),
+  groups: z.optional(z.array(RooModeGroupSchema)),
+  customInstructions: z.optional(z.string()),
+});
+
+export type RooMode = z.infer<typeof RooModeSchema>;
+
+export const RooModesFileSchema = z.looseObject({
+  customModes: z.array(RooModeSchema),
+});
+
+export type RooModesFile = z.infer<typeof RooModesFileSchema>;
+
+export type RooSubagentParams = {
+  modes: RooMode[];
+} & Omit<AiFileParams, "fileContent">;
+
+/**
+ * Sanitize a string into a valid Roo mode slug (`^[a-zA-Z0-9-]+$`): lowercase,
+ * non-alphanumeric runs collapsed to a single hyphen, leading/trailing hyphens
+ * trimmed. Falls back to `"mode"` if nothing usable remains.
+ */
+export function sanitizeRooSlug(raw: string): string {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "mode";
+}
+
+function stringifyRooModes(modes: RooMode[]): string {
+  return dump({ customModes: modes }, { lineWidth: -1, noRefs: true });
+}
+
+/**
+ * Roo Code custom-modes adapter.
+ *
+ * Roo reads project-level custom modes from a single aggregated `.roomodes`
+ * file at the workspace root (`docs.roocode.com` 301-redirects to the docs
+ * below). Each rulesync subagent becomes one entry in the `customModes` array.
+ * Because the native format aggregates N subagents into ONE file, every
+ * `RooSubagent` instance carries the FULL `customModes` array and targets the
+ * same `.roomodes` path; generation builds the aggregate once via
+ * {@link RooSubagent.fromRulesyncSubagents}.
+ *
+ * @see https://roocodeinc.github.io/Roo-Code/features/custom-modes
+ */
+export class RooSubagent extends ToolSubagent {
+  private readonly modes: RooMode[];
+
+  constructor({ modes, ...rest }: RooSubagentParams) {
+    if (rest.validate !== false) {
+      const result = RooModesFileSchema.safeParse({ customModes: modes });
+      if (!result.success) {
+        throw new Error(
+          `Invalid .roomodes in ${join(rest.relativeDirPath, rest.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+    }
+
+    super({
+      ...rest,
+      fileContent: stringifyRooModes(modes),
+    });
+
+    this.modes = modes;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolSubagentSettablePaths {
     return {
-      relativeDirPath: ROO_SUBAGENTS_DIR_PATH,
+      relativeDirPath: ".",
     };
   }
 
-  static async fromFile(params: ToolSubagentFromFileParams): Promise<RooSubagent> {
-    const baseParams = await this.fromFileDefault(params);
-    return new RooSubagent(baseParams);
+  getModes(): RooMode[] {
+    return this.modes;
   }
 
-  static fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent {
-    const baseParams = this.fromRulesyncSubagentDefault(params);
-    return new RooSubagent(baseParams);
+  getBody(): string {
+    return this.fileContent;
+  }
+
+  /**
+   * Map a single rulesync subagent to a Roo custom mode. The body becomes
+   * `roleDefinition`; the optional `roo:` frontmatter section supplies
+   * `groups`, `whenToUse`, `customInstructions`, an explicit `slug`, and may
+   * override `roleDefinition`. rulesync `name`/`description` are preferred,
+   * while tool-specific `roo:` values take precedence where defined.
+   */
+  static toRooMode(rulesyncSubagent: RulesyncSubagent): RooMode {
+    const frontmatter = rulesyncSubagent.getFrontmatter();
+    const rawSection = (frontmatter.roo ?? {}) as Record<string, unknown>;
+
+    const slug =
+      typeof rawSection.slug === "string" && rawSection.slug.length > 0
+        ? sanitizeRooSlug(rawSection.slug)
+        : sanitizeRooSlug(basename(rulesyncSubagent.getRelativeFilePath()).replace(/\.[^.]+$/, ""));
+
+    const roleDefinition =
+      typeof rawSection.roleDefinition === "string"
+        ? rawSection.roleDefinition
+        : rulesyncSubagent.getBody();
+
+    const groups = Array.isArray(rawSection.groups)
+      ? (rawSection.groups as RooMode["groups"])
+      : [...DEFAULT_GROUPS];
+
+    const mode: RooMode = {
+      slug,
+      name: frontmatter.name,
+      roleDefinition,
+      groups,
+    };
+
+    if (frontmatter.description) {
+      mode.description = frontmatter.description;
+    }
+    if (typeof rawSection.whenToUse === "string") {
+      mode.whenToUse = rawSection.whenToUse;
+    }
+    if (typeof rawSection.customInstructions === "string") {
+      mode.customInstructions = rawSection.customInstructions;
+    }
+
+    return mode;
+  }
+
+  /**
+   * Aggregate every targeted rulesync subagent into a single `.roomodes` file.
+   * Modes are de-duplicated by `slug` (last one wins) to keep the array unique.
+   */
+  static fromRulesyncSubagents({
+    outputRoot = process.cwd(),
+    rulesyncSubagents,
+    validate = true,
+  }: {
+    outputRoot?: string;
+    rulesyncSubagents: RulesyncSubagent[];
+    validate?: boolean;
+  }): RooSubagent {
+    const bySlug = new Map<string, RooMode>();
+    for (const rulesyncSubagent of rulesyncSubagents) {
+      const mode = this.toRooMode(rulesyncSubagent);
+      bySlug.set(mode.slug, mode);
+    }
+
+    return new RooSubagent({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: ROO_MODES_FILE_NAME,
+      modes: [...bySlug.values()],
+      validate,
+    });
+  }
+
+  static fromRulesyncSubagent({
+    outputRoot = process.cwd(),
+    rulesyncSubagent,
+    validate = true,
+  }: ToolSubagentFromRulesyncSubagentParams): RooSubagent {
+    return this.fromRulesyncSubagents({
+      outputRoot,
+      rulesyncSubagents: [rulesyncSubagent],
+      validate,
+    });
+  }
+
+  /**
+   * Convert every custom mode in the aggregated `.roomodes` file back into an
+   * individual rulesync subagent. The processor calls this in the import
+   * direction (one `.roomodes` tool file fans out to N rulesync files).
+   */
+  toRulesyncSubagents(): RulesyncSubagent[] {
+    return this.modes.map((mode) => {
+      const {
+        slug,
+        name,
+        description,
+        roleDefinition,
+        whenToUse,
+        groups,
+        customInstructions,
+        ...rest
+      } = mode;
+
+      const rooSection: Record<string, unknown> = {
+        ...rest,
+        slug,
+        ...(groups ? { groups } : {}),
+        ...(whenToUse !== undefined ? { whenToUse } : {}),
+        ...(customInstructions !== undefined ? { customInstructions } : {}),
+      };
+
+      const rulesyncFrontmatter: RulesyncSubagentFrontmatter = {
+        targets: ["roo"],
+        name,
+        ...(description !== undefined ? { description } : {}),
+        roo: rooSection,
+      };
+
+      return new RulesyncSubagent({
+        outputRoot: ".",
+        frontmatter: rulesyncFrontmatter,
+        body: roleDefinition,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: `${slug}.md`,
+        validate: true,
+      });
+    });
+  }
+
+  toRulesyncSubagent(): RulesyncSubagent {
+    const subagents = this.toRulesyncSubagents();
+    const first = subagents[0];
+    if (!first) {
+      throw new Error("No custom modes found in .roomodes to convert.");
+    }
+    return first;
+  }
+
+  validate(): ValidationResult {
+    const result = RooModesFileSchema.safeParse({ customModes: this.modes });
+    if (result.success) {
+      return { success: true, error: null };
+    }
+    return {
+      success: false,
+      error: new Error(
+        `Invalid .roomodes in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+      ),
+    };
   }
 
   static isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean {
@@ -33,7 +281,49 @@ export class RooSubagent extends SimulatedSubagent {
     });
   }
 
-  static forDeletion(params: ToolSubagentForDeletionParams): RooSubagent {
-    return new RooSubagent(this.forDeletionDefault(params));
+  static async fromFile({
+    outputRoot = process.cwd(),
+    relativeFilePath,
+    validate = true,
+  }: ToolSubagentFromFileParams): Promise<RooSubagent> {
+    const paths = this.getSettablePaths();
+    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
+    const fileContent = await readFileContent(filePath);
+
+    let parsed: unknown;
+    try {
+      parsed = load(fileContent);
+    } catch (error) {
+      throw new Error(`Failed to parse .roomodes (${filePath}): ${formatError(error)}`, {
+        cause: error,
+      });
+    }
+
+    const result = RooModesFileSchema.safeParse(parsed ?? { customModes: [] });
+    if (!result.success) {
+      throw new Error(`Invalid .roomodes in ${filePath}: ${formatError(result.error)}`);
+    }
+
+    return new RooSubagent({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: basename(relativeFilePath),
+      modes: result.data.customModes,
+      validate,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolSubagentForDeletionParams): RooSubagent {
+    return new RooSubagent({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      modes: [],
+      validate: false,
+    });
   }
 }

--- a/src/features/subagents/rulesync-subagent.ts
+++ b/src/features/subagents/rulesync-subagent.ts
@@ -25,6 +25,15 @@ export const RulesyncSubagentFrontmatterSchema = z.looseObject({
       name: z.optional(z.string()),
     }),
   ),
+  roo: z.optional(
+    z.looseObject({
+      slug: z.optional(z.string()),
+      whenToUse: z.optional(z.string()),
+      roleDefinition: z.optional(z.string()),
+      customInstructions: z.optional(z.string()),
+      groups: z.optional(z.array(z.unknown())),
+    }),
+  ),
   vibe: z.optional(
     z.looseObject({
       agent_type: z.optional(z.enum(["agent", "subagent"])),

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -1101,7 +1101,7 @@ Second global content`;
     });
 
     it("should export subagentsProcessorToolTargetsSimulated constant", () => {
-      expect(new Set(subagentsProcessorToolTargetsSimulated)).toEqual(new Set(["agentsmd", "roo"]));
+      expect(new Set(subagentsProcessorToolTargetsSimulated)).toEqual(new Set(["agentsmd"]));
       expect(Array.isArray(subagentsProcessorToolTargetsSimulated)).toBe(true);
     });
 

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -50,6 +50,17 @@ type ToolSubagentFactory = {
   class: {
     isTargetedByRulesyncSubagent(rulesyncSubagent: RulesyncSubagent): boolean;
     fromRulesyncSubagent(params: ToolSubagentFromRulesyncSubagentParams): ToolSubagent;
+    /**
+     * Optional aggregation hook. Tools whose native format collapses N subagents
+     * into a single shared file (e.g. Roo's `.roomodes`) implement this to emit
+     * one tool file holding every targeted subagent. When absent, the processor
+     * falls back to mapping each rulesync subagent independently.
+     */
+    fromRulesyncSubagents?(params: {
+      outputRoot?: string;
+      rulesyncSubagents: RulesyncSubagent[];
+      global?: boolean;
+    }): ToolSubagent;
     fromFile(params: ToolSubagentFromFileParams): Promise<ToolSubagent>;
     forDeletion(params: ToolSubagentForDeletionParams): ToolSubagent;
     getSettablePaths(options?: { global?: boolean }): ToolSubagentSettablePaths;
@@ -280,8 +291,12 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
   [
     "roo",
     {
+      // Roo Code reads project custom modes from a single aggregated `.roomodes`
+      // file at the workspace root (YAML). rulesync collapses every targeted
+      // subagent into that file's `customModes` array.
+      // https://roocodeinc.github.io/Roo-Code/features/custom-modes
       class: RooSubagent,
-      meta: { supportsSimulated: true, supportsGlobal: false, filePattern: "*.md" },
+      meta: { supportsSimulated: false, supportsGlobal: false, filePattern: ".roomodes" },
     },
   ],
   [
@@ -381,21 +396,34 @@ export class SubagentsProcessor extends FeatureProcessor {
 
     const factory = this.getFactory(this.toolTarget);
 
-    const toolSubagents = rulesyncSubagents
-      .map((rulesyncSubagent) => {
-        if (!factory.class.isTargetedByRulesyncSubagent(rulesyncSubagent)) {
-          return null;
-        }
-        return factory.class.fromRulesyncSubagent({
-          outputRoot: this.outputRoot,
-          relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
-          rulesyncSubagent: rulesyncSubagent,
-          global: this.global,
-        });
-      })
-      .filter((subagent): subagent is ToolSubagent => subagent !== null);
+    const targeted = rulesyncSubagents.filter((rulesyncSubagent) =>
+      factory.class.isTargetedByRulesyncSubagent(rulesyncSubagent),
+    );
 
-    return toolSubagents;
+    // Tools whose native format aggregates every subagent into a single shared
+    // file (e.g. Roo's `.roomodes`) implement `fromRulesyncSubagents` to emit
+    // one tool file holding all targeted subagents. Otherwise map one-to-one.
+    if (factory.class.fromRulesyncSubagents) {
+      if (targeted.length === 0) {
+        return [];
+      }
+      return [
+        factory.class.fromRulesyncSubagents({
+          outputRoot: this.outputRoot,
+          rulesyncSubagents: targeted,
+          global: this.global,
+        }),
+      ];
+    }
+
+    return targeted.map((rulesyncSubagent) =>
+      factory.class.fromRulesyncSubagent({
+        outputRoot: this.outputRoot,
+        relativeDirPath: RulesyncSubagent.getSettablePaths().relativeDirPath,
+        rulesyncSubagent: rulesyncSubagent,
+        global: this.global,
+      }),
+    );
   }
 
   async convertToolFilesToRulesyncFiles(toolFiles: ToolFile[]): Promise<RulesyncFile[]> {
@@ -411,6 +439,13 @@ export class SubagentsProcessor extends FeatureProcessor {
         this.logger.debug(
           `Skipping simulated subagent conversion: ${toolSubagent.getRelativeFilePath()}`,
         );
+        continue;
+      }
+
+      // Tools whose native format aggregates many subagents into one file
+      // (e.g. Roo's `.roomodes`) fan out to N rulesync subagents on import.
+      if (toolSubagent.toRulesyncSubagents) {
+        rulesyncSubagents.push(...toolSubagent.toRulesyncSubagents());
         continue;
       }
 

--- a/src/features/subagents/tool-subagent.ts
+++ b/src/features/subagents/tool-subagent.ts
@@ -57,6 +57,14 @@ export abstract class ToolSubagent extends ToolFile {
 
   abstract toRulesyncSubagent(): RulesyncSubagent;
 
+  /**
+   * Optional fan-out hook for tools whose native format aggregates several
+   * subagents into one file (e.g. Roo's `.roomodes`). When implemented, the
+   * processor uses it during import so one tool file yields N rulesync
+   * subagents. Tools with a one-file-per-subagent layout omit it.
+   */
+  toRulesyncSubagents?(): RulesyncSubagent[];
+
   static isTargetedByRulesyncSubagent(_rulesyncSubagent: RulesyncSubagent): boolean {
     throw new Error("Please implement this method in the subclass.");
   }


### PR DESCRIPTION
Closes #1884

## Summary

rulesync's `roo` subagents adapter wrote per-agent Markdown to `.roo/subagents/`, which Roo Code never reads — the output was inert. Roo's native project custom-mode format is a single aggregated `.roomodes` file (YAML; JSON also accepted) at the workspace root, with a `customModes:` array. This PR replaces the inert output with native `.roomodes` generation.

## Evidence

Verified against the primary doc (`docs.roocode.com` 301-redirects here):
https://roocodeinc.github.io/Roo-Code/features/custom-modes

- Project custom modes live in `.roomodes` at the workspace root (YAML, JSON also accepted).
- Each mode object: `slug` (`^[a-zA-Z0-9-]+$`), `name`, `description?`, `roleDefinition`, `whenToUse?`, `groups?` (`read`/`edit`/`command`/`mcp`/`browser`, where `edit` may carry a `{ fileRegex, description }` restriction tuple), `customInstructions?`.
- Confirmed there is **no** `.roo/subagents/` reader anywhere in the docs.

## Aggregation approach

The subagents processor maps N rulesync subagents to N tool files independently, but the native `.roomodes` is ONE file aggregating N modes. To handle this without invasively refactoring the shared processor (which other tools depend on), I added a small, generic, opt-in hook mirroring the shared-file-merge pattern used by config adapters:

- `RooSubagent.fromRulesyncSubagents` (plural) collapses every targeted subagent into a single `.roomodes` instance carrying the full `customModes` array (de-duplicated by `slug`, last one wins).
- `SubagentsProcessor.convertRulesyncFilesToToolFiles` calls `fromRulesyncSubagents` when a factory class defines it, otherwise falls back to the existing one-to-one `fromRulesyncSubagent`. Every other tool is unaffected (they don't define the hook).
- Mapping: `slug` from the file name (sanitized to `^[a-zA-Z0-9-]+$`, or an explicit `roo.slug`), `name`/`description` from shared frontmatter, body → `roleDefinition`. The optional `roo:` frontmatter section (a `z.looseObject`) supplies `groups` (default `["read", "edit", "command", "mcp"]`), `whenToUse`, `customInstructions`, and a `roleDefinition` override. rulesync `name`/`description` are preferred; tool-specific `roo:` values take precedence where defined.

`RooSubagent` no longer extends `SimulatedSubagent` — it is now a native `ToolSubagent`. Roo's subagents factory meta becomes `supportsSimulated: false`, and the `additionalConventions.subagents` entry (plus the now-unused `createsSeparateConventionsRule`) was removed from roo's rules convention, mirroring how native subagent tools like geminicli are wired.

## Import direction

`.roomodes` holds N modes but the processor produces one tool file per `.roomodes`. I added an optional `toRulesyncSubagents` (plural) fan-out hook on `ToolSubagent`; `convertToolFilesToRulesyncFiles` uses it when present so one `.roomodes` yields N rulesync subagents (one per mode). No limitation — both directions round-trip.

## Other changes

- `src/constants/roo-paths.ts`: added `ROO_MODES_FILE_NAME = ".roomodes"` (and the global `custom_modes.yaml` constants in `~/.roo/` for reference). Project scope is implemented; Roo subagents remain project-only (`supportsGlobal: false`, unchanged).
- gitignore: replaced `**/.roo/subagents/` with `**/.roomodes`.
- README/docs: kept Roo subagents ✅; documented `.roomodes`, the `roo:` block, and the aggregation in the "Each File Format" section; synced `skills/rulesync/`.
- Tests: rewrote `roo-subagent.test.ts` (slug sanitization, default groups, multi-mode aggregation, `roo:` precedence, import fan-out) and updated the e2e Tool × Feature happy-path to assert `.roomodes`. Matrix coverage preserved.

## Verification

`pnpm cicheck` — fully green (6449 tests passed). E2E subagents + rules specs (separate config) — 161 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
