### PR TITLE
test(grokcli): add rules global-mode e2e happy-path case (#1953)

### DIFF
--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -394,6 +394,7 @@ describe("E2E: rules (global mode)", () => {
     { target: "goose", outputPath: join(".config", "goose", ".goosehints") },
     { target: "copilotcli", outputPath: join(".copilot", "copilot-instructions.md") },
     { target: "deepagents", outputPath: join(".deepagents", "deepagents", "AGENTS.md") },
+    { target: "grokcli", outputPath: join(".grok", "AGENTS.md") },
     { target: "factorydroid", outputPath: join(".factory", "AGENTS.md") },
     { target: "kilo", outputPath: join(".config", "kilo", "AGENTS.md") },
     { target: "rovodev", outputPath: join(".rovodev", "AGENTS.md") },


### PR DESCRIPTION
## Summary

Closes #1953 (Finding 1). Adds the missing global-mode happy-path e2e entry for the grokcli **rules** target in `src/e2e/e2e-rules.spec.ts`:

```ts
{ target: "grokcli", outputPath: join(".grok", "AGENTS.md") },
```

grokcli registers `supportsGlobal: true` and the docs advertise the global scope, but the global-mode matrix only covered project mode. This mirrors the `deepagents` precedent (also `supportsGlobal` + folds non-root rules into the single root `AGENTS.md`), and matches the equivalent grokcli **skills** fix (#1944) and **subagents** global coverage (#1950).

Finding 2 in #1953 (stale PR description) needs no code change.

## Testing
- The `grokcli` rules e2e cases (project + the new global-mode) pass; `pnpm check` (oxfmt/oxlint/tsgo) and `cicheck:content` are clean.

Also closes the e2e gap recorded in #1917.
