### PR TITLE
feat(roo): support global-scope rules at ~/.roo/rules/

### DIFF
--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -22,7 +22,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |     ✅      |
 | Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Roo Code               | roo             |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     | ✅ 🌏  |       |             |
+| Roo Code               | roo             | ✅ 🌏 |   ✅   |    ✅    |    ✅    |    ✅     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian)    | rovodev         | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |     🌏      |
 | Takt                   | takt            | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Vibe Code              | vibe            | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -22,7 +22,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | OpenCode               | opencode        | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Cline                  | cline           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |     ✅      |
 | Kilo Code              | kilo            | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| Roo Code               | roo             |  ✅   |   ✅   |    ✅    |    ✅    |    ✅     | ✅ 🌏  |       |             |
+| Roo Code               | roo             | ✅ 🌏 |   ✅   |    ✅    |    ✅    |    ✅     | ✅ 🌏  |       |             |
 | Rovodev (Atlassian)    | rovodev         | ✅ 🌏 |        |    🌏    |          |   ✅ 🌏   | ✅ 🌏  |       |     🌏      |
 | Takt                   | takt            | ✅ 🌏 |        |          |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |       |             |
 | Vibe Code              | vibe            | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -712,4 +712,37 @@ globs: ["src/**/*.ts"]
     expect(nonRootContent).toContain("Global Non-Root Rule");
     expect(nonRootContent).toContain("src/**/*.ts");
   });
+
+  it("should generate roo non-root rules into ~/.roo/rules in global mode", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+
+    // Roo has no root memory file; every rule is a non-root file under the
+    // rules directory. In global mode that directory resolves to ~/.roo/rules/.
+    const nonRootRuleContent = `---
+targets: ["*"]
+description: "Global coding guidelines"
+globs: ["src/**/*"]
+---
+
+# Global Roo Rule
+`;
+    await writeFileContent(
+      join(projectDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "coding-guidelines.md"),
+      nonRootRuleContent,
+    );
+
+    await runGenerate({
+      target: "roo",
+      features: "rules",
+      global: true,
+      env: { HOME_DIR: homeDir },
+    });
+
+    // Non-root rule -> ~/.roo/rules/*.md (plain Markdown, Roo reads no frontmatter)
+    const nonRootContent = await readFileContent(
+      join(homeDir, ".roo", "rules", "coding-guidelines.md"),
+    );
+    expect(nonRootContent).toContain("Global Roo Rule");
+  });
 });

--- a/src/features/rules/roo-rule.test.ts
+++ b/src/features/rules/roo-rule.test.ts
@@ -199,6 +199,30 @@ describe("RooRule", () => {
       expect(rooRule.getFilePath()).toBe("/custom/base/.roo/rules/custom-base.md");
     });
 
+    it("should emit non-root rules to ~/.roo/rules in global mode", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "global-rule.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "Global rule",
+          globs: [],
+        },
+        body: "# Global rule",
+      });
+
+      const rooRule = RooRule.fromRulesyncRule({
+        outputRoot: "/home/user",
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(rooRule.getRelativeDirPath()).toBe(".roo/rules");
+      expect(rooRule.getFilePath()).toBe("/home/user/.roo/rules/global-rule.md");
+      expect(rooRule.isRoot()).toBe(false);
+    });
+
     it("should handle validation parameter", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
@@ -374,6 +398,16 @@ describe("RooRule", () => {
 
       expect(paths).toHaveProperty("nonRoot");
       expect(paths.nonRoot).toHaveProperty("relativeDirPath");
+    });
+
+    it("should return the same non-root directory in global mode (~/.roo/rules)", () => {
+      // Global scope reuses the project relative directory; only the output root
+      // (the home directory) differs, producing `~/.roo/rules/`.
+      const paths = RooRule.getSettablePaths({ global: true });
+
+      expect(paths.nonRoot).toEqual({
+        relativeDirPath: ".roo/rules",
+      });
     });
   });
 

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -28,6 +28,11 @@ export type RooRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
  * Generates rule files for Roo Code's hierarchical rule system.
  * Supports plain Markdown without frontmatter, mode-specific rules,
  * and both directory-based and single-file configurations.
