### PR TITLE
fix(gitignore): correct 7 drifted tool output entries and add getSettablePaths coverage test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ rulesync.local.jsonc
 **/.claude/*.lock
 **/.clinerules/
 **/.clinerules/workflows/
+**/.cline/skills/
 **/.clineignore
 **/.cline/agents/
 **/.cline/command-permissions.json
@@ -282,6 +283,7 @@ rulesync.local.jsonc
 **/.gemini/agents/
 **/.gemini/skills/
 **/.gemini/memories/
+**/.gemini/policies/
 **/.goosehints
 **/.goose/
 **/.gooseignore
@@ -300,13 +302,16 @@ rulesync.local.jsonc
 **/.copilot/agents/
 **/.copilot/hooks/
 **/.junie/guidelines.md
+**/.junie/commands/
 **/.junie/mcp/mcp.json
 **/.junie/skills/
 **/.junie/agents/
 **/.kilo/rules/
 **/.kilo/skills/
-**/.kilo/workflows/
+**/.kilo/commands/
+**/.kilo/agents/
 **/.kilo/mcp.json
+**/.kilo/plugins/
 **/.kilocodeignore
 **/.kiro/steering/
 **/.kiro/prompts/
@@ -332,6 +337,7 @@ rulesync.local.jsonc
 **/.qwen/settings.json
 **/replit.md
 **/.roo/rules/
+**/.roo/commands/
 **/.roo/skills/
 **/.rooignore
 **/.roo/mcp.json

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { toolCommandFactories } from "../../features/commands/commands-processor.js";
+import { toolHooksFactories } from "../../features/hooks/hooks-processor.js";
+import { toolMcpFactories } from "../../features/mcp/mcp-processor.js";
+import { toolPermissionsFactories } from "../../features/permissions/permissions-processor.js";
+import { toolSkillFactories } from "../../features/skills/skills-processor.js";
+import { toolSubagentFactories } from "../../features/subagents/subagents-processor.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { ALL_TOOL_TARGETS } from "../../types/tool-targets.js";
+import { toPosixPath } from "../../utils/file.js";
 import {
   ALL_GITIGNORE_ENTRIES,
   GITIGNORE_ENTRY_REGISTRY,
@@ -58,6 +65,95 @@ describe("GITIGNORE_ENTRY_REGISTRY", () => {
       }
     }
   });
