### PR TITLE
chore: release v8.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.30.1",
+  "version": "8.31.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",
@@ -53,7 +53,6 @@
     "cicheck": "pnpm run cicheck:code && pnpm run cicheck:content",
     "cicheck:code": "pnpm run check && pnpm run test",
     "cicheck:content": "pnpm run check:sync-skill-docs && pnpm run check:gitignore && pnpm run check:supported-tools && pnpm run cspell && pnpm run secretlint",
-    "generate:tables": "tsx scripts/generate-supported-tools-tables.ts",
     "cspell": "cspell --no-progress --gitignore .",
     "dev": "tsx src/cli/index.ts",
     "docs:build": "vitepress build docs",
@@ -64,6 +63,7 @@
     "fmt:check": "oxfmt --check .",
     "generate": "pnpm run dev generate",
     "generate:schema": "tsx scripts/generate-json-schema.ts",
+    "generate:tables": "tsx scripts/generate-supported-tools-tables.ts",
     "knip": "knip",
     "oxlint": "oxlint . --max-warnings 0",
     "oxlint:fix": "oxlint . --fix --max-warnings 0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.30.1";
+const getVersion = () => "8.31.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v8.31.0 preparation:
- Bump version in `src/cli/index.ts` to 8.31.0
- Bump version in `package.json` to 8.31.0

See [full changelog](https://github.com/dyoshikawa/rulesync/compare/v8.30.1...v8.31.0) for details.