### PR TITLE
feat(aiassistant): add JetBrains AI Assistant support (rules + ignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,7 @@ rulesync.local.jsonc
 **/.codexignore
 **/AGENTS.md
 **/.agents/memories/
+**/.aiassistant/rules/
 **/.agents/rules/
 **/.augment/rules/
 **/CLAUDE.md
@@ -374,12 +375,12 @@ rulesync.local.jsonc
 **/.cline/command-permissions.json
 **/.cursor/cli.json
 **/.gemini/policies/rulesync.toml
+**/.aiignore
 **/.geminiignore
 **/.augmentignore
 **/.clineignore
 **/.cursorignore
 **/.gooseignore
-**/.aiignore
 **/.kilocodeignore
 **/.kiroignore
 **/.qwenignore

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | Google Antigravity IDE |  ✅   |        | ✅  |    ✅    |           |   ✅   |  ✅   |     ✅      |
 | Google Antigravity CLI |  ✅   |   ✅   | ✅  |          |           |   ✅   |  ✅   |     ✅      |
 | Google Antigravity ⚠️  |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
+| JetBrains AI Assistant |  ✅   |   ✅   |     |          |           |        |       |             |
 | JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | AugmentCode            |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Devin Desktop          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |

--- a/cspell.json
+++ b/cspell.json
@@ -23,6 +23,7 @@
   ],
   "words": [
     "agentic",
+    "aiassistant",
     "anthropics",
     "agentrequested",
     "agentsignore",

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -35,6 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
+| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |        |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -35,6 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
+| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |        |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |

--- a/src/constants/aiassistant-paths.ts
+++ b/src/constants/aiassistant-paths.ts
@@ -1,0 +1,7 @@
+import { join } from "node:path";
+
+export const AIASSISTANT_DIR = ".aiassistant";
+export const AIASSISTANT_RULES_DIR_PATH = join(AIASSISTANT_DIR, "rules");
+// JetBrains AI Assistant shares the JetBrains-wide `.aiignore` filename (the
+// same file Junie uses) at the project root.
+export const AIASSISTANT_IGNORE_FILE_NAME = ".aiignore";

--- a/src/e2e/e2e-ignore.spec.ts
+++ b/src/e2e/e2e-ignore.spec.ts
@@ -28,6 +28,7 @@ describe("E2E: ignore", () => {
     { target: "kiro-cli", outputPath: KIRO_IGNORE_FILE_NAME, format: "plaintext" as const },
     { target: "kiro-ide", outputPath: KIRO_IGNORE_FILE_NAME, format: "plaintext" as const },
     { target: "junie", outputPath: ".aiignore", format: "plaintext" as const },
+    { target: "aiassistant", outputPath: ".aiignore", format: "plaintext" as const },
     { target: "augmentcode", outputPath: ".augmentignore", format: "plaintext" as const },
     { target: "devin", outputPath: ".devinignore", format: "plaintext" as const },
     {

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -23,6 +23,7 @@ describe("E2E: rules", () => {
   it.each([
     { target: "claudecode", outputPath: "CLAUDE.md" },
     { target: "cursor", outputPath: join(".cursor", "rules", "overview.mdc") },
+    { target: "aiassistant", outputPath: join(".aiassistant", "rules", "overview.md") },
     { target: "amp", outputPath: "AGENTS.md" },
     { target: "codexcli", outputPath: "AGENTS.md" },
     { target: "grokcli", outputPath: "AGENTS.md" },

--- a/src/features/ignore/aiassistant-ignore.test.ts
+++ b/src/features/ignore/aiassistant-ignore.test.ts
@@ -1,0 +1,87 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AiassistantIgnore } from "./aiassistant-ignore.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
+
+describe("AiassistantIgnore", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("targets the project-root .aiignore", () => {
+      const paths = AiassistantIgnore.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(".");
+      expect(paths.relativeFilePath).toBe(".aiignore");
+    });
+  });
+
+  describe("fromRulesyncIgnore", () => {
+    it("writes the ignore content to .aiignore", () => {
+      const rulesyncIgnore = new RulesyncIgnore({
+        relativeDirPath: ".",
+        relativeFilePath: ".aiignore",
+        fileContent: "tmp/\n*.log",
+      });
+
+      const ignore = AiassistantIgnore.fromRulesyncIgnore({
+        outputRoot: testDir,
+        rulesyncIgnore,
+      });
+
+      expect(ignore.getRelativeDirPath()).toBe(".");
+      expect(ignore.getRelativeFilePath()).toBe(".aiignore");
+      expect(ignore.getFileContent()).toBe("tmp/\n*.log");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("reads the project-root .aiignore", async () => {
+      await ensureDir(testDir);
+      await writeFileContent(join(testDir, ".aiignore"), "secrets/\n.env");
+
+      const ignore = await AiassistantIgnore.fromFile({ outputRoot: testDir });
+
+      expect(ignore.getRelativeFilePath()).toBe(".aiignore");
+      expect(ignore.getFileContent()).toBe("secrets/\n.env");
+    });
+  });
+
+  describe("toRulesyncIgnore round-trip", () => {
+    it("preserves the content", () => {
+      const ignore = new AiassistantIgnore({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".aiignore",
+        fileContent: "build/\ndist/",
+      });
+
+      expect(ignore.toRulesyncIgnore().getFileContent()).toBe("build/\ndist/");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("returns an instance with empty content", () => {
+      const ignore = AiassistantIgnore.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: ".aiignore",
+      });
+      expect(ignore).toBeInstanceOf(AiassistantIgnore);
+      expect(ignore.getFileContent()).toBe("");
+    });
+  });
+});

--- a/src/features/ignore/aiassistant-ignore.ts
+++ b/src/features/ignore/aiassistant-ignore.ts
@@ -1,0 +1,80 @@
+import { join } from "node:path";
+
+import { AIASSISTANT_IGNORE_FILE_NAME } from "../../constants/aiassistant-paths.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncIgnore } from "./rulesync-ignore.js";
+import {
+  ToolIgnore,
+  ToolIgnoreForDeletionParams,
+  ToolIgnoreFromFileParams,
+  ToolIgnoreFromRulesyncIgnoreParams,
+  ToolIgnoreSettablePaths,
+} from "./tool-ignore.js";
+
+/**
+ * Ignore generator for JetBrains AI Assistant.
+ *
+ * AI Assistant honours the JetBrains-wide `.aiignore` file (gitignore syntax) at
+ * the project root — the same file Junie uses.
+ *
+ * @see https://www.jetbrains.com/help/ai-assistant/configure-project-rules.html
+ */
+export class AiassistantIgnore extends ToolIgnore {
+  static getSettablePaths(): ToolIgnoreSettablePaths {
+    return {
+      relativeDirPath: ".",
+      relativeFilePath: AIASSISTANT_IGNORE_FILE_NAME,
+    };
+  }
+
+  toRulesyncIgnore(): RulesyncIgnore {
+    return this.toRulesyncIgnoreDefault();
+  }
+
+  static fromRulesyncIgnore({
+    outputRoot = process.cwd(),
+    rulesyncIgnore,
+  }: ToolIgnoreFromRulesyncIgnoreParams): AiassistantIgnore {
+    return new AiassistantIgnore({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      fileContent: rulesyncIgnore.getFileContent(),
+    });
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+  }: ToolIgnoreFromFileParams): Promise<AiassistantIgnore> {
+    const fileContent = await readFileContent(
+      join(
+        outputRoot,
+        this.getSettablePaths().relativeDirPath,
+        this.getSettablePaths().relativeFilePath,
+      ),
+    );
+
+    return new AiassistantIgnore({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().relativeDirPath,
+      relativeFilePath: this.getSettablePaths().relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolIgnoreForDeletionParams): AiassistantIgnore {
+    return new AiassistantIgnore({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+    });
+  }
+}

--- a/src/features/ignore/ignore-processor.test.ts
+++ b/src/features/ignore/ignore-processor.test.ts
@@ -428,6 +428,7 @@ describe("IgnoreProcessor", () => {
     it("should return all supported tool targets", () => {
       const toolTargets = IgnoreProcessor.getToolTargets();
       const expectedTargets = [
+        "aiassistant",
         "antigravity-cli",
         "augmentcode",
         "claudecode",

--- a/src/features/ignore/ignore-processor.ts
+++ b/src/features/ignore/ignore-processor.ts
@@ -9,6 +9,7 @@ import { ignoreProcessorToolTargetTuple } from "../../types/tool-target-tuples.j
 import { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
+import { AiassistantIgnore } from "./aiassistant-ignore.js";
 import { AntigravityCliIgnore } from "./antigravity-cli-ignore.js";
 import { AugmentcodeIgnore } from "./augmentcode-ignore.js";
 import { ClaudecodeIgnore } from "./claudecode-ignore.js";
@@ -51,6 +52,7 @@ type ToolIgnoreFactory = {
 };
 
 export const toolIgnoreFactories = new Map<IgnoreProcessorToolTarget, ToolIgnoreFactory>([
+  ["aiassistant", { class: AiassistantIgnore }],
   ["antigravity-cli", { class: AntigravityCliIgnore }],
   ["augmentcode", { class: AugmentcodeIgnore }],
   ["claudecode", { class: ClaudecodeIgnore }],

--- a/src/features/rules/aiassistant-rule.test.ts
+++ b/src/features/rules/aiassistant-rule.test.ts
@@ -1,0 +1,125 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AiassistantRule } from "./aiassistant-rule.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+
+describe("AiassistantRule", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("targets .aiassistant/rules as a flat non-root directory", () => {
+      const paths = AiassistantRule.getSettablePaths();
+      expect(paths.nonRoot.relativeDirPath).toBe(join(".aiassistant", "rules"));
+    });
+  });
+
+  describe("fromRulesyncRule", () => {
+    it("emits a plain Markdown file (no frontmatter) under .aiassistant/rules", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "coding-style.md",
+        frontmatter: {
+          root: false,
+          targets: ["*"],
+          description: "Coding style",
+          globs: ["**/*.kt"],
+        },
+        body: "# Coding style\n\nUse 4-space indentation.",
+      });
+
+      const rule = AiassistantRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+
+      expect(rule.getRelativeDirPath()).toBe(join(".aiassistant", "rules"));
+      expect(rule.getRelativeFilePath()).toBe("coding-style.md");
+      // Plain Markdown body — no YAML frontmatter is emitted.
+      expect(rule.getFileContent()).toBe("# Coding style\n\nUse 4-space indentation.");
+      expect(rule.getFileContent()).not.toContain("---");
+    });
+  });
+
+  describe("fromFile", () => {
+    it("reads a flat rule file from .aiassistant/rules", async () => {
+      const dir = join(testDir, ".aiassistant", "rules");
+      await ensureDir(dir);
+      await writeFileContent(join(dir, "overview.md"), "# Overview\n\nProject context.");
+
+      const rule = await AiassistantRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "overview.md",
+      });
+
+      expect(rule.getRelativeDirPath()).toBe(join(".aiassistant", "rules"));
+      expect(rule.getRelativeFilePath()).toBe("overview.md");
+      expect(rule.getFileContent()).toBe("# Overview\n\nProject context.");
+    });
+  });
+
+  describe("toRulesyncRule round-trip", () => {
+    it("carries the body back into a rulesync rule", () => {
+      const rule = new AiassistantRule({
+        outputRoot: testDir,
+        relativeDirPath: join(".aiassistant", "rules"),
+        relativeFilePath: "overview.md",
+        fileContent: "# Overview\n\nBody content.",
+        root: false,
+      });
+
+      expect(rule.toRulesyncRule().getBody()).toContain("Body content.");
+    });
+  });
+
+  describe("isTargetedByRulesyncRule", () => {
+    it("matches wildcard and explicit aiassistant targets", () => {
+      const wildcard = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "a.md",
+        frontmatter: { root: false, targets: ["*"], description: "", globs: [] },
+        body: "x",
+      });
+      const explicit = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "b.md",
+        frontmatter: { root: false, targets: ["aiassistant"], description: "", globs: [] },
+        body: "y",
+      });
+      const other = new RulesyncRule({
+        relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+        relativeFilePath: "c.md",
+        frontmatter: { root: false, targets: ["cursor"], description: "", globs: [] },
+        body: "z",
+      });
+
+      expect(AiassistantRule.isTargetedByRulesyncRule(wildcard)).toBe(true);
+      expect(AiassistantRule.isTargetedByRulesyncRule(explicit)).toBe(true);
+      expect(AiassistantRule.isTargetedByRulesyncRule(other)).toBe(false);
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("returns an empty instance", () => {
+      const rule = AiassistantRule.forDeletion({
+        outputRoot: testDir,
+        relativeDirPath: join(".aiassistant", "rules"),
+        relativeFilePath: "overview.md",
+      });
+      expect(rule).toBeInstanceOf(AiassistantRule);
+      expect(rule.getFileContent()).toBe("");
+    });
+  });
+});

--- a/src/features/rules/aiassistant-rule.ts
+++ b/src/features/rules/aiassistant-rule.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { AIASSISTANT_RULES_DIR_PATH } from "../../constants/aiassistant-paths.js";
-import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
@@ -11,6 +11,12 @@ import {
   ToolRuleFromRulesyncRuleParams,
   ToolRuleSettablePaths,
 } from "./tool-rule.js";
+
+export type AiassistantRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
+  nonRoot: {
+    relativeDirPath: string;
+  };
+};
 
 /**
  * Rule generator for JetBrains AI Assistant.
@@ -27,14 +33,6 @@ import {
  *
  * @see https://www.jetbrains.com/help/ai-assistant/configure-project-rules.html
  */
-export type AiassistantRuleParams = AiFileParams;
-
-export type AiassistantRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
-  nonRoot: {
-    relativeDirPath: string;
-  };
-};
-
 export class AiassistantRule extends ToolRule {
   static getSettablePaths(
     _options: {

--- a/src/features/rules/aiassistant-rule.ts
+++ b/src/features/rules/aiassistant-rule.ts
@@ -1,0 +1,116 @@
+import { join } from "node:path";
+
+import { AIASSISTANT_RULES_DIR_PATH } from "../../constants/aiassistant-paths.js";
+import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { readFileContent } from "../../utils/file.js";
+import { RulesyncRule } from "./rulesync-rule.js";
+import {
+  ToolRule,
+  ToolRuleForDeletionParams,
+  ToolRuleFromFileParams,
+  ToolRuleFromRulesyncRuleParams,
+  ToolRuleSettablePaths,
+} from "./tool-rule.js";
+
+/**
+ * Rule generator for JetBrains AI Assistant.
+ *
+ * AI Assistant reads project rules as flat Markdown files in
+ * `.aiassistant/rules/*.md` (one file per rule, identified by filename). The rule
+ * type (Always / Manually / By model decision / By file patterns) is configured
+ * in the IDE, not in the file, so the generated files are plain Markdown with no
+ * frontmatter. There is no special root file (unlike Junie's `guidelines.md`), so
+ * every rule — root or non-root — is written as its own file under `rules/`.
+ *
+ * AI Assistant and Junie are different JetBrains products (real-time assistance
+ * vs. autonomous agent) with different layouts, so this is a separate target.
+ *
+ * @see https://www.jetbrains.com/help/ai-assistant/configure-project-rules.html
+ */
+export type AiassistantRuleParams = AiFileParams;
+
+export type AiassistantRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
+  nonRoot: {
+    relativeDirPath: string;
+  };
+};
+
+export class AiassistantRule extends ToolRule {
+  static getSettablePaths(
+    _options: {
+      global?: boolean;
+      excludeToolDir?: boolean;
+    } = {},
+  ): AiassistantRuleSettablePaths {
+    return {
+      nonRoot: {
+        relativeDirPath: AIASSISTANT_RULES_DIR_PATH,
+      },
+    };
+  }
+
+  toRulesyncRule(): RulesyncRule {
+    return this.toRulesyncRuleDefault();
+  }
+
+  static fromRulesyncRule({
+    outputRoot = process.cwd(),
+    rulesyncRule,
+    validate = true,
+  }: ToolRuleFromRulesyncRuleParams): AiassistantRule {
+    // AI Assistant rules are plain Markdown without frontmatter; emit the rule
+    // body as-is. Both root and non-root rules map to a flat file under rules/.
+    return new AiassistantRule({
+      outputRoot,
+      relativeDirPath: this.getSettablePaths().nonRoot.relativeDirPath,
+      relativeFilePath: rulesyncRule.getRelativeFilePath(),
+      fileContent: rulesyncRule.getBody(),
+      validate,
+      root: false,
+    });
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    relativeFilePath,
+    validate = true,
+  }: ToolRuleFromFileParams): Promise<AiassistantRule> {
+    const relativeDirPath = this.getSettablePaths().nonRoot.relativeDirPath;
+    const fileContent = await readFileContent(join(outputRoot, relativeDirPath, relativeFilePath));
+
+    return new AiassistantRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: fileContent.trim(),
+      validate,
+      root: false,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolRuleForDeletionParams): AiassistantRule {
+    return new AiassistantRule({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      root: false,
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static isTargetedByRulesyncRule(rulesyncRule: RulesyncRule): boolean {
+    return this.isTargetedByRulesyncRuleDefault({
+      rulesyncRule,
+      toolTarget: "aiassistant",
+    });
+  }
+}

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -29,6 +29,7 @@ import { QwencodeSubagent } from "../subagents/qwencode-subagent.js";
 import { RovodevSubagent } from "../subagents/rovodev-subagent.js";
 import { SubagentsProcessor } from "../subagents/subagents-processor.js";
 import { AgentsMdRule } from "./agentsmd-rule.js";
+import { AiassistantRule } from "./aiassistant-rule.js";
 import { AmpRule } from "./amp-rule.js";
 import { AntigravityCliRule } from "./antigravity-cli-rule.js";
 import { AntigravityIdeRule } from "./antigravity-ide-rule.js";
@@ -260,6 +261,19 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
           subagents: { subagentClass: AgentsmdSubagent },
           skills: { skillClass: AgentsmdSkill },
         },
+      },
+    },
+  ],
+  [
+    "aiassistant",
+    {
+      class: AiassistantRule,
+      meta: {
+        extension: "md",
+        // JetBrains AI Assistant auto-discovers every `.md` in `.aiassistant/rules/`,
+        // so no reference section is injected into a root file (there is no root).
+        supportsGlobal: false,
+        ruleDiscoveryMode: "auto",
       },
     },
   ],

--- a/src/types/tool-display.ts
+++ b/src/types/tool-display.ts
@@ -44,6 +44,7 @@ export const TOOL_DISPLAY: ReadonlyArray<ToolDisplayEntry> = [
   { key: "antigravity-ide", label: "Google Antigravity IDE", group: "ai" },
   { key: "antigravity-cli", label: "Google Antigravity CLI", group: "ai" },
   { key: "antigravity", label: "Google Antigravity ⚠️", group: "ai" },
+  { key: "aiassistant", label: "JetBrains AI Assistant", group: "ai" },
   { key: "junie", label: "JetBrains Junie", group: "ai" },
   { key: "augmentcode", label: "AugmentCode", group: "ai" },
   { key: "devin", label: "Devin Desktop", group: "ai" },

--- a/src/types/tool-target-tuples.ts
+++ b/src/types/tool-target-tuples.ts
@@ -4,6 +4,7 @@
 
 export const rulesProcessorToolTargetTuple = [
   "agentsmd",
+  "aiassistant",
   "amp",
   "antigravity",
   "antigravity-cli",
@@ -42,6 +43,7 @@ export const rulesProcessorToolTargetTuple = [
 ] as const;
 
 export const ignoreProcessorToolTargetTuple = [
+  "aiassistant",
   "antigravity-cli",
   "augmentcode",
   "claudecode",

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -17,6 +17,7 @@ describe("tool targets", () => {
       // unique to skills, therefore lands last).
       const expectedTargets = [
         "agentsmd",
+        "aiassistant",
         "amp",
         "antigravity",
         "antigravity-cli",


### PR DESCRIPTION
## Summary

Adds a new tool target `aiassistant` for **JetBrains AI Assistant** (a separate product from Junie — real-time assistance vs. autonomous agent).

- **Rules** → `.aiassistant/rules/*.md` (flat, one file per rule, identified by filename). The rule type (Always / Manually / By model decision / By file patterns) is configured in the IDE, so files are plain Markdown with **no frontmatter**. There is no root file (unlike Junie's `guidelines.md`).
- **Ignore** → `.aiignore` (gitignore syntax, the JetBrains-wide ignore file shared with Junie).

Project scope only. MCP / commands / subagents / skills are IDE-settings-based with no file output, so they are intentionally unsupported (shown as such in the generated matrix). This matches the maintainer's specification investigation in the issue.

Refs: https://www.jetbrains.com/help/ai-assistant/configure-project-rules.html

## Changes
- New: `aiassistant-rule.ts`, `aiassistant-ignore.ts`, `aiassistant-paths.ts` (+ unit tests)
- Registered `aiassistant` in the rules + ignore processors, tuples, display names, and e2e matrices
- Regenerated supported-tools tables and `.gitignore`

## Verification
`pnpm cicheck` passes (lint, types, tests, content/spelling/secrets).

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)