### PR TITLE
fix: use .kiroignore for Kiro ignore files

### DIFF
--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -11,6 +11,8 @@ import {
   CLAUDECODE_SETTINGS_LOCAL_FILE_NAME,
   CLAUDECODE_SKILLS_DIR_PATH,
 } from "../../constants/claudecode-paths.js";
+import { JUNIE_IGNORE_FILE_NAME } from "../../constants/junie-paths.js";
+import { KIRO_IGNORE_FILE_NAME } from "../../constants/kiro-paths.js";
 import { RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import {
   ALL_FEATURES_WITH_WILDCARD,
@@ -291,6 +293,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "junie", feature: "mcp", entry: "**/.junie/mcp/mcp.json" },
   { target: "junie", feature: "skills", entry: "**/.junie/skills/" },
   { target: "junie", feature: "subagents", entry: "**/.junie/agents/" },
+  { target: "junie", feature: "ignore", entry: `**/${JUNIE_IGNORE_FILE_NAME}` },
 
   // Kilo Code
   { target: "kilo", feature: "rules", entry: "**/.kilo/rules/" },
@@ -309,7 +312,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "kiro", feature: "skills", entry: "**/.kiro/skills/" },
   { target: "kiro", feature: "subagents", entry: "**/.kiro/agents/" },
   { target: "kiro", feature: "mcp", entry: "**/.kiro/settings/mcp.json" },
-  { target: "kiro", feature: "ignore", entry: "**/.aiignore" },
+  { target: "kiro", feature: "ignore", entry: `**/${KIRO_IGNORE_FILE_NAME}` },
   // Kiro IDE and CLI write to the same `.kiro/` tree as the legacy `kiro` alias.
   // (Kiro IDE subagents are Markdown under `.kiro/agents/`, the CLI's are JSON —
   // both covered by the shared `**/.kiro/agents/` entry.)
@@ -318,8 +321,8 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: ["kiro-cli", "kiro-ide"], feature: "skills", entry: "**/.kiro/skills/" },
   { target: ["kiro-cli", "kiro-ide"], feature: "subagents", entry: "**/.kiro/agents/" },
   { target: ["kiro-cli", "kiro-ide"], feature: "mcp", entry: "**/.kiro/settings/mcp.json" },
-  { target: ["kiro-cli", "kiro-ide"], feature: "ignore", entry: "**/.aiignore" },
-  // Keep this after ignore entries like "**/.aiignore" so the exception remains effective.
+  { target: ["kiro-cli", "kiro-ide"], feature: "ignore", entry: `**/${KIRO_IGNORE_FILE_NAME}` },
+  // Keep this after ignore entries like Junie's "**/.aiignore" so the exception remains effective.
   { target: "common", feature: "general", entry: "!.rulesync/.aiignore" },
 
   // OpenCode

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConfigResolver } from "../../config/config-resolver.js";
+import { KIRO_IGNORE_FILE_NAME } from "../../constants/kiro-paths.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
 import { ALL_GITIGNORE_ENTRIES, filterGitignoreEntries } from "./gitignore-entries.js";
