### PR TITLE
fix(codexcli): preserve per-tool MCP approval_mode on regenerate

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -411,6 +411,40 @@ approval_mode = "approve"
       });
     });
 
+    it("does not clobber a rulesync-emitted tools value with the preserved approval table", async () => {
+      // When rulesync itself supplies a `tools` value, rulesync owns it: the
+      // preserved approval table must NOT override it.
+      const existingToml = `[mcp_servers.srv]
+command = "node"
+
+[mcp_servers.srv.tools.some_tool]
+approval_mode = "approve"
+`;
+      await ensureDir(join(testDir, ".codex"));
+      await writeFileContent(join(testDir, ".codex/config.toml"), existingToml);
+
+      const jsonData = {
+        mcpServers: {
+          srv: { command: "node", tools: ["explicit_tool"] },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const servers = codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>;
+      // rulesync's `tools` value wins; the existing approval table is not restored.
+      expect(servers.srv?.tools).toEqual(["explicit_tool"]);
+    });
+
     it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -363,6 +363,54 @@ fontSize = 14
       expect(json.mcp_servers).toEqual(jsonData.mcpServers);
     });
 
+    it("should preserve per-tool approval_mode decisions on regenerate (#1709)", async () => {
+      // Codex's CLI writes nested `[mcp_servers.<server>.tools.<tool>]` tables
+      // with `approval_mode` when the user approves an MCP tool. rulesync does
+      // not model this, so a regenerate must not wipe these saved approvals.
+      const existingToml = `[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]
+
+[mcp_servers.playwright.tools.browser_navigate]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_click]
+approval_mode = "approve"
+`;
+      await ensureDir(join(testDir, ".codex"));
+      await writeFileContent(join(testDir, ".codex/config.toml"), existingToml);
+
+      const jsonData = {
+        mcpServers: {
+          playwright: {
+            command: "npx",
+            args: ["@playwright/mcp@latest"],
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+
+      const servers = codexcliMcp.getToml().mcp_servers as Record<string, Record<string, unknown>>;
+      // The rulesync-owned fields are present...
+      expect(servers.playwright?.command).toBe("npx");
+      expect(servers.playwright?.args).toEqual(["@playwright/mcp@latest"]);
+      // ...and the user's saved per-tool approval decisions survive.
+      expect(servers.playwright?.tools).toEqual({
+        browser_navigate: { approval_mode: "approve" },
+        browser_click: { approval_mode: "approve" },
+      });
+    });
+
     it("should create instance from RulesyncMcp with custom outputRoot", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -211,8 +211,12 @@ export class CodexcliMcp extends ToolMcp {
     // `approval_mode` decisions) that Codex's CLI writes when the user approves
     // an MCP tool. rulesync does not model this nested `tools` table, so without
     // re-merging it here a regenerate would wipe the user's saved approvals and
-    // re-introduce approval prompts (#1709). rulesync still fully owns every
-    // field it does emit (command/args/env/env_vars/enabled_tools/etc.).
+    // re-introduce approval prompts (#1709). It is the only user/CLI-written
+    // nested state Codex persists under a server that rulesync does not own.
+    // rulesync still fully owns every field it does emit, including `tools` when
+    // it is supplied as a rulesync value: the existing table is only restored
+    // when rulesync emits no `tools` key at all, so a rulesync-owned `tools`
+    // (e.g. an array) is never clobbered by the preserved approval table.
     const existingMcpServers = isRecord(configToml["mcp_servers"]) ? configToml["mcp_servers"] : {};
     const mergedMcpServers = Object.fromEntries(
       Object.entries(filteredMcpServers).map(([name, serverConfig]) => {
@@ -220,11 +224,7 @@ export class CodexcliMcp extends ToolMcp {
           ? existingMcpServers[name]
           : undefined;
         const serverRecord = serverConfig as Record<string, unknown>;
-        if (
-          existingServer &&
-          isRecord(existingServer["tools"]) &&
-          !isRecord(serverRecord["tools"])
-        ) {
+        if (existingServer && isRecord(existingServer["tools"]) && !("tools" in serverRecord)) {
           return [name, { ...serverRecord, tools: existingServer["tools"] }];
         }
         return [name, serverConfig];

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -207,7 +207,31 @@ export class CodexcliMcp extends ToolMcp {
       }
     }
 
-    configToml["mcp_servers"] = filteredMcpServers as smolToml.TomlTable;
+    // Preserve per-tool approval state (`[mcp_servers.<server>.tools.<tool>]`
+    // `approval_mode` decisions) that Codex's CLI writes when the user approves
+    // an MCP tool. rulesync does not model this nested `tools` table, so without
+    // re-merging it here a regenerate would wipe the user's saved approvals and
+    // re-introduce approval prompts (#1709). rulesync still fully owns every
+    // field it does emit (command/args/env/env_vars/enabled_tools/etc.).
+    const existingMcpServers = isRecord(configToml["mcp_servers"]) ? configToml["mcp_servers"] : {};
+    const mergedMcpServers = Object.fromEntries(
+      Object.entries(filteredMcpServers).map(([name, serverConfig]) => {
+        const existingServer = isRecord(existingMcpServers[name])
+          ? existingMcpServers[name]
+          : undefined;
+        const serverRecord = serverConfig as Record<string, unknown>;
+        if (
+          existingServer &&
+          isRecord(existingServer["tools"]) &&
+          !isRecord(serverRecord["tools"])
+        ) {
+          return [name, { ...serverRecord, tools: existingServer["tools"] }];
+        }
+        return [name, serverConfig];
+      }),
+    );
+
+    configToml["mcp_servers"] = mergedMcpServers as smolToml.TomlTable;
 
     return new CodexcliMcp({
       outputRoot,


### PR DESCRIPTION
## Summary

Fixes #1709. When a user approves an MCP tool in Codex, the CLI saves that decision as a nested table in `.codex/config.toml`:

```toml
[mcp_servers.playwright.tools.browser_navigate]
approval_mode = "approve"
```

rulesync's `CodexcliMcp.fromRulesyncMcp` rebuilt the entire `mcp_servers` table from its own model (command/args/env/env_vars/enabled_tools/…), which does **not** include this per-tool `tools` table, and assigned it wholesale — so every `rulesync generate` silently **wiped the user's saved approvals**, re-introducing approval prompts.

## Fix

Re-merge each existing server's `tools` approval table onto the regenerated server config (only when rulesync doesn't itself emit a `tools` key, which it never does for codex). rulesync still fully owns every field it emits; only the unmodeled approval-policy state is preserved.

## Verification

- New regression test asserts that pre-existing `tools.<tool>.approval_mode` entries survive a regenerate while the rulesync-owned `command`/`args` are still written. (Fails without the fix.)
- `pnpm cicheck` passes (68 codex MCP tests + full suite).

Closes #1709