### PR TITLE
fix(hermesagent): carry MCP server timeout through conversion

### DIFF
--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -173,6 +173,25 @@ describe("HermesagentMcp", () => {
       expect(server?.args).toEqual(["-y", "server", "--flag"]);
     });
 
+    it("carries the timeout field through (from networkTimeout alias too)", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { fetch: { command: "uvx", networkTimeout: 120 } },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.timeout).toBe(120);
+    });
+
     it("translates a disabled server to enabled: false", async () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
@@ -228,6 +247,7 @@ describe("HermesagentMcp", () => {
           "  fetch:",
           "    command: uvx",
           "    args: [mcp-server-fetch]",
+          "    timeout: 120",
           "  remote:",
           "    url: https://example.com/mcp",
           "  legacy:",
@@ -244,6 +264,7 @@ describe("HermesagentMcp", () => {
       expect(servers.fetch).toMatchObject({
         command: "uvx",
         args: ["mcp-server-fetch"],
+        timeout: 120,
       });
       expect(servers.remote).toMatchObject({ url: "https://example.com/mcp" });
       // `enabled: false` maps back to the canonical `disabled: true`.

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -60,6 +60,15 @@ function resolveHermesUrl(config: Record<string, unknown>): string | undefined {
 }
 
 /**
+ * Resolves the canonical timeout for a server (`timeout` or the `networkTimeout` alias).
+ */
+function resolveHermesTimeout(config: Record<string, unknown>): number | undefined {
+  if (typeof config.timeout === "number") return config.timeout;
+  if (typeof config.networkTimeout === "number") return config.networkTimeout;
+  return undefined;
+}
+
+/**
  * Converts a single rulesync canonical MCP server into a Hermes `mcp_servers:` entry.
  *
  * Hermes is close to the MCP spec but not identical: `command` must be a single
@@ -93,6 +102,9 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
 
   // Hermes defaults a server to enabled, so only emit the flag when disabling.
   if (config.disabled === true) out.enabled = false;
+
+  const timeout = resolveHermesTimeout(config);
+  if (timeout !== undefined) out.timeout = timeout;
 
   return out;
 }
@@ -130,6 +142,7 @@ function convertFromHermesFormat(mcpServers: Record<string, unknown>): McpServer
     if (typeof config.url === "string") server.url = config.url;
     if (isRecord(config.headers)) server.headers = config.headers;
     if (config.enabled === false) server.disabled = true;
+    if (typeof config.timeout === "number") server.timeout = config.timeout;
 
     result[name] = server;
   }


### PR DESCRIPTION
## Summary

Follow-up to #2019 (Hermes Agent support). During review of #2019, a finding was raised that the canonical `timeout` field (and the `networkTimeout` alias) was silently dropped in both MCP conversion directions. #2019 was merged before this fix landed, so this PR completes it.

Hermes `mcp_servers` entries support a `timeout` key, so the conversion now maps it like the Goose adapter does:
- Export: `timeout` / `networkTimeout` (canonical) → `timeout` (Hermes)
- Import: `timeout` (Hermes) → `timeout` (canonical)

Adds tests for both directions.

Refs #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)