### PR TITLE
fix(pi): fold non-root rules into root AGENTS.md instead of inert .agents/memories

### DIFF
--- a/src/constants/pi-paths.ts
+++ b/src/constants/pi-paths.ts
@@ -7,4 +7,3 @@ export const PI_AGENT_SKILLS_DIR_PATH = join(PI_AGENT_DIR, "skills");
 export const PI_PROMPTS_DIR_PATH = join(PI_DIR, "prompts");
 export const PI_SKILLS_DIR_PATH = join(PI_DIR, "skills");
 export const PI_RULE_FILE_NAME = "AGENTS.md";
-export const PI_MEMORIES_DIR = ".agents";

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -111,6 +111,44 @@ This is a test rule for E2E testing.
     expect(generatedContent).toContain("Test Rule");
   });
 
+  it("should fold pi non-root rules into the root AGENTS.md", async () => {
+    const testDir = getTestDir();
+
+    const rootRuleContent = `---
+root: true
+targets: ["pi"]
+description: "Root rule"
+globs: ["**/*"]
+---
+
+# Pi Root Rule
+`;
+    const nonRootRuleContent = `---
+targets: ["pi"]
+description: "Detail rule"
+globs: ["src/**/*"]
+---
+
+# Pi Detail Rule
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+      rootRuleContent,
+    );
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "detail.md"),
+      nonRootRuleContent,
+    );
+
+    await runGenerate({ target: "pi", features: "rules" });
+
+    // Both bodies land in the single root AGENTS.md; no inert .agents/memories tree.
+    const rootContent = await readFileContent(join(testDir, "AGENTS.md"));
+    expect(rootContent).toContain("Pi Root Rule");
+    expect(rootContent).toContain("Pi Detail Rule");
+    expect(await fileExists(join(testDir, ".agents", "memories", "detail.md"))).toBe(false);
+  });
+
   it("should generate qwencode non-root rules into .qwen/rules with paths frontmatter", async () => {
     const testDir = getTestDir();
 

--- a/src/features/rules/pi-rule.test.ts
+++ b/src/features/rules/pi-rule.test.ts
@@ -22,16 +22,14 @@ describe("PiRule", () => {
   });
 
   describe("getSettablePaths", () => {
-    it("should return project paths by default", () => {
+    it("should return a root-only project path (non-root folds into root)", () => {
       const paths = PiRule.getSettablePaths();
 
       expect(paths.root).toEqual({
         relativeDirPath: ".",
         relativeFilePath: "AGENTS.md",
       });
-      expect(paths.nonRoot).toEqual({
-        relativeDirPath: join(".agents", "memories"),
-      });
+      expect(paths.nonRoot).toBeUndefined();
     });
 
     it("should return global paths when global is true", () => {
@@ -41,7 +39,7 @@ describe("PiRule", () => {
         relativeDirPath: join(".pi", "agent"),
         relativeFilePath: "AGENTS.md",
       });
-      expect("nonRoot" in paths).toBe(false);
+      expect(paths.nonRoot).toBeUndefined();
     });
 
     it("should honor excludeToolDir for global paths", () => {
@@ -50,14 +48,6 @@ describe("PiRule", () => {
       expect(paths.root).toEqual({
         relativeDirPath: "agent",
         relativeFilePath: "AGENTS.md",
-      });
-    });
-
-    it("should honor excludeToolDir for project non-root paths", () => {
-      const paths = PiRule.getSettablePaths({ excludeToolDir: true });
-
-      expect(paths.nonRoot).toEqual({
-        relativeDirPath: "memories",
       });
     });
   });
@@ -78,11 +68,9 @@ describe("PiRule", () => {
       expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
     });
 
-    it("should load a non-root memories file", async () => {
-      const memoriesDir = join(testDir, ".agents", "memories");
-      await ensureDir(memoriesDir);
-      const content = "# Memory\nBody.";
-      await writeFileContent(join(memoriesDir, "memory.md"), content);
+    it("should always read the root AGENTS.md regardless of the requested file", async () => {
+      const content = "# Root Pi Agent\n\nContent.";
+      await writeFileContent(join(testDir, "AGENTS.md"), content);
 
       const rule = await PiRule.fromFile({
         outputRoot: testDir,
@@ -90,9 +78,9 @@ describe("PiRule", () => {
       });
 
       expect(rule.getFileContent()).toBe(content);
-      expect(rule.isRoot()).toBe(false);
-      expect(rule.getRelativeDirPath()).toBe(join(".agents", "memories"));
-      expect(rule.getRelativeFilePath()).toBe("memory.md");
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
     });
 
     it("should load root AGENTS.md in global mode", async () => {
@@ -112,14 +100,21 @@ describe("PiRule", () => {
       expect(rule.getRelativeDirPath()).toBe(join(".pi", "agent"));
     });
 
-    it("should throw when asked for non-root file in global mode", async () => {
-      await expect(
-        PiRule.fromFile({
-          outputRoot: testDir,
-          relativeFilePath: "memory.md",
-          global: true,
-        }),
-      ).rejects.toThrow(/global mode/i);
+    it("should read the global root AGENTS.md regardless of the requested file", async () => {
+      const globalDir = join(testDir, ".pi", "agent");
+      await ensureDir(globalDir);
+      const content = "# Global Pi Agent";
+      await writeFileContent(join(globalDir, "AGENTS.md"), content);
+
+      const rule = await PiRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "memory.md",
+        global: true,
+      });
+
+      expect(rule.getFileContent()).toBe(content);
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getRelativeDirPath()).toBe(join(".pi", "agent"));
     });
   });
 
@@ -147,7 +142,7 @@ describe("PiRule", () => {
       expect(rule.getFileContent()).toContain("# Root");
     });
 
-    it("should produce a non-root rule under .agents/memories", () => {
+    it("should write a non-root rule to the root AGENTS.md (folded)", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
@@ -164,12 +159,15 @@ describe("PiRule", () => {
         rulesyncRule,
       });
 
+      // Non-root rules share the root path so the RulesProcessor folds their
+      // bodies into the single AGENTS.md.
       expect(rule.isRoot()).toBe(false);
-      expect(rule.getRelativeDirPath()).toBe(join(".agents", "memories"));
-      expect(rule.getRelativeFilePath()).toBe("memory.md");
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(rule.getFileContent()).toBe("# Memory\nBody.");
     });
 
-    it("should throw for non-root rule in global mode", () => {
+    it("should write a non-root rule to the global root path (folded)", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
         relativeDirPath: ".rulesync/rules",
@@ -181,13 +179,14 @@ describe("PiRule", () => {
         body: "# Memory\nBody.",
       });
 
-      expect(() =>
-        PiRule.fromRulesyncRule({
-          outputRoot: testDir,
-          rulesyncRule,
-          global: true,
-        }),
-      ).toThrow(/global mode/i);
+      const rule = PiRule.fromRulesyncRule({
+        outputRoot: testDir,
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(rule.getRelativeDirPath()).toBe(join(".pi", "agent"));
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
     });
 
     it("should use global root paths when global is true", () => {

--- a/src/features/rules/pi-rule.ts
+++ b/src/features/rules/pi-rule.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
-import { PI_DIR, PI_MEMORIES_DIR, PI_RULE_FILE_NAME } from "../../constants/pi-paths.js";
-import { ValidationResult } from "../../types/ai-file.js";
+import { PI_DIR, PI_RULE_FILE_NAME } from "../../constants/pi-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
@@ -10,99 +10,77 @@ import {
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
-  ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
 
-export type PiRuleSettablePaths = ToolRuleSettablePaths & {
+export type PiRuleParams = AiFileParams & {
+  root?: boolean;
+};
+
+export type PiRuleSettablePaths = Pick<ToolRuleSettablePaths, "root"> & {
   root: {
     relativeDirPath: string;
     relativeFilePath: string;
   };
+  nonRoot?: undefined;
 };
-
-export type PiRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
 
 /**
  * Rule generator for Pi Coding Agent.
  *
- * Pi uses a single `AGENTS.md` file at the project root for the overview,
- * plus optional `.agents/memories/*.md` files referenced from the root via
- * TOON format (`ruleDiscoveryMode: "toon"`).
+ * Pi loads instruction context only from the `AGENTS.md` / `CLAUDE.md` family —
+ * the global `~/.pi/agent/AGENTS.md` plus files discovered by walking up the
+ * directory tree from the current working directory. It does NOT resolve
+ * `@`-imports or a TOON file list, and has no `.agents/memories/` concept, so
+ * non-root rule bodies written to a subdirectory are never read.
+ * (Verified against the official docs: https://pi.dev/docs/latest/usage)
  *
- * In global mode, only the root `~/.pi/agent/AGENTS.md` is emitted; non-root
- * rules are not supported.
+ * rulesync's topic-based non-root rules therefore have no project subdirectory
+ * to map onto; their bodies are folded into the single root `AGENTS.md` by the
+ * RulesProcessor (there is no separate non-root output location — `nonRoot` is
+ * `undefined`). This mirrors the codexcli, grokcli, warp, and deepagents targets.
  */
 export class PiRule extends ToolRule {
+  constructor({ fileContent, root, ...rest }: PiRuleParams) {
+    super({
+      ...rest,
+      fileContent,
+      root: root ?? false,
+    });
+  }
+
   static getSettablePaths({
-    global,
+    global = false,
     excludeToolDir,
   }: {
     global?: boolean;
     excludeToolDir?: boolean;
-  } = {}): PiRuleSettablePaths | PiRuleSettablePathsGlobal {
-    if (global) {
-      // When excludeToolDir is true the caller drops the `.pi` prefix and only
-      // the `agent` directory remains (e.g. when emitting into a pre-scoped
-      // global directory). Pi has no non-root memories in global mode, so we
-      // return only the root path entry.
-      return {
-        root: {
-          relativeDirPath: buildToolPath(PI_DIR, "agent", excludeToolDir),
-          relativeFilePath: PI_RULE_FILE_NAME,
-        },
-      };
-    }
+  } = {}): PiRuleSettablePaths {
     return {
       root: {
-        relativeDirPath: ".",
+        relativeDirPath: global ? buildToolPath(PI_DIR, "agent", excludeToolDir) : ".",
         relativeFilePath: PI_RULE_FILE_NAME,
-      },
-      nonRoot: {
-        relativeDirPath: buildToolPath(PI_MEMORIES_DIR, "memories", excludeToolDir),
       },
     };
   }
 
   static async fromFile({
     outputRoot = process.cwd(),
-    relativeFilePath,
+    relativeFilePath: _relativeFilePath,
     validate = true,
     global = false,
   }: ToolRuleFromFileParams): Promise<PiRule> {
-    const paths = this.getSettablePaths({ global });
-    const isRoot = relativeFilePath === paths.root.relativeFilePath;
-
-    if (isRoot) {
-      const fileContent = await readFileContent(
-        join(outputRoot, paths.root.relativeDirPath, paths.root.relativeFilePath),
-      );
-
-      return new PiRule({
-        outputRoot,
-        relativeDirPath: paths.root.relativeDirPath,
-        relativeFilePath: paths.root.relativeFilePath,
-        fileContent,
-        validate,
-        root: true,
-      });
-    }
-
-    if (!paths.nonRoot) {
-      throw new Error(
-        `PiRule does not support non-root rules in global mode; expected '${paths.root.relativeFilePath}' but got '${relativeFilePath}'`,
-      );
-    }
-
-    const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
+    const { root } = this.getSettablePaths({ global });
+    const relativePath = join(root.relativeDirPath, root.relativeFilePath);
     const fileContent = await readFileContent(join(outputRoot, relativePath));
+
     return new PiRule({
       outputRoot,
-      relativeDirPath: paths.nonRoot.relativeDirPath,
-      relativeFilePath,
+      relativeDirPath: root.relativeDirPath,
+      relativeFilePath: root.relativeFilePath,
       fileContent,
       validate,
-      root: false,
+      root: true,
     });
   }
 
@@ -112,23 +90,17 @@ export class PiRule extends ToolRule {
     validate = true,
     global = false,
   }: ToolRuleFromRulesyncRuleParams): PiRule {
-    const paths = this.getSettablePaths({ global });
+    const { root } = this.getSettablePaths({ global });
+    const isRoot = rulesyncRule.getFrontmatter().root ?? false;
 
-    if (global && !rulesyncRule.getFrontmatter().root) {
-      throw new Error(
-        `PiRule does not support non-root rules in global mode; expected a root rule but got '${rulesyncRule.getRelativeFilePath()}'`,
-      );
-    }
-
-    return new PiRule(
-      this.buildToolRuleParamsAgentsmd({
-        outputRoot,
-        rulesyncRule,
-        validate,
-        rootPath: paths.root,
-        nonRootPath: paths.nonRoot,
-      }),
-    );
+    return new PiRule({
+      outputRoot,
+      relativeDirPath: root.relativeDirPath,
+      relativeFilePath: root.relativeFilePath,
+      fileContent: rulesyncRule.getBody(),
+      validate,
+      root: isRoot,
+    });
   }
 
   toRulesyncRule(): RulesyncRule {
@@ -147,8 +119,10 @@ export class PiRule extends ToolRule {
     relativeFilePath,
     global = false,
   }: ToolRuleForDeletionParams): PiRule {
-    const paths = this.getSettablePaths({ global });
-    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+    const { root } = this.getSettablePaths({ global });
+    const isRoot =
+      relativeFilePath === PI_RULE_FILE_NAME &&
+      (relativeDirPath === "." || relativeDirPath === root.relativeDirPath);
 
     return new PiRule({
       outputRoot,

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -564,7 +564,8 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
       meta: {
         extension: "md",
         supportsGlobal: true,
-        ruleDiscoveryMode: "toon",
+        ruleDiscoveryMode: "auto",
+        foldsNonRootIntoRoot: true,
       },
     },
   ],


### PR DESCRIPTION
## Summary

rulesync's `pi` (Pi Coding Agent) rules adapter wrote non-root rules to `.agents/memories/*.md` and referenced them from the root `AGENTS.md` via a TOON list. But Pi loads instruction context **only** from the AGENTS.md/CLAUDE.md family (global `~/.pi/agent/AGENTS.md` + upward directory walk) — it has no `@`-import / TOON resolution and no `.agents/memories` concept ([usage docs](https://pi.dev/docs/latest/usage)), so those non-root bodies were silently dropped. Same class of bug fixed for Codex CLI in #1765.

## Changes

Applies the codexcli/grokcli/warp folding pattern:

- `rules-processor.ts`: add `foldsNonRootIntoRoot: true` and switch `ruleDiscoveryMode` from `"toon"` to `"auto"` for the `pi` entry.
- `pi-rule.ts`: make `PiRule` root-only (drop the `.agents/memories` `nonRoot` path) so root + non-root bodies concatenate into the single project-root `AGENTS.md`; rewrite the class docstring to match Pi's real context model. Global scope was already root-only.
- Remove the now-unused `PI_MEMORIES_DIR` constant.
- Update `pi-rule.test.ts` and add an e2e folding case asserting both bodies land in `AGENTS.md` and no `.agents/memories` tree is written.

## Test

`pnpm cicheck` (code) and the full `e2e-rules` suite (98 tests) pass.

Closes #1985
