### PR TITLE
fix(cursor): flatten multi-line .mdc description to avoid YAML block scalar

### DIFF
--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -438,6 +438,36 @@ This is the rule content
       expect(parsed.getBody()).toBe("Always enable strict mode.");
     });
 
+    it("should flatten a multi-line description into a single-line scalar Cursor can read", async () => {
+      // A genuinely multi-line description must NOT serialize to a YAML block scalar
+      // (`description: |-`): Cursor's simplified MDC parser does not read block-scalar
+      // indicators. The newlines are flattened to spaces before serialization.
+      const generated = new CursorRule({
+        frontmatter: { description: "Line one\nLine two", globs: "*.ts", alwaysApply: false },
+        body: "Body.",
+        relativeDirPath: ".cursor/rules",
+        relativeFilePath: "multiline.mdc",
+      });
+
+      const content = generated.getFileContent();
+      // No block-scalar indicator, and the value is on a single line.
+      expect(content).not.toContain("description: |");
+      expect(content).not.toContain("description: >");
+      expect(content).toContain("description: Line one Line two");
+
+      const filePath = join(testDir, ".cursor/rules", "multiline.mdc");
+      await writeFileContent(filePath, content);
+      const parsed = await CursorRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "multiline.mdc",
+      });
+      expect(parsed.getFrontmatter()).toEqual({
+        description: "Line one Line two",
+        globs: "*.ts",
+        alwaysApply: false,
+      });
+    });
+
     it("should handle file with no frontmatter", async () => {
       const filePath = join(testDir, ".cursor/rules", "simple.mdc");
       const content = "Just plain content without frontmatter";

--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -468,6 +468,54 @@ This is the rule content
       });
     });
 
