### PR TITLE
Release v8.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.30.0",
+  "version": "8.30.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.30.0";
+const getVersion = () => "8.30.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### Bug Fixes
- Omit the unsupported `short-description` field when generating Codex CLI subagents, preventing invalid frontmatter from being emitted (#1914)

### Documentation & Tests
- Add a Grok CLI note, align MCP tool ordering, and strengthen the related tests (#1913)

### Internal
- Rename the `scrap-issues` command and add the `batch-all-issues` command definition (#1911)

## Contributors

Thanks to everyone who contributed to this release:

- @dyoshikawa
- @ProfTrader

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v8.30.0...v8.30.1