### PR TITLE
fix(rovodev): preserve skill compatibility frontmatter on round-trip

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -488,6 +488,7 @@ copilotcli: # for GitHub Copilot CLI-specific parameters (optional; project .git
 rovodev: # for Rovo Dev CLI-specific parameters (optional; Agent Skills standard)
   allowed-tools: "grep bash" # (optional) space-separated string (a YAML list is also accepted)
   license: MIT # (optional)
+  compatibility: "Requires Python 3.14+ and uv" # (optional) free-form string (object form also accepted)
   metadata: # (optional) free-form metadata
     author: rulesync
 zed: # for Zed-specific parameters (optional)

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -488,6 +488,7 @@ copilotcli: # for GitHub Copilot CLI-specific parameters (optional; project .git
 rovodev: # for Rovo Dev CLI-specific parameters (optional; Agent Skills standard)
   allowed-tools: "grep bash" # (optional) space-separated string (a YAML list is also accepted)
   license: MIT # (optional)
+  compatibility: "Requires Python 3.14+ and uv" # (optional) free-form string (object form also accepted)
   metadata: # (optional) free-form metadata
     author: rulesync
 zed: # for Zed-specific parameters (optional)

--- a/src/features/skills/rovodev-skill.test.ts
+++ b/src/features/skills/rovodev-skill.test.ts
@@ -295,6 +295,7 @@ body`,
           description: "Desc",
           "allowed-tools": "grep bash",
           license: "MIT",
+          compatibility: "Requires Python 3.14+ and uv",
           metadata: { author: "rulesync" },
         },
         body: "Body",
@@ -305,6 +306,7 @@ body`,
       expect(rulesync.getFrontmatter().rovodev).toEqual({
         "allowed-tools": "grep bash",
         license: "MIT",
+        compatibility: "Requires Python 3.14+ and uv",
         metadata: { author: "rulesync" },
       });
 
@@ -317,6 +319,7 @@ body`,
       const fm = roundTripped.getFrontmatter();
       expect(fm["allowed-tools"]).toBe("grep bash");
       expect(fm.license).toBe("MIT");
+      expect(fm.compatibility).toBe("Requires Python 3.14+ and uv");
       expect(fm.metadata).toEqual({ author: "rulesync" });
     });
   });

--- a/src/features/skills/rovodev-skill.ts
+++ b/src/features/skills/rovodev-skill.ts
@@ -27,6 +27,9 @@ export const RovodevSkillFrontmatterSchema = z.looseObject({
   // https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/
   "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
   license: z.optional(z.string()),
+  // The Agent Skills spec defines `compatibility` as a free-form string
+  // (1–500 chars); the object form stays accepted for back-compat.
+  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
   metadata: z.optional(z.looseObject({})),
 });
 
@@ -138,6 +141,9 @@ export class RovodevSkill extends ToolSkill {
         "allowed-tools": frontmatter["allowed-tools"],
       }),
       ...(frontmatter.license !== undefined && { license: frontmatter.license }),
+      ...(frontmatter.compatibility !== undefined && {
+        compatibility: frontmatter.compatibility,
+      }),
       ...(frontmatter.metadata !== undefined && { metadata: frontmatter.metadata }),
     };
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
@@ -176,6 +182,9 @@ export class RovodevSkill extends ToolSkill {
         "allowed-tools": rovodevSection["allowed-tools"],
       }),
       ...(rovodevSection?.license !== undefined && { license: rovodevSection.license }),
+      ...(rovodevSection?.compatibility !== undefined && {
+        compatibility: rovodevSection.compatibility,
+      }),
       ...(rovodevSection?.metadata !== undefined && { metadata: rovodevSection.metadata }),
     };
 

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -136,6 +136,9 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
     z.looseObject({
       "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
       license: z.optional(z.string()),
+      // The Agent Skills spec defines `compatibility` as a free-form string
+      // (1–500 chars); the object form stays accepted for back-compat.
+      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
       metadata: z.optional(z.looseObject({})),
     }),
   ),
@@ -268,6 +271,7 @@ export type RulesyncSkillFrontmatterInput = {
   rovodev?: {
     "allowed-tools"?: string | string[];
     license?: string;
+    compatibility?: string | Record<string, unknown>;
     metadata?: Record<string, unknown>;
   };
   cursor?: {


### PR DESCRIPTION
## Summary

Partially addresses #1986. Fixes the skills sub-gap: `RovodevSkillFrontmatterSchema` declared `name`/`description`/`allowed-tools`/`license`/`metadata` but not `compatibility`, and `toRulesyncSkill`/`fromRulesyncSkill` map fields explicitly, so the documented optional Agent Skills `compatibility` field was silently dropped on round-trip (a residual of #1696).

## Changes

- Add `compatibility` (free-form string; object form accepted for back-compat) to `RovodevSkillFrontmatterSchema` and to the rulesync skill `rovodev` section schema/type.
- Carry `compatibility` through both round-trip mappings, mirroring the `agentsskills`/`vibe` adapters.
- Extend the round-trip test and the `file-formats` docs.

## Deferred: event-hooks adapter

The issue's primary gap — a `RovodevHooks` adapter writing the `eventHooks` block into `~/.rovodev/config.yml` — is **intentionally not implemented here**. The exact `eventHooks` YAML schema is **not officially documented**: it is a preview feature surfaced only via the interactive `/hooks` command, and both primary sources (the [Atlassian blog](https://www.atlassian.com/blog/development/streamline-rovo-dev-cli-with-event-hooks) and the [settings docs](https://support.atlassian.com/rovo/docs/manage-rovo-dev-cli-settings/)) describe the interactive flow without publishing the literal key/nesting structure. The issue itself flags this: *"Confirm the schema against a live `/hooks help` / config dump before implementing."* Implementing it now would mean inventing a schema that could emit config Rovo Dev cannot read, so it remains blocked on schema confirmation. This PR uses `Refs` (not `Closes`) so #1986 stays open for the hooks work.

## Test

`pnpm cicheck` (code + content) passes.

Refs #1986