+    it("should flatten and still quote a multi-line description containing YAML indicators", async () => {
+      // The riskiest combination: newlines AND injection-significant characters. The
+      // value must be flattened to one line AND quoted so it cannot break out of the
+      // frontmatter.
+      const generated = new CursorRule({
+        frontmatter: {
+          description: "Line one: foo\n---\nalwaysApply: true",
+          globs: "*.ts",
+          alwaysApply: false,
+        },
+        body: "Body.",
+        relativeDirPath: ".cursor/rules",
+        relativeFilePath: "tricky.mdc",
+      });
+
+      const content = generated.getFileContent();
+      expect(content).not.toContain("description: |");
+      // The flattened value is quoted (single line), keeping `---`/`alwaysApply:`
+      // safely inside the scalar.
+      expect(content).toContain("description: 'Line one: foo --- alwaysApply: true'");
+
+      const filePath = join(testDir, ".cursor/rules", "tricky.mdc");
+      await writeFileContent(filePath, content);
+      const parsed = await CursorRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "tricky.mdc",
+      });
+      expect(parsed.getFrontmatter()).toEqual({
+        description: "Line one: foo --- alwaysApply: true",
+        globs: "*.ts",
+        alwaysApply: false,
+      });
+    });
+
+    it("should pass a non-string description through unchanged when validation is skipped", () => {
+      // On the validate: false path a non-string description must not throw (the flatten
+      // guard skips it) and is serialized as-is by js-yaml.
+      const generated = new CursorRule({
+        frontmatter: { description: 123 as unknown as string },
+        body: "Body.",
+        relativeDirPath: ".cursor/rules",
+        relativeFilePath: "nonstring.mdc",
+        validate: false,
+      });
+
+      expect(generated.getFileContent()).toContain("description: 123");
+    });
+
     it("should handle file with no frontmatter", async () => {
       const filePath = join(testDir, ".cursor/rules", "simple.mdc");
       const content = "Just plain content without frontmatter";

--- a/src/features/rules/cursor-rule.test.ts
+++ b/src/features/rules/cursor-rule.test.ts
@@ -509,7 +509,7 @@ This is the rule content
         frontmatter: { description: 123 as unknown as string },
         body: "Body.",
         relativeDirPath: ".cursor/rules",
-        relativeFilePath: "nonstring.mdc",
+        relativeFilePath: "non-string.mdc",
         validate: false,
       });
 

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -97,9 +97,22 @@ export class CursorRule extends ToolRule {
       // indicators (e.g. a ": " sequence, a leading "#", or values like "true"/"123"),
       // producing a file that this tool's own parser can no longer read. js-yaml only
       // adds quotes when required, so plain descriptions stay unquoted (matching the
-      // MDC "no unnecessary quotes" convention used for globs below). lineWidth: -1
-      // prevents js-yaml from wrapping long descriptions into block scalars.
-      lines.push(dump({ description: frontmatter.description }, { lineWidth: -1 }).trimEnd());
+      // MDC "no unnecessary quotes" convention used for globs below).
+      //
+      // Flatten any newlines into spaces first: a genuinely multi-line value would
+      // otherwise serialize to a YAML block scalar (`description: |-`), and Cursor's
+      // simplified MDC frontmatter parser does not read block-scalar indicators (this
+      // mirrors the `avoidBlockScalars` serializer used by the sibling Cursor
+      // features). `lineWidth: -1` then keeps the resulting single-line value from
+      // being folded across lines.
+      // Guard against non-string values reaching here when validation is skipped
+      // (validate: false): only strings can be flattened, others pass through.
+      const rawDescription = frontmatter.description;
+      const description =
+        typeof rawDescription === "string"
+          ? rawDescription.replace(/\n+/g, " ").trim()
+          : rawDescription;
+      lines.push(dump({ description }, { lineWidth: -1 }).trimEnd());
     }
     if (frontmatter.globs !== undefined) {
       // Output globs without quotes

--- a/src/features/rules/cursor-rule.ts
+++ b/src/features/rules/cursor-rule.ts
@@ -91,27 +91,30 @@ export class CursorRule extends ToolRule {
     if (frontmatter.alwaysApply !== undefined) {
       lines.push(`alwaysApply: ${frontmatter.alwaysApply}`);
     }
-    if (frontmatter.description) {
-      // Serialize the description as a proper YAML scalar instead of raw interpolation.
-      // Raw interpolation corrupts the frontmatter whenever the value contains YAML
-      // indicators (e.g. a ": " sequence, a leading "#", or values like "true"/"123"),
-      // producing a file that this tool's own parser can no longer read. js-yaml only
-      // adds quotes when required, so plain descriptions stay unquoted (matching the
-      // MDC "no unnecessary quotes" convention used for globs below).
-      //
-      // Flatten any newlines into spaces first: a genuinely multi-line value would
-      // otherwise serialize to a YAML block scalar (`description: |-`), and Cursor's
-      // simplified MDC frontmatter parser does not read block-scalar indicators (this
-      // mirrors the `avoidBlockScalars` serializer used by the sibling Cursor
-      // features). `lineWidth: -1` then keeps the resulting single-line value from
-      // being folded across lines.
-      // Guard against non-string values reaching here when validation is skipped
-      // (validate: false): only strings can be flattened, others pass through.
-      const rawDescription = frontmatter.description;
-      const description =
-        typeof rawDescription === "string"
-          ? rawDescription.replace(/\n+/g, " ").trim()
-          : rawDescription;
+    // Serialize the description as a proper YAML scalar instead of raw interpolation.
+    // Raw interpolation corrupts the frontmatter whenever the value contains YAML
+    // indicators (e.g. a ": " sequence, a leading "#", or values like "true"/"123"),
+    // producing a file that this tool's own parser can no longer read. js-yaml only
+    // adds quotes when required, so plain descriptions stay unquoted (matching the
+    // MDC "no unnecessary quotes" convention used for globs below).
+    //
+    // Flatten any newlines into spaces first: a genuinely multi-line value would
+    // otherwise serialize to a YAML block scalar (`description: |-`), and Cursor's
+    // simplified MDC frontmatter parser does not read block-scalar indicators (this
+    // mirrors the `avoidBlockScalars` serializer used by the sibling Cursor
+    // features). `lineWidth: -1` then keeps the resulting single-line value from
+    // being folded across lines.
+    //
+    // Guard against non-string values reaching here when validation is skipped
+    // (validate: false): only strings can be flattened, others pass through. Guarding
+    // on the flattened value also keeps whitespace-only descriptions out of the
+    // output, consistent with how an empty-string description is omitted.
+    const rawDescription = frontmatter.description;
+    const description =
+      typeof rawDescription === "string"
+        ? rawDescription.replace(/\n+/g, " ").trim()
+        : rawDescription;
+    if (description) {
       lines.push(dump({ description }, { lineWidth: -1 }).trimEnd());
     }
     if (frontmatter.globs !== undefined) {


### PR DESCRIPTION
## Summary

Follow-ups from PR #1920 (Cursor `.mdc` description escaping). Addresses the multiline block-scalar compatibility gap.

- **Findings 1 & 2 (mid):** A genuinely multi-line `description` still serialized to a YAML block scalar (`description: |-`), which Cursor's simplified MDC frontmatter parser does not read. We now flatten newlines to spaces (`description.replace(/\n+/g, " ").trim()`) before `dump()`, matching the `avoidBlockScalars` semantics used by the sibling Cursor features, so Cursor itself — not just rulesync's parser — can read the description. Non-string values on the `validate: false` path pass through unchanged.
- **Finding 3 (low):** Corrected the misleading comment about `lineWidth: -1` (it only prevents folding of long single-line values, not block scalars for multi-line strings).
- Added a multi-line `description` round-trip test asserting no block-scalar indicator is emitted.

Note: `CursorRule` keeps its custom serializer because Cursor requires `globs` unquoted, so this targets the `description` line specifically rather than switching the whole path to the shared serializer.

## Verification

- `pnpm cicheck:code` passes (lint, types, 6728 unit tests incl. the new multi-line case).

Closes #1933

Ref: #1920