### PR TITLE
chore: change default build agent reasoning variant from medium to high

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "mode": "primary",
-      "variant": "medium",
+      "variant": "high",
       "tools": {
         "write": true,
         "edit": true,


### PR DESCRIPTION
Change the default build agent's reasoning variant in opencode.json from `medium` to `high`. This makes the primary coding agent use deeper reasoning by default.