### PR TITLE
feat(claudecode): model current skill frontmatter fields

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -408,13 +408,24 @@ disable-model-invocation: true
 user-invocable: false
 claudecode: # for claudecode-specific parameters
   model: sonnet # opus, sonnet, haiku, or any string
-  allowed-tools:
+  when_to_use: When the user asks to review a PR # (optional) extra trigger context appended to description
+  allowed-tools: # (optional) tools usable without asking; accepts a string or a list
     - "Bash"
     - "Read"
     - "Write"
     - "Grep"
   disallowed-tools: # (optional) removes these tools while the skill is active (string or list)
     - "WebFetch"
+  effort: high # (optional) effort while active: low | medium | high | xhigh | max
+  argument-hint: "[pr-number]" # (optional) autocomplete hint for expected arguments
+  arguments: # (optional) named positional arguments for $name substitution (string or list)
+    - "pr_number"
+  context: fork # (optional) set to "fork" to run the skill in a forked subagent context
+  agent: code-reviewer # (optional) subagent type to use when context: fork
+  shell: bash # (optional) shell for ! command blocks: bash (default) or powershell
+  hooks: # (optional) hooks scoped to the skill's lifecycle (free-form per the Claude Code docs)
+    PreToolUse:
+      - matcher: "Bash"
   disable-model-invocation: true # (optional) disable model invocation for this skill
   user-invocable: false # (optional) hide from the / menu while keeping model access
   scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -408,13 +408,24 @@ disable-model-invocation: true
 user-invocable: false
 claudecode: # for claudecode-specific parameters
   model: sonnet # opus, sonnet, haiku, or any string
-  allowed-tools:
+  when_to_use: When the user asks to review a PR # (optional) extra trigger context appended to description
+  allowed-tools: # (optional) tools usable without asking; accepts a string or a list
     - "Bash"
     - "Read"
     - "Write"
     - "Grep"
   disallowed-tools: # (optional) removes these tools while the skill is active (string or list)
     - "WebFetch"
+  effort: high # (optional) effort while active: low | medium | high | xhigh | max
+  argument-hint: "[pr-number]" # (optional) autocomplete hint for expected arguments
+  arguments: # (optional) named positional arguments for $name substitution (string or list)
+    - "pr_number"
+  context: fork # (optional) set to "fork" to run the skill in a forked subagent context
+  agent: code-reviewer # (optional) subagent type to use when context: fork
+  shell: bash # (optional) shell for ! command blocks: bash (default) or powershell
+  hooks: # (optional) hooks scoped to the skill's lifecycle (free-form per the Claude Code docs)
+    PreToolUse:
+      - matcher: "Bash"
   disable-model-invocation: true # (optional) disable model invocation for this skill
   user-invocable: false # (optional) hide from the / menu while keeping model access
   scheduled-task: true # (optional) emit to .claude/scheduled-tasks/<name>/SKILL.md instead of .claude/skills/<name>/SKILL.md

--- a/src/features/skills/claudecode-skill.test.ts
+++ b/src/features/skills/claudecode-skill.test.ts
@@ -308,6 +308,55 @@ describe("ClaudecodeSkill", () => {
       expect(rulesyncFrontmatter.claudecode).toEqual({ model: "opus" });
     });
 
