### PR TITLE
chore: add YAML schema comment and ignoreScripts to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,10 @@
+# yaml-language-server: $schema=https://json.schemastore.org/pnpm-workspace.json
 allowBuilds:
   "@openrouter/sdk": false
   esbuild: false
   simple-git-hooks: false
   tldjs: false
+ignoreScripts: false
 minimumReleaseAge: 1440 # 1 day
 overrides:
   gray-matter>js-yaml: 4.2.0


### PR DESCRIPTION
## Summary

- Added `# yaml-language-server: $schema=https://json.schemastore.org/pnpm-workspace.json` comment to `pnpm-workspace.yaml` for improved IDE support.
- Added `ignoreScripts: false` to `pnpm-workspace.yaml` to explicitly ensure build scripts are not skipped during installation.