### PR TITLE
feat(augmentcode): discover subagents and skills from the shared .agents/ tree on import

### DIFF
--- a/src/constants/augmentcode-paths.ts
+++ b/src/constants/augmentcode-paths.ts
@@ -4,6 +4,14 @@ export const AUGMENTCODE_DIR = ".augment";
 export const AUGMENTCODE_COMMANDS_DIR_PATH = join(AUGMENTCODE_DIR, "commands");
 export const AUGMENTCODE_SKILLS_DIR_PATH = join(AUGMENTCODE_DIR, "skills");
 export const AUGMENTCODE_AGENTS_DIR_PATH = join(AUGMENTCODE_DIR, "agents");
+// Auggie CLI 0.16.0+ also discovers subagents and skills from the cross-tool
+// `.agents/` directory (project `.agents/` and user `~/.agents/`) in addition to
+// `.augment/`. These are import-only discovery roots; generation still targets
+// `.augment/agents/` and `.augment/skills/`.
+// @see https://www.augmentcode.com/changelog/auggie-cli-0-16-0-release-notes
+// @see https://docs.augmentcode.com/cli/skills
+export const AUGMENTCODE_ALT_AGENTS_DIR_PATH = ".agents";
+export const AUGMENTCODE_AGENTS_SKILLS_DIR_PATH = join(".agents", "skills");
 export const AUGMENTCODE_SETTINGS_FILE_NAME = "settings.json";
 export const AUGMENTCODE_IGNORE_FILE_NAME = ".augmentignore";
 export const AUGMENTCODE_LEGACY_RULE_FILE_NAME = ".augment-guidelines";

--- a/src/features/skills/augmentcode-skill.test.ts
+++ b/src/features/skills/augmentcode-skill.test.ts
@@ -33,6 +33,15 @@ describe("AugmentcodeSkill", () => {
         join(".augment", "skills"),
       );
     });
+
+    it("should expose .agents/skills as an alternative discovery root", () => {
+      expect(AugmentcodeSkill.getSettablePaths().alternativeSkillRoots).toEqual([
+        join(".agents", "skills"),
+      ]);
+      expect(AugmentcodeSkill.getSettablePaths({ global: true }).alternativeSkillRoots).toEqual([
+        join(".agents", "skills"),
+      ]);
+    });
   });
 
   describe("fromRulesyncSkill", () => {
@@ -126,6 +135,28 @@ This is the skill body.`;
         name: "python-testing",
         description: "How to test python",
       });
+    });
+
+    it("should load a skill from the .agents/skills import root when relativeDirPath is set", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "shared-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: shared-skill
+description: Discovered from .agents/skills
+---
+
+Shared skill body.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await AugmentcodeSkill.fromDir({
+        outputRoot: testDir,
+        relativeDirPath: join(".agents", "skills"),
+        dirName: "shared-skill",
+      });
+
+      expect(skill.getRelativeDirPath()).toBe(join(".agents", "skills"));
+      expect(skill.getFrontmatter().name).toBe("shared-skill");
+      expect(skill.getBody()).toBe("Shared skill body.");
     });
 
     it("should throw when frontmatter is missing required fields", async () => {

--- a/src/features/skills/augmentcode-skill.ts
+++ b/src/features/skills/augmentcode-skill.ts
@@ -2,7 +2,10 @@ import { join } from "node:path";
 
 import { z } from "zod/mini";
 
-import { AUGMENTCODE_SKILLS_DIR_PATH } from "../../constants/augmentcode-paths.js";
+import {
+  AUGMENTCODE_AGENTS_SKILLS_DIR_PATH,
+  AUGMENTCODE_SKILLS_DIR_PATH,
+} from "../../constants/augmentcode-paths.js";
 import { SKILL_FILE_NAME } from "../../constants/general.js";
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-dir.js";
@@ -85,8 +88,14 @@ export class AugmentcodeSkill extends ToolSkill {
     // modes. The actual location differs based on outputRoot:
     // - Project mode: {process.cwd()}/.augment/skills/
     // - Global mode: {getHomeDirectory()}/.augment/skills/
+    //
+    // Auggie CLI 0.16.0+ additionally discovers skills from the cross-tool
+    // `.agents/skills/` directory (project `.agents/skills/` and user
+    // `~/.agents/skills/`). That is an import-only root: generation still writes
+    // to `.augment/skills/`.
     return {
       relativeDirPath: AUGMENTCODE_SKILLS_DIR_PATH,
+      alternativeSkillRoots: [AUGMENTCODE_AGENTS_SKILLS_DIR_PATH],
     };
   }
 

--- a/src/features/subagents/augmentcode-subagent.test.ts
+++ b/src/features/subagents/augmentcode-subagent.test.ts
@@ -26,12 +26,14 @@ describe("AugmentcodeSubagent", () => {
   });
 
   describe("getSettablePaths", () => {
-    it("should return .augment/agents for both project and global mode", () => {
+    it("should return .augment/agents with .agents as an import-only root for both modes", () => {
       expect(AugmentcodeSubagent.getSettablePaths()).toEqual({
         relativeDirPath: join(".augment", "agents"),
+        importDirPaths: [".agents"],
       });
       expect(AugmentcodeSubagent.getSettablePaths({ global: true })).toEqual({
         relativeDirPath: join(".augment", "agents"),
+        importDirPaths: [".agents"],
       });
     });
   });
@@ -177,6 +179,27 @@ Review carefully.`;
         disabled_tools: ["bash"],
       });
       expect(subagent.getBody()).toBe("Review carefully.");