+    it("should round-trip the extended Claude Code skill frontmatter fields", () => {
+      const frontmatter: ClaudecodeSkillFrontmatter = {
+        name: "extended-skill",
+        description: "Skill with extended fields",
+        when_to_use: "When the user asks to review a PR",
+        "allowed-tools": "Read Write Bash",
+        effort: "high",
+        "argument-hint": "[pr-number]",
+        arguments: ["pr_number"],
+        context: "fork",
+        agent: "code-reviewer",
+        hooks: { PreToolUse: [{ matcher: "Bash" }] },
+        shell: "bash",
+      };
+
+      const skill = new ClaudecodeSkill({
+        dirName: "extended-skill",
+        frontmatter,
+        body: "Extended body",
+      });
+
+      const rulesyncFrontmatter = skill.toRulesyncSkill().getFrontmatter();
+      expect(rulesyncFrontmatter.claudecode).toEqual({
+        when_to_use: "When the user asks to review a PR",
+        "allowed-tools": "Read Write Bash",
+        effort: "high",
+        "argument-hint": "[pr-number]",
+        arguments: ["pr_number"],
+        context: "fork",
+        agent: "code-reviewer",
+        hooks: { PreToolUse: [{ matcher: "Bash" }] },
+        shell: "bash",
+      });
+
+      // round-trip back to a ClaudecodeSkill preserves every extended field
+      const roundTripped = ClaudecodeSkill.fromRulesyncSkill({
+        rulesyncSkill: skill.toRulesyncSkill(),
+      }).getFrontmatter();
+      expect(roundTripped.when_to_use).toBe("When the user asks to review a PR");
+      expect(roundTripped["allowed-tools"]).toBe("Read Write Bash");
+      expect(roundTripped.effort).toBe("high");
+      expect(roundTripped["argument-hint"]).toBe("[pr-number]");
+      expect(roundTripped.arguments).toEqual(["pr_number"]);
+      expect(roundTripped.context).toBe("fork");
+      expect(roundTripped.agent).toBe("code-reviewer");
+      expect(roundTripped.hooks).toEqual({ PreToolUse: [{ matcher: "Bash" }] });
+      expect(roundTripped.shell).toBe("bash");
+    });
+
     it("should convert to RulesyncSkill with both model and allowed-tools", () => {
       const frontmatter: ClaudecodeSkillFrontmatter = {
         name: "full-skill",
@@ -1191,14 +1240,25 @@ Global skill content.`;
     });
 
     it("should reject invalid allowed-tools type", () => {
+      // `allowed-tools` accepts a string or a string array (per the Claude Code
+      // skills docs), so a number is the invalid case that must still be rejected.
       const invalidFrontmatter = {
         name: "test-skill",
         description: "Test description",
-        "allowed-tools": "not-an-array",
+        "allowed-tools": 123,
       };
 
       const result = ClaudecodeSkillFrontmatterSchema.safeParse(invalidFrontmatter);
       expect(result.success).toBe(false);
+    });
+
+    it("should accept allowed-tools as a space-separated string", () => {
+      const result = ClaudecodeSkillFrontmatterSchema.safeParse({
+        name: "test-skill",
+        description: "Test description",
+        "allowed-tools": "Read Write Bash",
+      });
+      expect(result.success).toBe(true);
     });
 
     it("should validate frontmatter with model field", () => {

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -75,22 +75,25 @@ function buildClaudecodeSkillFrontmatter({
   resolvedUserInvocable: boolean | undefined;
 }): ClaudecodeSkillFrontmatter {
   const section = rulesyncFrontmatter.claudecode ?? {};
-  // Every claudecode-specific field is a straight pass-through, plus the two
-  // resolved invocation flags. Build a candidate map and copy across only the
-  // keys that are actually present, so the function stays data-driven (and well
-  // under the cyclomatic-complexity cap) as more fields are added.
-  const candidate: Record<string, unknown> = {
+  // Build the frontmatter data-driven so the function stays well under the
+  // cyclomatic-complexity cap as fields are added. The two presence rules mirror
+  // `toRulesyncSkill` exactly so the conversion is symmetric: most fields are
+  // included only when truthy, while `arguments`/`hooks`/`paths` and the resolved
+  // invocation flags are included whenever they are explicitly defined.
+  const truthyFields: Record<string, unknown> = {
     when_to_use: section.when_to_use,
     "allowed-tools": section["allowed-tools"],
     "disallowed-tools": section["disallowed-tools"],
     model: section.model,
     effort: section.effort,
     "argument-hint": section["argument-hint"],
-    arguments: section.arguments,
     context: section.context,
     agent: section.agent,
-    hooks: section.hooks,
     shell: section.shell,
+  };
+  const definedFields: Record<string, unknown> = {
+    arguments: section.arguments,
+    hooks: section.hooks,
     "disable-model-invocation": resolvedDisableModelInvocation,
     "user-invocable": resolvedUserInvocable,
     paths: section.paths,
@@ -100,7 +103,12 @@ function buildClaudecodeSkillFrontmatter({
     name: rulesyncFrontmatter.name,
     description: rulesyncFrontmatter.description,
   };
-  for (const [key, value] of Object.entries(candidate)) {
+  for (const [key, value] of Object.entries(truthyFields)) {
+    if (value) {
+      frontmatter[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(definedFields)) {
     if (value !== undefined) {
       frontmatter[key] = value;
     }

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -10,7 +10,12 @@ import { SKILL_FILE_NAME } from "../../constants/general.js";
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-dir.js";
 import { formatError } from "../../utils/error.js";
-import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  RulesyncSkill,
+  RulesyncSkillFrontmatter,
+  RulesyncSkillFrontmatterInput,
+  SkillFile,
+} from "./rulesync-skill.js";
 import { resolveDisableModelInvocation, resolveUserInvocable } from "./skills-utils.js";
 import {
   ToolSkill,
@@ -23,17 +28,86 @@ import {
 export const ClaudecodeSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
-  "allowed-tools": z.optional(z.array(z.string())),
+  // Additional context for when Claude should invoke the skill (trigger phrases,
+  // example requests). Appended to `description` in the skill listing.
+  when_to_use: z.optional(z.string()),
+  // Tools Claude may use without asking while the skill is active.
+  // The docs accept a space/comma-separated string or a YAML list.
+  "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
   // Removes the listed tools from the model while the skill is active.
   // Accepts the space/comma-separated string form or a YAML list, mirroring `allowed-tools`.
   "disallowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
   model: z.optional(z.string()),
+  // Effort level while the skill is active (low | medium | high | xhigh | max).
+  effort: z.optional(z.string()),
+  // Hint shown during autocomplete to indicate expected arguments.
+  "argument-hint": z.optional(z.string()),
+  // Named positional arguments for `$name` substitution; string or YAML list.
+  arguments: z.optional(z.union([z.string(), z.array(z.string())])),
+  // `fork` runs the skill in a forked subagent context.
+  context: z.optional(z.string()),
+  // Which subagent type to use when `context: fork` is set.
+  agent: z.optional(z.string()),
+  // Hooks scoped to the skill's lifecycle (free-form per the docs).
+  hooks: z.optional(z.looseObject({})),
+  // Shell for `!` command blocks in the skill (`bash` default or `powershell`).
+  shell: z.optional(z.string()),
   "disable-model-invocation": z.optional(z.boolean()),
   "user-invocable": z.optional(z.boolean()),
   paths: z.optional(z.union([z.string(), z.array(z.string())])),
 });
 
 export type ClaudecodeSkillFrontmatter = z.infer<typeof ClaudecodeSkillFrontmatterSchema>;
+
+/**
+ * Builds the Claude Code SKILL.md frontmatter from a rulesync skill, carrying
+ * the `claudecode:` section's fields through and folding in the resolved
+ * model-invocation / user-invocable flags. Extracted to keep
+ * `fromRulesyncSkill` under the cyclomatic-complexity cap.
+ */
+function buildClaudecodeSkillFrontmatter({
+  rulesyncFrontmatter,
+  resolvedDisableModelInvocation,
+  resolvedUserInvocable,
+}: {
+  rulesyncFrontmatter: RulesyncSkillFrontmatter;
+  resolvedDisableModelInvocation: boolean | undefined;
+  resolvedUserInvocable: boolean | undefined;
+}): ClaudecodeSkillFrontmatter {
+  const section = rulesyncFrontmatter.claudecode ?? {};
+  // Every claudecode-specific field is a straight pass-through, plus the two
+  // resolved invocation flags. Build a candidate map and copy across only the
+  // keys that are actually present, so the function stays data-driven (and well
+  // under the cyclomatic-complexity cap) as more fields are added.
+  const candidate: Record<string, unknown> = {
+    when_to_use: section.when_to_use,
+    "allowed-tools": section["allowed-tools"],
+    "disallowed-tools": section["disallowed-tools"],
+    model: section.model,
+    effort: section.effort,
+    "argument-hint": section["argument-hint"],
+    arguments: section.arguments,
+    context: section.context,
+    agent: section.agent,
+    hooks: section.hooks,
+    shell: section.shell,
+    "disable-model-invocation": resolvedDisableModelInvocation,
+    "user-invocable": resolvedUserInvocable,
+    paths: section.paths,
+  };
+
+  const frontmatter: Record<string, unknown> = {
+    name: rulesyncFrontmatter.name,
+    description: rulesyncFrontmatter.description,
+  };
+  for (const [key, value] of Object.entries(candidate)) {
+    if (value !== undefined) {
+      frontmatter[key] = value;
+    }
+  }
+
+  return frontmatter as ClaudecodeSkillFrontmatter;
+}
 
 export type ClaudecodeSkillParams = {
   outputRoot?: string;
@@ -126,11 +200,19 @@ export class ClaudecodeSkill extends ToolSkill {
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
     const claudecodeSection = {
+      ...(frontmatter.when_to_use && { when_to_use: frontmatter.when_to_use }),
       ...(frontmatter["allowed-tools"] && { "allowed-tools": frontmatter["allowed-tools"] }),
       ...(frontmatter["disallowed-tools"] && {
         "disallowed-tools": frontmatter["disallowed-tools"],
       }),
       ...(frontmatter.model && { model: frontmatter.model }),
+      ...(frontmatter.effort && { effort: frontmatter.effort }),
+      ...(frontmatter["argument-hint"] && { "argument-hint": frontmatter["argument-hint"] }),
+      ...(frontmatter.arguments !== undefined && { arguments: frontmatter.arguments }),
+      ...(frontmatter.context && { context: frontmatter.context }),
+      ...(frontmatter.agent && { agent: frontmatter.agent }),
+      ...(frontmatter.hooks !== undefined && { hooks: frontmatter.hooks }),
+      ...(frontmatter.shell && { shell: frontmatter.shell }),
       ...(frontmatter["disable-model-invocation"] !== undefined && {
         "disable-model-invocation": frontmatter["disable-model-invocation"],
       }),
@@ -178,28 +260,11 @@ export class ClaudecodeSkill extends ToolSkill {
       section: rulesyncFrontmatter.claudecode,
     });
 
-    const claudecodeFrontmatter: ClaudecodeSkillFrontmatter = {
-      name: rulesyncFrontmatter.name,
-      description: rulesyncFrontmatter.description,
-      ...(rulesyncFrontmatter.claudecode?.["allowed-tools"] && {
-        "allowed-tools": rulesyncFrontmatter.claudecode["allowed-tools"],
-      }),
-      ...(rulesyncFrontmatter.claudecode?.["disallowed-tools"] && {
-        "disallowed-tools": rulesyncFrontmatter.claudecode["disallowed-tools"],
-      }),
-      ...(rulesyncFrontmatter.claudecode?.model && {
-        model: rulesyncFrontmatter.claudecode.model,
-      }),
-      ...(resolvedDisableModelInvocation !== undefined && {
-        "disable-model-invocation": resolvedDisableModelInvocation,
-      }),
-      ...(resolvedUserInvocable !== undefined && {
-        "user-invocable": resolvedUserInvocable,
-      }),
-      ...(rulesyncFrontmatter.claudecode?.paths !== undefined && {
-        paths: rulesyncFrontmatter.claudecode.paths,
-      }),
-    };
+    const claudecodeFrontmatter = buildClaudecodeSkillFrontmatter({
+      rulesyncFrontmatter,
+      resolvedDisableModelInvocation,
+      resolvedUserInvocable,
+    });
 
     const settablePaths = ClaudecodeSkill.getSettablePaths({ global });
     const relativeDirPath = rulesyncFrontmatter.claudecode?.["scheduled-task"]

--- a/src/features/skills/rulesync-skill.test.ts
+++ b/src/features/skills/rulesync-skill.test.ts
@@ -577,11 +577,13 @@ This has leading and trailing whitespace.
     });
 
     it("should reject invalid claudecode configuration", () => {
+      // `allowed-tools` accepts a string or a string array, so a number is the
+      // invalid case that must still be rejected.
       const frontmatter = {
         name: "test-skill",
         description: "Test",
         claudecode: {
-          "allowed-tools": "not-array",
+          "allowed-tools": 123,
         },
       };
 

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -22,9 +22,17 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   "user-invocable": z.optional(z.boolean()),
   claudecode: z.optional(
     z.looseObject({
-      "allowed-tools": z.optional(z.array(z.string())),
+      when_to_use: z.optional(z.string()),
+      "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
       "disallowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
       model: z.optional(z.string()),
+      effort: z.optional(z.string()),
+      "argument-hint": z.optional(z.string()),
+      arguments: z.optional(z.union([z.string(), z.array(z.string())])),
+      context: z.optional(z.string()),
+      agent: z.optional(z.string()),
+      hooks: z.optional(z.looseObject({})),
+      shell: z.optional(z.string()),
       "disable-model-invocation": z.optional(z.boolean()),
       "user-invocable": z.optional(z.boolean()),
       "scheduled-task": z.optional(z.boolean()),
@@ -196,9 +204,17 @@ export type RulesyncSkillFrontmatterInput = {
   "disable-model-invocation"?: boolean;
   "user-invocable"?: boolean;
   claudecode?: {
-    "allowed-tools"?: string[];
+    when_to_use?: string;
+    "allowed-tools"?: string | string[];
     "disallowed-tools"?: string | string[];
     model?: string;
+    effort?: string;
+    "argument-hint"?: string;
+    arguments?: string | string[];
+    context?: string;
+    agent?: string;
+    hooks?: Record<string, unknown>;
+    shell?: string;
     "disable-model-invocation"?: boolean;
     "user-invocable"?: boolean;
     "scheduled-task"?: boolean;


### PR DESCRIPTION
## Summary

Claude Code skills document more `SKILL.md` frontmatter fields than rulesync's `claudecode` skill adapter preserved, so importing a skill that used them and regenerating silently dropped them. This models the documented fields and round-trips them.

Verified against the current [Claude Code skills frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference).

## Changes

- **`ClaudecodeSkillFrontmatterSchema`** (and the rulesync `claudecode:` section + input type) now model: `when_to_use`, `argument-hint`, `arguments` (string or list), `effort`, `context`, `agent`, `hooks`, and `shell`.
- **`allowed-tools`** now accepts the documented space/comma-separated **string** form in addition to a YAML list (previously array-only).
- `toRulesyncSkill` / `fromRulesyncSkill` carry every new field through both directions via the `claudecode:` section, so the data round-trips.
- `fromRulesyncSkill`'s frontmatter construction was extracted into a data-driven `buildClaudecodeSkillFrontmatter` helper (keeps it under the complexity cap added in #2007).
- Documented the new fields in `docs/reference/file-formats.md` (synced to `skills/rulesync/`).

## Tests

- Existing "reject invalid allowed-tools type" tests updated to use a genuinely invalid type (a number), since strings are now valid; added a test that a space-separated string is accepted.
- Added a round-trip test covering all new fields.
- `pnpm cicheck` passes (6792 tests).

Closes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
