### PR TITLE
fix(devcontainer): run pnpm install through mise exec in init script

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -14,6 +14,6 @@ sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
 pnpm config set store-dir /home/node/.pnpm-store
 
 # Install project dependencies
-pnpm i
+mise exec -c "pnpm i"
 
 gh auth setup-git


### PR DESCRIPTION
## Summary

- Wrap the dependency install in `.devcontainer/init.sh` with `mise exec` so `pnpm i` runs with the toolchain versions pinned in `mise.toml` rather than whatever `pnpm` happens to be on `PATH` during container setup.
- This keeps devcontainer setup consistent with the runtimes/package managers managed by mise.

## Test plan

- `pnpm cicheck` passes (code style, type safety, tests, content checks).
- Change is limited to the devcontainer init script; no application code is affected.