### PR TITLE
fix: omit unsupported codex subagent short-description

### DIFF
--- a/src/features/subagents/codexcli-subagent.test.ts
+++ b/src/features/subagents/codexcli-subagent.test.ts
@@ -298,6 +298,34 @@ describe("CodexCliSubagent", () => {
       expect(codexcliSubagent.getBody()).not.toContain("wrong description");
     });
 
+    it("should not emit unsupported short-description field", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "reviewer.md",
+        frontmatter: {
+          targets: ["codexcli"],
+          name: "reviewer",
+          description: "Code reviewer",
+          codexcli: {
+            "short-description": "Review source changes",
+            model: "gpt-5",
+          },
+        },
+        body: "Review code changes",
+        validate: true,
+      });
+
+      const codexcliSubagent = CodexCliSubagent.fromRulesyncSubagent({
+        outputRoot: testDir,
+        rulesyncSubagent,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+      }) as CodexCliSubagent;
+
+      expect(codexcliSubagent.getBody()).toContain('model = "gpt-5"');
+      expect(codexcliSubagent.getBody()).not.toContain("short-description");
+    });
+
     it("should handle empty body and description", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         outputRoot: testDir,

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -132,6 +132,7 @@ export class CodexCliSubagent extends ToolSubagent {
       "name",
       "description",
       "developer_instructions",
+      "short-description",
     ]);
 
     // Build TOML object from rulesync frontmatter + codexcli section (tool-specific fields only)


### PR DESCRIPTION
## Summary
- Prevent codexcli subagent generation from emitting the unsupported `short-description` TOML field.
- Preserve supported Codex fields such as `model` while filtering this compatibility-only frontmatter key.
- Add a regression test for the Codex parser failure described in #1714.

## Validation
- `pnpm vitest run src/features/subagents/codexcli-subagent.test.ts --silent=true`

Closes #1714.