@@ -81,6 +82,7 @@ describe("gitignoreCommand", () => {
       expect(content).toContain("**/.kilo/rules/");
       expect(content).toContain("**/.kilo/workflows/");
       expect(content).toContain("**/.roo/skills/");
+      expect(content).toContain(`**/${KIRO_IGNORE_FILE_NAME}`);
       expect(content).toContain("**/.aiignore");
       expect(content).toContain("**/.mcp.json");
       expect(content).toContain("**/.github/agents/");
@@ -115,6 +117,22 @@ describe("gitignoreCommand", () => {
       const content = writeCall![1];
 
       expect(content.indexOf("**/.aiignore")).toBeLessThan(content.indexOf("!.rulesync/.aiignore"));
+    });
+
+    it("should include Kiro's dedicated .kiroignore entry for Kiro aliases", async () => {
+      for (const target of ["kiro", "kiro-cli", "kiro-ide"]) {
+        vi.mocked(fileExists).mockResolvedValue(false);
+        vi.mocked(writeFileContent).mockClear();
+
+        await gitignoreCommand(mockLogger, { targets: [target], features: ["ignore"] });
+
+        const writeCall = vi.mocked(writeFileContent).mock.calls[0];
+        expect(writeCall).toBeDefined();
+        const content = writeCall![1];
+
+        expect(content).toContain(`**/${KIRO_IGNORE_FILE_NAME}`);
+        expect(content).not.toContain("**/.aiignore");
+      }
     });
 
     it("should format content properly with newline at end", async () => {

--- a/src/constants/kiro-paths.ts
+++ b/src/constants/kiro-paths.ts
@@ -7,4 +7,4 @@ export const KIRO_SETTINGS_DIR_PATH = join(KIRO_DIR, "settings");
 export const KIRO_AGENTS_DIR_PATH = join(KIRO_DIR, "agents");
 export const KIRO_HOOKS_FILE_NAME = "default.json";
 export const KIRO_MCP_FILE_NAME = "mcp.json";
-export const KIRO_IGNORE_FILE_NAME = ".aiignore";
+export const KIRO_IGNORE_FILE_NAME = ".kiroignore";

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { KIRO_IGNORE_FILE_NAME } from "../constants/kiro-paths.js";
 import { RULESYNC_AIIGNORE_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
 import { readFileContent, writeFileContent } from "../utils/file.js";
 import { runGenerate, runImport, useTestDirectory } from "./e2e-helper.js";
@@ -23,7 +24,7 @@ describe("E2E: ignore", () => {
     { target: "kilo", outputPath: ".kilocodeignore", format: "plaintext" as const },
     { target: "roo", outputPath: ".rooignore", format: "plaintext" as const },
     { target: "qwencode", outputPath: ".qwenignore", format: "plaintext" as const },
-    { target: "kiro", outputPath: ".aiignore", format: "plaintext" as const },
+    { target: "kiro", outputPath: KIRO_IGNORE_FILE_NAME, format: "plaintext" as const },
     { target: "junie", outputPath: ".aiignore", format: "plaintext" as const },
     { target: "augmentcode", outputPath: ".augmentignore", format: "plaintext" as const },
     { target: "devin", outputPath: ".devinignore", format: "plaintext" as const },
@@ -78,7 +79,7 @@ credentials/
     { target: "kilo", orphanPath: ".kilocodeignore" },
     { target: "roo", orphanPath: ".rooignore" },
     { target: "qwencode", orphanPath: ".qwenignore" },
-    { target: "kiro", orphanPath: ".aiignore" },
+    { target: "kiro", orphanPath: KIRO_IGNORE_FILE_NAME },
     { target: "junie", orphanPath: ".aiignore" },
     { target: "augmentcode", orphanPath: ".augmentignore" },
     { target: "devin", orphanPath: ".devinignore" },
@@ -144,7 +145,7 @@ describe("E2E: ignore (import)", () => {
     { target: "kilo", sourcePath: ".kilocodeignore" },
     { target: "roo", sourcePath: ".rooignore" },
     { target: "qwencode", sourcePath: ".qwenignore" },
-    { target: "kiro", sourcePath: ".aiignore" },
+    { target: "kiro", sourcePath: KIRO_IGNORE_FILE_NAME },
     { target: "junie", sourcePath: ".aiignore" },
     { target: "augmentcode", sourcePath: ".augmentignore" },
     { target: "devin", sourcePath: ".devinignore" },

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -245,7 +245,7 @@ describe("IgnoreProcessor", () => {
     });
 
     it("should load KiroIgnore for kiro target", async () => {
-      await writeFileContent(join(testDir, ".aiignore"), "*.log\nnode_modules/");
+      await writeFileContent(join(testDir, ".kiroignore"), "*.log\nnode_modules/");
 
       const processor = new IgnoreProcessor({ logger, outputRoot: testDir, toolTarget: "kiro" });
 

--- a/src/features/ignore/kiro-ignore.test.ts
+++ b/src/features/ignore/kiro-ignore.test.ts
@@ -29,13 +29,13 @@ describe("KiroIgnore", () => {
     it("should create instance with default parameters", () => {
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "*.log\nnode_modules/",
       });
 
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
       expect(kiroIgnore.getFileContent()).toBe("*.log\nnode_modules/");
     });
 
@@ -43,18 +43,18 @@ describe("KiroIgnore", () => {
       const kiroIgnore = new KiroIgnore({
         outputRoot: "/custom/path",
         relativeDirPath: "subdir",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "*.tmp",
       });
 
-      expect(kiroIgnore.getFilePath()).toBe("/custom/path/subdir/.aiignore");
+      expect(kiroIgnore.getFilePath()).toBe("/custom/path/subdir/.kiroignore");
     });
 
     it("should validate content by default", () => {
       expect(() => {
         const _instance = new KiroIgnore({
           relativeDirPath: ".",
-          relativeFilePath: ".aiignore",
+          relativeFilePath: ".kiroignore",
           fileContent: "", // empty content should be valid
         });
       }).not.toThrow();
@@ -64,7 +64,7 @@ describe("KiroIgnore", () => {
       expect(() => {
         const _instance = new KiroIgnore({
           relativeDirPath: ".",
-          relativeFilePath: ".aiignore",
+          relativeFilePath: ".kiroignore",
           fileContent: "any content",
           validate: false,
         });
@@ -78,7 +78,7 @@ describe("KiroIgnore", () => {
       const kiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -94,7 +94,7 @@ describe("KiroIgnore", () => {
       const kiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "",
       });
 
@@ -108,7 +108,7 @@ describe("KiroIgnore", () => {
       const kiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -134,7 +134,7 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
       expect(kiroIgnore.getOutputRoot()).toBe(testDir);
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
@@ -152,7 +152,7 @@ describe("KiroIgnore", () => {
       });
 
       expect(kiroIgnore.getOutputRoot()).toBe("/custom/base");
-      expect(kiroIgnore.getFilePath()).toBe("/custom/base/.aiignore");
+      expect(kiroIgnore.getFilePath()).toBe("/custom/base/.kiroignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
@@ -187,10 +187,10 @@ describe("KiroIgnore", () => {
   });
 
   describe("fromFile", () => {
-    it("should read .aiignore file from outputRoot with default outputRoot", async () => {
+    it("should read .kiroignore file from outputRoot with default outputRoot", async () => {
       const fileContent = "*.log\nnode_modules/\n.env";
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -199,14 +199,14 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore).toBeInstanceOf(KiroIgnore);
       expect(kiroIgnore.getOutputRoot()).toBe(testDir);
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should read .aiignore file with validation enabled by default", async () => {
+    it("should read .kiroignore file with validation enabled by default", async () => {
       const fileContent = "*.log\nnode_modules/";
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -215,10 +215,10 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should read .aiignore file with validation disabled", async () => {
+    it("should read .kiroignore file with validation disabled", async () => {
       const fileContent = "*.log\nnode_modules/";
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -228,9 +228,9 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should handle empty .aiignore file", async () => {
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, "");
+    it("should handle empty .kiroignore file", async () => {
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, "");
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -239,7 +239,7 @@ describe("KiroIgnore", () => {
       expect(kiroIgnore.getFileContent()).toBe("");
     });
 
-    it("should handle .aiignore file with complex patterns", async () => {
+    it("should handle .kiroignore file with complex patterns", async () => {
       const fileContent = `# Build outputs
 build/
 dist/
@@ -270,8 +270,8 @@ logs/
 .DS_Store
 Thumbs.db`;
 
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -283,8 +283,8 @@ Thumbs.db`;
     it("should default outputRoot to process.cwd() when not provided", async () => {
       // process.cwd() is already mocked to return testDir in beforeEach
       const fileContent = "*.log\nnode_modules/";
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({});
 
@@ -292,7 +292,7 @@ Thumbs.db`;
       expect(kiroIgnore.getFileContent()).toBe(fileContent);
     });
 
-    it("should throw error when .aiignore file does not exist", async () => {
+    it("should throw error when .kiroignore file does not exist", async () => {
       await expect(
         KiroIgnore.fromFile({
           outputRoot: testDir,
@@ -302,8 +302,8 @@ Thumbs.db`;
 
     it("should handle file with Windows line endings", async () => {
       const fileContent = "*.log\r\nnode_modules/\r\n.env";
-      const aiignorePath = join(testDir, ".aiignore");
-      await writeFileContent(aiignorePath, fileContent);
+      const kiroignorePath = join(testDir, ".kiroignore");
+      await writeFileContent(kiroignorePath, fileContent);
 
       const kiroIgnore = await KiroIgnore.fromFile({
         outputRoot: testDir,
@@ -318,7 +318,7 @@ Thumbs.db`;
       const fileContent = "*.log\nnode_modules/\n.env";
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -331,7 +331,7 @@ Thumbs.db`;
     it("should inherit validation method", () => {
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "*.log\nnode_modules/",
       });
 
@@ -345,14 +345,14 @@ Thumbs.db`;
       const kiroIgnore = new KiroIgnore({
         outputRoot: "/test/base",
         relativeDirPath: "subdir",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "*.log",
       });
 
       expect(kiroIgnore.getOutputRoot()).toBe("/test/base");
       expect(kiroIgnore.getRelativeDirPath()).toBe("subdir");
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
-      expect(kiroIgnore.getFilePath()).toBe("/test/base/subdir/.aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
+      expect(kiroIgnore.getFilePath()).toBe("/test/base/subdir/.kiroignore");
       expect(kiroIgnore.getFileContent()).toBe("*.log");
     });
   });
@@ -371,7 +371,7 @@ dist/
       const originalKiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: originalContent,
       });
 
@@ -384,7 +384,7 @@ dist/
       expect(roundTripKiroIgnore.getFileContent()).toBe(originalContent);
       expect(roundTripKiroIgnore.getOutputRoot()).toBe(testDir);
       expect(roundTripKiroIgnore.getRelativeDirPath()).toBe(".");
-      expect(roundTripKiroIgnore.getRelativeFilePath()).toBe(".aiignore");
+      expect(roundTripKiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
     });
 
     it("should maintain patterns in round-trip conversion", () => {
@@ -393,7 +393,7 @@ dist/
 
       const originalKiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: originalContent,
       });
 
@@ -410,7 +410,7 @@ dist/
     it("should handle file content with only whitespace", () => {
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "   \n\t\n   ",
       });
 
@@ -423,7 +423,7 @@ dist/
       const fileContent = "*.log\r\nnode_modules/\n.env\r\nbuild/";
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -434,7 +434,7 @@ dist/
       const longPattern = "a".repeat(1000);
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: longPattern,
       });
 
@@ -446,7 +446,7 @@ dist/
       const unicodeContent = "*.log\n節点模块/\n環境.env\n🏗️build/";
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: unicodeContent,
       });
 
@@ -461,7 +461,7 @@ dist/
       const kiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -485,7 +485,7 @@ dist/
       const kiroIgnore = new KiroIgnore({
         outputRoot: testDir,
         relativeDirPath: "project/config",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -501,14 +501,14 @@ dist/
   });
 
   describe("Kiro-specific behavior", () => {
-    it("should use .aiignore as the filename", () => {
+    it("should use .kiroignore as the filename", () => {
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent: "*.log",
       });
 
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
     });
 
     it("should work with gitignore syntax patterns", () => {
@@ -525,7 +525,7 @@ temp*/
 
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -550,7 +550,7 @@ temp*/
       const fileContent = "# This should reflect immediately\n*.log\ntemp/";
       const kiroIgnore = new KiroIgnore({
         relativeDirPath: ".",
-        relativeFilePath: ".aiignore",
+        relativeFilePath: ".kiroignore",
         fileContent,
       });
 
@@ -568,10 +568,10 @@ temp*/
         }),
       });
 
-      // Should always place .aiignore in root (relativeDirPath: ".")
+      // Should always place .kiroignore in root (relativeDirPath: ".")
       expect(kiroIgnore.getRelativeDirPath()).toBe(".");
-      expect(kiroIgnore.getRelativeFilePath()).toBe(".aiignore");
-      expect(kiroIgnore.getFilePath()).toBe("/workspace/root/.aiignore");
+      expect(kiroIgnore.getRelativeFilePath()).toBe(".kiroignore");
+      expect(kiroIgnore.getFilePath()).toBe("/workspace/root/.kiroignore");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Use `.kiroignore` for Kiro ignore generation/import instead of `.aiignore`
- Add Kiro's `.kiroignore` entry to generated gitignore blocks
- Keep Junie's `.aiignore` gitignore coverage explicit

## Why
The Kiro feature map already documents `.kiroignore` as the Kiro ignore surface, but the implementation still generated/imported `.aiignore`. That collides with other tools that also use `.aiignore` and makes the Kiro target write the wrong ignore file.

## Testing
- `pnpm exec vitest run --silent=true src/e2e/e2e-ignore.spec.ts src/cli/commands/gitignore.test.ts`
- `pnpm exec tsgo --noEmit`
- `pnpm exec vitest run --config vitest.e2e.config.ts --silent=false src/e2e/e2e-ignore.spec.ts`
- `pnpm exec oxfmt --check src/constants/kiro-paths.ts src/cli/commands/gitignore-entries.ts src/e2e/e2e-ignore.spec.ts src/cli/commands/gitignore.test.ts`
- `git diff --check`