+ *
+ * - Project scope writes the non-root directory `.roo/rules/`.
+ * - Global scope writes the same non-root directory resolved under the home
+ *   directory (`~/.roo/rules/`), which Roo loads before workspace rules.
+ *   @see https://roocodeinc.github.io/Roo-Code/features/custom-instructions
  */
 export class RooRule extends ToolRule {
   static getSettablePaths(
@@ -36,6 +41,9 @@ export class RooRule extends ToolRule {
       excludeToolDir?: boolean;
     } = {},
   ): RooRuleSettablePaths {
+    // The relative directory is identical for project and global scope; global
+    // mode differs only by output root (the home directory), so `~/.roo/rules/`
+    // is produced without a separate branch here.
     return {
       nonRoot: {
         relativeDirPath: buildToolPath(ROO_DIR, "rules", _options.excludeToolDir),

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -932,6 +932,7 @@ Content that would fail parsing`;
         "opencode",
         "pi",
         "qwencode",
+        "roo",
         "rovodev",
         "takt",
         "vibe",
@@ -976,12 +977,13 @@ Content that would fail parsing`;
       expect(globalTargets).toContain("grokcli");
       expect(globalTargets).toContain("opencode");
       expect(globalTargets).toContain("pi");
+      expect(globalTargets).toContain("roo");
       expect(globalTargets).toContain("rovodev");
       expect(globalTargets).toContain("takt");
       expect(globalTargets).toContain("vibe");
       expect(globalTargets).toContain("devin");
       expect(globalTargets).toContain("zed");
-      expect(globalTargets.length).toBe(25);
+      expect(globalTargets.length).toBe(26);
 
       // These targets should NOT be in global mode
       expect(globalTargets).not.toContain("cursor");

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -606,10 +606,15 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
       // Roo subagents are native now (aggregated into `.roomodes`), so no
       // simulated `additionalConventions.subagents` block is needed — mirrors
       // how native subagent tools like geminicli are wired.
+      //
+      // Roo also reads user-scope rules from `~/.roo/rules/` (loaded before
+      // workspace `.roo/rules/`), so global mode emits the same non-root
+      // directory under the home directory.
+      // @see https://roocodeinc.github.io/Roo-Code/features/custom-instructions
       class: RooRule,
       meta: {
         extension: "md",
-        supportsGlobal: false,
+        supportsGlobal: true,
         ruleDiscoveryMode: "auto",
       },
     },


### PR DESCRIPTION
## Summary

Roo Code reads user-scope rules from `~/.roo/rules/` (and mode-specific `~/.roo/rules-{modeSlug}/`), loaded **before** workspace `.roo/rules/` ([docs](https://roocodeinc.github.io/Roo-Code/features/custom-instructions)). rulesync's `roo` rules adapter was project-only (`supportsGlobal: false`), so `--global` emitted no rules for `roo`. This closes that gap.

## Changes

- Flip the `roo` rules convention to `supportsGlobal: true` in `rules-processor.ts`. Global non-root directories are already supported by the processor (mirrors the `~/.qwen/rules/` precedent), so global mode now emits the same non-root `.roo/rules/` directory resolved under the home directory (`~/.roo/rules/`).
- Document the global behavior in `RooRule` and add global-scope unit tests (`getSettablePaths({ global: true })` and `fromRulesyncRule({ global: true })`).
- Update the global-target enumeration tests (count 25 → 26, `roo` added in map order).
- Regenerate the supported-tools matrix: the `roo` rules cell now shows `✅ 🌏`.

## Verification

- `pnpm cicheck` passes (fmt, oxlint, typecheck, 6738 tests, content checks).
- End-to-end smoke test: `generate --features rules --targets roo --global` writes to `<home>/.roo/rules/`.

> Note: Roo Code is EOL (repo archived 2026-05-15), but rulesync still ships the `roo` target, so the gap is genuine.

Closes #2002