### PR TITLE
feat(claudecode): support the current documented hook events

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -179,7 +179,7 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `elicitation`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `elicitationResult`    |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 
-> **Note:** `worktreeCreate`, `worktreeRemove`, and `messageDisplay` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
+> **Note:** `worktreeCreate`, `worktreeRemove`, `messageDisplay`, `postToolBatch`, `taskCreated`, `taskCompleted`, `teammateIdle`, and `cwdChanged` are Claude Code events that do not support the `matcher` field (they fire on every occurrence). Any matcher defined in the config is ignored for these events.
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin at `.opencode/plugins/rulesync-hooks.js` and Kilo hooks as a plugin at `.kilo/plugins/rulesync-hooks.js`, so importing from OpenCode/Kilo to rulesync is not supported. Both only support command-type hooks (not prompt-type).
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -139,12 +139,12 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
 | `preModelInvocation`   |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postModelInvocation`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
-| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |
+| `postToolUseFailure`   |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
-| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |     ✅      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
+| `subagentStart`        |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `subagentStop`         |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  —   |        —        |        —        |   —   |      —      |   —   |
-| `postCompact`          |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `postCompact`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
 | `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
 | `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
@@ -165,6 +165,19 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `workspaceOpen`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `messageDisplay`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `instructionsLoaded`   |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `userPromptExpansion`  |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `postToolBatch`        |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `permissionDenied`     |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `taskCreated`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `taskCompleted`        |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `stopFailure`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `teammateIdle`         |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `configChange`         |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `cwdChanged`           |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `fileChanged`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `elicitation`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `elicitationResult`    |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 
 > **Note:** `worktreeCreate`, `worktreeRemove`, and `messageDisplay` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -179,7 +179,7 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `elicitation`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `elicitationResult`    |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 
-> **Note:** `worktreeCreate`, `worktreeRemove`, and `messageDisplay` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
+> **Note:** `worktreeCreate`, `worktreeRemove`, `messageDisplay`, `postToolBatch`, `taskCreated`, `taskCompleted`, `teammateIdle`, and `cwdChanged` are Claude Code events that do not support the `matcher` field (they fire on every occurrence). Any matcher defined in the config is ignored for these events.
 
 > **Note:** Rulesync implements OpenCode hooks as a plugin at `.opencode/plugins/rulesync-hooks.js` and Kilo hooks as a plugin at `.kilo/plugins/rulesync-hooks.js`, so importing from OpenCode/Kilo to rulesync is not supported. Both only support command-type hooks (not prompt-type).
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -139,12 +139,12 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
 | `preModelInvocation`   |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postModelInvocation`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
-| `postToolUseFailure`   |   ✅   |      —      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |
+| `postToolUseFailure`   |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `stop`                 |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
-| `subagentStart`        |   ✅   |      —      |    —     |  —   |    —    |     ✅      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
+| `subagentStart`        |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `subagentStop`         |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |  ✅   |
 | `preCompact`           |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  —   |        —        |        —        |   —   |      —      |   —   |
-| `postCompact`          |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `postCompact`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |    ✅     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `afterFileEdit`        |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
 | `beforeShellExecution` |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
 | `afterShellExecution`  |   ✅   |      —      |    ✅    |  ✅  |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |  ✅   |      —      |  ✅   |
@@ -165,6 +165,19 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `workspaceOpen`        |   ✅   |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `messageDisplay`       |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 | `afterError`           |   —    |      —      |    —     |  —   |   ✅    |     ✅      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `instructionsLoaded`   |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `userPromptExpansion`  |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `postToolBatch`        |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `permissionDenied`     |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `taskCreated`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `taskCompleted`        |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `stopFailure`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `teammateIdle`         |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `configChange`         |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `cwdChanged`           |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `fileChanged`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `elicitation`          |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
+| `elicitationResult`    |   —    |     ✅      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |        —        |        —        |   —   |      —      |   —   |
 
 > **Note:** `worktreeCreate`, `worktreeRemove`, and `messageDisplay` are Claude Code-specific events and do not support the `matcher` field. Any matcher defined in the config is ignored for these events.
 

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -72,6 +72,69 @@ describe("ClaudecodeHooks", () => {
       expect(parsed.hooks.afterFileEdit).toBeUndefined();
     });
 
