### PR TITLE
feat: add Grok Build (grokcli) target — MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,7 +231,6 @@ rulesync.local.jsonc
 **/.agents/memories/
 **/.agents/skills/
 **/.agents/rules/
-**/GEMINI.md
 **/.geminiignore
 **/.agents/workflows/
 **/.agents/mcp_config.json
@@ -278,6 +277,7 @@ rulesync.local.jsonc
 **/.factory/skills/
 **/.factory/mcp.json
 **/.factory/hooks.json
+**/GEMINI.md
 **/.gemini/commands/
 **/.gemini/agents/
 **/.gemini/skills/
@@ -288,6 +288,7 @@ rulesync.local.jsonc
 **/.goose/recipes/
 **/.goose/recipes/subagents/
 **/.agents/plugins/
+**/.grok/config.toml
 **/.github/copilot-instructions.md
 **/.github/instructions/
 **/.github/prompts/

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | Codex CLI              |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Gemini CLI ⚠️          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Goose                  |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |        |  ✅   |             |
+| Grok CLI               |       |        | ✅  |          |           |        |       |             |
 | GitHub Copilot         |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |             |
 | Cursor                 |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |

--- a/cspell.json
+++ b/cspell.json
@@ -134,6 +134,8 @@
     "gooseignore",
     "gopd",
     "Grazie",
+    "grok",
+    "grokcli",
     "hasown",
     "HISTFILE",
     "icns",

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -13,6 +13,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |             |
+| Grok CLI               | grokcli         |       |        |  ✅ 🌏   |          |           |        |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -13,6 +13,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |             |
+| Grok CLI               | grokcli         |       |        |  ✅ 🌏   |          |           |        |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -247,6 +247,9 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   // (`~/.config/goose/config.yaml`), which lives under the home directory and is
   // not gitignored at the project level (mirrors Cline's global-only MCP).
 
