### PR TITLE
test(grokcli): cover global-mode skills + align adapter ordering (#1935)

### DIFF
--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -343,6 +343,10 @@ describe("E2E: skills (global mode)", () => {
       outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
     },
     {
+      target: "grokcli",
+      outputPath: join(".grok", "skills", "test-skill", "SKILL.md"),
+    },
+    {
       target: "copilotcli",
       outputPath: join(".copilot", "skills", "test-skill", "SKILL.md"),
     },

--- a/src/features/skills/grokcli-skill.ts
+++ b/src/features/skills/grokcli-skill.ts
@@ -42,6 +42,12 @@ export type GrokcliSkillParams = {
  * `name`/`description` frontmatter (verified via `grok inspect`). The format is
  * Claude-compatible, so only `name` and `description` are required; any extra
  * frontmatter keys are preserved verbatim via the loose schema.
+ *
+ * Scope: rulesync emits to the single canonical `.grok/skills/` root only. Grok
+ * Build also reads skills from `~/.agents/skills/` (Agents.md compatibility) and
+ * any extra `[skills] paths` declared in `~/.grok/config.toml`; those secondary
+ * sources are intentionally out of scope, matching how rulesync emits one
+ * canonical skills root per tool.
  * @see https://docs.x.ai/build/features/skills-plugins-marketplaces
  */
 export class GrokcliSkill extends ToolSkill {
@@ -143,14 +149,13 @@ export class GrokcliSkill extends ToolSkill {
     validate = true,
     global = false,
   }: ToolSkillFromRulesyncSkillParams): GrokcliSkill {
+    const settablePaths = GrokcliSkill.getSettablePaths({ global });
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
 
     const grokcliFrontmatter: GrokcliSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
     };
-
-    const settablePaths = GrokcliSkill.getSettablePaths({ global });
 
     return new GrokcliSkill({
       outputRoot,


### PR DESCRIPTION
## Summary

Addresses the non-blocking follow-ups captured in #1935 after the grokcli **skills** feature merged in #1912.

- **Finding 1 (primary)** — Add a `grokcli` case to the **global-mode** skills e2e matrix (`~/.grok/skills/test-skill/SKILL.md`). grokcli registers `supportsGlobal: true` and the docs advertise `✅ 🌏`, but global behaviour was previously only covered by the `getSettablePaths({ global: true })` unit assertion. Per the project's feature-change guideline ("preserve end-to-end happy-path test cases that cover the Tool × Feature matrix" + "implement both project and global scope"), the advertised global scope now has a real e2e case alongside every other global-supporting native-skill tool.
- **Finding 3** — Align `GrokcliSkill.fromRulesyncSkill` statement ordering with the `geminicli-skill.ts` template (compute `settablePaths` first). Behaviour is identical; this keeps the two near-identical adapters easy to diff.
- **Finding 2** — Document the intentional skills-discovery scope: rulesync emits to the single canonical `.grok/skills/` root only; Grok's secondary sources (`~/.agents/skills/` Agents.md compatibility, and `[skills] paths` in `~/.grok/config.toml`) are intentionally out of scope, matching how rulesync handles other tools.

## Testing

- `pnpm check` (oxfmt / oxlint / tsgo) — clean.
- `grokcli-skill` unit tests + the `grokcli` skills e2e cases (project **and** the new global-mode case) pass.
- `cicheck:content` (sync-skill-docs, cspell, secretlint) — clean.

No production-path behaviour changes (Finding 3 is a pure statement reorder; Finding 2 is a comment); the only new coverage is the global-mode e2e case.

Closes #1935.
