### PR TITLE
fix(test): update e2e rules test for codexcli AGENTS.md folding (unbreak main)

### DIFF
--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -8,7 +8,7 @@ import {
   RULESYNC_OVERVIEW_FILE_NAME,
   RULESYNC_RULES_RELATIVE_DIR_PATH,
 } from "../constants/rulesync-paths.js";
-import { readFileContent, writeFileContent } from "../utils/file.js";
+import { fileExists, readFileContent, writeFileContent } from "../utils/file.js";
 import {
   runGenerate,
   runImport,
@@ -314,9 +314,14 @@ globs: ["src/**/*"]
     // AGENTS.md exists (owned by antigravity-ide)
     expect(await readFileContent(join(testDir, "AGENTS.md"))).toContain("Root Rule");
 
-    // Codex non-root rules exist
-    const codexNonRoot = await readFileContent(join(testDir, ".codex", "memories", "detail.md"));
-    expect(codexNonRoot).toContain("Detail Rule");
+    // The non-root "Detail Rule" body is emitted by the owning target
+    // (antigravity-ide) under its own .agents/rules/ tree.
+    const nonRoot = await readFileContent(join(testDir, ".agents", "rules", "detail.md"));
+    expect(nonRoot).toContain("Detail Rule");
+
+    // codexcli folds non-root rules into the root AGENTS.md and no longer writes
+    // the inert .codex/memories/ tree (see #1765 / #1979).
+    expect(await fileExists(join(testDir, ".codex", "memories", "detail.md"))).toBe(false);
 
     // Check codexcli only — should pass even though AGENTS.md is owned by antigravity-ide
     const { stdout, stderr } = await runGenerate({


### PR DESCRIPTION
## Summary

Main's E2E suite is currently red. PR #1979 changed codexcli to fold non-root rules into the root `AGENTS.md` and stopped writing the inert `.codex/memories/` tree, but the e2e-rules case added in #1978 (`should pass check for a non-owning target when another target owns AGENTS.md`) still asserted `.codex/memories/detail.md` existed. The two PRs merged around the same time, leaving the assertion stale and the E2E job failing on `main`.

## Changes

- Update the e2e-rules assertions to the current behavior:
  - The non-root `Detail Rule` body is emitted by the owning target (antigravity-ide) under `.agents/rules/detail.md`.
  - codexcli no longer creates `.codex/memories/detail.md` (folds non-root into root `AGENTS.md`).
- Add `fileExists` import for the negative assertion.

This is a test-only change that restores a green E2E suite on `main`. The core intent of the test — `generate --check` passing for a non-owning target when another target owns the shared `AGENTS.md` — is preserved.

Refs #1979, #1980
