### PR TITLE
feat(copilot): support global-scope custom agents at ~/.copilot/agents/

### DIFF
--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -12,7 +12,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI ⚠️          | geminicli       | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
+| GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |   ✅ 🌏   |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |     🌏      |
 | Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |       |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -12,7 +12,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Claude Code            | claudecode      | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Codex CLI              | codexcli        | ✅ 🌏 |        | ✅ 🌏 🔧 |    🌏    |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Gemini CLI ⚠️          | geminicli       | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
-| GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |    ✅     |   ✅   |  ✅   |             |
+| GitHub Copilot         | copilot         | ✅ 🌏 |        |    ✅    |    ✅    |   ✅ 🌏   |   ✅   |  ✅   |             |
 | GitHub Copilot CLI     | copilotcli      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |
 | Goose                  | goose           | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   |        | ✅ 🌏 |     🌏      |
 | Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |       |             |

--- a/src/e2e/e2e-subagents.spec.ts
+++ b/src/e2e/e2e-subagents.spec.ts
@@ -445,6 +445,7 @@ describe("E2E: subagents (global mode)", () => {
     { target: "augmentcode", outputPath: join(".augment", "agents", "planner.md") },
     { target: "claudecode", outputPath: join(".claude", "agents", "planner.md") },
     { target: "codexcli", outputPath: join(".codex", "agents", "planner.toml") },
+    { target: "copilot", outputPath: join(".copilot", "agents", "planner.agent.md") },
     { target: "copilotcli", outputPath: join(".copilot", "agents", "planner.agent.md") },
     { target: "cursor", outputPath: join(".cursor", "agents", "planner.md") },
     { target: "geminicli", outputPath: join(".gemini", "agents", "planner.md") },

--- a/src/features/subagents/copilot-subagent.test.ts
+++ b/src/features/subagents/copilot-subagent.test.ts
@@ -39,6 +39,14 @@ Plan tasks`;
         relativeDirPath: ".github/agents",
       });
     });
+
+    it("returns the user-profile agents directory in global mode (~/.copilot/agents)", () => {
+      // Global agents resolve under the home directory via the harness's
+      // outputRoot, producing `~/.copilot/agents/`.
+      expect(CopilotSubagent.getSettablePaths({ global: true })).toEqual({
+        relativeDirPath: ".copilot/agents",
+      });
+    });
   });
 
   describe("fromRulesyncSubagent", () => {

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -2,7 +2,10 @@ import { join } from "node:path";
 
 import { z } from "zod/mini";
 
-import { COPILOT_AGENTS_DIR_PATH } from "../../constants/copilot-paths.js";
+import {
+  COPILOT_AGENTS_DIR_PATH,
+  COPILOTCLI_AGENTS_DIR_PATH,
+} from "../../constants/copilot-paths.js";
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import { formatError } from "../../utils/error.js";
@@ -87,7 +90,16 @@ export class CopilotSubagent extends ToolSubagent {
     this.body = body;
   }
 
-  static getSettablePaths(_options: { global?: boolean } = {}): ToolSubagentSettablePaths {
+  static getSettablePaths({
+    global = false,
+  }: { global?: boolean } = {}): ToolSubagentSettablePaths {
+    if (global) {
+      // VS Code Copilot user-profile (global) custom agents live under the home
+      // directory at `~/.copilot/agents/`, the same location the Copilot CLI
+      // uses. The harness sets `outputRoot` to the home dir for `--global`.
+      // Reference: https://code.visualstudio.com/docs/copilot/agents/custom-agents
+      return { relativeDirPath: COPILOTCLI_AGENTS_DIR_PATH };
+    }
     return {
       relativeDirPath: COPILOT_AGENTS_DIR_PATH,
     };

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -1029,6 +1029,7 @@ Second global content`;
         "claudecode-legacy",
         "cline",
         "codexcli",
+        "copilot",
         "copilotcli",
         "cursor",
         "deepagents",
@@ -1050,11 +1051,12 @@ Second global content`;
     it("should not include simulated targets", () => {
       const toolTargets = SubagentsProcessor.getToolTargets({ global: true });
 
-      expect(toolTargets).not.toContain("copilot");
       expect(toolTargets).not.toContain("agentsmd");
       expect(toolTargets).not.toContain("roo");
       // factorydroid is now native and global-capable.
       expect(toolTargets).toContain("factorydroid");
+      // copilot is native (not simulated) and now global-capable via ~/.copilot/agents.
+      expect(toolTargets).toContain("copilot");
     });
 
     it("should be callable without instance", () => {

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -147,7 +147,10 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
     "copilot",
     {
       class: CopilotSubagent,
-      meta: { supportsSimulated: false, supportsGlobal: false, filePattern: "*.md" },
+      // VS Code Copilot custom agents support both project (.github/agents/) and
+      // user-profile/global (~/.copilot/agents/) scopes.
+      // Reference: https://code.visualstudio.com/docs/copilot/agents/custom-agents
+      meta: { supportsSimulated: false, supportsGlobal: true, filePattern: "*.md" },
     },
   ],
   [


### PR DESCRIPTION
## Summary

Addresses #1982. The issue raised two points for the `copilot` subagent adapter; this PR resolves them as follows.

### ✅ Implemented: global-scope custom agents

VS Code Copilot supports **user-profile (global) custom agents at `~/.copilot/agents/`** across all workspaces, in addition to project-scoped `.github/agents/` ([VS Code docs](https://code.visualstudio.com/docs/copilot/agents/custom-agents)). rulesync's `copilot` subagent adapter was project-only (`supportsGlobal: false`).

- Flip the `copilot` subagents convention to `supportsGlobal: true`.
- `CopilotSubagent.getSettablePaths({ global: true })` now emits `~/.copilot/agents/` (the same directory the `copilotcli` sibling already targets; the harness sets `outputRoot` to the home dir for `--global`).
- Unit test + E2E global-mode happy-path coverage added; the `copilot` subagents cell in the generated matrix now shows `✅ 🌏`.

### ⛔ Intentionally NOT changed: the injected `agent/runSubagent` tool name

The issue proposed changing `REQUIRED_TOOL` from `agent/runSubagent` to `agent`, asserting `agent/runSubagent` is not a real tool. **Primary-source research refutes this:** the VS Code subagents docs explicitly document `agent/runSubagent` as the tool to enable subagent delegation ("To allow the main agent to invoke subagents, make sure the `agent/runSubagent` tool is enabled") — [code.visualstudio.com/docs/copilot/agents/subagents](https://code.visualstudio.com/docs/copilot/agents/subagents). `agent` is the equivalent on the [GitHub Docs reference](https://docs.github.com/en/copilot/reference/custom-agents-configuration). Since rulesync's `copilot` target is the VS Code / IDE Copilot surface, the current `agent/runSubagent` value is valid; changing it could break VS Code delegation. Left unchanged.

## Verification

- `pnpm cicheck` passes (fmt, oxlint, typecheck, tests, content).
- E2E: `generate --target copilot --features subagents --global` writes `~/.copilot/agents/planner.agent.md`.

Closes #1982