+    it("should support the current documented Claude Code hook events (#1628)", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          instructionsLoaded: [{ command: "a.sh" }],
+          userPromptExpansion: [{ command: "b.sh" }],
+          postToolUseFailure: [{ command: "c.sh" }],
+          postToolBatch: [{ command: "d.sh" }],
+          permissionDenied: [{ command: "e.sh" }],
+          subagentStart: [{ command: "f.sh" }],
+          taskCreated: [{ command: "g.sh" }],
+          taskCompleted: [{ command: "h.sh" }],
+          stopFailure: [{ command: "i.sh" }],
+          teammateIdle: [{ command: "j.sh" }],
+          configChange: [{ command: "k.sh" }],
+          cwdChanged: [{ command: "l.sh" }],
+          fileChanged: [{ command: "m.sh" }],
+          postCompact: [{ command: "n.sh" }],
+          elicitation: [{ command: "o.sh" }],
+          elicitationResult: [{ command: "p.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      // Each canonical event is emitted under its documented PascalCase name.
+      for (const eventName of [
+        "InstructionsLoaded",
+        "UserPromptExpansion",
+        "PostToolUseFailure",
+        "PostToolBatch",
+        "PermissionDenied",
+        "SubagentStart",
+        "TaskCreated",
+        "TaskCompleted",
+        "StopFailure",
+        "TeammateIdle",
+        "ConfigChange",
+        "CwdChanged",
+        "FileChanged",
+        "PostCompact",
+        "Elicitation",
+        "ElicitationResult",
+      ]) {
+        expect(parsed.hooks[eventName], `missing ${eventName}`).toBeDefined();
+      }
+    });
+
     it("should only prefix dot-relative commands with $CLAUDE_PROJECT_DIR", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -135,6 +135,38 @@ describe("ClaudecodeHooks", () => {
       }
     });
 
+    it("omits the matcher for no-matcher events but keeps it for matcher events (#1628)", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          // No-matcher event: matcher must be dropped.
+          taskCreated: [{ matcher: "Bash", command: "a.sh" }],
+          // Matcher-supporting event: matcher must be preserved.
+          postToolUseFailure: [{ matcher: "Bash", command: "b.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      expect(parsed.hooks.TaskCreated[0].matcher).toBeUndefined();
+      expect(parsed.hooks.PostToolUseFailure[0].matcher).toBe("Bash");
+    });
+
     it("should only prefix dot-relative commands with $CLAUDE_PROJECT_DIR", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -26,6 +26,13 @@ const CLAUDE_NO_MATCHER_EVENTS: ReadonlySet<string> = new Set([
   "worktreeCreate",
   "worktreeRemove",
   "messageDisplay",
+  // Documented as firing on every occurrence with no tool/argument matcher.
+  // @see https://code.claude.com/docs/en/hooks#hook-events
+  "postToolBatch",
+  "taskCreated",
+  "taskCompleted",
+  "teammateIdle",
+  "cwdChanged",
 ]);
 
 const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -91,7 +91,19 @@ export type HookEvent =
   | "messageDisplay"
   | "todoCreated"
   | "todoCompleted"
-  | "stopFailure";
+  | "stopFailure"
+  | "instructionsLoaded"
+  | "userPromptExpansion"
+  | "postToolBatch"
+  | "permissionDenied"
+  | "taskCreated"
+  | "taskCompleted"
+  | "teammateIdle"
+  | "configChange"
+  | "cwdChanged"
+  | "fileChanged"
+  | "elicitation"
+  | "elicitationResult";
 
 /** Hook events supported by Cursor. */
 export const CURSOR_HOOK_EVENTS: readonly HookEvent[] = [
@@ -118,7 +130,12 @@ export const CURSOR_HOOK_EVENTS: readonly HookEvent[] = [
   "workspaceOpen",
 ];
 
-/** Hook events supported by Claude Code. */
+/**
+ * Hook events supported by Claude Code.
+ *
+ * Covers the full documented event surface.
+ * @see https://code.claude.com/docs/en/hooks#hook-events
+ */
 export const CLAUDE_HOOK_EVENTS: readonly HookEvent[] = [
   "sessionStart",
   "sessionEnd",
@@ -134,6 +151,23 @@ export const CLAUDE_HOOK_EVENTS: readonly HookEvent[] = [
   "worktreeCreate",
   "worktreeRemove",
   "messageDisplay",
+  // Added to follow the current documented event surface.
+  "instructionsLoaded",
+  "userPromptExpansion",
+  "postToolUseFailure",
+  "postToolBatch",
+  "permissionDenied",
+  "subagentStart",
+  "taskCreated",
+  "taskCompleted",
+  "stopFailure",
+  "teammateIdle",
+  "configChange",
+  "cwdChanged",
+  "fileChanged",
+  "postCompact",
+  "elicitation",
+  "elicitationResult",
 ];
 
 /** Hook events supported by OpenCode. */
@@ -454,6 +488,22 @@ export const CANONICAL_TO_CLAUDE_EVENT_NAMES: Record<string, string> = {
   worktreeCreate: "WorktreeCreate",
   worktreeRemove: "WorktreeRemove",
   messageDisplay: "MessageDisplay",
+  instructionsLoaded: "InstructionsLoaded",
+  userPromptExpansion: "UserPromptExpansion",
+  postToolUseFailure: "PostToolUseFailure",
+  postToolBatch: "PostToolBatch",
+  permissionDenied: "PermissionDenied",
+  subagentStart: "SubagentStart",
+  taskCreated: "TaskCreated",
+  taskCompleted: "TaskCompleted",
+  stopFailure: "StopFailure",
+  teammateIdle: "TeammateIdle",
+  configChange: "ConfigChange",
+  cwdChanged: "CwdChanged",
+  fileChanged: "FileChanged",
+  postCompact: "PostCompact",
+  elicitation: "Elicitation",
+  elicitationResult: "ElicitationResult",
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes #1628. Claude Code's [hooks docs](https://code.claude.com/docs/en/hooks#hook-events) document 30 hook events, but rulesync's `claudecode` hook map covered only 14, so configs using the newer events were silently dropped for the `claudecode` target.

Adds the 16 missing events (each verified against the official docs):
`instructionsLoaded`, `userPromptExpansion`, `postToolUseFailure`, `postToolBatch`, `permissionDenied`, `subagentStart`, `taskCreated`, `taskCompleted`, `stopFailure`, `teammateIdle`, `configChange`, `cwdChanged`, `fileChanged`, `postCompact`, `elicitation`, `elicitationResult`.

## Changes

- Add 12 new canonical names to the `HookEvent` union (the other 4 — `postToolUseFailure`, `subagentStart`, `stopFailure`, `postCompact` — already existed for other tools).
- Add all 16 `canonical → PascalCase` mappings to `CANONICAL_TO_CLAUDE_EVENT_NAMES` (the reverse map for import is auto-derived).
- Add all 16 to `CLAUDE_HOOK_EVENTS`.
- Update the *Hook event × tool matrix* in `file-formats.md`.
- Add a generation test covering all 16 new events → their PascalCase names.

> Scope: hook **events** only, per the issue. Handler types/fields (`http`, `mcp_tool`, `agent`, `if`, `async`, …) and per-event `matcher` support remain out of scope (the issue notes they need separate design).

## Verification

- `pnpm cicheck` passes (typecheck, tests incl. the new event test and the existing `CLAUDE_HOOK_EVENTS ↔ CANONICAL_TO_CLAUDE_EVENT_NAMES` consistency test, content checks).

Closes #1628