### PR TITLE
fix(claudecode): generate global non-root rules to ~/.claude/rules

### DIFF
--- a/src/features/rules/claudecode-rule.test.ts
+++ b/src/features/rules/claudecode-rule.test.ts
@@ -130,7 +130,10 @@ describe("ClaudecodeRule (Modular Rules)", () => {
         relativeDirPath: ".claude",
         relativeFilePath: "CLAUDE.md",
       });
-      expect(paths).not.toHaveProperty("nonRoot");
+      // Global non-root rules go to ~/.claude/rules/*.md (Claude Code user-level rules).
+      expect(paths.nonRoot).toEqual({
+        relativeDirPath: ".claude/rules",
+      });
     });
 
     it("should not return alternativeRoots for global mode", () => {
@@ -491,6 +494,29 @@ Rules for TypeScript files.`;
       expect(claudecodeRule.getRelativeDirPath()).toBe(".claude");
       expect(claudecodeRule.getRelativeFilePath()).toBe("CLAUDE.md");
       expect(claudecodeRule.isRoot()).toBe(true);
+    });
+
+    it("should write a non-root rule to ~/.claude/rules when global=true", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "coding-style.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "Global non-root rule",
+          globs: [],
+        },
+        body: "# Coding style\n\nApplies to every project.",
+      });
+
+      const claudecodeRule = ClaudecodeRule.fromRulesyncRule({
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(claudecodeRule.getRelativeDirPath()).toBe(".claude/rules");
+      expect(claudecodeRule.getRelativeFilePath()).toBe("coding-style.md");
+      expect(claudecodeRule.isRoot()).toBe(false);
     });
   });
 

--- a/src/features/rules/claudecode-rule.ts
+++ b/src/features/rules/claudecode-rule.ts
@@ -79,10 +79,16 @@ export class ClaudecodeRule extends ToolRule {
     excludeToolDir?: boolean;
   } = {}): ClaudecodeRuleSettablePaths | ClaudecodeRuleSettablePathsGlobal {
     if (global) {
+      // Claude Code reads user-scoped modular rules from `~/.claude/rules/*.md`
+      // (https://code.claude.com/docs/en/memory — "User-level rules"), so global
+      // non-root rules are generated there instead of being dropped.
       return {
         root: {
           relativeDirPath: buildToolPath(CLAUDECODE_DIR, ".", excludeToolDir),
           relativeFilePath: CLAUDECODE_RULE_FILE_NAME,
+        },
+        nonRoot: {
+          relativeDirPath: buildToolPath(CLAUDECODE_DIR, CLAUDECODE_RULES_DIR_NAME, excludeToolDir),
         },
       };
     }

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -2100,7 +2100,7 @@ targets: ["copilot"]
       expect(nonRootRule).toBeDefined();
     });
 
-    it("should exclude non-root rules in global mode for claudecode (no global nonRoot support)", async () => {
+    it("should include non-root rules in global mode for claudecode (global nonRoot support)", async () => {
       await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
       await writeFileContent(
         join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
@@ -2124,6 +2124,44 @@ targets: ["claudecode"]
         logger,
         outputRoot: testDir,
         toolTarget: "claudecode",
+        global: true,
+      });
+
+      // Claude Code reads user-level rules from ~/.claude/rules/*.md, so global
+      // non-root rules are kept rather than dropped.
+      const result = await processor.loadRulesyncFiles();
+      expect(result).toHaveLength(2);
+      expect(result.some((r) => (r as RulesyncRule).getFrontmatter().root)).toBe(true);
+      expect(result.some((r) => !(r as RulesyncRule).getFrontmatter().root)).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("non-root rulesync rules found, but it's in global mode"),
+      );
+    });
+
+    it("should exclude non-root rules in global mode for a target without global nonRoot support", async () => {
+      await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
+        `---
+root: true
+targets: ["geminicli"]
+---
+# Root`,
+      );
+      await writeFileContent(
+        join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "non-root.md"),
+        `---
+targets: ["geminicli"]
+---
+# Non-root`,
+      );
+
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "geminicli",
         global: true,
       });
 

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -54,7 +54,15 @@ export type ToolRuleSettablePathsGlobal = {
     relativeFilePath: string;
   };
   alternativeRoots?: undefined;
-  nonRoot?: undefined;
+  /**
+   * Optional non-root rules directory for global scope. Most tools have no
+   * user-scoped modular-rules location and leave this unset, but tools that do
+   * (e.g. Claude Code's `~/.claude/rules/`) set it so global non-root rules are
+   * generated instead of being silently dropped.
+   */
+  nonRoot?: {
+    relativeDirPath: string;
+  };
 };
 
 type BuildToolRuleParamsParams = ToolRuleFromRulesyncRuleParams & {


### PR DESCRIPTION
## Summary

In global mode, rulesync dropped every non-root Claude Code rule with a warning ("non-root rulesync rules found, but it's in global mode, so ignoring them"), because the claudecode global settable-paths only defined a root file (`~/.claude/CLAUDE.md`).

Claude Code does support user-level modular rules at `~/.claude/rules/*.md` (https://code.claude.com/docs/en/memory — "User-level rules": *"Personal rules in `~/.claude/rules/` apply to every project on your machine"*). This makes the earlier assumption (that global non-root rules aren't supported) outdated.

## Changes
- Add a `nonRoot` entry to `ClaudecodeRule.getSettablePaths({ global: true })` pointing at `~/.claude/rules`, so global non-root rules are generated there instead of being ignored.
- Widen the shared `ToolRuleSettablePathsGlobal` type to allow an optional global `nonRoot` directory (additive; other tools that don't set it are unaffected). The generic processor already branches on `supportsGlobalNonRoot`.
- Update/extend tests: claudecode now keeps non-root rules in global mode (no warning); a negative case (geminicli) still drops them.

## Verification
`pnpm cicheck` passes (lint, types, 6823 tests, content/spelling/secrets); generated tables and gitignore unchanged.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)