### PR TITLE
fix(skills): serialize deepagents allowed-tools as space-delimited string and round-trip metadata

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -435,6 +435,17 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     agent-skills: ">=1.0.0"
   metadata: # (optional) free-form metadata
     author: rulesync
+deepagents: # for deepagents-cli (dcode)-specific parameters (optional; Agent Skills standard)
+  # Authored as a canonical list; emitted to SKILL.md as a space-delimited string
+  # (e.g. "Bash Read") because dcode rejects a YAML list at runtime.
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    deepagents-version: ">=0.1.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
 opencode: # for OpenCode-specific parameters (optional)
   license: MIT # (optional)
   compatibility: # (optional) free-form compatibility metadata

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -435,6 +435,17 @@ replit: # for Replit Agent-specific parameters (optional; Agent Skills standard)
     agent-skills: ">=1.0.0"
   metadata: # (optional) free-form metadata
     author: rulesync
+deepagents: # for deepagents-cli (dcode)-specific parameters (optional; Agent Skills standard)
+  # Authored as a canonical list; emitted to SKILL.md as a space-delimited string
+  # (e.g. "Bash Read") because dcode rejects a YAML list at runtime.
+  allowed-tools:
+    - "Bash"
+    - "Read"
+  license: MIT # (optional)
+  compatibility: # (optional) free-form compatibility metadata
+    deepagents-version: ">=0.1.0"
+  metadata: # (optional) free-form metadata
+    author: rulesync
 opencode: # for OpenCode-specific parameters (optional)
   license: MIT # (optional)
   compatibility: # (optional) free-form compatibility metadata

--- a/src/features/skills/deepagents-skill.test.ts
+++ b/src/features/skills/deepagents-skill.test.ts
@@ -275,6 +275,24 @@ Do the thing.`;
       expect(deepagents?.compatibility).toEqual({ "deepagents-version": ">=0.1.0" });
       expect(deepagents?.metadata).toEqual({ author: "rulesync" });
     });
+
+    it("should accept a string-form compatibility (Agent Skills spec) on import", () => {
+      // dcode follows the Agent Skills spec, where `compatibility` is a free-form
+      // string. A hand-authored SKILL.md using that form must not be rejected.
+      const skill = new DeepagentsSkill({
+        outputRoot: testDir,
+        dirName: "string-compat-skill",
+        frontmatter: {
+          name: "String Compat Skill",
+          description: "Has string compatibility.",
+          compatibility: "deepagents>=0.1.0",
+        },
+        body: "Instructions.",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      expect(rulesyncSkill.getFrontmatter().deepagents?.compatibility).toBe("deepagents>=0.1.0");
+    });
   });
 
   describe("allowed-tools round-trip", () => {

--- a/src/features/skills/deepagents-skill.test.ts
+++ b/src/features/skills/deepagents-skill.test.ts
@@ -48,19 +48,19 @@ describe("DeepagentsSkill", () => {
       expect(skill.getBody()).toBe("## Instructions\n\nDo the thing.");
     });
 
-    it("should create with allowed-tools", () => {
+    it("should create with allowed-tools as a space-delimited string", () => {
       const skill = new DeepagentsSkill({
         outputRoot: testDir,
         dirName: "tool-skill",
         frontmatter: {
           name: "Tool Skill",
           description: "Uses specific tools.",
-          "allowed-tools": ["read_file", "write_file"],
+          "allowed-tools": "read_file write_file",
         },
         body: "Use the tools.",
       });
 
-      expect(skill.getFrontmatter()["allowed-tools"]).toEqual(["read_file", "write_file"]);
+      expect(skill.getFrontmatter()["allowed-tools"]).toBe("read_file write_file");
     });
 
     it("should not throw on invalid frontmatter when validate=false", () => {
@@ -132,6 +132,51 @@ Do the thing.`;
 
       expect(skill.getFrontmatter()).not.toHaveProperty("allowed-tools");
     });
