### PR TITLE
fix: validate frontmatter existence, graceful import fallback, js-yaml regression tests

### DIFF
--- a/src/features/commands/rulesync-command.ts
+++ b/src/features/commands/rulesync-command.ts
@@ -128,7 +128,13 @@ export class RulesyncCommand extends RulesyncFile {
       relativeFilePath,
     );
     const fileContent = await readFileContent(filePath);
-    const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
+    const { frontmatter, body: content, hasFrontmatter } = parseFrontmatter(fileContent, filePath);
+
+    if (!hasFrontmatter) {
+      throw new Error(
+        `Missing frontmatter in ${filePath}. Rulesync files must begin with a YAML frontmatter block delimited by '---'.`,
+      );
+    }
 
     // Validate frontmatter using CommandFrontmatterSchema
     const result = RulesyncCommandFrontmatterSchema.safeParse(frontmatter);

--- a/src/features/ignore/claudecode-ignore.test.ts
+++ b/src/features/ignore/claudecode-ignore.test.ts
@@ -690,12 +690,16 @@ describe("ClaudecodeIgnore", () => {
       expect(claudecodeIgnore.getPatterns()).toEqual(["Read(*.log)"]);
     });
 
-    it("should throw error when shared settings file does not exist", async () => {
-      await expect(
-        ClaudecodeIgnore.fromFile({
-          outputRoot: testDir,
-        }),
-      ).rejects.toThrow("File not found");
+    it("should fall back to empty settings when shared settings.json does not exist", async () => {
+      // See issue #1769: `rulesync import` should not crash when .claude/settings.json
+      // is missing. Instead, it should gracefully fall back to an empty settings
+      // document with no deny patterns.
+      const claudecodeIgnore = await ClaudecodeIgnore.fromFile({
+        outputRoot: testDir,
+      });
+
+      expect(claudecodeIgnore.getRelativeFilePath()).toBe("settings.json");
+      expect(claudecodeIgnore.getPatterns()).toEqual([]);
     });
 
     it("should fall back to empty settings when settings.local.json is missing", async () => {

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -172,18 +172,14 @@ export class ClaudecodeIgnore extends ToolIgnore {
     validate = true,
     options,
   }: ToolIgnoreFromFileParams): Promise<ClaudecodeIgnore> {
-    const fileMode = resolveFileMode(options);
     const paths = this.getSettablePaths({ options });
     const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
-    // When `fileMode: "local"` is configured but the user has not yet created
-    // `.claude/settings.local.json` (a common case during `rulesync import`),
+    // When the settings file does not exist (either shared or local mode),
     // gracefully fall back to an empty settings document instead of throwing.
-    // For "shared" mode, missing settings.json is still an error — it should
-    // exist if the user has configured shared ignore patterns.
+    // This matches the pattern used by ClaudecodePermissions and ClaudecodeHooks,
+    // and prevents `rulesync import` from crashing when .claude/settings.json
+    // has not been created yet (see issue #1769).
     const exists = await fileExists(filePath);
-    if (!exists && fileMode === "shared") {
-      throw new Error(`File not found: ${filePath}`);
-    }
     const fileContent = exists ? await readFileContent(filePath) : "{}";
 
     return new ClaudecodeIgnore({

--- a/src/features/rules/rulesync-rule.test.ts
+++ b/src/features/rules/rulesync-rule.test.ts
@@ -332,6 +332,23 @@ Invalid rule`;
       ).rejects.toThrow("Invalid frontmatter");
     });
 
+    it("should throw error when frontmatter is missing (issue #316)", async () => {
+      const rulesDir = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
+      await ensureDir(rulesDir);
+
+      // A markdown file without any YAML frontmatter fence
+      const ruleContent = "This is just plain markdown without frontmatter.";
+
+      const filePath = join(rulesDir, "no-frontmatter.md");
+      await writeFileContent(filePath, ruleContent);
+
+      await expect(
+        RulesyncRule.fromFile({
+          relativeFilePath: "no-frontmatter.md",
+        }),
+      ).rejects.toThrow("Missing frontmatter");
+    });
+
     it("should handle cursor configuration in frontmatter", async () => {
       const rulesDir = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
       await ensureDir(rulesDir);

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -189,7 +189,17 @@ export class RulesyncRule extends RulesyncFile {
 
     // Read file content
     const fileContent = await readFileContent(filePath);
-    const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
+    const { frontmatter, body: content, hasFrontmatter } = parseFrontmatter(fileContent, filePath);
+
+    // Check that the file actually contains a YAML frontmatter block.
+    // Without this check, a file without frontmatter would be silently accepted
+    // with default values (targets: ["*"], root: false, etc.), which is almost
+    // certainly not what the user intended. See issue #316.
+    if (!hasFrontmatter) {
+      throw new Error(
+        `Missing frontmatter in ${filePath}. Rulesync files must begin with a YAML frontmatter block delimited by '---'.`,
+      );
+    }
 
     // Validate frontmatter using RuleFrontmatterSchema
     const result = RulesyncRuleFrontmatterSchema.safeParse(frontmatter);

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -414,7 +414,17 @@ export class RulesyncSkill extends AiDir {
     }
 
     const fileContent = await readFileContent(skillFilePath);
-    const { frontmatter, body: content } = parseFrontmatter(fileContent, skillFilePath);
+    const {
+      frontmatter,
+      body: content,
+      hasFrontmatter,
+    } = parseFrontmatter(fileContent, skillFilePath);
+
+    if (!hasFrontmatter) {
+      throw new Error(
+        `Missing frontmatter in ${skillFilePath}. Rulesync files must begin with a YAML frontmatter block delimited by '---'.`,
+      );
+    }
 
     const result = RulesyncSkillFrontmatterSchema.safeParse(frontmatter);
     if (!result.success) {

--- a/src/features/subagents/rulesync-subagent.ts
+++ b/src/features/subagents/rulesync-subagent.ts
@@ -138,7 +138,13 @@ export class RulesyncSubagent extends RulesyncFile {
     // Read file content
     const filePath = join(outputRoot, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, relativeFilePath);
     const fileContent = await readFileContent(filePath);
-    const { frontmatter, body: content } = parseFrontmatter(fileContent, filePath);
+    const { frontmatter, body: content, hasFrontmatter } = parseFrontmatter(fileContent, filePath);
+
+    if (!hasFrontmatter) {
+      throw new Error(
+        `Missing frontmatter in ${filePath}. Rulesync files must begin with a YAML frontmatter block delimited by '---'.`,
+      );
+    }
 
     // Validate frontmatter using SubagentFrontmatterSchema
     const result = RulesyncSubagentFrontmatterSchema.safeParse(frontmatter);

--- a/src/mcp/rules.test.ts
+++ b/src/mcp/rules.test.ts
@@ -76,7 +76,7 @@ description: "Second rule"
       expect(parsed.rules[1].frontmatter.root).toBe(false);
     });
 
-    it("should handle rules without frontmatter", async () => {
+    it("should skip rules without frontmatter (issue #316)", async () => {
       const rulesDir = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH);
       await ensureDir(rulesDir);
 
@@ -85,15 +85,9 @@ description: "Second rule"
       const result = await ruleTools.listRules.execute();
       const parsed = JSON.parse(result);
 
-      expect(parsed.rules).toHaveLength(1);
-      // RulesyncRule adds default values for missing frontmatter fields
-      expect(parsed.rules[0].frontmatter).toEqual({
-        root: false,
-        localRoot: false,
-        targets: ["*"],
-        description: undefined,
-        globs: [],
-      });
+      // Rules without frontmatter are now rejected with a clear error
+      // (see issue #316), so listRules skips them via its error handler.
+      expect(parsed.rules).toHaveLength(0);
     });
 
     it("should skip non-markdown files", async () => {

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -230,6 +230,28 @@ This is the body content.`;
 
       expect(result.frontmatter).toEqual({});
       expect(result.body).toBe(content);
+      expect(result.hasFrontmatter).toBe(false);
+    });
+
+    it("should set hasFrontmatter to true when frontmatter is present", () => {
+      const content = `---
+title: Test
+---
+Body content.`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.hasFrontmatter).toBe(true);
+    });
+
+    it("should set hasFrontmatter to true for empty frontmatter section", () => {
+      const content = `---
+---
+Body content.`;
+
+      const result = parseFrontmatter(content);
+
+      expect(result.hasFrontmatter).toBe(true);
     });
 
     it("should parse complex nested frontmatter", () => {
@@ -461,6 +483,76 @@ const code = "preserved";
 
       // Reset mock
       mockMatter.shouldThrow = false;
+    });
+  });
+
+  // Regression tests for issue #1973: verify that the gray-matter js-yaml
+  // override (PR #1959) is actually effective. The patch rewrites gray-matter's
+  // YAML engine from the deprecated js-yaml v3 API (safeLoad/safeDump) to the
+  // js-yaml v4 API (load/dump). If the patch is silently dropped by a future
+  // `pnpm install`, these tests will catch the regression.
+  describe("js-yaml v4 engine regression (issue #1973)", () => {
+    it("should parse YAML 1.2 scalars correctly (yes/no as strings, not booleans)", () => {
+      // js-yaml v3 (YAML 1.1) parses yes/no/on/off as booleans.
+      // js-yaml v4 (YAML 1.2 core schema) parses them as strings.
+      // This difference is the most reliable way to detect which engine is active.
+      const content = `---
+flag: yes
+status: no
+toggle: on
+---
+Body.`;
+
+      const result = parseFrontmatter(content);
+
+      // With js-yaml v4, these should be strings, not booleans
+      expect(result.frontmatter.flag).toBe("yes");
+      expect(result.frontmatter.status).toBe("no");
+      expect(result.frontmatter.toggle).toBe("on");
+    });
+
+    it("should not line-wrap long strings when avoidBlockScalars is true (lineWidth: -1)", () => {
+      // The custom engine override in stringifyFrontmatter uses lineWidth: -1
+      // to prevent js-yaml from wrapping long lines. If the override is not
+      // applied, js-yaml's default lineWidth of 80 would cause wrapping.
+      const body = "Body";
+      const veryLongValue =
+        "This is an intentionally very long string value that exceeds the default " +
+        "js-yaml lineWidth of 80 characters and would be wrapped if lineWidth is not " +
+        "set to -1 in the dump options for the custom YAML engine override";
+
+      const result = stringifyFrontmatter(
+        body,
+        { description: veryLongValue },
+        { avoidBlockScalars: true },
+      );
+
+      // The long value should appear on a single line, not wrapped
+      const lines = result.split("\n");
+      const descriptionLine = lines.find((line) => line.startsWith("description:"));
+      expect(descriptionLine).toBeDefined();
+      // The full value should be on one line (no wrapping)
+      expect(descriptionLine).toContain(veryLongValue);
+    });
+
+    it("should round-trip correctly with avoidBlockScalars custom engine", () => {
+      // Verify that stringify (with custom engine) and parse (with patched default
+      // engine) are consistent — both use js-yaml v4.
+      const body = "Body content";
+      const frontmatter = {
+        name: "test-agent",
+        description:
+          "A very long description that would normally be wrapped by js-yaml at column 80 but should remain on a single line when using the custom engine with lineWidth disabled",
+        targets: ["claudecode", "cursor"],
+      };
+
+      const stringified = stringifyFrontmatter(body, frontmatter, { avoidBlockScalars: true });
+      const parsed = parseFrontmatter(stringified);
+
+      expect(parsed.frontmatter.name).toBe("test-agent");
+      expect(parsed.frontmatter.description).toBe(frontmatter.description);
+      expect(parsed.frontmatter.targets).toEqual(["claudecode", "cursor"]);
+      expect(parsed.hasFrontmatter).toBe(true);
     });
   });
 });

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -137,13 +137,19 @@ export function parseFrontmatter(
 ): {
   frontmatter: Record<string, unknown>;
   body: string;
+  hasFrontmatter: boolean;
 } {
   let frontmatter: Record<string, unknown>;
   let body: string;
+  let hasFrontmatter: boolean;
   try {
     const result = matter(content);
     frontmatter = result.data;
     body = result.content;
+    // gray-matter returns an empty .matter string and sets .content equal to
+    // the original input when no YAML frontmatter fence (---) is present.
+    // Use this to detect whether the file actually contained frontmatter.
+    hasFrontmatter = result.matter !== "" || content.trimStart().startsWith("---");
   } catch (error) {
     if (filePath) {
       throw new Error(`Failed to parse frontmatter in ${filePath}: ${formatError(error)}`, {
@@ -158,5 +164,5 @@ export function parseFrontmatter(
   // Zod validation (z.optional(z.string()) does not accept null).
   const cleanFrontmatter = deepRemoveNullishObject(frontmatter);
 
-  return { frontmatter: cleanFrontmatter, body };
+  return { frontmatter: cleanFrontmatter, body, hasFrontmatter };
 }


### PR DESCRIPTION
## Summary

This PR addresses three issues:

- **#316** — Add frontmatter existence validation: `parseFrontmatter` now returns a `hasFrontmatter` flag. Rulesync files (`RulesyncRule`, `RulesyncCommand`, `RulesyncSubagent`, `RulesyncSkill`) that lack a YAML frontmatter block are rejected with a clear error message instead of being silently accepted with default values.
- **#1769** — Fix `rulesync import` crash when `.claude/settings.json` does not exist: `ClaudecodeIgnore.fromFile()` now gracefully falls back to an empty settings document for both shared and local modes, matching the pattern already used by `ClaudecodePermissions` and `ClaudecodeHooks`.
- **#1973** — Add regression tests for the gray-matter js-yaml override (PR #1959): verifies js-yaml v4 engine is active (YAML 1.2 scalar parsing where `yes`/`no` are strings), `lineWidth: -1` is honored in `avoidBlockScalars` mode, and round-trip consistency.

## Changes

- `src/utils/frontmatter.ts` — Added `hasFrontmatter: boolean` to `parseFrontmatter` return type
- `src/features/rules/rulesync-rule.ts` — Check `hasFrontmatter` before Zod validation
- `src/features/commands/rulesync-command.ts` — Same check
- `src/features/subagents/rulesync-subagent.ts` — Same check
- `src/features/skills/rulesync-skill.ts` — Same check
- `src/features/ignore/claudecode-ignore.ts` — Removed throw for missing shared `settings.json`
- Test files updated to reflect new behavior

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `npx oxlint` passes on all modified files
- [x] `npx oxfmt --check` passes on all modified files
- [x] All new tests pass (29 frontmatter tests, 41 rulesync-rule tests, 22 MCP rules tests)
- [x] Zero new test failures introduced (verified by diffing test results against baseline)
- [x] Pre-commit hooks (secretlint, lint-staged) pass

Closes #316, #1769, #1973