### PR TITLE
docs: sync feature-change-guidelines instructions with updated source rule

### DIFF
--- a/.github/instructions/feature-change-guidelines.instructions.md
+++ b/.github/instructions/feature-change-guidelines.instructions.md
@@ -1,11 +1,11 @@
 ---
-description: 'When you add or change features, must follow these guidelines.'
+description: When you add or change features, must follow these guidelines.
 ---
 # Guidelines for Adding or Modifying Features
 
 - Check whether `rules-processor.ts` needs an updated Additional Convention, especially values within `additionalConvention`. For example, if you remove support for Cursor's Skill feature simulation, remove `skills: { skillClass: CursorSkill }` within convention entry for Cursor.
 - Review frontmatter in both rulesync files (`rulesync-{feature}.ts`) and tool files (`{tool}-{feature}.ts`). For overlapping parameters (e.g., `description`), prefer the rulesync value by default, but if the tool file defines the parameter, that tool-specific value takes precedence.
-- Evaluate whether `gitignore.ts` needs additions or changes in its generated output. And `pnpm dev gitignore` should be run to update `.gitignore` in the project.
+- Gitignore entries are derived from each tool's `getSettablePaths` in `gitignore-derive.ts`, so they update automatically; only add to `HAND_MAINTAINED_GITIGNORE_ENTRIES` in `gitignore-entries.ts` for paths a tool does not emit itself (third-party by-products, shared or global-only trees). Run `pnpm dev gitignore` to update the project `.gitignore`.
 - Consider project scope and global scope support. Simulated support should cover project scope only. For native support, implement both project and global scope when the target tool supports them. Consult the tool’s official documentation to decide scope support.
-- Keep `Supported Tools and Features` section and `Each File Format` section in `README.md` and `docs/**/*.md` synchronized with the implemented functionality.
+- The `Supported Tools and Features` matrix in `README.md` and `docs/reference/supported-tools.md` is generated from each feature's `getToolTargets` by `scripts/generate-supported-tools-tables.ts` (run `pnpm run generate:tables`; CI fails on drift), so it never needs manual editing — only keep the `Each File Format` prose synchronized by hand.
 - Always preserve the existence of end-to-end happy-path test cases that cover the Tool × Feature matrix.


### PR DESCRIPTION
## Summary

Regenerates the tracked Copilot instructions file `.github/instructions/feature-change-guidelines.instructions.md` from its updated `.rulesync` source rule so it matches the current generation output.

The working tree had this file staged as a deletion, which was inconsistent with:
- its three sibling instruction files (`coding-guidelines`, `github-actions-security`, `testing-guidelines`), which remain tracked, and
- `.github/copilot-instructions.md`, which still references it.

Running `pnpm run generate` confirmed the file is still produced; the correct state is a content update (single-quote vs unquoted `description`, refreshed gitignore/supported-tools wording), not a removal.

## Verification

- `pnpm cicheck` passes (fmt, oxlint, typecheck, 6736 tests, content checks).