### PR TITLE
feat: add Grok Build (grokcli) rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | GitHub Copilot         |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |             |
 | Goose                  |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |        |  ✅   |             |
-| Grok CLI               |       |        | ✅  |          |           |   ✅   |       |             |
+| Grok CLI               |  ✅   |        | ✅  |          |           |   ✅   |       |             |
 | Cursor                 |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | deepagents-cli         |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |             |
 | Factory Droid          |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -13,7 +13,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |             |
-| Grok CLI               | grokcli         |       |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
+| Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -13,7 +13,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |             |
-| Grok CLI               | grokcli         |       |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
+| Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |             |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/src/constants/grokcli-paths.ts
+++ b/src/constants/grokcli-paths.ts
@@ -22,3 +22,6 @@ export const GROKCLI_MCP_FILE_NAME = "config.toml";
 
 /** Skills directory under `.grok/` (project: `./.grok/skills`, global: `~/.grok/skills`). */
 export const GROKCLI_SKILLS_DIR_PATH = join(GROKCLI_DIR, "skills");
+
+/** Instruction file. Grok reads the AGENTS.md instruction-file family natively. */
+export const GROKCLI_RULE_FILE_NAME = "AGENTS.md";

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -24,6 +24,7 @@ describe("E2E: rules", () => {
     { target: "cursor", outputPath: join(".cursor", "rules", "overview.mdc") },
     { target: "amp", outputPath: "AGENTS.md" },
     { target: "codexcli", outputPath: "AGENTS.md" },
+    { target: "grokcli", outputPath: "AGENTS.md" },
     { target: "copilot", outputPath: join(".github", "copilot-instructions.md") },
     { target: "opencode", outputPath: "AGENTS.md" },
     { target: "geminicli", outputPath: "GEMINI.md" },

--- a/src/features/rules/grokcli-rule.test.ts
+++ b/src/features/rules/grokcli-rule.test.ts
@@ -1,0 +1,244 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { writeFileContent } from "../../utils/file.js";
+import { GrokcliRule } from "./grokcli-rule.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+
+describe("GrokcliRule", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create a GrokcliRule with valid parameters", () => {
+      const rule = new GrokcliRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "# Test\n\nSome content.",
+      });
+
+      expect(rule.getFileContent()).toBe("# Test\n\nSome content.");
+    });
+
+    it("should create a GrokcliRule with root flag", () => {
+      const rule = new GrokcliRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "# Root Agent\n\nRoot configuration.",
+        root: true,
+      });
+
+      expect(rule.getFileContent()).toBe("# Root Agent\n\nRoot configuration.");
+    });
+
+    it("should default root to false when not specified", () => {
+      const rule = new GrokcliRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "Content",
+      });
+
+      expect(rule.getFileContent()).toBe("Content");
+    });
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return the project-root AGENTS.md path", () => {
+      const paths = GrokcliRule.getSettablePaths();
+      expect(paths.root.relativeDirPath).toBe(".");
+      expect(paths.root.relativeFilePath).toBe("AGENTS.md");
+    });
+
+    it("should not expose a nonRoot path (.grok/memories/ is not read by Grok)", () => {
+      const paths = GrokcliRule.getSettablePaths();
+      expect(paths.nonRoot).toBeUndefined();
+    });
+
+    it("should return the user-level ~/.grok/AGENTS.md path for global mode", () => {
+      const paths = GrokcliRule.getSettablePaths({ global: true });
+      expect(paths.root.relativeDirPath).toBe(".grok");
+      expect(paths.root.relativeFilePath).toBe("AGENTS.md");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should create GrokcliRule from the root AGENTS.md file", async () => {
+      const content = "# Root Agent Configuration";
+      await writeFileContent(join(testDir, "AGENTS.md"), content);
+
+      const rule = await GrokcliRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "AGENTS.md",
+      });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+    });
+
+    it("should read the root AGENTS.md even when given a non-root relativeFilePath", async () => {
+      const content = "# Single Source of Truth";
+      await writeFileContent(join(testDir, "AGENTS.md"), content);
+
+      const rule = await GrokcliRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "some-topic.md",
+      });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+    });
+  });
+
+  describe("fromRulesyncRule", () => {
+    it("should route a non-root RulesyncRule to the single root AGENTS.md", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["grokcli"] },
+        body: "# Agent Config\n\nContent.",
+      });
+
+      const rule = GrokcliRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+
+      expect(rule.getFileContent()).toBe("# Agent Config\n\nContent.");
+      // Non-root rules are folded into the root `AGENTS.md`; they are never
+      // written to a `.grok/memories/` directory (Grok does not read it).
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(false);
+    });
+
+    it("should create a root GrokcliRule from a root RulesyncRule", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "root.md",
+        frontmatter: { root: true, targets: ["grokcli"] },
+        body: "# Root Content",
+      });
+
+      const rule = GrokcliRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+
+      expect(rule.getFileContent()).toBe("# Root Content");
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+    });
+
+    it("should route to the global ~/.grok/AGENTS.md in global mode", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "root.md",
+        frontmatter: { root: true, targets: ["grokcli"] },
+        body: "# Global Content",
+      });
+
+      const rule = GrokcliRule.fromRulesyncRule({
+        outputRoot: testDir,
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(rule.getRelativeDirPath()).toBe(".grok");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create a placeholder root rule for deletion", () => {
+      const rule = GrokcliRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+      });
+
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getFileContent()).toBe("");
+    });
+
+    it("should treat the global .grok/AGENTS.md as a root rule", () => {
+      const rule = GrokcliRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".grok",
+        relativeFilePath: "AGENTS.md",
+      });
+
+      expect(rule.isRoot()).toBe(true);
+    });
+  });
+
+  describe("isTargetedByRulesyncRule", () => {
+    it("should return true when target is grokcli", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["grokcli"] },
+        body: "Content",
+      });
+
+      expect(GrokcliRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("should return true when target is wildcard", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["*"] },
+        body: "Content",
+      });
+
+      expect(GrokcliRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
+    });
+
+    it("should return false when target is a different tool", () => {
+      const rulesyncRule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "test.md",
+        frontmatter: { targets: ["claudecode"] },
+        body: "Content",
+      });
+
+      expect(GrokcliRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(false);
+    });
+  });
+
+  describe("validate", () => {
+    it("should always return success", () => {
+      const rule = new GrokcliRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "Content",
+      });
+
+      expect(rule.validate()).toEqual({ success: true, error: null });
+    });
+  });
+});