+    });
+
+    it("should load a subagent from the .agents/ import root when relativeDirPath is set", async () => {
+      const fileContent = `---
+name: planner
+description: Plans work
+---
+
+Plan ahead.`;
+      await writeFileContent(join(testDir, ".agents", "planner.md"), fileContent);
+
+      const subagent = await AugmentcodeSubagent.fromFile({
+        outputRoot: testDir,
+        relativeDirPath: ".agents",
+        relativeFilePath: "planner.md",
+        validate: true,
+      });
+
+      expect(subagent.getRelativeDirPath()).toBe(".agents");
+      expect(subagent.getFrontmatter().name).toBe("planner");
+      expect(subagent.getBody()).toBe("Plan ahead.");
     });
 
     it("should throw for invalid frontmatter", async () => {

--- a/src/features/subagents/augmentcode-subagent.ts
+++ b/src/features/subagents/augmentcode-subagent.ts
@@ -2,7 +2,10 @@ import { join } from "node:path";
 
 import { z } from "zod/mini";
 
-import { AUGMENTCODE_AGENTS_DIR_PATH } from "../../constants/augmentcode-paths.js";
+import {
+  AUGMENTCODE_AGENTS_DIR_PATH,
+  AUGMENTCODE_ALT_AGENTS_DIR_PATH,
+} from "../../constants/augmentcode-paths.js";
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import { formatError } from "../../utils/error.js";
@@ -71,8 +74,12 @@ export class AugmentcodeSubagent extends ToolSubagent {
   }
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolSubagentSettablePaths {
+    // Auggie CLI additionally discovers subagents from the cross-tool `.agents/`
+    // directory (project `.agents/` and user `~/.agents/`). That is an
+    // import-only root: generation still writes to `.augment/agents/`.
     return {
       relativeDirPath: AUGMENTCODE_AGENTS_DIR_PATH,
+      importDirPaths: [AUGMENTCODE_ALT_AGENTS_DIR_PATH],
     };
   }
 
@@ -166,12 +173,15 @@ export class AugmentcodeSubagent extends ToolSubagent {
 
   static async fromFile({
     outputRoot = process.cwd(),
+    relativeDirPath,
     relativeFilePath,
     validate = true,
     global = false,
   }: ToolSubagentFromFileParams): Promise<AugmentcodeSubagent> {
-    const paths = this.getSettablePaths({ global });
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
+    // Honor an explicit discovery root (e.g. the `.agents/` import root) when
+    // provided; otherwise fall back to the canonical `.augment/agents/` location.
+    const dirPath = relativeDirPath ?? this.getSettablePaths({ global }).relativeDirPath;
+    const filePath = join(outputRoot, dirPath, relativeFilePath);
     const fileContent = await readFileContent(filePath);
     const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
 
@@ -182,7 +192,7 @@ export class AugmentcodeSubagent extends ToolSubagent {
 
     return new AugmentcodeSubagent({
       outputRoot,
-      relativeDirPath: paths.relativeDirPath,
+      relativeDirPath: dirPath,
       relativeFilePath,
       frontmatter: result.data,
       body: content.trim(),


### PR DESCRIPTION
## Summary

Auggie CLI 0.16.0+ discovers subagents and skills from the cross-tool `.agents/` tree in addition to `.augment/`. This adds those as **import-only** discovery roots so a rulesync import from an Auggie project that uses `.agents/` is not missed. Generation is unchanged — it still targets `.augment/agents/` and `.augment/skills/`.

- **Subagents** (`augmentcode-subagent.ts`): added `importDirPaths: [".agents"]` to `getSettablePaths` and taught `fromFile` to honor an explicit discovery root, mirroring the established Junie precedent (`junie-subagent.ts`).
- **Skills** (`augmentcode-skill.ts`): added `alternativeSkillRoots: [".agents/skills"]` to `getSettablePaths`, mirroring the established Rovo Dev precedent (`rovodev-skill.ts`). `.agents/skills/` is already covered by `.gitignore`.

Path constants added to `src/constants/augmentcode-paths.ts`. No generation change → no new gitignore entry and no support-matrix change (AugmentCode subagents/skills were already ✅).

## Validation evidence

- `.agents/` discovery (subagents + skills): https://www.augmentcode.com/changelog/auggie-cli-0-16-0-release-notes
- Skills `.agents/skills/`: https://docs.augmentcode.com/cli/skills

## Out of scope / deferred (maintainer decision)

This PR intentionally delivers only the clean, well-precedented import-fidelity subset and uses `Refs #1890` (not `Closes`). The remaining parts of #1890 each require a design decision and are left for a maintainer:

- **Commands `.agents/commands` import** — the command framework (`ToolCommandSettablePaths`) has no import-root field; adding one is a cross-cutting change affecting every command adapter.
- **`settings.local.json` permission/hook layering** — needs a secondary-import-file type extension, and the `/etc/augment/settings.json` system-layer path referenced in the issue is not confirmed by primary docs.

## Test plan

`pnpm cicheck` is fully green (format, oxlint, typecheck, 6549 unit tests, skill-docs sync, cspell, secretlint). Added unit tests asserting the new import roots in `getSettablePaths` and import round-trips reading a subagent from `.agents/` and a skill from `.agents/skills/`. Existing generate-to-`.augment/*` happy-path and Tool × Feature e2e coverage preserved.

Refs #1890
