### PR TITLE
fix(generate): correct root-file ownership for wildcard configs and mirrored roots

### DIFF
--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -158,6 +158,44 @@ describe("config-resolver", () => {
     });
   });
 
+  describe("config file targets (getConfigFileTargets)", () => {
+    it("expands wildcard targets ['*'] to the full non-legacy target list", async () => {
+      // Regression for #1981 / #1894: a `targets: ["*"]` config must not collapse
+      // to an empty config-file target list, otherwise root-file ownership in
+      // `generate --check` is computed against no targets and the bug reproduces.
+      const configContent = JSON.stringify({ outputRoots: ["./"], targets: ["*"] });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      const configFileTargets = config.getConfigFileTargets();
+      expect(configFileTargets.length).toBeGreaterThan(1);
+      expect(configFileTargets).toContain("claudecode");
+      expect(configFileTargets).toContain("codexcli");
+      // Legacy targets are excluded from wildcard expansion (must be explicit).
+      expect(configFileTargets).not.toContain("claudecode-legacy");
+      expect(configFileTargets).not.toContain("antigravity");
+    });
+
+    it("keeps the full config-file target list even when CLI -t selects one target", async () => {
+      const configContent = JSON.stringify({ outputRoots: ["./"], targets: ["*"] });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+        targets: ["codexcli"],
+      });
+
+      // CLI -t narrows the generated targets, but config-file ownership must
+      // still see every target the config lists.
+      expect(config.getTargets()).toEqual(["codexcli"]);
+      expect(config.getConfigFileTargets().length).toBeGreaterThan(1);
+      expect(config.getConfigFileTargets()).toContain("claudecode");
+    });
+  });
+
   describe("base directory resolution", () => {
     it("should load configured outputRoots from file", async () => {
       const configContent = JSON.stringify({

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -26,6 +26,7 @@ import {
   ConfigFile,
   ConfigFileSchema,
   ConfigParams,
+  LEGACY_TARGETS,
   PartialConfigParams,
   RequiredConfigParams,
 } from "./config.js";
@@ -358,6 +359,18 @@ function extractConfigFileTargets(
   const validTargets = new Set<string>(ALL_TOOL_TARGETS);
   if (isRulesyncConfigTargetsObject(targets)) {
     return Object.keys(targets).filter((key): key is ToolTarget => validTargets.has(key));
+  }
+  // The wildcard form `["*"]` lists every (non-legacy) target in the config
+  // file. Expand it here — mirroring `Config.getTargets()` — so the returned
+  // list is the full config-file target set rather than an empty array. An
+  // empty result would make `getConfigFileTargets()` fall back to the
+  // CLI-filtered `getTargets()`, breaking root-file ownership computation for
+  // the very common `targets: ["*"]` form (see #1981 / #1894).
+  if (targets.includes("*")) {
+    const legacy = new Set<string>(LEGACY_TARGETS);
+    return ALL_TOOL_TARGETS.filter(
+      (target): target is ToolTarget => validTargets.has(target) && !legacy.has(target),
+    );
   }
   return targets.filter((key): key is ToolTarget => key !== "*" && validTargets.has(key));
 }

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -26,7 +26,7 @@ import {
   ConfigFile,
   ConfigFileSchema,
   ConfigParams,
-  LEGACY_TARGETS,
+  expandWildcardTargets,
   PartialConfigParams,
   RequiredConfigParams,
 } from "./config.js";
@@ -361,16 +361,13 @@ function extractConfigFileTargets(
     return Object.keys(targets).filter((key): key is ToolTarget => validTargets.has(key));
   }
   // The wildcard form `["*"]` lists every (non-legacy) target in the config
-  // file. Expand it here — mirroring `Config.getTargets()` — so the returned
-  // list is the full config-file target set rather than an empty array. An
-  // empty result would make `getConfigFileTargets()` fall back to the
-  // CLI-filtered `getTargets()`, breaking root-file ownership computation for
-  // the very common `targets: ["*"]` form (see #1981 / #1894).
+  // file. Expand it via the shared helper (also used by `Config.getTargets()`)
+  // so the returned list is the full config-file target set rather than an
+  // empty array. An empty result would make `getConfigFileTargets()` fall back
+  // to the CLI-filtered `getTargets()`, breaking root-file ownership
+  // computation for the very common `targets: ["*"]` form (see #1981 / #1894).
   if (targets.includes("*")) {
-    const legacy = new Set<string>(LEGACY_TARGETS);
-    return ALL_TOOL_TARGETS.filter(
-      (target): target is ToolTarget => validTargets.has(target) && !legacy.has(target),
-    );
+    return expandWildcardTargets();
   }
   return targets.filter((key): key is ToolTarget => key !== "*" && validTargets.has(key));
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -152,7 +152,7 @@ const CONFLICTING_TARGET_PAIRS: Array<[string, string]> = [
  * Legacy targets that should NOT be included in wildcard (*) expansion.
  * These targets must be explicitly specified.
  */
-const LEGACY_TARGETS = ["augmentcode-legacy", "claudecode-legacy", "antigravity"] as const;
+export const LEGACY_TARGETS = ["augmentcode-legacy", "claudecode-legacy", "antigravity"] as const;
 
 /**
  * Validates that the user-authored config does not double-define the

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -155,6 +155,17 @@ const CONFLICTING_TARGET_PAIRS: Array<[string, string]> = [
 export const LEGACY_TARGETS = ["augmentcode-legacy", "claudecode-legacy", "antigravity"] as const;
 
 /**
+ * Expand the wildcard target (`*`) to every non-legacy tool target. Legacy
+ * targets are excluded because they must be requested explicitly. Shared by
+ * `Config.getTargets()` and `extractConfigFileTargets()` so the two never drift.
+ */
+export function expandWildcardTargets(): ToolTarget[] {
+  return ALL_TOOL_TARGETS.filter(
+    (target) => !LEGACY_TARGETS.includes(target as (typeof LEGACY_TARGETS)[number]),
+  );
+}
+
+/**
  * Validates that the user-authored config does not double-define the
  * target set in both `targets` and `features` object forms.
  *
@@ -422,11 +433,7 @@ export class Config {
     }
 
     if (arrayTargets.includes("*")) {
-      // Exclude legacy targets from wildcard expansion
-      // Legacy targets must be explicitly specified
-      return ALL_TOOL_TARGETS.filter(
-        (target) => !LEGACY_TARGETS.includes(target as (typeof LEGACY_TARGETS)[number]),
-      );
+      return expandWildcardTargets();
     }
 
     return arrayTargets.filter((target): target is ToolTarget => target !== "*");

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -436,6 +436,63 @@ globs: ["src/**/*"]
     expect(stderr).toBe("");
     expect(stdout).toContain("All files are up to date.");
   });
+
+  it("should attribute rovodev's mirrored ./AGENTS.md so a non-owning target passes check (#1981 #2)", async () => {
+    const testDir = getTestDir();
+
+    const rootRuleContent = `---
+root: true
+targets: ["*"]
+description: "Root rule"
+---
+
+# Root Rule
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+      rootRuleContent,
+    );
+
+    await writeFileContent(
+      join(testDir, RULESYNC_CONFIG_RELATIVE_FILE_PATH),
+      JSON.stringify(
+        {
+          targets: {
+            codexcli: ["rules"],
+            rovodev: ["rules"],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    // rovodev is last in config order and mirrors its root rule to the project
+    // root ./AGENTS.md, so that mirrored file ends up on disk with rovodev's
+    // content (an "Additional Conventions" preamble codexcli never emits).
+    await runGenerate({
+      target: "codexcli,rovodev",
+      features: "rules",
+      env: { NODE_ENV: "e2e" },
+    });
+
+    const agentsMd = await readFileContent(join(testDir, "AGENTS.md"));
+    expect(agentsMd).toContain("Additional Conventions");
+
+    // Check codexcli only. Even though codexcli's own root output is ./AGENTS.md,
+    // rovodev owns the on-disk mirror, so the file is skipped and the check
+    // passes. Without crediting the mirror to rovodev, codexcli would be treated
+    // as the owner and fail on the content mismatch.
+    const { stdout, stderr } = await runGenerate({
+      target: "codexcli",
+      features: "rules",
+      check: true,
+      env: { NODE_ENV: "e2e" },
+    });
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("All files are up to date.");
+  });
 });
 
 describe("E2E: rules (import)", () => {

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -280,7 +280,9 @@ function computeRootFileOwnership(params: {
     if ("root" in paths && paths.root) {
       register(paths.root.relativeDirPath, paths.root.relativeFilePath, target);
     }
-    // Alternative root files (fallback root locations) are also emitted/owned.
+    // Secondary/fallback root locations a target recognizes are attributed to
+    // it as well, so a shared collision at one of those paths is skipped for
+    // non-owning targets.
     if ("alternativeRoots" in paths && paths.alternativeRoots) {
       for (const alt of paths.alternativeRoots) {
         register(alt.relativeDirPath, alt.relativeFilePath, target);
@@ -290,6 +292,8 @@ function computeRootFileOwnership(params: {
     // subdirectory — to a project-root `./AGENTS.md` at generation time (project
     // scope only). That mirror is exactly the shared-collision path, so it must
     // be attributed to the target too, otherwise ownership/skip decisions invert.
+    // (For rovodev this overlaps its `alternativeRoots` today; the explicit
+    // block keeps ownership correct even if that alt root is ever removed.)
     if (!params.global && factory.meta.mirrorsRootToAgentsMd) {
       register(".", AGENTSMD_RULE_FILE_NAME, target);
     }

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { intersection } from "es-toolkit";
 
 import { Config } from "../config/config.js";
+import { AGENTSMD_RULE_FILE_NAME } from "../constants/agentsmd-paths.js";
 import { RULESYNC_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";
 import { CommandsProcessor } from "../features/commands/commands-processor.js";
 import { HooksProcessor } from "../features/hooks/hooks-processor.js";
@@ -249,18 +250,48 @@ export async function generate(params: {
   };
 }
 
+// Maps every root-rule file path a target actually emits to that target, so
+// `generate --check` can skip root files a (CLI-selected) target does not own.
+//
+// Ownership is "last target in config order wins": the loop iterates the config
+// file's full target list and `Map.set` overwrites, so the final writer in
+// config order owns a shared path — consistent with generation write order,
+// where the last target's content is what ends up on disk.
+//
+// Note: a single ownership decision is applied uniformly across all output
+// roots (paths are output-root-relative). Multi-output-root `--check` would
+// need per-output-root keying; that is out of scope here.
 function computeRootFileOwnership(params: {
   targets: ToolTarget[];
   global: boolean;
 }): Map<string, ToolTarget> {
   const ownerByPath = new Map<string, ToolTarget>();
+  const register = (
+    relativeDirPath: string,
+    relativeFilePath: string,
+    target: ToolTarget,
+  ): void => {
+    ownerByPath.set(toPosixPath(join(relativeDirPath, relativeFilePath)), target);
+  };
   for (const target of params.targets) {
     const factory = RulesProcessor.getFactory(target);
     if (!factory) continue;
     const paths = factory.class.getSettablePaths({ global: params.global });
     if ("root" in paths && paths.root) {
-      const rootPath = toPosixPath(join(paths.root.relativeDirPath, paths.root.relativeFilePath));
-      ownerByPath.set(rootPath, target);
+      register(paths.root.relativeDirPath, paths.root.relativeFilePath, target);
+    }
+    // Alternative root files (fallback root locations) are also emitted/owned.
+    if ("alternativeRoots" in paths && paths.alternativeRoots) {
+      for (const alt of paths.alternativeRoots) {
+        register(alt.relativeDirPath, alt.relativeFilePath, target);
+      }
+    }
+    // Some targets (e.g. rovodev) mirror their primary root — which lives in a
+    // subdirectory — to a project-root `./AGENTS.md` at generation time (project
+    // scope only). That mirror is exactly the shared-collision path, so it must
+    // be attributed to the target too, otherwise ownership/skip decisions invert.
+    if (!params.global && factory.meta.mirrorsRootToAgentsMd) {
+      register(".", AGENTSMD_RULE_FILE_NAME, target);
     }
   }
   return ownerByPath;


### PR DESCRIPTION
## Summary

Follow-up fixes for the #1978 root-file-ownership work, addressing the non-blocking findings in #1981.

### #1 (mid) — wildcard `targets: ["*"]` silently bypassed the fix
`extractConfigFileTargets` filtered out `*` and returned `[]` (not `undefined`), so `getConfigFileTargets()` did not fall back and root-file ownership was computed against an empty target list — reproducing #1894 for the very common `targets: ["*"]` config (e.g. `generate --check -t codexcli -f rules` failing on `AGENTS.md`). Now `*` is expanded to the full non-legacy target set, mirroring `Config.getTargets()`.

> The `?? getTargets()` fallback is intentionally **not** relied on here: `getTargets()` is CLI `-t` filtered, whereas ownership needs the full *config-file* target list (CLI-independent).

### #2 (mid) — rovodev's mirrored `./AGENTS.md` was invisible to ownership
`computeRootFileOwnership` derived owned roots only from `getSettablePaths().root`, so rovodev's generation-time mirror to the project-root `./AGENTS.md` (`mirrorsRootToAgentsMd`) and any target's `alternativeRoots` were never attributed — inverting ownership in configs like `{ codexcli, rovodev }`. Both are now registered.

### #3 / #4 (low) — documentation
Documented the single-ownership-decision-across-output-roots assumption and the load-bearing "last target in config order wins" semantics at the call site.

### #5 (low) — tests
- config-resolver regression test: `["*"]` expands to the full non-legacy list (and stays full even when CLI `-t` selects one target).
- E2E: a non-owning target (`codexcli`) passes `--check` when rovodev owns the mirrored `./AGENTS.md`.

## Verification

- `pnpm cicheck` passes (fmt, oxlint, typecheck, tests, content).
- E2E smoke: `generate --check -t codexcli` passes when rovodev (last in config) owns the mirrored `AGENTS.md`.

Closes #1981