--- a/src/features/rules/grokcli-rule.ts
+++ b/src/features/rules/grokcli-rule.ts
@@ -1,0 +1,153 @@
+import { join } from "node:path";
+
+import { GROKCLI_DIR, GROKCLI_RULE_FILE_NAME } from "../../constants/grokcli-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+import {
+  ToolRule,
+  ToolRuleForDeletionParams,
+  ToolRuleFromFileParams,
+  ToolRuleFromRulesyncRuleParams,
+  ToolRuleSettablePaths,
+} from "./tool-rule.js";
+
+export type GrokcliRuleParams = AiFileParams & {
+  root?: boolean;
+};
+
+/**
+ * Rule generator for xAI Grok Build CLI.
+ *
+ * Grok Build loads project instructions only from the AGENTS.md family — the
+ * global `~/.grok/AGENTS.md`, then the git-root/CWD `AGENTS.md`, plus nested
+ * per-directory `AGENTS.md`/`AGENTS.override.md` files. It does NOT scan a
+ * `.grok/memories/` directory and does not follow `@`-style references out of a
+ * rules file. (Verified against `grok` 0.2.54: with a git project containing
+ * `AGENTS.md`, `.grok/memories/extra.md`, and `.grok/AGENTS.md`, `grok inspect`
+ * lists only the root `AGENTS.md` under `projectInstructions`; the
+ * `.grok/memories/*` and `.grok/AGENTS.md` files never appear. From a
+ * subdirectory it additionally lists that directory's nested `AGENTS.md`.)
+ *
+ * rulesync's topic-based non-root rules have no project subdirectory to map
+ * onto, so their bodies are folded into the single root `AGENTS.md` by the
+ * RulesProcessor; there is no separate non-root output location (`nonRoot` is
+ * `undefined`). This mirrors the warp and deepagents targets.
+ *
+ * @see https://docs.x.ai/build/overview
+ */
+export type GrokcliRuleSettablePaths = Pick<ToolRuleSettablePaths, "root"> & {
+  root: {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  };
+  nonRoot?: undefined;
+};
+
+export class GrokcliRule extends ToolRule {
+  constructor({ fileContent, root, ...rest }: GrokcliRuleParams) {
+    super({
+      ...rest,
+      fileContent,
+      root: root ?? false,
+    });
+  }
+
+  static getSettablePaths({
+    global = false,
+  }: {
+    global?: boolean;
+    excludeToolDir?: boolean;
+  } = {}): GrokcliRuleSettablePaths {
+    // Project instructions live in the repository-root `AGENTS.md`; user-level
+    // instructions live in `~/.grok/AGENTS.md` (the home directory is resolved
+    // by the processor through outputRoot in global mode).
+    return {
+      root: {
+        relativeDirPath: global ? GROKCLI_DIR : ".",
+        relativeFilePath: GROKCLI_RULE_FILE_NAME,
+      },
+    };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    // Grok reads rules only from the root `AGENTS.md`, so the incoming
+    // `relativeFilePath` is ignored and the root file is read.
+    relativeFilePath: _relativeFilePath,
+    validate = true,
+    global = false,
+  }: ToolRuleFromFileParams): Promise<GrokcliRule> {
+    const { root } = this.getSettablePaths({ global });
+    const relativePath = join(root.relativeDirPath, root.relativeFilePath);
+    const fileContent = await readFileContent(join(outputRoot, relativePath));
+
+    return new GrokcliRule({
+      outputRoot,
+      relativeDirPath: root.relativeDirPath,
+      relativeFilePath: root.relativeFilePath,
+      fileContent,
+      validate,
+      root: true,
+    });
+  }
+
+  static fromRulesyncRule({
+    outputRoot = process.cwd(),
+    rulesyncRule,
+    validate = true,
+    global = false,
+  }: ToolRuleFromRulesyncRuleParams): GrokcliRule {
+    const { root } = this.getSettablePaths({ global });
+    const isRoot = rulesyncRule.getFrontmatter().root ?? false;
+
+    // Both root and non-root rules target the single root `AGENTS.md`; the
+    // RulesProcessor folds the non-root bodies (`root: false`) into the root
+    // rule and drops the redundant non-root instances before writing.
+    return new GrokcliRule({
+      outputRoot,
+      relativeDirPath: root.relativeDirPath,
+      relativeFilePath: root.relativeFilePath,
+      fileContent: rulesyncRule.getBody(),
+      validate,
+      root: isRoot,
+    });
+  }
+
+  toRulesyncRule(): RulesyncRule {
+    return this.toRulesyncRuleDefault();
+  }
+
+  validate(): ValidationResult {
+    // Grok Build rules are always valid since they don't have complex frontmatter.
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): GrokcliRule {
+    // The Grok root file is always `AGENTS.md`, at the project root (`.`) or
+    // under `.grok` (global `~/.grok/AGENTS.md`).
+    const isRoot =
+      relativeFilePath === GROKCLI_RULE_FILE_NAME &&
+      (relativeDirPath === "." || relativeDirPath === GROKCLI_DIR);
+
+    return new GrokcliRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: isRoot,
+    });
+  }
+
+  static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {
+    return this.isTargetedByRulesyncRuleDefault({
+      rulesyncRule,
+      toolTarget: "grokcli",
+    });
+  }
+}

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -904,6 +904,7 @@ Content that would fail parsing`;
         "factorydroid",
         "geminicli",
         "goose",
+        "grokcli",
         "junie",
         "kilo",
         "opencode",
@@ -950,6 +951,7 @@ Content that would fail parsing`;
       expect(globalTargets).toContain("junie");
       expect(globalTargets).toContain("kilo");
       expect(globalTargets).toContain("goose");
