### PR TITLE
refactor(rules): object-arg mirrorRootRuleToAgentsMd; test global local-root clean

### DIFF
--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -812,6 +812,28 @@ Content that would fail parsing`;
       expect(filePaths).toContain("CLAUDE.local.md");
     });
 
+    it("should NOT include CLAUDE.local.md for deletion for claudecode in global mode", async () => {
+      // Local-root files (CLAUDE.local.md) are a project-scope concept; rulesync
+      // never generates them in global mode, so the clean path must skip them in
+      // global scope rather than searching for and deleting a user's hand-placed
+      // global file.
+      await writeFileContent(join(testDir, "CLAUDE.local.md"), "# Local");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+        global: true,
+      });
+
+      const filesToDelete = await processor.loadToolFiles({
+        forDeletion: true,
+      });
+
+      const filePaths = filesToDelete.map((f) => f.getRelativeFilePath());
+      expect(filePaths).not.toContain("CLAUDE.local.md");
+    });
+
     it("should include AGENTS.local.md for deletion for rovodev", async () => {
       await ensureDir(join(testDir, ".rovodev"));
       await writeFileContent(join(testDir, ".rovodev", "AGENTS.md"), "# Root");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -943,7 +943,7 @@ export class RulesProcessor extends FeatureProcessor {
     rootRule.setFileContent(newContent);
 
     if (meta.mirrorsRootToAgentsMd && !this.global) {
-      this.mirrorRootRuleToAgentsMd(toolRules, rootRule, newContent);
+      this.mirrorRootRuleToAgentsMd({ toolRules, rootRule, content: newContent });
     }
 
     return [...toolRules, ...extraFiles];
@@ -953,11 +953,15 @@ export class RulesProcessor extends FeatureProcessor {
    * Mirror the primary root rule to a project-root `AGENTS.md` for tools whose
    * primary root lives in a subdirectory (rovodev: `.rovodev/AGENTS.md`).
    */
-  private mirrorRootRuleToAgentsMd(
-    toolRules: ToolRule[],
-    rootRule: ToolRule,
-    content: string,
-  ): void {
+  private mirrorRootRuleToAgentsMd({
+    toolRules,
+    rootRule,
+    content,
+  }: {
+    toolRules: ToolRule[];
+    rootRule: ToolRule;
+    content: string;
+  }): void {
     if (!(rootRule instanceof RovodevRule)) {
       return;
     }


### PR DESCRIPTION
## Summary

Follow-ups from PR #1962 (RulesProcessor decoupling refactor), both low-severity.

- **Finding 2 (low):** Converted the new private `mirrorRootRuleToAgentsMd` from three positional arguments to a single object argument, per the coding-guideline ("use an object argument when there are multiple arguments").
- **Finding 1 (low):** Added a regression test asserting that claudecode's local-root file (`CLAUDE.local.md`) is **not** included for deletion in **global** mode — locking in the `this.global` guard the refactor consolidated into the clean path (rulesync never generates `CLAUDE.local.md` in global scope, so it must not search for / delete a user's hand-placed global file).

## Verification
- `pnpm cicheck` passes (code + content; 81 rules-processor tests incl. the new global-mode case).

Closes #1966

Ref: #1962