### PR TITLE
feat(warp): support .warpindexingignore ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -385,4 +385,5 @@ rulesync.local.jsonc
 **/.rooignore
 **/.devinignore
 **/.vibeignore
+**/.warpindexingignore
 !.rulesync/.aiignore

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | AugmentCode            |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Devin Desktop          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
-| Warp                   |  ✅   |        | ✅  |          |           |   ✅   |       |     ✅      |
+| Warp                   |  ✅   |   ✅   | ✅  |          |           |   ✅   |       |     ✅      |
 | Replit                 |  ✅   |        |     |          |           |   ✅   |       |             |
 | Pi Coding Agent        |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
 | Zed                    |  ✅   |   ✅   | ✅  |          |           |   ✅   |       |     ✅      |

--- a/cspell.json
+++ b/cspell.json
@@ -310,6 +310,7 @@
     "vibeignore",
     "vite",
     "vuepress",
+    "warpindexingignore",
     "weakmap",
     "webfetch",
     "websearch",

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -36,7 +36,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
-| Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
+| Warp                   | warp            |  ✅   |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
 | Replit                 | replit          |  ✅   |        |          |          |           | ✅ 🌏  |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
 | Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |    ✅ 🌏    |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -36,7 +36,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
-| Warp                   | warp            |  ✅   |        |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
+| Warp                   | warp            |  ✅   |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
 | Replit                 | replit          |  ✅   |        |          |          |           | ✅ 🌏  |       |             |
 | Pi Coding Agent        | pi              | ✅ 🌏 |        |          |  ✅ 🌏   |           | ✅ 🌏  |       |             |
 | Zed                    | zed             | ✅ 🌏 |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |    ✅ 🌏    |

--- a/src/constants/warp-paths.ts
+++ b/src/constants/warp-paths.ts
@@ -9,3 +9,7 @@ export const WARP_WIN32_DIR = join("AppData", "Local", "warp", "Warp", "config")
 export const WARP_RULE_FILE_NAME = "AGENTS.md";
 export const WARP_MCP_FILE_NAME = ".mcp.json";
 export const WARP_PERMISSIONS_FILE_NAME = "settings.toml";