+  // Grok Build
+  { target: "grokcli", feature: "general", entry: "**/.grok/config.toml" },
+
   // GitHub Copilot
   {
     target: ["copilot", "copilotcli"],

--- a/src/constants/grokcli-paths.ts
+++ b/src/constants/grokcli-paths.ts
@@ -1,0 +1,19 @@
+/**
+ * Grok Build CLI (xAI) configuration-layout conventions.
+ *
+ * Single source of truth for where Grok Build expects its files. Grok Build
+ * stores MCP servers (and other settings) in a `config.toml` under `.grok/`,
+ * with project/global scopes resolved by the directory the CLI runs in
+ * (`./.grok/config.toml` vs `~/.grok/config.toml`).
+ *
+ * Verified against `grok` 0.2.54 (`grok mcp add --help`, `grok mcp add`):
+ * `-s project` writes `./.grok/config.toml`, `-s user` writes
+ * `~/.grok/config.toml`, both as a TOML `[mcp_servers.<name>]` table.
+ * @see https://docs.x.ai/build/overview
+ */
+
+/** Root directory for Grok Build configuration, relative to the scope root. */
+export const GROKCLI_DIR = ".grok";
+
+/** MCP servers and other settings live in `config.toml` under `.grok/`. */
+export const GROKCLI_MCP_FILE_NAME = "config.toml";

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -26,6 +26,7 @@ describe("E2E: mcp", () => {
     { target: "geminicli", outputPath: join(".gemini", "settings.json") },
     { target: "qwencode", outputPath: join(".qwen", "settings.json") },
     { target: "codexcli", outputPath: join(".codex", "config.toml") },
+    { target: "grokcli", outputPath: join(".grok", "config.toml") },
     { target: "copilot", outputPath: join(".vscode", "mcp.json") },
     { target: "copilotcli", outputPath: join(".copilot", "mcp-config.json") },
     { target: "opencode", outputPath: "opencode.jsonc" },
@@ -71,7 +72,7 @@ describe("E2E: mcp", () => {
   });
 
   it.each([
-    // amp, geminicli, codexcli, opencode, kilo use merged config files (isDeletable=false) — excluded
+    // amp, geminicli, codexcli, grokcli, opencode, kilo use merged config files (isDeletable=false) — excluded
     { target: "claudecode", orphanPath: ".mcp.json" },
     { target: "cursor", orphanPath: join(".cursor", "mcp.json") },
     { target: "copilot", orphanPath: join(".vscode", "mcp.json") },
@@ -132,6 +133,11 @@ describe("E2E: mcp", () => {
     {
       target: "codexcli",
       outputPath: join(".codex", "config.toml"),
+      content: '[ui]\ntheme = "dark"\n',
+    },
+    {
+      target: "grokcli",
+      outputPath: join(".grok", "config.toml"),
       content: '[ui]\ntheme = "dark"\n',
     },
     {
@@ -375,6 +381,7 @@ describe("E2E: mcp (global mode)", () => {
     { target: "goose", outputPath: join(".config", "goose", "config.yaml") },
     { target: "opencode", outputPath: join(".config", "opencode", "opencode.jsonc") },
     { target: "codexcli", outputPath: join(".codex", "config.toml") },
+    { target: "grokcli", outputPath: join(".grok", "config.toml") },
     { target: "copilotcli", outputPath: join(".copilot", "mcp-config.json") },
     { target: "deepagents", outputPath: join(".deepagents", ".mcp.json") },
     { target: "factorydroid", outputPath: join(".factory", "mcp.json") },

--- a/src/features/mcp/grokcli-mcp.test.ts
+++ b/src/features/mcp/grokcli-mcp.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { isRecord } from "../../utils/type-guards.js";
+import { GrokcliMcp } from "./grokcli-mcp.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+
+describe("GrokcliMcp", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("writes MCP servers to .grok/config.toml", () => {
+      const paths = GrokcliMcp.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(".grok");
+      expect(paths.relativeFilePath).toBe("config.toml");
+    });
+
+    it("uses the same relative path in global mode (resolved by outputRoot)", () => {
+      const paths = GrokcliMcp.getSettablePaths({ global: true });
+      expect(paths.relativeDirPath).toBe(".grok");
+      expect(paths.relativeFilePath).toBe("config.toml");
+    });
+  });
+
+  describe("fromRulesyncMcp", () => {
+    it("emits a [mcp_servers.<name>] table for a stdio server with args and env", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            filesystem: {
+              command: "npx",
+              args: ["-y", "filesystem-mcp"],
+              env: { TOKEN_NAME: "value" },
+            },
+          },
+        }),
+      });
+
+      const grokcliMcp = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const servers = grokcliMcp.getToml().mcp_servers;
+      const filesystem = isRecord(servers) ? servers.filesystem : undefined;
+
+      expect(filesystem).toEqual({
+        command: "npx",
+        args: ["-y", "filesystem-mcp"],
+        env: { TOKEN_NAME: "value" },
+      });
+    });
+
+    it("maps disabled: true to enabled: false", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { off: { command: "node", args: ["x.js"], disabled: true } },
+        }),
+      });
+
+      const grokcliMcp = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const servers = grokcliMcp.getToml().mcp_servers;
+      const off = isRecord(servers) ? servers.off : undefined;
+
+      expect(isRecord(off) && off.enabled).toBe(false);
+      expect(isRecord(off) && "disabled" in off).toBe(false);
+    });
+
+    it("omits an empty env table for a server with no env vars (no dangling [mcp_servers.X.env])", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { plain: { command: "node", args: ["s.js"], env: {} } },
+        }),
+      });
+
+      const grokcliMcp = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const servers = grokcliMcp.getToml().mcp_servers;
+      const plain = isRecord(servers) ? servers.plain : undefined;
+
+      expect(isRecord(plain) && "env" in plain).toBe(false);
+      expect(grokcliMcp.getFileContent()).not.toContain("[mcp_servers.plain.env]");
+    });
+
+    it("emits url for a remote server", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { remote: { url: "https://mcp.example.com/mcp" } },
+        }),
+      });
+
+      const grokcliMcp = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const servers = grokcliMcp.getToml().mcp_servers;
+      const remote = isRecord(servers) ? servers.remote : undefined;
+
+      expect(isRecord(remote) && remote.url).toBe("https://mcp.example.com/mcp");
+    });
+
+    it("preserves unrelated config.toml settings when adding mcp_servers", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: { a: { command: "a" } } }),
+      });
+
+      // Pre-existing config with an unrelated table.
+      const first = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      expect(first.getToml().mcp_servers).toBeDefined();
+    });
+  });
+
+  describe("toRulesyncMcp", () => {
+    it("round-trips enabled: false back to disabled: true", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { off: { command: "node", disabled: true } },
+        }),
+      });
+
+      const grokcliMcp = await GrokcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp });
+      const back = grokcliMcp.toRulesyncMcp();
+      const servers = JSON.parse(back.getFileContent()).mcpServers;
+
+      expect(servers.off.disabled).toBe(true);
+      expect("enabled" in servers.off).toBe(false);
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("never deletes config.toml since it holds other Grok settings", async () => {
+      const grokcliMcp = await GrokcliMcp.fromFile({ outputRoot: testDir, validate: false });
+      expect(grokcliMcp.isDeletable()).toBe(false);
+    });
+  });
+});

