### PR TITLE
chore: enable oxlint complexity rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,6 +17,7 @@
     "no-new": "off",
     "no-underscore-dangle": "off",
     "typescript/no-explicit-any": "warn",
+    "complexity": ["warn", { "max": 52 }],
     "unicorn/prefer-node-protocol": "error",
     "unicorn/no-array-reduce": "off"
   },


### PR DESCRIPTION
## Summary

Enables the `eslint/complexity` rule (cyclomatic complexity) in oxlint with a conservative initial threshold of 52.

## Details

- The rule is set to `warn` level with `max: 52`
- This matches the current maximum complexity in the codebase (`config-resolver.ts` resolve method at 52)
- The threshold will be lowered gradually as complex functions are refactored

## Rationale

Measuring cyclomatic complexity helps identify overly complex functions that are harder to test, maintain, and reason about. By enabling this rule, we establish a baseline for complexity tracking and encourage gradual improvement.