### PR TITLE
test(grokcli): add global-mode e2e skills case and align adapter ordering

### DIFF
--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -347,6 +347,10 @@ describe("E2E: skills (global mode)", () => {
       outputPath: join(".copilot", "skills", "test-skill", "SKILL.md"),
     },
     {
+      target: "grokcli",
+      outputPath: join(".grok", "skills", "test-skill", "SKILL.md"),
+    },
+    {
       target: "geminicli",
       outputPath: join(".gemini", "skills", "test-skill", "SKILL.md"),
     },

--- a/src/features/skills/grokcli-skill.ts
+++ b/src/features/skills/grokcli-skill.ts
@@ -84,6 +84,12 @@ export class GrokcliSkill extends ToolSkill {
     // Grok Build skills use the same relative path for both project and global
     // modes; the location differs based on outputRoot (./.grok/skills vs
     // ~/.grok/skills).
+    //
+    // Grok also discovers skills from `~/.agents/skills/` (Agents.md
+    // compatibility) and from extra `[skills] paths` entries in
+    // `~/.grok/config.toml`. rulesync intentionally emits only the canonical
+    // `.grok/skills/` root, matching how the other native-skill tools target a
+    // single canonical directory.
     return {
       relativeDirPath: GROKCLI_SKILLS_DIR_PATH,
     };
@@ -144,13 +150,12 @@ export class GrokcliSkill extends ToolSkill {
     global = false,
   }: ToolSkillFromRulesyncSkillParams): GrokcliSkill {
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+    const settablePaths = GrokcliSkill.getSettablePaths({ global });
 
     const grokcliFrontmatter: GrokcliSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
     };
-
-    const settablePaths = GrokcliSkill.getSettablePaths({ global });
 
     return new GrokcliSkill({
       outputRoot,


### PR DESCRIPTION
## Summary

Follow-ups from PR #1912 (grokcli skills). Addresses the non-blocking findings captured in the issue.

- **Finding 1 (mid):** Add a `grokcli` entry to the **global-mode** e2e skills matrix in `src/e2e/e2e-skills.spec.ts`, covering the advertised global scope (`~/.grok/skills/test-skill/SKILL.md`). grokcli registers `supportsGlobal: true` and the docs advertise `✅ 🌏`, but only the project-mode matrix had a case. This restores full Tool × Feature happy-path coverage per the feature-change guidelines.
- **Finding 3 (low):** Align `fromRulesyncSkill` statement ordering with the `geminicli-skill.ts` template (compute `settablePaths` before building the frontmatter). Behavior is identical; this keeps the two near-identical adapters easy to diff.
- **Finding 2 (low):** Document the intentional single-canonical-root scope — grokcli skills are not also emitted to `~/.agents/skills/` or `[skills] paths`, matching how other native-skill tools target one canonical directory.

## Verification

- `pnpm cicheck:code` passes (lint, types, 6727 unit tests incl. the new global-mode grokcli e2e case).

Closes #1935

Ref: #1912