### PR TITLE
fix(kilo): emit canonical plugin export and probe additional import locations

### DIFF
--- a/src/constants/kilo-paths.ts
+++ b/src/constants/kilo-paths.ts
@@ -10,6 +10,12 @@ export const KILO_AGENTS_DIR_PATH = join(KILO_DIR, "agents");
 export const KILO_GLOBAL_AGENTS_DIR_PATH = join(KILO_GLOBAL_DIR, "agents");
 export const KILO_PLUGINS_DIR_PATH = join(KILO_DIR, "plugins");
 export const KILO_GLOBAL_PLUGINS_DIR_PATH = join(KILO_GLOBAL_DIR, "plugins");
+// Kilo reads plugins from BOTH the plural `plugins/` and the singular `plugin/`
+// directory inside any config dir. rulesync writes to the plural directory but
+// also probes the singular one on import so an existing singular-dir plugin is
+// picked up. https://kilo.ai/docs/automate/extending/plugins
+export const KILO_PLUGIN_DIR_PATH = join(KILO_DIR, "plugin");
+export const KILO_GLOBAL_PLUGIN_DIR_PATH = join(KILO_GLOBAL_DIR, "plugin");
 export const KILO_RULE_FILE_NAME = "AGENTS.md";
 export const KILO_IGNORE_FILE_NAME = ".kilocodeignore";
 export const KILO_JSONC_FILE_NAME = "kilo.jsonc";

