### PR TITLE
docs(skills): add a vibe user-invocable example to file-formats

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -508,6 +508,9 @@ qwencode: # for Qwen Code-specific parameters (optional; project .qwen/skills/, 
     - "src/**/*.ts"
   user-invocable: false # (optional) hide from slash-command invocation, keep model access
   disable-model-invocation: true # (optional) hide from the model but allow direct user invocation
+vibe: # for Vibe Code-specific parameters (optional)
+  user-invocable: false # (optional) hide from slash-command invocation, keep model access
+  allowed-tools: "Bash Read" # (optional) space-delimited or list of allowed tool names
 ---
 
 This is the skill body content.

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -508,6 +508,9 @@ qwencode: # for Qwen Code-specific parameters (optional; project .qwen/skills/, 
     - "src/**/*.ts"
   user-invocable: false # (optional) hide from slash-command invocation, keep model access
   disable-model-invocation: true # (optional) hide from the model but allow direct user invocation
+vibe: # for Vibe Code-specific parameters (optional)
+  user-invocable: false # (optional) hide from slash-command invocation, keep model access
+  allowed-tools: "Bash Read" # (optional) space-delimited or list of allowed tool names
 ---
 
 This is the skill body content.


### PR DESCRIPTION
## Summary

Follow-up from PR #1961 (skills `user-invocable`).

- **Finding 1 (low):** The skills frontmatter example in `file-formats.md` showed `user-invocable` for `claudecode:`/`factorydroid:`/`qwencode:` but had no `vibe:` section at all, even though vibe supports `user-invocable` (and `allowed-tools`). Added a `vibe:` example for consistency, synced to `skills/rulesync/`.
- **Finding 2 (low):** Confirmed Factory Droid honors `user-invocable` as a SKILL.md frontmatter field per its official docs (https://docs.factory.ai/cli/configuration/skills — "name, description, user-invocable, and disable-model-invocation"), so the existing `factorydroid` schema is correct and no change is needed.

## Verification
- `pnpm cicheck` passes (docs-only change; skill-doc sync, cspell, secretlint clean).

Closes #1967

Ref: #1961