### PR TITLE
Release v8.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.29.0",
+  "version": "8.30.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.29.0";
+const getVersion = () => "8.30.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### New Tool Targets

* feat: add Grok Build (grokcli) target — MCP servers by @hernaninverso in https://github.com/dyoshikawa/rulesync/pull/1907
* feat(kiro): split kiro target into kiro-cli and kiro-ide by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1893

### New Features

* feat(augmentcode): discover subagents and skills from the shared .agents/ tree on import by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1905
* feat(qwencode): add mcp, commands, subagents, skills, and hooks adapters by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1904
* feat(roo): emit native .roomodes custom modes instead of inert .roo/subagents/ by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1903
* feat(devin): add subagents adapter (.devin/agents/{name}/AGENT.md) by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1902
* feat(rovodev): add permissions adapter (~/.rovodev/config.yml toolPermissions) by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1901
* feat(vibe): add experimental hooks adapter (.vibe/hooks.toml) by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1900
* feat(claudecode): add first-class subagent frontmatter fields by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1899
* feat(cursor): add first-class model, readonly, is_background subagent frontmatter fields by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1898
* feat(junie): support UserPromptSubmit, Stop, and SessionEnd hook events by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1897
* feat(copilot): add agentStop/subagentStop hook events and prompt-file agent frontmatter by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1896
* feat(codexcli): add PostCompact hook event and preserve prompt frontmatter by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1895
* feat(goose): map commands to recipes and subagents to sub-recipes by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1892
* feat(antigravity-cli): emit root rules as AGENTS.md instead of GEMINI.md by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1877
* feat(junie): import subagents from the shared .agents directory by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/1875

## Contributors

* @dyoshikawa
* @hernaninverso

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v8.29.0...v8.30.0

---

This PR bumps the version to 8.30.0 for release.