--- a/src/features/hooks/kilo-hooks.test.ts
+++ b/src/features/hooks/kilo-hooks.test.ts
@@ -266,13 +266,52 @@ describe("KiloHooks", () => {
 
       expect(kiloHooks.getFileContent()).toBe(
         [
-          "export const RulesyncHooksPlugin = async ({ $ }) => {",
-          "  return {",
-          "  };",
+          "export default {",
+          '  id: "rulesync-hooks",',
+          "  server: async ({ $ }) => {",
+          "    return {",
+          "    };",
+          "  },",
           "};",
           "",
         ].join("\n"),
       );
+    });
+
+    it("should emit a canonical default-export { id, server } plugin descriptor", () => {
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
+          preToolUse: [{ type: "command", command: "lint.sh", matcher: "Write" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const kiloHooks = KiloHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = kiloHooks.getFileContent();
+      // Canonical Kilo plugin shape: default export with id + server descriptor.
+      expect(content).toContain("export default {");
+      expect(content).toContain('  id: "rulesync-hooks",');
+      expect(content).toContain("  server: async ({ $ }) => {");
+      // Must NOT emit the legacy named export used by the OpenCode target.
+      expect(content).not.toContain("export const RulesyncHooksPlugin");
+      // Handlers are still present, just nested under `server`.
+      expect(content).toContain('event.type === "session.created"');
+      expect(content).toContain('new RegExp("Write")');
+      // Generated module must be syntactically valid ESM.
+      execFileSync("node", ["--input-type=module", "--check"], { input: content });
     });
 
     it("should escape ${} interpolation in commands", () => {
@@ -361,32 +400,32 @@ describe("KiloHooks", () => {
       const content = kiloHooks.getFileContent();
       expect(content).toContain(
         [
-          "      {",
-          '        const __re = new RegExp("Read");',
-          "        if (__re.test(input.tool)) {",
-          "          await $`audit-read.sh`;",
+          "        {",
+          '          const __re = new RegExp("Read");',
+          "          if (__re.test(input.tool)) {",
+          "            await $`audit-read.sh`;",
+          "          }",
           "        }",
-          "      }",
         ].join("\n"),
       );
       expect(content).toContain(
         [
-          "      {",
-          '        const __re = new RegExp("Write");',
-          "        if (__re.test(input.tool)) {",
-          "          await $`audit-write.sh`;",
+          "        {",
+          '          const __re = new RegExp("Write");',
+          "          if (__re.test(input.tool)) {",
+          "            await $`audit-write.sh`;",
+          "          }",
           "        }",
-          "      }",
         ].join("\n"),
       );
       expect(content).toContain(
         [
-          "      {",
-          '        const __re = new RegExp("Edit");',
-          "        if (__re.test(input.tool)) {",
-          "          await $`audit-edit.sh`;",
+          "        {",
+          '          const __re = new RegExp("Edit");',
+          "          if (__re.test(input.tool)) {",
+          "            await $`audit-edit.sh`;",
+          "          }",
           "        }",
-          "      }",
         ].join("\n"),
       );
 
@@ -584,6 +623,44 @@ describe("KiloHooks", () => {
       });
       expect(kiloHooks).toBeInstanceOf(KiloHooks);
       expect(kiloHooks.getFileContent()).toBe(content);
+    });
+
+    it("should load from the singular .kilo/plugin/ directory when the plural one is absent", async () => {
+      const pluginDir = join(testDir, ".kilo", "plugin");
+      await ensureDir(pluginDir);
+      const content = [
+        "export default {",
+        '  id: "rulesync-hooks",',
+        "  server: async ({ $ }) => {",
+        "    return {}",
+        "  },",
+        "}",
+      ].join("\n");
+      await writeFileContent(join(pluginDir, "rulesync-hooks.js"), content);
+
+      const kiloHooks = await KiloHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(kiloHooks).toBeInstanceOf(KiloHooks);
+      expect(kiloHooks.getFileContent()).toBe(content);
+      expect(kiloHooks.getRelativeDirPath()).toBe(join(".kilo", "plugin"));
+    });
+
+    it("should prefer the plural .kilo/plugins/ directory over the singular one", async () => {
+      const pluralDir = join(testDir, ".kilo", "plugins");
+      const singularDir = join(testDir, ".kilo", "plugin");
+      await ensureDir(pluralDir);
+      await ensureDir(singularDir);
+      await writeFileContent(join(pluralDir, "rulesync-hooks.js"), "// plural");
+      await writeFileContent(join(singularDir, "rulesync-hooks.js"), "// singular");
+
+      const kiloHooks = await KiloHooks.fromFile({
+        outputRoot: testDir,
+        validate: false,
+      });
+      expect(kiloHooks.getFileContent()).toBe("// plural");
+      expect(kiloHooks.getRelativeDirPath()).toBe(join(".kilo", "plugins"));
     });
   });
 

--- a/src/features/hooks/kilo-hooks.ts
+++ b/src/features/hooks/kilo-hooks.ts
@@ -1,13 +1,15 @@
 import { join } from "node:path";
 
 import {
+  KILO_GLOBAL_PLUGIN_DIR_PATH,
   KILO_GLOBAL_PLUGINS_DIR_PATH,
   KILO_HOOKS_FILE_NAME,
+  KILO_PLUGIN_DIR_PATH,
   KILO_PLUGINS_DIR_PATH,
 } from "../../constants/kilo-paths.js";
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import { CANONICAL_TO_KILO_EVENT_NAMES, KILO_HOOK_EVENTS } from "../../types/hooks.js";
-import { readFileContent } from "../../utils/file.js";
+import { readFileContent, readFileContentOrNull } from "../../utils/file.js";
 import { generateOpencodeStylePluginCode } from "./opencode-style-generator.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import {
@@ -38,14 +40,38 @@ export class KiloHooks extends ToolHooks {
     validate = true,
     global = false,
   }: ToolHooksFromFileParams): Promise<KiloHooks> {
-    const paths = KiloHooks.getSettablePaths({ global });
-    const fileContent = await readFileContent(
-      join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+    // Kilo loads plugins from both the plural `plugins/` and the singular
+    // `plugin/` directory. The write side always targets the plural directory,
+    // but on import we probe the plural directory first and fall back to the
+    // singular one so a user's singular-dir plugin file is picked up too.
+    // https://kilo.ai/docs/automate/extending/plugins
+    const pluralDirPath = global ? KILO_GLOBAL_PLUGINS_DIR_PATH : KILO_PLUGINS_DIR_PATH;
+    const singularDirPath = global ? KILO_GLOBAL_PLUGIN_DIR_PATH : KILO_PLUGIN_DIR_PATH;
+
+    let relativeDirPath = pluralDirPath;
+    let fileContent = await readFileContentOrNull(
+      join(outputRoot, pluralDirPath, KILO_HOOKS_FILE_NAME),
     );
+    if (fileContent === null) {
+      const singularContent = await readFileContentOrNull(
+        join(outputRoot, singularDirPath, KILO_HOOKS_FILE_NAME),
+      );
+      if (singularContent !== null) {
+        relativeDirPath = singularDirPath;
+        fileContent = singularContent;
+      }
+    }
+
+    // Preserve the original throw-on-missing behavior when neither directory has
+    // the plugin file: re-read the plural path so the error message points there.
+    if (fileContent === null) {
+      fileContent = await readFileContent(join(outputRoot, pluralDirPath, KILO_HOOKS_FILE_NAME));
+    }
+
     return new KiloHooks({
       outputRoot,
-      relativeDirPath: paths.relativeDirPath,
-      relativeFilePath: paths.relativeFilePath,
+      relativeDirPath,
+      relativeFilePath: KILO_HOOKS_FILE_NAME,
       fileContent,
       validate,
     });
@@ -58,11 +84,16 @@ export class KiloHooks extends ToolHooks {
     global = false,
   }: ToolHooksFromRulesyncHooksParams & { global?: boolean }): KiloHooks {
     const config = rulesyncHooks.getJson();
+    // Kilo's canonical plugin shape is a default-export module descriptor
+    // `export default { id, server }`. Named exports are documented as legacy,
+    // so the Kilo target emits the default-export form (unlike OpenCode, which
+    // keeps the named export). https://kilo.ai/docs/automate/extending/plugins
     const fileContent = generateOpencodeStylePluginCode(
       config,
       KILO_HOOK_EVENTS,
       "kilo",
       CANONICAL_TO_KILO_EVENT_NAMES,
+      "default",
     );
     const paths = KiloHooks.getSettablePaths({ global });
     return new KiloHooks({

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -30,6 +30,14 @@ export function generateOpencodeStylePluginCode(
   supportedEvents: readonly string[],
   toolConfigKey: "kilo" | "opencode",
   eventMap: Record<string, string>,
+  // Export shape of the generated plugin module:
+  // - "named" (default): `export const RulesyncHooksPlugin = async ({ $ }) => {...}`
+  //   — the OpenCode convention.
+  // - "default": `export default { id: "rulesync-hooks", server: async ({ $ }) => {...} }`
+  //   — Kilo's canonical `{ id, server }` module descriptor. Kilo marks named
+  //   exports as legacy, so the Kilo target emits this form.
+  //   https://kilo.ai/docs/automate/extending/plugins
+  exportStyle: "named" | "default" = "named",
 ): string {
   const supported: Set<string> = new Set(supportedEvents);
   const configHooks = { ...config.hooks, ...config[toolConfigKey]?.hooks };
@@ -67,46 +75,67 @@ export function generateOpencodeStylePluginCode(
     }
   }
 
-  const lines: string[] = [];
-  lines.push("export const RulesyncHooksPlugin = async ({ $ }) => {");
-  lines.push("  return {");
+  // Build the handler entries (the contents of the returned object) once with a
+  // base indentation, then wrap them in the requested export shape. The default
+  // (Kilo) export nests the function one level deeper, so its body is re-indented
+  // by an extra two spaces relative to the named (OpenCode) export.
+  const bodyLines: string[] = [];
 
   if (Object.keys(genericEventHandlers).length > 0) {
-    lines.push("    event: async ({ event }) => {");
+    bodyLines.push("    event: async ({ event }) => {");
     let isFirst = true;
     for (const [eventName, handlers] of Object.entries(genericEventHandlers)) {
-      lines.push(`      ${isFirst ? "if" : "else if"} (event.type === "${eventName}") {`);
+      bodyLines.push(`      ${isFirst ? "if" : "else if"} (event.type === "${eventName}") {`);
       isFirst = false;
       for (const handler of handlers) {
         const escapedCommand = escapeForTemplateLiteral(handler.command);
-        lines.push(`        await $\`${escapedCommand}\`;`);
+        bodyLines.push(`        await $\`${escapedCommand}\`;`);
       }
-      lines.push("      }");
+      bodyLines.push("      }");
     }
-    lines.push("    },");
+    bodyLines.push("    },");
   }
 
   for (const [eventName, handlers] of Object.entries(namedEventHandlers)) {
-    lines.push(`    "${eventName}": async (input) => {`);
+    bodyLines.push(`    "${eventName}": async (input) => {`);
     for (const handler of handlers) {
       const escapedCommand = escapeForTemplateLiteral(handler.command);
       if (handler.matcher) {
         const safeMatcher = validateAndSanitizeMatcher(handler.matcher);
-        lines.push("      {");
-        lines.push(`        const __re = new RegExp("${safeMatcher}");`);
-        lines.push(`        if (__re.test(input.tool)) {`);
-        lines.push(`          await $\`${escapedCommand}\`;`);
-        lines.push("        }");
-        lines.push("      }");
+        bodyLines.push("      {");
+        bodyLines.push(`        const __re = new RegExp("${safeMatcher}");`);
+        bodyLines.push(`        if (__re.test(input.tool)) {`);
+        bodyLines.push(`          await $\`${escapedCommand}\`;`);
+        bodyLines.push("        }");
+        bodyLines.push("      }");
       } else {
-        lines.push(`      await $\`${escapedCommand}\`;`);
+        bodyLines.push(`      await $\`${escapedCommand}\`;`);
       }
     }
-    lines.push("    },");
+    bodyLines.push("    },");
   }
 
-  lines.push("  };");
-  lines.push("};");
+  const lines: string[] = [];
+  if (exportStyle === "default") {
+    lines.push("export default {");
+    lines.push('  id: "rulesync-hooks",');
+    lines.push("  server: async ({ $ }) => {");
+    lines.push("    return {");
+    // Indent the handler entries by an extra two spaces to account for the
+    // additional `server` function nesting level. Blank lines stay empty.
+    for (const line of bodyLines) {
+      lines.push(line === "" ? "" : `  ${line}`);
+    }
+    lines.push("    };");
+    lines.push("  },");
+    lines.push("};");
+  } else {
+    lines.push("export const RulesyncHooksPlugin = async ({ $ }) => {");
+    lines.push("  return {");
+    lines.push(...bodyLines);
+    lines.push("  };");
+    lines.push("};");
+  }
   lines.push("");
 
   return lines.join("\n");

--- a/src/features/mcp/kilo-mcp.test.ts
+++ b/src/features/mcp/kilo-mcp.test.ts
@@ -378,6 +378,65 @@ describe("KiloMcp", () => {
       });
       expect((json as any).version).toBe("1.0.0");
     });
+
+    it("should import from the alternative .kilo/kilo.jsonc project location", async () => {
+      const kiloDir = join(testDir, ".kilo");
+      await ensureDir(kiloDir);
+      const jsonData = {
+        mcp: {
+          "scoped-server": {
+            type: "local",
+            command: ["node", "scoped.js"],
+            enabled: true,
+          },
+        },
+      };
+      await writeFileContent(join(kiloDir, "kilo.jsonc"), JSON.stringify(jsonData, null, 2));
+
+      const kiloMcp = await KiloMcp.fromFile({ outputRoot: testDir });
+
+      expect(kiloMcp.getJson().mcp).toEqual(jsonData.mcp);
+      expect(kiloMcp.getRelativeDirPath()).toBe(".kilo");
+      expect(kiloMcp.getFilePath()).toBe(join(testDir, ".kilo", "kilo.jsonc"));
+    });
+
+    it("should import from the alternative .kilo/kilo.json project location", async () => {
+      const kiloDir = join(testDir, ".kilo");
+      await ensureDir(kiloDir);
+      const jsonData = {
+        mcp: {
+          "scoped-json": {
+            type: "local",
+            command: ["node", "scoped.js"],
+            enabled: true,
+          },
+        },
+      };
+      await writeFileContent(join(kiloDir, "kilo.json"), JSON.stringify(jsonData, null, 2));
+
+      const kiloMcp = await KiloMcp.fromFile({ outputRoot: testDir });
+
+      expect(kiloMcp.getJson().mcp).toEqual(jsonData.mcp);
+      expect(kiloMcp.getFilePath()).toBe(join(testDir, ".kilo", "kilo.json"));
+    });
+
+    it("should prefer the root kilo.jsonc over the .kilo/ alternative location", async () => {
+      const kiloDir = join(testDir, ".kilo");
+      await ensureDir(kiloDir);
+      await writeFileContent(
+        join(testDir, "kilo.jsonc"),
+        JSON.stringify({ mcp: { root: { type: "local", command: ["root"], enabled: true } } }),
+      );
+      await writeFileContent(
+        join(kiloDir, "kilo.jsonc"),
+        JSON.stringify({ mcp: { nested: { type: "local", command: ["nested"], enabled: true } } }),
+      );
+
+      const kiloMcp = await KiloMcp.fromFile({ outputRoot: testDir });
+
+      expect(Object.keys(kiloMcp.getJson().mcp ?? {})).toEqual(["root"]);
+      expect(kiloMcp.getRelativeDirPath()).toBe(".");
+    });
   });
 
   describe("fromRulesyncMcp", () => {

--- a/src/features/mcp/kilo-mcp.ts
+++ b/src/features/mcp/kilo-mcp.ts
@@ -4,6 +4,7 @@ import { parse as parseJsonc } from "jsonc-parser";
 import { z } from "zod/mini";
 
 import {
+  KILO_DIR,
   KILO_GLOBAL_DIR,
   KILO_JSON_FILE_NAME,
   KILO_JSONC_FILE_NAME,
@@ -264,28 +265,75 @@ export class KiloMcp extends ToolMcp {
     };
   }
 
+  /**
+   * Resolve the config file to import from, probing in priority order:
+   *   1. project root `kilo.jsonc` / `kilo.json` (or the global `.config/kilo`
+   *      directory in global mode), then
+   *   2. the alternative project location `.kilo/kilo.jsonc` / `.kilo/kilo.json`.
+   *
+   * Kilo accepts project config at the root OR under `.kilo/` ("for a cleaner
+   * setup"), so the import side probes both. The write side intentionally stays
+   * at the root location returned by `getSettablePaths`.
+   * https://kilo.ai/docs/automate/mcp/using-in-kilo-code
+   */
+  private static async resolveImportConfig({
+    outputRoot,
+    global,
+  }: {
+    outputRoot: string;
+    global: boolean;
+  }): Promise<{ fileContent: string | null; relativeDirPath: string; relativeFilePath: string }> {
+    const rootDirPath = this.getSettablePaths({ global }).relativeDirPath;
+    // The alternative `.kilo/` project location only applies to project scope.
+    const candidateDirPaths = global ? [rootDirPath] : [rootDirPath, KILO_DIR];
+
+    // Track the first existing-but-empty file so the empty-content path is
+    // preserved (an existing empty `kilo.json` should be parsed as-is, matching
+    // the previous root-only behavior, rather than silently defaulting to an
+    // empty `mcp` object).
+    let emptyFallback: { relativeDirPath: string; relativeFilePath: string } | null = null;
+
+    for (const relativeDirPath of candidateDirPaths) {
+      const jsonDir = join(outputRoot, relativeDirPath);
+
+      // Always try JSONC first (preferred format), then fall back to JSON.
+      for (const relativeFilePath of [KILO_JSONC_FILE_NAME, KILO_JSON_FILE_NAME]) {
+        const content = await readFileContentOrNull(join(jsonDir, relativeFilePath));
+        if (content === null) {
+          continue;
+        }
+        if (content) {
+          return { fileContent: content, relativeDirPath, relativeFilePath };
+        }
+        // Existing but empty file: remember the first one as a fallback.
+        emptyFallback ??= { relativeDirPath, relativeFilePath };
+      }
+    }
+
+    if (emptyFallback) {
+      return {
+        fileContent: "",
+        relativeDirPath: emptyFallback.relativeDirPath,
+        relativeFilePath: emptyFallback.relativeFilePath,
+      };
+    }
+
+    return {
+      fileContent: null,
+      relativeDirPath: rootDirPath,
+      relativeFilePath: KILO_JSONC_FILE_NAME,
+    };
+  }
+
   static async fromFile({
     outputRoot = process.cwd(),
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<KiloMcp> {
-    const basePaths = this.getSettablePaths({ global });
-    const jsonDir = join(outputRoot, basePaths.relativeDirPath);
-
-    let fileContent: string | null = null;
-    let relativeFilePath = KILO_JSONC_FILE_NAME;
-
-    const jsoncPath = join(jsonDir, KILO_JSONC_FILE_NAME);
-    const jsonPath = join(jsonDir, KILO_JSON_FILE_NAME);
-
-    // Always try JSONC first (preferred format), then fall back to JSON
-    fileContent = await readFileContentOrNull(jsoncPath);
-    if (!fileContent) {
-      fileContent = await readFileContentOrNull(jsonPath);
-      if (fileContent) {
-        relativeFilePath = KILO_JSON_FILE_NAME;
-      }
-    }
+    const { fileContent, relativeDirPath, relativeFilePath } = await this.resolveImportConfig({
+      outputRoot,
+      global,
+    });
 
     const fileContentToUse = fileContent ?? '{"mcp":{}}';
     const json = parseJsonc(fileContentToUse);
@@ -293,7 +341,7 @@ export class KiloMcp extends ToolMcp {
 
     return new KiloMcp({
       outputRoot,
-      relativeDirPath: basePaths.relativeDirPath,
+      relativeDirPath,
       relativeFilePath,
       fileContent: JSON.stringify(newJson, null, 2),
       validate,

--- a/src/features/permissions/kilo-permissions.test.ts
+++ b/src/features/permissions/kilo-permissions.test.ts
@@ -198,6 +198,53 @@ describe("KiloPermissions", () => {
     expect(rulesync.permission.bash).toEqual({ "*": "ask" });
   });
 
+  it("should import from the alternative .kilo/kilo.jsonc project location", async () => {
+    await ensureDir(join(testDir, ".kilo"));
+    await writeFileContent(
+      join(testDir, ".kilo", "kilo.jsonc"),
+      JSON.stringify({ permission: { bash: "ask" } }),
+    );
+
+    const instance = await KiloPermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission.bash).toEqual({ "*": "ask" });
+    expect(instance.getRelativeDirPath()).toBe(".kilo");
+    expect(instance.getFilePath()).toBe(join(testDir, ".kilo", "kilo.jsonc"));
+  });
+
+  it("should import from the alternative .kilo/kilo.json project location", async () => {
+    await ensureDir(join(testDir, ".kilo"));
+    await writeFileContent(
+      join(testDir, ".kilo", "kilo.json"),
+      JSON.stringify({ permission: { read: { ".env": "deny" } } }),
+    );
+
+    const instance = await KiloPermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission.read).toEqual({ ".env": "deny" });
+    expect(instance.getFilePath()).toBe(join(testDir, ".kilo", "kilo.json"));
+  });
+
+  it("should prefer the root kilo.jsonc over the .kilo/ alternative location", async () => {
+    await ensureDir(join(testDir, ".kilo"));
+    await writeFileContent(
+      join(testDir, "kilo.jsonc"),
+      JSON.stringify({ permission: { bash: "allow" } }),
+    );
+    await writeFileContent(
+      join(testDir, ".kilo", "kilo.jsonc"),
+      JSON.stringify({ permission: { bash: "deny" } }),
+    );
+
+    const instance = await KiloPermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission.bash).toEqual({ "*": "allow" });
+    expect(instance.getRelativeDirPath()).toBe(".");
+  });
+
   it("forDeletion returns non-deletable instance", () => {
     const instance = KiloPermissions.forDeletion({
       outputRoot: testDir,

--- a/src/features/permissions/kilo-permissions.ts
+++ b/src/features/permissions/kilo-permissions.ts
@@ -3,7 +3,12 @@ import { join } from "node:path";
 import { type ParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser";
 import { z } from "zod/mini";
 
-import { KILO_GLOBAL_DIR, KILO_JSONC_FILE_NAME } from "../../constants/kilo-paths.js";
+import {
+  KILO_DIR,
+  KILO_GLOBAL_DIR,
+  KILO_JSON_FILE_NAME,
+  KILO_JSONC_FILE_NAME,
+} from "../../constants/kilo-paths.js";
 import type { AiFileParams } from "../../types/ai-file.js";
 import { type ValidationResult } from "../../types/ai-file.js";
 import type { PermissionsConfig } from "../../types/permissions.js";
@@ -119,21 +124,65 @@ export class KiloPermissions extends ToolPermissions {
     validate = true,
     global = false,
   }: ToolPermissionsFromFileParams): Promise<KiloPermissions> {
-    const basePaths = KiloPermissions.getSettablePaths({ global });
-    const filePath = join(outputRoot, basePaths.relativeDirPath, basePaths.relativeFilePath);
-
-    const fileContent = await readFileContentOrNull(filePath);
+    const { fileContent, filePath, relativeDirPath, relativeFilePath } =
+      await KiloPermissions.resolveImportConfig({ outputRoot, global });
 
     const parsed = parseKiloJsoncStrict(fileContent ?? "{}", filePath);
     const nextJson = { ...parsed, permission: parsed.permission ?? {} };
 
     return new KiloPermissions({
       outputRoot,
-      relativeDirPath: basePaths.relativeDirPath,
-      relativeFilePath: basePaths.relativeFilePath,
+      relativeDirPath,
+      relativeFilePath,
       fileContent: JSON.stringify(nextJson, null, 2),
       validate,
     });
+  }
+
+  /**
+   * Resolve the config file to import permissions from, probing in priority order:
+   *   1. project root `kilo.jsonc` / `kilo.json` (or the global `.config/kilo`
+   *      directory in global mode), then
+   *   2. the alternative project location `.kilo/kilo.jsonc` / `.kilo/kilo.json`.
+   *
+   * Kilo accepts project config at the root OR under `.kilo/`, so the import side
+   * probes both. The write side intentionally stays at the root location returned
+   * by `getSettablePaths`.
+   * https://kilo.ai/docs/automate/mcp/using-in-kilo-code
+   */
+  private static async resolveImportConfig({
+    outputRoot,
+    global,
+  }: {
+    outputRoot: string;
+    global: boolean;
+  }): Promise<{
+    fileContent: string | null;
+    filePath: string;
+    relativeDirPath: string;
+    relativeFilePath: string;
+  }> {
+    const rootDirPath = KiloPermissions.getSettablePaths({ global }).relativeDirPath;
+    // The alternative `.kilo/` project location only applies to project scope.
+    const candidateDirPaths = global ? [rootDirPath] : [rootDirPath, KILO_DIR];
+
+    for (const relativeDirPath of candidateDirPaths) {
+      for (const relativeFilePath of [KILO_JSONC_FILE_NAME, KILO_JSON_FILE_NAME]) {
+        const filePath = join(outputRoot, relativeDirPath, relativeFilePath);
+        const fileContent = await readFileContentOrNull(filePath);
+        if (fileContent !== null) {
+          return { fileContent, filePath, relativeDirPath, relativeFilePath };
+        }
+      }
+    }
+
+    // Nothing found: fall back to the root JSONC path for the (empty) result.
+    return {
+      fileContent: null,
+      filePath: join(outputRoot, rootDirPath, KILO_JSONC_FILE_NAME),
+      relativeDirPath: rootDirPath,
+      relativeFilePath: KILO_JSONC_FILE_NAME,
+    };
   }
 
   static async fromRulesyncPermissions({


### PR DESCRIPTION
## Summary

Closes #1937
Issue: https://github.com/dyoshikawa/rulesync/issues/1937

Aligns Kilo Code support with Kilo's documented plugin format and project-config discovery. Three import/output drifts are fixed; the write side intentionally stays where it already was (valid per Kilo docs), and the OpenCode target is untouched.

## Changes

### 1. Hooks plugin export shape — emit canonical default export
Kilo's [Plugins docs](https://kilo.ai/docs/automate/extending/plugins) document the canonical plugin shape as a default-export module descriptor `export default { id, server }` and mark named function exports as legacy.

The Kilo target previously reused `opencode-style-generator.ts`, which emits a named export `export const RulesyncHooksPlugin = async ({ $ }) => {...}`. `generateOpencodeStylePluginCode` now takes an `exportStyle: "named" | "default"` option:
- `KiloHooks.fromRulesyncHooks` passes `"default"`, producing `export default { id: "rulesync-hooks", server: async ({ $ }) => {...} }`.
- `OpencodeHooks` keeps the default `"named"` form, so OpenCode output is unchanged.

The handler entries are built once and re-indented for the extra `server` nesting level, keeping the generator DRY (no duplicated generator).

### 2. Hooks import — also probe the singular `plugin/` directory
Kilo reads plugins from both the plural `plugins/` and the singular `plugin/` directory in any config dir. `KiloHooks.fromFile` now probes the plural `.kilo/plugins/` first and falls back to the singular `.kilo/plugin/` (project and global) on import. The write side stays plural (valid).

### 3. MCP + permissions import — also probe `.kilo/kilo.jsonc`
Kilo project config may live at the root `kilo.jsonc` **or** at `.kilo/kilo.jsonc`. `KiloMcp.fromFile` and `KiloPermissions.fromFile` now probe the root location first, then the `.kilo/` alternative (`kilo.jsonc` preferred, `kilo.json` fallback) on import. The write side intentionally stays at the root.

## OpenCode vs Kilo export divergence
Handled with a single optional `exportStyle` parameter on the shared generator rather than duplicating the generator. Kilo emits the canonical `{ id, server }` default export; OpenCode keeps its existing named export. The Kilo parse/import side reads the file back as opaque content, so the new shape round-trips fine.

## Tests
- New: canonical default-export plugin shape (with `node --check` ESM validity), singular `.kilo/plugin/` import + plural-preferred precedence, `.kilo/kilo.jsonc` / `.kilo/kilo.json` import for MCP and permissions + root-preferred precedence.
- Updated existing kilo-hooks assertions for the new default-export output and indentation.
- Existing Tool × Feature happy-path E2E tests preserved.

`pnpm cicheck` passes (6727 tests, format, lint, typecheck, content checks). `pnpm dev gitignore` produced no `.gitignore` change (import-only probes do not affect generated output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
