### PR TITLE
fix: ignore shared AGENTS root in rules check

### DIFF
--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -166,6 +166,69 @@ This is a test rule for E2E testing.
     expect(stdout).not.toContain("All files are up to date (rules)");
   });
 
+  it("should check codexcli non-root rules when another target owns project AGENTS.md", async () => {
+    const testDir = getTestDir();
+
+    const codexRootRuleContent = `---
+root: true
+targets: ["codexcli"]
+description: "Codex root rule"
+globs: ["**/*"]
+---
+
+# Codex Root Rule
+`;
+    const opencodeRootRuleContent = `---
+root: true
+targets: ["opencode"]
+description: "OpenCode root rule"
+globs: ["**/*"]
+---
+
+# OpenCode Root Rule
+`;
+    const codexMemoryRuleContent = `---
+targets: ["codexcli"]
+description: "Codex memory"
+globs: ["src/**/*"]
+---
+
+# Codex Memory Rule
+`;
+
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "codex-root.md"),
+      codexRootRuleContent,
+    );
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "opencode-root.md"),
+      opencodeRootRuleContent,
+    );
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "codex-memory.md"),
+      codexMemoryRuleContent,
+    );
+
+    await runGenerate({ target: "codexcli,opencode", features: "rules", deleteFiles: true });
+
+    expect(await readFileContent(join(testDir, "AGENTS.md"))).toContain("OpenCode Root Rule");
+    expect(await readFileContent(join(testDir, ".codex", "memories", "codex-memory.md"))).toContain(
+      "Codex Memory Rule",
+    );
+
+    const { stdout, stderr } = await runGenerate({
+      target: "codexcli",
+      features: "rules",
+      deleteFiles: true,
+      check: true,
+      env: { NODE_ENV: "e2e" },
+    });
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("All files are up to date.");
+    expect(stdout).not.toContain("Would write: AGENTS.md");
+  });
+
   it("should write BOTH instructions (rules) and mcp into a single kilo.jsonc when generating rules+mcp together", async () => {
     const testDir = getTestDir();
 

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -1717,6 +1717,80 @@ targets: ["opencode", "agentsmd"]
       expect(finalContent).toContain("# Reversed Order Content");
       expect(agentsMdToolFiles[0]).toBeInstanceOf(AgentsMdRule);
     });
