### PR TITLE
fix(amp): default MCP settings file to settings.json to co-locate with permissions

### DIFF
--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -5,7 +5,10 @@ import { setTimeout } from "node:timers/promises";
 import * as smolToml from "smol-toml";
 import { describe, expect, it } from "vitest";
 
-import { RULESYNC_MCP_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
+import {
+  RULESYNC_MCP_RELATIVE_FILE_PATH,
+  RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
+} from "../constants/rulesync-paths.js";
 import { fileExists, readFileContent, writeFileContent } from "../utils/file.js";
 import {
   runGenerate,
@@ -20,7 +23,7 @@ describe("E2E: mcp", () => {
   const { getTestDir } = useTestDirectory();
 
   it.each([
-    { target: "amp", outputPath: join(".amp", "settings.jsonc") },
+    { target: "amp", outputPath: join(".amp", "settings.json") },
     { target: "claudecode", outputPath: ".mcp.json" },
     { target: "cursor", outputPath: join(".cursor", "mcp.json") },
     { target: "geminicli", outputPath: join(".gemini", "settings.json") },
@@ -69,6 +72,38 @@ describe("E2E: mcp", () => {
     // Verify that the expected output file was generated and contains the server
     const generatedContent = await readFileContent(join(testDir, outputPath));
     expect(generatedContent).toContain("test-server");
+  });
+
+  it("should co-locate amp mcp and permissions in a single settings.json on a clean repo", async () => {
+    const testDir = getTestDir();
+
+    // Setup: both an MCP source and a permissions source, no pre-existing Amp settings file.
+    await writeFileContent(
+      join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          mcpServers: {
+            "test-server": { type: "stdio", command: "echo", args: ["hello"], env: {} },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFileContent(
+      join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify({ permission: { edit_file: { "*": "deny" } } }, null, 2),
+    );
+
+    // Execute: generate both features together for Amp.
+    await runGenerate({ target: "amp", features: "mcp,permissions" });
+
+    // Both adapters default to settings.json, so the keys must co-locate there and
+    // no stray settings.jsonc should be created.
+    expect(await fileExists(join(testDir, ".amp", "settings.jsonc"))).toBe(false);
+    const content = JSON.parse(await readFileContent(join(testDir, ".amp", "settings.json")));
+    expect(content["amp.mcpServers"]).toHaveProperty("test-server");
+    expect(content["amp.tools.disable"]).toEqual(["edit_file"]);
   });
 
   it.each([
@@ -122,7 +157,7 @@ describe("E2E: mcp", () => {
   it.each([
     {
       target: "amp",
-      outputPath: join(".amp", "settings.jsonc"),
+      outputPath: join(".amp", "settings.json"),
       content: JSON.stringify({ "amp.dangerouslyAllowAll": false, "amp.mcpServers": {} }, null, 2),
     },
     {
@@ -392,7 +427,7 @@ describe("E2E: mcp (global mode)", () => {
     },
     { target: "kilo", outputPath: join(".config", "kilo", "kilo.jsonc") },
     { target: "junie", outputPath: join(".junie", "mcp", "mcp.json") },
-    { target: "amp", outputPath: join(".config", "amp", "settings.jsonc") },
+    { target: "amp", outputPath: join(".config", "amp", "settings.json") },
     {
       target: "antigravity-ide",
       outputPath: join(".gemini", "config", "mcp_config.json"),

--- a/src/features/mcp/amp-mcp.test.ts
+++ b/src/features/mcp/amp-mcp.test.ts
@@ -26,18 +26,18 @@ describe("AmpMcp", () => {
   });
 
   describe("getSettablePaths", () => {
-    it("should return project settings path with jsonc preferred", () => {
+    it("should return project settings path defaulting to settings.json", () => {
       const paths = AmpMcp.getSettablePaths();
 
       expect(paths.relativeDirPath).toBe(".amp");
-      expect(paths.relativeFilePath).toBe("settings.jsonc");
+      expect(paths.relativeFilePath).toBe("settings.json");
     });
 
-    it("should return global settings path with jsonc preferred", () => {
+    it("should return global settings path defaulting to settings.json", () => {
       const paths = AmpMcp.getSettablePaths({ global: true });
 
       expect(paths.relativeDirPath).toBe(join(".config", "amp"));
-      expect(paths.relativeFilePath).toBe("settings.jsonc");
+      expect(paths.relativeFilePath).toBe("settings.json");
     });
   });
 
@@ -150,7 +150,7 @@ describe("AmpMcp", () => {
           },
         },
       });
-      expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.jsonc"));
+      expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.json"));
     });
 
     it("should preserve existing non-MCP Amp settings", async () => {
@@ -229,7 +229,7 @@ describe("AmpMcp", () => {
         global: true,
       });
 
-      expect(ampMcp.getFilePath()).toBe(join(testDir, ".config", "amp", "settings.jsonc"));
+      expect(ampMcp.getFilePath()).toBe(join(testDir, ".config", "amp", "settings.json"));
     });
 
     it("should reject malformed existing settings instead of replacing them", async () => {
@@ -463,11 +463,11 @@ describe("AmpMcp", () => {
       expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.json"));
     });
 
-    it("should create settings.jsonc when neither file exists", async () => {
+    it("should create settings.json when neither file exists", async () => {
       const ampMcp = await AmpMcp.fromFile({ outputRoot: testDir });
 
       expect(ampMcp.getJson()).toEqual({ "amp.mcpServers": {} });
-      expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.jsonc"));
+      expect(ampMcp.getFilePath()).toBe(join(testDir, ".amp", "settings.json"));
     });
   });
 });

--- a/src/features/mcp/amp-mcp.ts
+++ b/src/features/mcp/amp-mcp.ts
@@ -79,12 +79,12 @@ export class AmpMcp extends ToolMcp {
     if (global) {
       return {
         relativeDirPath: AMP_GLOBAL_DIR,
-        relativeFilePath: AMP_SETTINGS_JSONC_FILE_NAME,
+        relativeFilePath: AMP_SETTINGS_FILE_NAME,
       };
     }
     return {
       relativeDirPath: AMP_DIR,
-      relativeFilePath: AMP_SETTINGS_JSONC_FILE_NAME,
+      relativeFilePath: AMP_SETTINGS_FILE_NAME,
     };
   }
 
@@ -92,7 +92,10 @@ export class AmpMcp extends ToolMcp {
    * Probe `<jsonDir>/settings.jsonc` first, falling back to `settings.json`,
    * so existing user files are read-modified-written in place instead of a
    * fresh `.json` sibling being created next to a hand-authored `.jsonc`.
-   * Defaults to `settings.jsonc` when neither file exists.
+   * Defaults to `settings.json` when neither file exists. This matches Amp's
+   * canonically documented settings file (`.amp/settings.json`) and keeps the
+   * default co-located with `amp-permissions.ts`, so generating MCP and
+   * permissions together on a clean repo writes a single shared settings file.
    */
   private static async resolveSettingsFile(
     jsonDir: string,
@@ -105,7 +108,7 @@ export class AmpMcp extends ToolMcp {
     if (jsonContent !== null) {
       return { fileContent: jsonContent, relativeFilePath: AMP_SETTINGS_FILE_NAME };
     }
-    return { fileContent: null, relativeFilePath: AMP_SETTINGS_JSONC_FILE_NAME };
+    return { fileContent: null, relativeFilePath: AMP_SETTINGS_FILE_NAME };
   }
 
   static async fromFile({


### PR DESCRIPTION
## Summary

rulesync's two Amp adapters that share Amp's settings file defaulted to **different** file extensions when no file pre-existed: `amp-mcp.ts` defaulted to `settings.jsonc`, while `amp-permissions.ts` defaulted to `settings.json`. On a clean repo, `generate --features "*"` therefore wrote `amp.mcpServers` into `.amp/settings.jsonc` and `amp.tools.disable` into a separate `.amp/settings.json`, splitting keys Amp expects in one settings file.

## Changes

- Align `amp-mcp.ts` (`getSettablePaths` and `resolveSettingsFile`'s default-when-neither-exists) to `settings.json`, matching `amp-permissions.ts`. Both adapters still probe `settings.jsonc` first so a hand-authored `.jsonc` is read-modified-written in place.
- `settings.json` is Amp's canonically documented settings file (`.amp/settings.json` / `~/.config/amp/settings.json`); the `.jsonc` extension is not documented. ([Amp Owner's Manual](https://ampcode.com/manual), [Workspace Settings](https://ampcode.com/news/cli-workspace-settings))
- Because MCP runs before permissions in `generate`, permissions reads the freshly written `settings.json` and augments it in place (`{ ...json, "amp.tools.disable": ... }`), so both key sets co-locate.
- Add an e2e case generating both features together on a clean repo to lock in single-file output and assert no stray `settings.jsonc` is created.

## Test

- `src/features/mcp/amp-mcp.test.ts`, `src/e2e/e2e-mcp.spec.ts` updated; `pnpm cicheck` and the amp e2e suite pass.

Closes #1989