--- a/src/features/mcp/grokcli-mcp.ts
+++ b/src/features/mcp/grokcli-mcp.ts
@@ -1,0 +1,243 @@
+import { join } from "node:path";
+
+import * as smolToml from "smol-toml";
+
+import { GROKCLI_DIR, GROKCLI_MCP_FILE_NAME } from "../../constants/grokcli-paths.js";
+import { ValidationResult } from "../../types/ai-file.js";
+import { McpServers } from "../../types/mcp.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { warnWithFallback } from "../../utils/logger.js";
+import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
+import { isPlainObject, isRecord } from "../../utils/type-guards.js";
+import { RulesyncMcp } from "./rulesync-mcp.js";
+import {
+  ToolMcp,
+  ToolMcpForDeletionParams,
+  ToolMcpFromFileParams,
+  ToolMcpFromRulesyncMcpParams,
+  type ToolMcpParams,
+  ToolMcpSettablePaths,
+} from "./tool-mcp.js";
+
+const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
+
+/**
+ * Grok Build stores MCP servers in `config.toml` under a `[mcp_servers.<name>]`
+ * table. Verified against `grok mcp add` (grok 0.2.54): a stdio server emits
+ * `command`, `args`, `enabled = true`, and an `[mcp_servers.<name>.env]` table;
+ * a remote server emits `url` and `enabled`. Unlike Codex CLI, Grok uses a
+ * literal `env` table (not the `env_vars` passthrough list) and has no
+ * per-server tool allow/deny lists, so the only field rename is
+ * `disabled` (rulesync) ↔ `enabled = false` (grok).
+ */
+function convertToGrokFormat(mcpServers: McpServers): Record<string, unknown> {
+  const result: Record<string, Record<string, unknown>> = {};
+
+  for (const [name, config] of Object.entries(mcpServers)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
+    if (!isRecord(config)) continue;
+    const converted: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+      if (key === "disabled") {
+        if (value === true) {
+          converted["enabled"] = false;
+        }
+      } else {
+        converted[key] = value;
+      }
+    }
+    result[name] = converted;
+  }
+
+  return result;
+}
+
+function convertFromGrokFormat(grokMcp: Record<string, unknown>): McpServers {
+  const result: McpServers = {};
+
+  for (const [name, config] of Object.entries(grokMcp)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(name) || !isRecord(config)) continue;
+
+    const converted: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+      if (key === "enabled") {
+        if (value === false) {
+          converted["disabled"] = true;
+        }
+      } else {
+        converted[key] = value;
+      }
+    }
+
+    result[name] = converted;
+  }
+
+  return result;
+}
+
+export class GrokcliMcp extends ToolMcp {
+  private readonly toml: smolToml.TomlTable;
+
+  constructor({ ...rest }: ToolMcpParams) {
+    super({
+      ...rest,
+      validate: false,
+    });
+
+    this.toml = smolToml.parse(this.fileContent);
+
+    if (rest.validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  getToml(): smolToml.TomlTable {
+    return this.toml;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolMcpSettablePaths {
+    // Both global (~/.grok/config.toml) and project (.grok/config.toml) use the
+    // same relative path; the difference is resolved by the outputRoot passed to
+    // the processor.
+    return {
+      relativeDirPath: GROKCLI_DIR,
+      relativeFilePath: GROKCLI_MCP_FILE_NAME,
+    };
+  }
+
+  /**
+   * config.toml may contain other Grok settings, so it should not be deleted.
+   */
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolMcpFromFileParams): Promise<GrokcliMcp> {
+    const paths = this.getSettablePaths({ global });
+    const fileContent =
+      (await readFileContentOrNull(
+        join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+      )) ?? smolToml.stringify({});
+
+    return new GrokcliMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncMcp({
+    outputRoot = process.cwd(),
+    rulesyncMcp,
+    validate = true,
+    global = false,
+  }: ToolMcpFromRulesyncMcpParams): Promise<GrokcliMcp> {
+    const paths = this.getSettablePaths({ global });
+
+    const configTomlFilePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const configTomlFileContent = await readOrInitializeFileContent(
+      configTomlFilePath,
+      smolToml.stringify({}),
+    );
+
+    const configToml = smolToml.parse(configTomlFileContent);
+
+    const strippedMcpServers = rulesyncMcp.getMcpServers();
+    const converted = convertToGrokFormat(strippedMcpServers);
+    const filteredMcpServers = this.removeEmptyEntries(converted);
+
+    for (const name of Object.keys(converted)) {
+      if (!Object.hasOwn(filteredMcpServers, name)) {
+        warnWithFallback(
+          undefined,
+          `MCP server "${name}" had no non-empty configuration and was dropped from the grok CLI config`,
+        );
+      }
+    }
+
+    configToml["mcp_servers"] = filteredMcpServers as smolToml.TomlTable;
+
+    return new GrokcliMcp({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent: smolToml.stringify(configToml),
+      validate,
+    });
+  }
+
+  toRulesyncMcp(): RulesyncMcp {
+    const mcpServers = (this.toml.mcp_servers ?? {}) as Record<string, unknown>;
+    const converted = convertFromGrokFormat(mcpServers);
+
+    return this.toRulesyncMcpDefault({
+      fileContent: JSON.stringify({ mcpServers: converted }, null, 2),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  private static removeEmptyEntries(
+    obj: Record<string, unknown> | undefined,
+    depth = 0,
+  ): Record<string, unknown> {
+    if (!obj) return {};
+    if (depth > MAX_REMOVE_EMPTY_ENTRIES_DEPTH) {
+      warnWithFallback(
+        undefined,
+        `removeEmptyEntries: maximum recursion depth (${MAX_REMOVE_EMPTY_ENTRIES_DEPTH}) exceeded; empty nested objects may remain`,
+      );
+      return obj;
+    }
+
+    const filtered: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+      // Skip null values
+      if (value === null) continue;
+
+      // Recurse into nested plain objects so empty inner tables (e.g.
+      // `env: {}`) are stripped too. Without this, smol-toml emits an empty
+      // `[mcp_servers.X.env]` header for servers with no env vars.
+      // Arrays are preserved verbatim.
+      if (isPlainObject(value)) {
+        const cleaned = this.removeEmptyEntries(value, depth + 1);
+        if (Object.keys(cleaned).length === 0) continue;
+        filtered[key] = cleaned;
+        continue;
+      }
+
+      filtered[key] = value;
+    }
+
+    return filtered;
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolMcpForDeletionParams): GrokcliMcp {
+    return new GrokcliMcp({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
+  }
+}

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -22,6 +22,7 @@ import { DevinMcp } from "./devin-mcp.js";
 import { FactorydroidMcp } from "./factorydroid-mcp.js";
 import { GeminiCliMcp } from "./geminicli-mcp.js";
 import { GooseMcp } from "./goose-mcp.js";
+import { GrokcliMcp } from "./grokcli-mcp.js";
 import { JunieMcp } from "./junie-mcp.js";
 import { KiloMcp } from "./kilo-mcp.js";
 import { KiroMcp } from "./kiro-mcp.js";
@@ -61,6 +62,7 @@ const mcpProcessorToolTargetTuple = [
   "factorydroid",
   "geminicli",
   "goose",
+  "grokcli",
   "kilo",
   "kiro",
   "kiro-cli",
@@ -296,6 +298,22 @@ export const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>(
       class: GooseMcp,
       meta: {
         supportsProject: false,
+        supportsGlobal: true,
+        supportsEnabledTools: false,
+        supportsDisabledTools: false,
+      },
+    },
+  ],
+  [
+    "grokcli",
+    {
+      // Grok Build stores MCP servers in `.grok/config.toml` (project) and
+      // `~/.grok/config.toml` (global) as `[mcp_servers.<name>]` tables. It has
+      // no per-server tool allow/deny lists.
+      // https://docs.x.ai/build/overview
+      class: GrokcliMcp,
+      meta: {
+        supportsProject: true,
         supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -60,6 +60,7 @@ describe("tool targets", () => {
         "factorydroid",
         "geminicli",
         "goose",
+        "grokcli",
         "junie",
         "kilo",
         "kiro",

--- a/src/types/tool-targets.ts
+++ b/src/types/tool-targets.ts
@@ -23,6 +23,7 @@ export const ALL_TOOL_TARGETS = [
   "factorydroid",
   "geminicli",
   "goose",
+  "grokcli",
   "junie",
   "kilo",
   "kiro",


### PR DESCRIPTION
Part of #1906. This PR adds the **MCP** feature for a new `grokcli` target (xAI's Grok Build CLI). `rules` and `skills` follow in separate PRs to respect the contributor size limit.

## MCP

Grok Build stores MCP servers as `[mcp_servers.<name>]` tables in `.grok/config.toml` (project) / `~/.grok/config.toml` (global). The adapter:

- maps rulesync `disabled` ↔ grok `enabled = false`
- uses a literal `env` table (not Codex's `env_vars` list)
- has no per-server tool allow/deny lists
- strips empty nested tables so no dangling `[mcp_servers.X.env]` is emitted

## Empirical verification

Confirmed against `grok` 0.2.54, not just docs:

- `grok mcp add --help` → `-s project` writes `./.grok/config.toml`, `-s user` writes `~/.grok/config.toml`
- `grok mcp add filesystem -s project -e FOO=bar -- npx -y some-server` → `[mcp_servers.filesystem]` with `command`/`args`/`enabled = true` + `[mcp_servers.filesystem.env]`; a remote server → `url`/`enabled`

## Tests & docs

- Unit tests (round-trip, disabled↔enabled, empty-env stripping) + e2e happy-path
- Supported Tools table (README + `docs/reference/supported-tools.md`, synced to `skills/rulesync/`)
- gitignore entry + cspell dictionary
- `pnpm cicheck` green (~452 added lines)
