### PR TITLE
test(warp): fix warp-permissions test on macOS by using platform-specific config dir

### DIFF
--- a/src/features/permissions/warp-permissions.test.ts
+++ b/src/features/permissions/warp-permissions.test.ts
@@ -117,7 +117,7 @@ describe("WarpPermissions", () => {
     });
 
     it("preserves other agents.profiles keys and other top-level tables", async () => {
-      const dir = join(testDir, ".config", "warp-terminal");
+      const dir = join(testDir, WarpPermissions.getSettablePaths().relativeDirPath);
       await ensureDir(dir);
       await writeFileContent(
         join(dir, "settings.toml"),


### PR DESCRIPTION
## Background

The "preserves other agents.profiles keys" test seeded `settings.toml` at a hardcoded `.config/warp-terminal`, but `WarpPermissions` reads it back via the platform-specific `getSettablePaths()` (`.warp` on macOS). On macOS the paths diverged, so the seed was never read and the test failed. This is the pre-existing failure #1962/#1964/#1975 each noted as unrelated.

## Changes

- Seed into `getSettablePaths().relativeDirPath` instead of the literal, so the test writes where the implementation reads.

## Test plan

- [x] `pnpm cicheck` — clean (6893 pass on macOS)

Closes #1963