+
+    it("should serialize allowed-tools as a space-delimited string", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/skills",
+        dirName: "my-skill",
+        frontmatter: {
+          name: "My Skill",
+          description: "Does something.",
+          targets: ["*"],
+          deepagents: { "allowed-tools": ["Bash", "Read", "Write"] },
+        },
+        body: "Instructions here.",
+      });
+
+      const skill = DeepagentsSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
+
+      expect(skill.getFrontmatter()["allowed-tools"]).toBe("Bash Read Write");
+    });
+
+    it("should carry license, compatibility, and metadata through", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/skills",
+        dirName: "my-skill",
+        frontmatter: {
+          name: "My Skill",
+          description: "Does something.",
+          targets: ["*"],
+          deepagents: {
+            license: "MIT",
+            compatibility: { "deepagents-version": ">=0.1.0" },
+            metadata: { author: "rulesync" },
+          },
+        },
+        body: "Instructions here.",
+      });
+
+      const skill = DeepagentsSkill.fromRulesyncSkill({ outputRoot: testDir, rulesyncSkill });
+      const frontmatter = skill.getFrontmatter();
+
+      expect(frontmatter.license).toBe("MIT");
+      expect(frontmatter.compatibility).toEqual({ "deepagents-version": ">=0.1.0" });
+      expect(frontmatter.metadata).toEqual({ author: "rulesync" });
+    });
   });
 
   describe("isTargetedByRulesyncSkill", () => {
@@ -186,6 +231,82 @@ Do the thing.`;
       expect(rulesyncSkill.getFrontmatter().name).toBe("My Skill");
       expect(rulesyncSkill.getFrontmatter().description).toBe("Does something.");
       expect(rulesyncSkill.getFrontmatter().targets).toEqual(["*"]);
+    });
+
+    it("should parse a space-delimited allowed-tools string back into an array", () => {
+      const skill = new DeepagentsSkill({
+        outputRoot: testDir,
+        dirName: "tool-skill",
+        frontmatter: {
+          name: "Tool Skill",
+          description: "Uses tools.",
+          "allowed-tools": "Bash Read Write",
+        },
+        body: "Instructions.",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill.getFrontmatter().deepagents?.["allowed-tools"]).toEqual([
+        "Bash",
+        "Read",
+        "Write",
+      ]);
+    });
+
+    it("should carry license, compatibility, and metadata through", () => {
+      const skill = new DeepagentsSkill({
+        outputRoot: testDir,
+        dirName: "meta-skill",
+        frontmatter: {
+          name: "Meta Skill",
+          description: "Has metadata.",
+          license: "MIT",
+          compatibility: { "deepagents-version": ">=0.1.0" },
+          metadata: { author: "rulesync" },
+        },
+        body: "Instructions.",
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+      const deepagents = rulesyncSkill.getFrontmatter().deepagents;
+
+      expect(deepagents?.license).toBe("MIT");
+      expect(deepagents?.compatibility).toEqual({ "deepagents-version": ">=0.1.0" });
+      expect(deepagents?.metadata).toEqual({ author: "rulesync" });
+    });
+  });
+
+  describe("allowed-tools round-trip", () => {
+    it("should preserve the canonical array across emit and import", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync/skills",
+        dirName: "round-trip-skill",
+        frontmatter: {
+          name: "Round Trip Skill",
+          description: "Round-trips allowed-tools.",
+          targets: ["*"],
+          deepagents: { "allowed-tools": ["Bash", "Read", "Write"] },
+        },
+        body: "Instructions.",
+      });
+
+      const deepagentsSkill = DeepagentsSkill.fromRulesyncSkill({
+        outputRoot: testDir,
+        rulesyncSkill,
+      });
+
+      // dcode-specific serialization is a space-delimited string.
+      expect(deepagentsSkill.getFrontmatter()["allowed-tools"]).toBe("Bash Read Write");
+
+      // Importing back yields the canonical array representation again.
+      const roundTripped = deepagentsSkill.toRulesyncSkill();
+      expect(roundTripped.getFrontmatter().deepagents?.["allowed-tools"]).toEqual([
+        "Bash",
+        "Read",
+        "Write",
+      ]);
     });
   });
 

--- a/src/features/skills/deepagents-skill.ts
+++ b/src/features/skills/deepagents-skill.ts
@@ -22,7 +22,16 @@ import {
 export const DeepagentsSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
-  "allowed-tools": z.optional(z.array(z.string())),
+  // dcode's `_parse_allowed_tools` only accepts a space-delimited string; a YAML
+  // list is rejected at runtime (the allowlist is silently dropped). A list is
+  // still accepted here for tolerant parsing of hand-written files, but on emit
+  // rulesync always writes the space-delimited string form.
+  "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
+  // Agent Skills spec fields read by dcode's `_parse_skill_metadata`.
+  // https://agentskills.io/specification
+  license: z.optional(z.string()),
+  compatibility: z.optional(z.looseObject({})),
+  metadata: z.optional(z.looseObject({})),
 });
 
 export type DeepagentsSkillFrontmatter = z.infer<typeof DeepagentsSkillFrontmatterSchema>;
@@ -111,13 +120,27 @@ export class DeepagentsSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const allowedTools = frontmatter["allowed-tools"];
+    // Normalize back to the canonical rulesync array representation. dcode
+    // serializes `allowed-tools` as a whitespace-delimited string, so split it.
+    const allowedToolsArray =
+      allowedTools === undefined
+        ? undefined
+        : Array.isArray(allowedTools)
+          ? allowedTools
+          : allowedTools.split(/\s+/).filter((tool) => tool.length > 0);
+    const deepagentsBlock = {
+      ...(allowedToolsArray !== undefined &&
+        allowedToolsArray.length > 0 && { "allowed-tools": allowedToolsArray }),
+      ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && { compatibility: frontmatter.compatibility }),
+      ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
+    };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
-      ...(frontmatter["allowed-tools"] && {
-        deepagents: { "allowed-tools": frontmatter["allowed-tools"] },
-      }),
+      ...(Object.keys(deepagentsBlock).length > 0 && { deepagents: deepagentsBlock }),
     };
 
     return new RulesyncSkill({
@@ -141,12 +164,20 @@ export class DeepagentsSkill extends ToolSkill {
     const settablePaths = DeepagentsSkill.getSettablePaths({ global });
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
 
+    const deepagentsSection = rulesyncFrontmatter.deepagents;
+    const allowedTools = deepagentsSection?.["allowed-tools"];
+    // dcode only honors a space-delimited string; serialize the canonical array
+    // into that form so the allowlist is not dropped at runtime.
+    const allowedToolsString = Array.isArray(allowedTools) ? allowedTools.join(" ") : allowedTools;
     const deepagentsFrontmatter: DeepagentsSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
-      ...(rulesyncFrontmatter.deepagents?.["allowed-tools"] && {
-        "allowed-tools": rulesyncFrontmatter.deepagents["allowed-tools"],
+      ...(allowedToolsString && { "allowed-tools": allowedToolsString }),
+      ...(deepagentsSection?.license !== undefined && { license: deepagentsSection.license }),
+      ...(deepagentsSection?.compatibility !== undefined && {
+        compatibility: deepagentsSection.compatibility,
       }),
+      ...(deepagentsSection?.metadata !== undefined && { metadata: deepagentsSection.metadata }),
     };
 
     return new DeepagentsSkill({

--- a/src/features/skills/deepagents-skill.ts
+++ b/src/features/skills/deepagents-skill.ts
@@ -30,7 +30,10 @@ export const DeepagentsSkillFrontmatterSchema = z.looseObject({
   // Agent Skills spec fields read by dcode's `_parse_skill_metadata`.
   // https://agentskills.io/specification
   license: z.optional(z.string()),
-  compatibility: z.optional(z.looseObject({})),
+  // The Agent Skills spec defines `compatibility` as a free-form string
+  // (1–500 chars), which is what dcode actually reads; an object form is also
+  // tolerated for backward compatibility (matches the `agentsskills` adapter).
+  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
   metadata: z.optional(z.looseObject({})),
 });
 

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -85,6 +85,9 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   deepagents: z.optional(
     z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
+      license: z.optional(z.string()),
+      compatibility: z.optional(z.looseObject({})),
+      metadata: z.optional(z.looseObject({})),
     }),
   ),
   copilot: z.optional(
@@ -223,6 +226,9 @@ export type RulesyncSkillFrontmatterInput = {
   };
   deepagents?: {
     "allowed-tools"?: string[];
+    license?: string;
+    compatibility?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
   };
   copilot?: {
     license?: string;

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -86,7 +86,9 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
     z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
       license: z.optional(z.string()),
-      compatibility: z.optional(z.looseObject({})),
+      // The Agent Skills spec defines `compatibility` as a free-form string
+      // (1–500 chars); an object form is also tolerated for back-compat.
+      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
       metadata: z.optional(z.looseObject({})),
     }),
   ),
@@ -227,7 +229,7 @@ export type RulesyncSkillFrontmatterInput = {
   deepagents?: {
     "allowed-tools"?: string[];
     license?: string;
-    compatibility?: Record<string, unknown>;
+    compatibility?: string | Record<string, unknown>;
     metadata?: Record<string, unknown>;
   };
   copilot?: {


### PR DESCRIPTION
## Summary

Fixes two deepagents-cli (`dcode`) skill issues found against deepagents' `middleware/skills.py`.

Closes #1924
https://github.com/dyoshikawa/rulesync/issues/1924

### 1. `allowed-tools` serialization (correctness bug)

dcode's `_parse_allowed_tools` accepts `allowed-tools` **only** as a space-delimited string (it splits on whitespace). When it receives a YAML list it logs a warning and returns an empty list, so the allowlist is **silently dropped at runtime**. rulesync previously emitted an array, which dcode rejected.

- The canonical rulesync representation stays an **array**.
- When writing the deepagents `SKILL.md`, the array is now joined into a **space-delimited string** (e.g. `allowed-tools: Bash Read Write`).
- On import, the string is split on whitespace back into an array (a YAML list is still accepted for tolerant parsing of hand-written files).
- `DeepagentsSkillFrontmatterSchema` now types the deepagents-side field as `string | string[]`; the rulesync-side `deepagents` section stays an array.

### 2. Round-trip `license`, `compatibility`, `metadata`

dcode's `_parse_skill_metadata` also reads `license`, `compatibility`, and `metadata` (Agent Skills spec). These were lost on round-trip. They are now carried in both directions (`toRulesyncSkill` / `fromRulesyncSkill`), mirroring the existing `replit` / `pi` / `kilo` skill adapters (`license` string, `compatibility`/`metadata` objects).

## Changes

- `src/features/skills/deepagents-skill.ts` — schema + both-direction serialization.
- `src/features/skills/rulesync-skill.ts` — added `license`/`compatibility`/`metadata` to the `deepagents` section schema and input type.
- `src/features/skills/deepagents-skill.test.ts` — updated/added unit tests (space-delimited string emit, string→array parse, license/compatibility/metadata round-trip both directions).
- `docs/reference/file-formats.md` + synced `skills/rulesync/file-formats.md` — documented the `deepagents` skill section.

## Testing

Full `pnpm cicheck` (code + content) passes: format, oxlint, typecheck, 6748 unit tests, skill-doc sync, cspell, secretlint. Tool×Feature happy-path e2e tests preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