+// Warp excludes files from agent codebase indexing/context via a project-scoped
+// `.warpindexingignore` file (gitignore syntax) at the repository root.
+// @see https://docs.warp.dev/agent-platform/capabilities/codebase-context/
+export const WARP_IGNORE_FILE_NAME = ".warpindexingignore";

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -36,6 +36,7 @@ describe("E2E: ignore", () => {
       format: "json" as const,
     },
     { target: "vibe", outputPath: ".vibeignore", format: "plaintext" as const },
+    { target: "warp", outputPath: ".warpindexingignore", format: "plaintext" as const },
   ])("should generate $target ignore", async ({ target, outputPath, format }) => {
     const testDir = getTestDir();
 
@@ -88,6 +89,7 @@ credentials/
     { target: "augmentcode", orphanPath: ".augmentignore" },
     { target: "devin", orphanPath: ".devinignore" },
     { target: "vibe", orphanPath: ".vibeignore" },
+    { target: "warp", orphanPath: ".warpindexingignore" },
     // zed ignore uses .zed/settings.json which is not deletable by rulesync
   ])(
     "should fail in check mode when delete would remove an orphan $target ignore file",

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -158,6 +158,7 @@ describe("E2E: ignore (import)", () => {
     { target: "augmentcode", sourcePath: ".augmentignore" },
     { target: "devin", sourcePath: ".devinignore" },
     { target: "vibe", sourcePath: ".vibeignore" },
+    { target: "warp", sourcePath: ".warpindexingignore" },
   ])("should import $target ignore", async ({ target, sourcePath }) => {
     const testDir = getTestDir();
 

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -445,6 +445,7 @@ describe("IgnoreProcessor", () => {
         "roo",
         "devin",
         "vibe",
+        "warp",
         "zed",
       ];
 

--- a/src/features/ignore/ignore-processor.ts
+++ b/src/features/ignore/ignore-processor.ts
@@ -32,6 +32,7 @@ import {
   ToolIgnoreSettablePathsParams,
 } from "./tool-ignore.js";
 import { VibeIgnore } from "./vibe-ignore.js";
+import { WarpIgnore } from "./warp-ignore.js";
 import { ZedIgnore } from "./zed-ignore.js";
 
 export type IgnoreProcessorToolTarget = (typeof ignoreProcessorToolTargetTuple)[number];
@@ -67,6 +68,7 @@ export const toolIgnoreFactories = new Map<IgnoreProcessorToolTarget, ToolIgnore
   ["roo", { class: RooIgnore }],
   ["devin", { class: DevinIgnore }],
   ["vibe", { class: VibeIgnore }],
+  ["warp", { class: WarpIgnore }],
   ["zed", { class: ZedIgnore }],
 ]);
 

--- a/src/features/ignore/warp-ignore.test.ts
+++ b/src/features/ignore/warp-ignore.test.ts
@@ -1,0 +1,135 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_AIIGNORE_RELATIVE_FILE_PATH } from "../../constants/rulesync-paths.js";
+import { WARP_IGNORE_FILE_NAME } from "../../constants/warp-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { writeFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
+import { WarpIgnore } from "./warp-ignore.js";
+
+describe("WarpIgnore", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should emit .warpindexingignore at the repository root", () => {
+      const paths = WarpIgnore.getSettablePaths();
+
+      expect(paths.relativeDirPath).toBe(".");
+      expect(paths.relativeFilePath).toBe(WARP_IGNORE_FILE_NAME);
+      expect(paths.relativeFilePath).toBe(".warpindexingignore");
+    });
+  });
+
+  describe("fromRulesyncIgnore", () => {
+    it("should create WarpIgnore from RulesyncIgnore with default outputRoot", () => {
+      const fileContent = "*.log\nnode_modules/\n.env";
+      const rulesyncIgnore = new RulesyncIgnore({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".rulesignore",
+        fileContent,
+      });
+
+      const warpIgnore = WarpIgnore.fromRulesyncIgnore({ rulesyncIgnore });
+
+      expect(warpIgnore).toBeInstanceOf(WarpIgnore);
+      expect(warpIgnore.getOutputRoot()).toBe(testDir);
+      expect(warpIgnore.getRelativeDirPath()).toBe(".");
+      expect(warpIgnore.getRelativeFilePath()).toBe(".warpindexingignore");
+      expect(warpIgnore.getFileContent()).toBe(fileContent);
+    });
+
+    it("should create WarpIgnore from RulesyncIgnore with custom outputRoot", () => {
+      const rulesyncIgnore = new RulesyncIgnore({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".rulesignore",
+        fileContent: "*.tmp\nbuild/",
+      });
+
+      const warpIgnore = WarpIgnore.fromRulesyncIgnore({
+        outputRoot: "/custom/base",
+        rulesyncIgnore,
+      });
+
+      expect(warpIgnore.getFilePath()).toBe("/custom/base/.warpindexingignore");
+    });
+  });
+
+  describe("toRulesyncIgnore", () => {
+    it("should convert to RulesyncIgnore with same content", () => {
+      const fileContent = "# Generated files\n*.log\n\n# Dependencies\nnode_modules/";
+      const warpIgnore = new WarpIgnore({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".warpindexingignore",
+        fileContent,
+      });
+
+      const rulesyncIgnore = warpIgnore.toRulesyncIgnore();
+
+      expect(rulesyncIgnore).toBeInstanceOf(RulesyncIgnore);
+      expect(rulesyncIgnore.getFileContent()).toBe(fileContent);
+      expect(rulesyncIgnore.getRelativeFilePath()).toBe(RULESYNC_AIIGNORE_RELATIVE_FILE_PATH);
+    });
+  });
+
+  describe("fromFile", () => {
+    it("should read .warpindexingignore file from outputRoot", async () => {
+      const fileContent = "*.log\nnode_modules/\ndist/";
+      await writeFileContent(join(testDir, ".warpindexingignore"), fileContent);
+
+      const warpIgnore = await WarpIgnore.fromFile({ outputRoot: testDir });
+
+      expect(warpIgnore).toBeInstanceOf(WarpIgnore);
+      expect(warpIgnore.getRelativeFilePath()).toBe(".warpindexingignore");
+      expect(warpIgnore.getFileContent()).toBe(fileContent);
+    });
+
+    it("should throw when .warpindexingignore file does not exist", async () => {
+      await expect(WarpIgnore.fromFile({ outputRoot: testDir })).rejects.toThrow();
+    });
+  });
+
+  describe("round-trip conversion", () => {
+    it("should maintain content integrity in round-trip conversion", () => {
+      const originalContent = "# Warp ignore patterns\n*.log\nnode_modules/\n!.env.example";
+
+      const warpIgnore = new WarpIgnore({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".warpindexingignore",
+        fileContent: originalContent,
+      });
+
+      const rulesyncIgnore = warpIgnore.toRulesyncIgnore();
+      const roundTrip = WarpIgnore.fromRulesyncIgnore({ outputRoot: testDir, rulesyncIgnore });
+
+      expect(roundTrip.getFileContent()).toBe(originalContent);
+      expect(roundTrip.getRelativeFilePath()).toBe(".warpindexingignore");
+    });
+  });
+
+  describe("inheritance from ToolIgnore", () => {
+    it("should inherit getPatterns method (gitignore syntax, comments filtered)", () => {
+      const warpIgnore = new WarpIgnore({
+        relativeDirPath: ".",
+        relativeFilePath: ".warpindexingignore",
+        fileContent: "# comment\n*.log\nnode_modules/\n!.env.example",
+      });
+
+      expect(warpIgnore.getPatterns()).toEqual(["*.log", "node_modules/", "!.env.example"]);
+    });
+  });
+});