+});
+
+// Project-scope outputs that are intentionally NOT gitignored because they are
+// user-managed settings files that rulesync merges into (and round-trips),
+// rather than fully-owned generated artifacts.
+const DERIVED_PATHS_NOT_GITIGNORED = new Set([
+  "**/.amp/settings.json",
+  "**/.amp/settings.jsonc",
+  "**/.antigravity/settings.json",
+  "**/.claude/settings.json",
+  "**/.factory/settings.json",
+  "**/.gemini/settings.json",
+  "**/.zed/settings.json",
+  "**/.warp/settings.toml",
+  "**/kilo.json",
+  "**/kilo.jsonc",
+  "**/opencode.json",
+]);
+
+const dirToGlob = (relativeDirPath: string): string =>
+  `**/${toPosixPath(relativeDirPath).replace(/\/$/, "")}/`;
+
+const fileToGlob = (relativeDirPath: string | undefined, relativeFilePath: string): string => {
+  const hasDir = relativeDirPath && relativeDirPath !== ".";
+  return `**/${toPosixPath(hasDir ? `${relativeDirPath}/${relativeFilePath}` : relativeFilePath)}`;
+};
+
+const isCoveredByRegistry = (glob: string): boolean => {
+  const normalized = glob.replace(/\/$/, "");
+  return GITIGNORE_ENTRY_REGISTRY.some((tag) => {
+    const entry = tag.entry.replace(/\/$/, "");
+    return entry === normalized || normalized.startsWith(`${entry}/`);
+  });
+};
+
+describe("getSettablePaths coverage", () => {
+  // Guards against the implicit coupling between each tool's getSettablePaths
+  // (the source of truth for output locations) and the hand-written registry:
+  // every project-scope output must be gitignored, or explicitly excepted.
+  const dirFeatures = [
+    ["commands", toolCommandFactories],
+    ["skills", toolSkillFactories],
+    ["subagents", toolSubagentFactories],
+  ] as const;
+
+  for (const [feature, factories] of dirFeatures) {
+    for (const [target, factory] of factories) {
+      if (TARGETS_WITHOUT_GITIGNORE_ENTRIES.has(target)) continue;
+      it(`covers ${feature} output for ${target}`, () => {
+        let paths: { relativeDirPath?: string };
+        try {
+          paths = factory.class.getSettablePaths({ global: false });
+        } catch {
+          return;
+        }
+        const dir = paths.relativeDirPath;
+        if (!dir || dir === ".") return;
+        const glob = dirToGlob(dir);
+        if (DERIVED_PATHS_NOT_GITIGNORED.has(glob.replace(/\/$/, ""))) return;
+        expect(isCoveredByRegistry(glob)).toBe(true);
+      });
+    }
+  }
+
+  const fileFeatures = [
+    ["mcp", toolMcpFactories],
+    ["hooks", toolHooksFactories],
+    ["permissions", toolPermissionsFactories],
+  ] as const;
+
+  for (const [feature, factories] of fileFeatures) {
+    for (const [target, factory] of factories) {
+      if (TARGETS_WITHOUT_GITIGNORE_ENTRIES.has(target)) continue;
+      const meta = factory.meta as { supportsProject?: boolean } | undefined;
+      if (meta && meta.supportsProject === false) continue;
+      it(`covers ${feature} output for ${target}`, () => {
+        let paths: { relativeDirPath?: string; relativeFilePath?: string };
+        try {
+          paths = factory.class.getSettablePaths({ global: false });
+        } catch {
+          return;
+        }
+        if (!paths.relativeFilePath) return;
+        const glob = fileToGlob(paths.relativeDirPath, paths.relativeFilePath);
+        if (DERIVED_PATHS_NOT_GITIGNORED.has(glob)) return;
+        expect(isCoveredByRegistry(glob)).toBe(true);
+      });
+    }
+  }
 });
 
 describe("ALL_GITIGNORE_ENTRIES", () => {

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -161,6 +161,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   // Cline
   { target: "cline", feature: "rules", entry: "**/.clinerules/" },
   { target: "cline", feature: "commands", entry: "**/.clinerules/workflows/" },
+  { target: "cline", feature: "skills", entry: "**/.cline/skills/" },
   { target: "cline", feature: "ignore", entry: "**/.clineignore" },
   // Cline reads MCP only from a global settings file
   // (`~/.cline/data/settings/cline_mcp_settings.json`), which lives under the
@@ -230,6 +231,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   { target: "geminicli", feature: "skills", entry: "**/.gemini/skills/" },
   { target: "geminicli", feature: "ignore", entry: "**/.geminiignore" },
   { target: "geminicli", feature: "general", entry: "**/.gemini/memories/" },
+  { target: "geminicli", feature: "permissions", entry: "**/.gemini/policies/" },
 
   // Goose
   { target: "goose", feature: "rules", entry: "**/.goosehints" },
@@ -288,6 +290,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
 
   // Junie
   { target: "junie", feature: "rules", entry: "**/.junie/guidelines.md" },
+  { target: "junie", feature: "commands", entry: "**/.junie/commands/" },
   { target: "junie", feature: "mcp", entry: "**/.junie/mcp/mcp.json" },
   { target: "junie", feature: "skills", entry: "**/.junie/skills/" },
   { target: "junie", feature: "subagents", entry: "**/.junie/agents/" },
@@ -295,8 +298,10 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
   // Kilo Code
   { target: "kilo", feature: "rules", entry: "**/.kilo/rules/" },
   { target: "kilo", feature: "skills", entry: "**/.kilo/skills/" },
-  { target: "kilo", feature: "commands", entry: "**/.kilo/workflows/" },
+  { target: "kilo", feature: "commands", entry: "**/.kilo/commands/" },
+  { target: "kilo", feature: "subagents", entry: "**/.kilo/agents/" },
   { target: "kilo", feature: "mcp", entry: "**/.kilo/mcp.json" },
+  { target: "kilo", feature: "hooks", entry: "**/.kilo/plugins/" },
   { target: "kilo", feature: "ignore", entry: "**/.kilocodeignore" },
   // No `**/kilo.jsonc` entry: structurally identical to `opencode.jsonc` (no
   // entry). The Kilo translator preserves non-permissions Kilo settings on
@@ -354,6 +359,7 @@ export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [
 
   // Roo
   { target: "roo", feature: "rules", entry: "**/.roo/rules/" },
+  { target: "roo", feature: "commands", entry: "**/.roo/commands/" },
   { target: "roo", feature: "skills", entry: "**/.roo/skills/" },
   { target: "roo", feature: "ignore", entry: "**/.rooignore" },
   { target: "roo", feature: "mcp", entry: "**/.roo/mcp.json" },

--- a/src/cli/commands/gitignore.test.ts
+++ b/src/cli/commands/gitignore.test.ts
@@ -79,7 +79,7 @@ describe("gitignoreCommand", () => {
       expect(content).toContain("**/.roo/rules/");
       expect(content).toContain("**/.kilo/skills/");
       expect(content).toContain("**/.kilo/rules/");
-      expect(content).toContain("**/.kilo/workflows/");
+      expect(content).toContain("**/.kilo/commands/");
       expect(content).toContain("**/.roo/skills/");
       expect(content).toContain("**/.aiignore");
       expect(content).toContain("**/.mcp.json");


### PR DESCRIPTION
## Background

`gitignore-entries.ts` hand-maintains a `{ target, feature, entry }` registry of where every tool writes output, duplicating each tool class's `getSettablePaths` (the real source of truth). Drift produces **no type error and no test failure** — it only surfaces when users find rulesync-generated files committed to their repo.

Auditing the registry against `getSettablePaths` found **7 already-shipping drifts**:

| Tool / feature | Was | Should be |
|---|---|---|
| kilo / commands | `**/.kilo/workflows/` | `**/.kilo/commands/` |
| kilo / subagents | (missing) | `**/.kilo/agents/` |
| kilo / hooks | (missing) | `**/.kilo/plugins/` |
| junie / commands | (missing) | `**/.junie/commands/` |
| roo / commands | (missing) | `**/.roo/commands/` |
| cline / skills | (missing) | `**/.cline/skills/` |
| geminicli / permissions | (missing) | `**/.gemini/policies/` |

Each confirmed by running `generate` and observing un-gitignored artifacts.

## Changes

- Fix the 7 entries and regenerate `.gitignore`.
- Add a `getSettablePaths coverage` test asserting every tool's project-scope output is covered by the registry, or in an explicit exception set (user-managed `settings.json` files, global-only paths, deprecated `antigravity` alias). Turns the implicit coupling into a CI-enforced invariant.

This is the recommended first step, not the full derivation (deliberately-broad entries like `**/.cursor/` make naive derivation behavior-changing — left as follow-up).

## Related

- #619 — same hardcoded list in `gitignore-entries.ts`; that issue asks to filter it by config, this PR guards it against drift. Complementary, not overlapping.
- #1207, #1830 (closed) — prior instances of the exact same drift (a tool's output not gitignored), motivating the CI guard added here.

## Test plan

- [x] `pnpm fmt:check` / `oxlint` / `typecheck` / `cspell` / `secretlint` — clean
- [x] `gitignore-entries.test.ts` — 166 pass (verified to fail when an entry is reverted)
- [ ] `pnpm test` (full) — `EPERM` in sandbox (pre-existing, unrelated); run before merge
