### PR TITLE
fix(codexcli): drop short-description on subagent import for symmetry

### DIFF
--- a/src/features/subagents/codexcli-subagent.test.ts
+++ b/src/features/subagents/codexcli-subagent.test.ts
@@ -323,7 +323,34 @@ describe("CodexCliSubagent", () => {
       }) as CodexCliSubagent;
 
       expect(codexcliSubagent.getBody()).toContain('model = "gpt-5"');
-      expect(codexcliSubagent.getBody()).not.toContain("short-description");
+      // Assert the TOML-key assignment form is absent rather than a bare
+      // substring, so the check cannot be satisfied incidentally by the value.
+      expect(codexcliSubagent.getBody()).not.toMatch(/^\s*"?short-description"?\s*=/m);
+    });
+
+    it("should drop short-description on import so it does not round-trip", () => {
+      // A (hypothetical) Codex TOML carrying `short-description` must not carry
+      // that field into the rulesync `codexcli` section — import/export symmetry.
+      const toml = [
+        'name = "reviewer"',
+        'description = "Code reviewer"',
+        '"short-description" = "Review source changes"',
+        'model = "gpt-5"',
+        'developer_instructions = "Review code changes"',
+      ].join("\n");
+      const codexcliSubagent = new CodexCliSubagent({
+        outputRoot: testDir,
+        relativeDirPath: ".codex/agents",
+        relativeFilePath: "reviewer.toml",
+        body: toml,
+        fileContent: toml,
+        validate: false,
+      });
+
+      const rulesyncSubagent = codexcliSubagent.toRulesyncSubagent();
+      const frontmatter = rulesyncSubagent.getFrontmatter();
+      expect(frontmatter.codexcli).toEqual({ model: "gpt-5" });
+      expect(frontmatter.codexcli).not.toHaveProperty("short-description");
     });
 
     it("should handle empty body and description", () => {

--- a/src/features/subagents/codexcli-subagent.ts
+++ b/src/features/subagents/codexcli-subagent.ts
@@ -95,9 +95,19 @@ export class CodexCliSubagent extends ToolSubagent {
         { cause: error },
       );
     }
-    const { name, description, developer_instructions, ...restFields } = parsed;
+    const {
+      name,
+      description,
+      developer_instructions,
+      // `short-description` is a field Codex rejects, so it is excluded on the
+      // generation side; drop it here too so import/export stay symmetric and a
+      // stray value never round-trips into the rulesync `codexcli` section.
+      "short-description": _shortDescription,
+      ...restFields
+    } = parsed;
 
-    // Build codexcli section with all fields except name, description, and developer_instructions
+    // Build codexcli section with all fields except name, description,
+    // developer_instructions, and short-description.
     const codexcliSection: Record<string, unknown> = {
       ...restFields,
     };


### PR DESCRIPTION
## Summary

Follow-ups from PR #1914 (Codex CLI subagent `short-description`).

- **Finding 1 (low):** `toRulesyncSubagent` (import) spread all unknown TOML fields into the rulesync `codexcli` section, including `short-description` — asymmetric with the generation side, which already excludes it (`short-description` is the field Codex rejects). Now dropped on import too, so a stray value never round-trips. Added an import regression test asserting the field does not reach the `codexcli` section.
- **Finding 2 (low):** Hardened the "does not emit short-description" assertion to match the TOML-key assignment form (`^\s*"?short-description"?\s*=`) instead of a bare substring, so it cannot be satisfied incidentally by a value.

## Verification

- `pnpm cicheck` passes (code + content; 40 codexcli-subagent tests incl. the new import case).

Closes #1915

Ref: #1914