--- a/src/features/ignore/warp-ignore.ts
+++ b/src/features/ignore/warp-ignore.ts
@@ -1,0 +1,89 @@
+import { join } from "node:path";
+
+import { RULESYNC_AIIGNORE_RELATIVE_FILE_PATH } from "../../constants/rulesync-paths.js";
+import { WARP_IGNORE_FILE_NAME } from "../../constants/warp-paths.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
+import {
+  ToolIgnore,
+  ToolIgnoreForDeletionParams,
+  ToolIgnoreFromFileParams,
+  ToolIgnoreFromRulesyncIgnoreParams,
+  ToolIgnoreSettablePaths,
+} from "./tool-ignore.js";
+
+/**
+ * Ignore generator for Warp.
+ *
+ * Warp excludes files/folders from agent codebase indexing and context via a
+ * project-scoped `.warpindexingignore` file at the repository root, using
+ * gitignore syntax. Warp documents no global/user-scope ignore file, so this is
+ * project-only.
+ * @see https://docs.warp.dev/agent-platform/capabilities/codebase-context/
+ */
+export class WarpIgnore extends ToolIgnore {
+  static getSettablePaths(): ToolIgnoreSettablePaths {
+    return {
+      relativeDirPath: ".",
+      relativeFilePath: WARP_IGNORE_FILE_NAME,
+    };
+  }
+
+  toRulesyncIgnore(): RulesyncIgnore {
+    return new RulesyncIgnore({
+      outputRoot: ".",
+      relativeDirPath: ".",
+      relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+      fileContent: this.fileContent,
+    });
+  }
+
+  static fromRulesyncIgnore({
+    outputRoot = process.cwd(),
+    rulesyncIgnore,
+  }: ToolIgnoreFromRulesyncIgnoreParams): WarpIgnore {
+    const body = rulesyncIgnore.getFileContent();
+
+    return new WarpIgnore({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      fileContent: body,
+    });
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+  }: ToolIgnoreFromFileParams): Promise<WarpIgnore> {
+    const fileContent = await readFileContent(
+      join(
+        outputRoot,
+        this.getSettablePaths().relativeDirPath,
+        this.getSettablePaths().relativeFilePath,
+      ),
+    );
+
+    return new WarpIgnore({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): WarpIgnore {
+    return new WarpIgnore({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
+  }
+}

--- a/src/types/tool-target-tuples.ts
+++ b/src/types/tool-target-tuples.ts
@@ -58,6 +58,7 @@ export const ignoreProcessorToolTargetTuple = [
   "roo",
   "devin",
   "vibe",
+  "warp",
   "zed",
 ] as const;
 


### PR DESCRIPTION
## Summary

Warp excludes files/folders from agent codebase indexing and context via a project-scoped `.warpindexingignore` file (gitignore syntax) at the repository root ([docs](https://docs.warp.dev/agent-platform/capabilities/codebase-context/)). rulesync previously reported the `ignore` feature as **unsupported** for the `warp` target (`Target 'warp' does not support the feature 'ignore'. Skipping.`). This closes that gap.

## Changes

- Add `WarpIgnore` adapter (`src/features/ignore/warp-ignore.ts`) emitting a project-scoped `.warpindexingignore` at the repo root, mirroring the single-file `CursorIgnore` pattern. Project-only — Warp documents no global ignore file.
- Add `WARP_IGNORE_FILE_NAME` constant, register `warp` in the ignore processor factory map and `ignoreProcessorToolTargetTuple`.
- Unit tests (`warp-ignore.test.ts`) + E2E coverage (generate + orphan-delete check) in `e2e-ignore.spec.ts`.
- Regenerate the supported-tools matrix (warp `ignore` now supported) and `.gitignore` (`**/.warpindexingignore`); add `warpindexingignore` to the cspell dictionary.

## Verification

- `pnpm cicheck` passes (fmt, oxlint, typecheck, tests, content checks).
- E2E: `generate --target warp --features ignore` writes `.warpindexingignore`; orphan-delete check covered.

Closes #2001