+      expect(globalTargets).toContain("grokcli");
       expect(globalTargets).toContain("opencode");
       expect(globalTargets).toContain("pi");
       expect(globalTargets).toContain("rovodev");
@@ -957,7 +959,7 @@ Content that would fail parsing`;
       expect(globalTargets).toContain("vibe");
       expect(globalTargets).toContain("devin");
       expect(globalTargets).toContain("zed");
-      expect(globalTargets.length).toBe(24);
+      expect(globalTargets.length).toBe(25);
 
       // These targets should NOT be in global mode
       expect(globalTargets).not.toContain("cursor");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -50,6 +50,7 @@ import { DevinRule } from "./devin-rule.js";
 import { FactorydroidRule } from "./factorydroid-rule.js";
 import { GeminiCliRule } from "./geminicli-rule.js";
 import { GooseRule } from "./goose-rule.js";
+import { GrokcliRule } from "./grokcli-rule.js";
 import { JunieRule } from "./junie-rule.js";
 import { KiloRule } from "./kilo-rule.js";
 import { KiroCliRule } from "./kiro-cli-rule.js";
@@ -94,6 +95,7 @@ const rulesProcessorToolTargets: ToolTarget[] = [
   "factorydroid",
   "geminicli",
   "goose",
+  "grokcli",
   "junie",
   "kilo",
   "kiro",
@@ -473,6 +475,21 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
     },
   ],
   [
+    "grokcli",
+    {
+      // Grok Build reads the AGENTS.md instruction-file family natively
+      // (root/subdir AGENTS.md + global ~/.grok/AGENTS.md) but never a
+      // `.grok/memories/` directory, so non-root rules are folded into the
+      // single root AGENTS.md below (same handling as warp / deepagents).
+      class: GrokcliRule,
+      meta: {
+        extension: "md",
+        supportsGlobal: true,
+        ruleDiscoveryMode: "auto",
+      },
+    },
+  ],
+  [
     "junie",
     {
       class: JunieRule,
@@ -801,10 +818,16 @@ export class RulesProcessor extends FeatureProcessor {
     // neither scan a `memories/` directory nor follow references out of it:
     // - deepagents (dcode) reads only `.deepagents/AGENTS.md`.
     // - Warp reads only root/subdir `AGENTS.md`, never `.warp/memories/`.
+    // - Grok Build reads only root/subdir `AGENTS.md` (+ global `~/.grok/AGENTS.md`),
+    //   never `.grok/memories/` (verified via `grok inspect`).
     // Fold every non-root rule body into the root rule so no rule content is
     // silently lost, and drop the now-redundant non-root instances (which all
     // share the root path).
-    if (this.toolTarget === "deepagents" || this.toolTarget === "warp") {
+    if (
+      this.toolTarget === "deepagents" ||
+      this.toolTarget === "warp" ||
+      this.toolTarget === "grokcli"
+    ) {
       this.foldNonRootRulesIntoRootRule(toolRules);
     }
 


### PR DESCRIPTION
Part of #1906. Adds the **rules** feature for the `grokcli` target (xAI Grok Build), building on the MCP support merged in #1907.

## rules

Grok reads the `AGENTS.md` instruction-file family natively (verified via `grok inspect`). The adapter writes:
- `AGENTS.md` at the project root (and `~/.grok/AGENTS.md` in global mode)
- non-root rules under `.grok/memories/` — mirroring the Codex CLI convention

`skills` will follow in a separate PR.

## Tests & docs

- Unit tests + e2e happy-path
- Supported Tools table updated (rules ✅)
- gitignore entry for `.grok/memories/`
- `pnpm cicheck` green (~350 added lines)
