### PR TITLE
test(gitignore): make global-only skip symmetric and remove silent catch-swallow

### DIFF
--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -113,13 +113,17 @@ describe("getSettablePaths coverage", () => {
   for (const [feature, factories] of dirFeatures) {
     for (const [target, factory] of factories) {
       if (TARGETS_WITHOUT_GITIGNORE_ENTRIES.has(target)) continue;
+      // Skip global-only tools explicitly (same guard as the fileFeatures branch
+      // below) rather than relying on `getSettablePaths({ global: false })`
+      // throwing and a broad catch swallowing it — otherwise a global-only tool
+      // refactored to return a project path would silently change coverage.
+      const meta = factory.meta as { supportsProject?: boolean } | undefined;
+      if (meta && meta.supportsProject === false) continue;
       it(`covers ${feature} output for ${target}`, () => {
-        let paths: { relativeDirPath?: string };
-        try {
-          paths = factory.class.getSettablePaths({ global: false });
-        } catch {
-          return;
-        }
+        // No try/catch: a project-supporting tool must resolve a project path
+        // without throwing, so an unexpected throw fails the test instead of
+        // passing silently.
+        const paths = factory.class.getSettablePaths({ global: false });
         const dir = paths.relativeDirPath;
         if (!dir || dir === ".") return;
         const glob = dirToGlob(dir);
@@ -141,12 +145,11 @@ describe("getSettablePaths coverage", () => {
       const meta = factory.meta as { supportsProject?: boolean } | undefined;
       if (meta && meta.supportsProject === false) continue;
       it(`covers ${feature} output for ${target}`, () => {
-        let paths: { relativeDirPath?: string; relativeFilePath?: string };
-        try {
-          paths = factory.class.getSettablePaths({ global: false });
-        } catch {
-          return;
-        }
+        // No try/catch: project-supporting tools must resolve without throwing
+        // (global-only tools are already skipped above), so an unexpected throw
+        // fails the test instead of passing silently.
+        const paths: { relativeDirPath?: string; relativeFilePath?: string } =
+          factory.class.getSettablePaths({ global: false });
         if (!paths.relativeFilePath) return;
         const glob = fileToGlob(paths.relativeDirPath, paths.relativeFilePath);
         if (DERIVED_PATHS_NOT_GITIGNORED.has(glob)) return;


### PR DESCRIPTION
## Summary

Follow-ups from PR #1929 (gitignore coverage test maintainability polish).

- **Finding 1 (mid):** The `dirFeatures` branch of `gitignore-entries.test.ts` relied on `getSettablePaths({ global: false })` *throwing* for global-only tools, with a broad `catch` swallowing it — asymmetric with the `fileFeatures` branch, which cleanly skips via `meta.supportsProject === false`. If a global-only dir tool were ever refactored to return a path instead of throwing, the test would falsely require that global path to be gitignored. Now both branches use the same explicit `meta.supportsProject === false` guard.
- **Finding 2 (low):** Removed the broad `try/catch` in both branches. With global-only tools skipped explicitly, a project-supporting tool must resolve a path without throwing, so an unexpected throw now fails the test instead of silently passing (a returning Vitest `it` with no assertion passes).

**Finding 3 (`.gemini/policies/` directory- vs file-level precision) is intentionally NOT changed.** Narrowing the registry entry to `**/.gemini/policies/rulesync.toml` is technically more precise, but it diverges from the established directory-level convention used elsewhere (`.kilo/commands/`, `.cline/skills/`) and, because this project dogfoods rulesync, regeneration leaves the old broad directory entry preserved as an unmanaged line — defeating the precision goal without manual cleanup. Keeping the directory-level convention is the cleaner decision; this can be revisited if precise per-file ignoring becomes a priority.

## Verification

- `pnpm cicheck` passes (code + content; 6737 unit tests incl. the 166 gitignore coverage tests, cspell, secretlint, skill-doc sync).

Closes #1930

Ref: #1929