+
+    it("should ignore shared root AGENTS.md in check mode while checking codexcli non-root rules", async () => {
+      await ensureDir(join(testDir, ".rulesync", "rules"));
+      await writeFileContent(
+        join(testDir, ".rulesync", "rules", "codex-root.md"),
+        `---
+root: true
+targets: ["codexcli"]
+---
+# Codex Root`,
+      );
+      await writeFileContent(
+        join(testDir, ".rulesync", "rules", "opencode-root.md"),
+        `---
+root: true
+targets: ["opencode"]
+---
+# OpenCode Root`,
+      );
+      await writeFileContent(
+        join(testDir, ".rulesync", "rules", "codex-memory.md"),
+        `---
+targets: ["codexcli"]
+---
+# Codex Memory`,
+      );
+
+      const codexProcessor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "codexcli",
+      });
+      const codexRulesyncFiles = await codexProcessor.loadRulesyncFiles();
+      const codexToolFiles =
+        await codexProcessor.convertRulesyncFilesToToolFiles(codexRulesyncFiles);
+      await codexProcessor.writeAiFiles(codexToolFiles);
+
+      const openCodeProcessor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "opencode",
+      });
+      const openCodeRulesyncFiles = await openCodeProcessor.loadRulesyncFiles();
+      const openCodeToolFiles =
+        await openCodeProcessor.convertRulesyncFilesToToolFiles(openCodeRulesyncFiles);
+      await openCodeProcessor.writeAiFiles(openCodeToolFiles);
+
+      expect(await readFileContent(join(testDir, "AGENTS.md"))).toContain("# OpenCode Root");
+      expect(await readFileContent(join(testDir, ".codex", "memories", "codex-memory.md"))).toBe(
+        "# Codex Memory\n",
+      );
+
+      const codexCheckProcessor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "codexcli",
+        dryRun: true,
+        check: true,
+      });
+      const codexCheckRulesyncFiles = await codexCheckProcessor.loadRulesyncFiles();
+      const codexCheckToolFiles =
+        await codexCheckProcessor.convertRulesyncFilesToToolFiles(codexCheckRulesyncFiles);
+
+      await expect(codexCheckProcessor.writeAiFiles(codexCheckToolFiles)).resolves.toEqual({
+        count: 0,
+        paths: [],
+      });
+      await expect(
+        codexCheckProcessor.removeOrphanAiFiles(
+          await codexCheckProcessor.loadToolFiles({ forDeletion: true }),
+          codexCheckToolFiles,
+        ),
+      ).resolves.toBe(0);
+    });
   });
 
   describe("loadRulesyncFiles warning for missing root rule", () => {

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -10,6 +10,7 @@ import {
   RULESYNC_RULES_RELATIVE_DIR_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
+import type { AiFile } from "../../types/ai-file.js";
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import type { FeatureOptions } from "../../types/features.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
@@ -18,6 +19,7 @@ import { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { checkPathTraversal, findFilesByGlobs, toPosixPath } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import type { WriteResult } from "../../utils/result.js";
 import { AgentsmdCommand } from "../commands/agentsmd-command.js";
 import { CommandsProcessor } from "../commands/commands-processor.js";
 import { KiloMcp } from "../mcp/kilo-mcp.js";
@@ -722,6 +724,7 @@ export class RulesProcessor extends FeatureProcessor {
   private readonly getFactory: GetFactory;
   private readonly skills?: RulesyncSkill[];
   private readonly featureOptions?: FeatureOptions;
+  private readonly check: boolean;
 
   constructor({
     outputRoot = process.cwd(),
@@ -735,6 +738,7 @@ export class RulesProcessor extends FeatureProcessor {
     skills,
     featureOptions,
     dryRun = false,
+    check = false,
     logger,
   }: {
     outputRoot?: string;
@@ -748,6 +752,7 @@ export class RulesProcessor extends FeatureProcessor {
     skills?: RulesyncSkill[];
     featureOptions?: FeatureOptions;
     dryRun?: boolean;
+    check?: boolean;
     logger: Logger;
   }) {
     super({ outputRoot, inputRoot, dryRun, logger });
@@ -765,6 +770,47 @@ export class RulesProcessor extends FeatureProcessor {
     this.getFactory = getFactory;
     this.skills = skills;
     this.featureOptions = featureOptions;
+    this.check = check;
+  }
+
+  private shouldSkipSharedProjectRootRuleInCheck(
+    aiFile: AiFile,
+    generatedFiles: AiFile[],
+  ): boolean {
+    if (!this.check || this.global || !(aiFile instanceof ToolRule) || !aiFile.isRoot()) {
+      return false;
+    }
+
+    const settablePaths = this.getFactory(this.toolTarget).class.getSettablePaths({
+      global: this.global,
+    });
+    const hasModularRuleOutput =
+      "nonRoot" in settablePaths &&
+      settablePaths.nonRoot !== null &&
+      generatedFiles.some((file) => file instanceof ToolRule && !file.isRoot());
+
+    return (
+      hasModularRuleOutput &&
+      aiFile.getRelativeDirPath() === "." &&
+      aiFile.getRelativeFilePath() === "AGENTS.md"
+    );
+  }
+
+  async writeAiFiles(aiFiles: AiFile[]): Promise<WriteResult> {
+    const filesToCheck = aiFiles.filter(
+      (aiFile) => !this.shouldSkipSharedProjectRootRuleInCheck(aiFile, aiFiles),
+    );
+    return super.writeAiFiles(filesToCheck);
+  }
+
+  async removeOrphanAiFiles(existingFiles: AiFile[], generatedFiles: AiFile[]): Promise<number> {
+    const existingFilesToCheck = existingFiles.filter(
+      (aiFile) => !this.shouldSkipSharedProjectRootRuleInCheck(aiFile, generatedFiles),
+    );
+    const generatedFilesToCheck = generatedFiles.filter(
+      (aiFile) => !this.shouldSkipSharedProjectRootRuleInCheck(aiFile, generatedFiles),
+    );
+    return super.removeOrphanAiFiles(existingFilesToCheck, generatedFilesToCheck);
   }
 
   async convertRulesyncFilesToToolFiles(rulesyncFiles: RulesyncFile[]): Promise<ToolFile[]> {

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -269,6 +269,7 @@ async function generateRulesCore(params: {
         skills: skills,
         featureOptions: config.getFeatureOptions(toolTarget, "rules"),
         dryRun: config.isPreviewMode(),
+        check: config.getCheck(),
         logger,
       });
 


### PR DESCRIPTION
## Summary
- Skip project-root `AGENTS.md` during rules `--check` for modular rule targets when non-root rule outputs are present.
- Keep normal generation unchanged, and keep Codex memory files checked.
- Add unit and e2e coverage for the shared-root `AGENTS.md` case.

Fixes #1894

## Verification
- `pnpm exec vitest run src/features/rules/rules-processor.test.ts -t "ignore shared root AGENTS.md" --silent=true`
- `pnpm exec oxfmt --check src/features/rules/rules-processor.test.ts src/features/rules/rules-processor.ts src/lib/generate.ts src/e2e/e2e-rules.spec.ts`
- `pnpm exec oxlint src/features/rules/rules-processor.test.ts src/features/rules/rules-processor.ts src/lib/generate.ts src/e2e/e2e-rules.spec.ts --max-warnings 0`
- `pnpm run typecheck`

## Notes
- Full `src/e2e/e2e-rules.spec.ts` is blocked locally on Windows because the e2e helper spawns `node_modules/.bin/tsx` without the `.cmd` shim, so every e2e case fails before reaching this change.
- The full `rules-processor.test.ts` file currently has an unrelated failure on this branch: `should generate copilot global non-root files via round-trip`.
