### PR TITLE
fix(cursor): escape rule description in generated .mdc frontmatter

### DIFF
--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -410,6 +410,34 @@ This is the rule content
       expect(rule.getRelativeFilePath()).toBe("test.mdc");
     });
 
+    it("should round-trip a description containing YAML-special characters", async () => {
+      // A description with a ": " sequence (and other YAML indicators) must be emitted
+      // as a quoted scalar; otherwise the generated frontmatter is invalid YAML and
+      // fromFile throws when reading it back. See the constructor stringify path.
+      const description = "Use this rule: enforce strict TypeScript settings";
+      const generated = new CursorRule({
+        frontmatter: { description, globs: "*.ts", alwaysApply: false },
+        body: "Always enable strict mode.",
+        relativeDirPath: ".cursor/rules",
+        relativeFilePath: "strict.mdc",
+      });
+
+      const filePath = join(testDir, ".cursor/rules", "strict.mdc");
+      await writeFileContent(filePath, generated.getFileContent());
+
+      const parsed = await CursorRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "strict.mdc",
+      });
+
+      expect(parsed.getFrontmatter()).toEqual({
+        description,
+        globs: "*.ts",
+        alwaysApply: false,
+      });
+      expect(parsed.getBody()).toBe("Always enable strict mode.");
+    });
+
     it("should handle file with no frontmatter", async () => {
       const filePath = join(testDir, ".cursor/rules", "simple.mdc");
       const content = "Just plain content without frontmatter";

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { dump } from "js-yaml";
 import { z } from "zod/mini";
 
 import { CURSOR_DIR } from "../../constants/cursor-paths.js";
@@ -91,7 +92,14 @@ export class CursorRule extends ToolRule {
       lines.push(`alwaysApply: ${frontmatter.alwaysApply}`);
     }
     if (frontmatter.description) {
-      lines.push(`description: ${frontmatter.description}`);
+      // Serialize the description as a proper YAML scalar instead of raw interpolation.
+      // Raw interpolation corrupts the frontmatter whenever the value contains YAML
+      // indicators (e.g. a ": " sequence, a leading "#", or values like "true"/"123"),
+      // producing a file that this tool's own parser can no longer read. js-yaml only
+      // adds quotes when required, so plain descriptions stay unquoted (matching the
+      // MDC "no unnecessary quotes" convention used for globs below). lineWidth: -1
+      // prevents js-yaml from wrapping long descriptions into block scalars.
+      lines.push(dump({ description: frontmatter.description }, { lineWidth: -1 }).trimEnd());
     }
     if (frontmatter.globs !== undefined) {
       // Output globs without quotes


### PR DESCRIPTION
Closes #1919.

## Problem

`stringifyCursorFrontmatter` interpolated the rule `description` directly into the `.mdc` YAML frontmatter without quoting. Any description containing a YAML indicator — most commonly a `": "` sequence (`"Use when: ..."`, `"Note: ..."`), but also a leading `#` or bare values like `true`/`123` — produced **invalid YAML**. The generated file then failed to parse with rulesync's own parser, so `rulesync import -t cursor` threw a `YAMLException` and **silently dropped the rule**. Cursor (which reads the `.mdc` frontmatter as YAML) is affected the same way.

## Fix

Serialize the description with `js-yaml`'s `dump` (already a dependency, with `lineWidth: -1`), which quotes only when required:

- plain descriptions stay unquoted (`description: Test rule`) — output is unchanged, matching the existing "no unnecessary quotes" MDC convention already used for `globs`;
- `": "`, leading `#`, `true`/`123`, etc. are emitted as valid quoted scalars and round-trip cleanly.

`globs` handling is intentionally left untouched — Cursor requires it unquoted, and `parseCursorFrontmatter` already preprocesses that line on the way back in.

## Tests

- Added a round-trip regression test in `cursor-rule.test.ts` (`generate` → `fromFile` parse) for a description containing a colon. It **fails on `main`** with the `YAMLException` and **passes** with this change.
- `pnpm cicheck` is green locally: `fmt:check`, `oxlint`, `typecheck`, full test suite (6560 tests), `cspell`, `secretlint`.

Diff is ~38 lines across 2 files (1 implementation line + comment, plus the test).
