### PR TITLE
refactor(opencode): apply strict frontmatter schema to OpenCodeSubagent

### DIFF
--- a/src/features/subagents/opencode-subagent.test.ts
+++ b/src/features/subagents/opencode-subagent.test.ts
@@ -204,6 +204,35 @@ Assist with any tasks`,
     expect(result.success).toBe(true);
   });
 
+  it("should validate the documented field types but keep unknown fields (looseObject)", () => {
+    // Known fields are now typed explicitly (strict-schema pattern, #1658)...
+    expect(
+      OpenCodeSubagentFrontmatterSchema.safeParse({
+        description: "Agent",
+        temperature: 0.4,
+        top_p: 0.9,
+        model: "some-model",
+        tools: { read: true, write: false },
+      }).success,
+    ).toBe(true);
+    // ...a wrong type for a declared field is rejected...
+    expect(
+      OpenCodeSubagentFrontmatterSchema.safeParse({
+        description: "Agent",
+        temperature: "hot",
+      }).success,
+    ).toBe(false);
+    // ...while forward-compatible unknown fields still round-trip.
+    const loose = OpenCodeSubagentFrontmatterSchema.safeParse({
+      description: "Agent",
+      futureOpenCodeField: "kept",
+    });
+    expect(loose.success).toBe(true);
+    expect(loose.success && (loose.data as Record<string, unknown>).futureOpenCodeField).toBe(
+      "kept",
+    );
+  });
+
   it("should apply default mode 'subagent' when mode is omitted", async () => {
     const dirPath = join(testDir, ".opencode", "agents");
     const filePath = join(dirPath, "no-mode.md");

--- a/src/features/subagents/opencode-subagent.ts
+++ b/src/features/subagents/opencode-subagent.ts
@@ -1,19 +1,17 @@
 import { join } from "node:path";
 
+import { z } from "zod/mini";
+
 import {
   OPENCODE_AGENTS_DIR_PATH,
   OPENCODE_GLOBAL_AGENTS_DIR_PATH,
 } from "../../constants/opencode-paths.js";
+import { ValidationResult } from "../../types/ai-file.js";
 import { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContent } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
-import {
-  OpenCodeStyleSubagent,
-  OpenCodeStyleSubagentFrontmatter,
-  OpenCodeStyleSubagentFrontmatterSchema,
-  OpenCodeStyleSubagentParams,
-} from "./opencode-style-subagent.js";
+import { OpenCodeStyleSubagent, OpenCodeStyleSubagentParams } from "./opencode-style-subagent.js";
 import { RulesyncSubagent } from "./rulesync-subagent.js";
 import {
   ToolSubagent,
@@ -23,13 +21,84 @@ import {
   ToolSubagentSettablePaths,
 } from "./tool-subagent.js";
 
-export const OpenCodeSubagentFrontmatterSchema = OpenCodeStyleSubagentFrontmatterSchema;
-export type OpenCodeSubagentFrontmatter = OpenCodeStyleSubagentFrontmatter;
-export type OpenCodeSubagentParams = OpenCodeStyleSubagentParams;
+/** Default `mode` applied to OpenCode subagents (single source of truth). */
+export const OPENCODE_DEFAULT_MODE = "subagent";
+
+/**
+ * Explicit OpenCode subagent frontmatter schema.
+ *
+ * Mirrors the strict-schema pattern applied to {@link KiloSubagent} (#1655):
+ * the documented OpenCode agent fields are declared explicitly (instead of
+ * aliasing the shared `OpenCodeStyleSubagent` base schema), tightening
+ * validation and documenting the supported surface. The object stays
+ * `looseObject` so forward-compatible/unknown fields still round-trip.
+ * @see https://opencode.ai/docs/agents/
+ */
+export const OpenCodeSubagentFrontmatterSchema = z.looseObject({
+  description: z.optional(z.string()),
+  mode: z._default(z.string(), OPENCODE_DEFAULT_MODE),
+  name: z.optional(z.string()),
+  model: z.optional(z.string()),
+  temperature: z.optional(z.number()),
+  top_p: z.optional(z.number()),
+  prompt: z.optional(z.string()),
+  disable: z.optional(z.boolean()),
+  // OpenCode accepts a per-tool enable map (`{ <tool>: boolean }`) as well as a
+  // per-tool permission object, so both are kept permissive.
+  tools: z.optional(z.record(z.string(), z.unknown())),
+  permission: z.optional(z.union([z.string(), z.record(z.string(), z.unknown())])),
+});
+export type OpenCodeSubagentFrontmatter = z.infer<typeof OpenCodeSubagentFrontmatterSchema>;
+export type OpenCodeSubagentParams = Omit<OpenCodeStyleSubagentParams, "frontmatter"> & {
+  frontmatter: OpenCodeSubagentFrontmatter;
+};
 
 export class OpenCodeSubagent extends OpenCodeStyleSubagent {
+  declare protected readonly frontmatter: OpenCodeSubagentFrontmatter;
+
+  constructor(params: OpenCodeSubagentParams) {
+    // Apply the OpenCode schema (which also fills the `mode` default) up front so
+    // the stored frontmatter is normalized and `validate()` stays side-effect-free.
+    // The schema is a strict superset of the parent's, so the parent's own
+    // validation is redundant — skip it with `validate: false`.
+    let frontmatter = params.frontmatter;
+    if (params.validate !== false) {
+      const result = OpenCodeSubagentFrontmatterSchema.safeParse(params.frontmatter);
+      if (!result.success) {
+        throw new Error(
+          `Invalid frontmatter in ${join(params.relativeDirPath, params.relativeFilePath)}: ${formatError(result.error)}`,
+        );
+      }
+      frontmatter = result.data;
+    }
+
+    super({ ...params, frontmatter, validate: false });
+  }
+
   protected getToolTarget(): Extract<ToolTarget, "opencode" | "kilo"> {
     return "opencode";
+  }
+
+  getFrontmatter(): OpenCodeSubagentFrontmatter {
+    return this.frontmatter;
+  }
+
+  /**
+   * Pure validation against the OpenCode schema (default application happens in
+   * the constructor, not here), matching every sibling subagent.
+   */
+  validate(): ValidationResult {
+    const result = OpenCodeSubagentFrontmatterSchema.safeParse(this.frontmatter);
+    if (result.success) {
+      return { success: true, error: null };
+    }
+
+    return {
+      success: false,
+      error: new Error(
+        `Invalid frontmatter in ${join(this.relativeDirPath, this.relativeFilePath)}: ${formatError(result.error)}`,
+      ),
+    };
   }
 
   static getSettablePaths({
@@ -54,12 +123,18 @@ export class OpenCodeSubagent extends OpenCodeStyleSubagent {
     const rulesyncFrontmatter = rulesyncSubagent.getFrontmatter();
     const opencodeSection = rulesyncFrontmatter.opencode ?? {};
 
-    const opencodeFrontmatter: OpenCodeSubagentFrontmatter = {
+    const parseResult = OpenCodeSubagentFrontmatterSchema.safeParse({
       ...opencodeSection,
       description: rulesyncFrontmatter.description,
-      mode: typeof opencodeSection.mode === "string" ? opencodeSection.mode : "subagent",
       ...(rulesyncFrontmatter.name && { name: rulesyncFrontmatter.name }),
-    };
+    });
+
+    if (!parseResult.success) {
+      throw new Error(
+        `Invalid frontmatter in ${rulesyncSubagent.getRelativeFilePath()}: ${formatError(parseResult.error)}`,
+      );
+    }
+    const opencodeFrontmatter: OpenCodeSubagentFrontmatter = parseResult.data;
 
     const body = rulesyncSubagent.getBody();
     const fileContent = stringifyFrontmatter(body, opencodeFrontmatter);


### PR DESCRIPTION
## Summary

Closes #1658. `OpenCodeSubagent` merely aliased the shared `OpenCodeStyleSubagent` base frontmatter schema, whereas `KiloSubagent` (the other tool extending the same parent) declares an explicit schema since #1655. This applies the same strict-schema pattern across the OpenCode-style family.

## Changes

- Declare an explicit `OpenCodeSubagentFrontmatterSchema` (`z.looseObject`) enumerating the documented OpenCode agent fields: `description`, `mode` (default `subagent`), `name`, `model`, `temperature`, `top_p`, `prompt`, `disable`, `tools`, `permission`.
- Mirror the Kilo pattern: normalize the `mode` default in the constructor, `declare` the narrowed `frontmatter` type, validate through the schema in `validate()`, and `safeParse` in `fromRulesyncSubagent()` / `fromFile()`.
- The schema stays `looseObject`, so forward-compatible/unknown fields (e.g. `hidden`) still round-trip — behavior is unchanged for valid configs; validation is merely tightened for the declared field types.

## Verification

- `pnpm cicheck` passes (typecheck + 12 OpenCodeSubagent tests + subagents processor + full suite). New test asserts the declared field types validate, a wrong type is rejected, and unknown fields still round-trip.

Closes #1658