### PR TITLE
chore(knip): align config with official recommendations and remove dead code

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -2,7 +2,9 @@ import { type KnipConfig } from "knip";
 
 const config: KnipConfig = {
   entry: [
-    "src/cli/index.ts",
+    // `src/cli/index.ts` is auto-detected from the package.json `bin` field, so it
+    // does not need to be listed here. The library entry and the test files are kept
+    // explicit because they are not covered by an enabled plugin's defaults.
     "src/index.ts",
     "src/**/*.test.ts",
     // Standalone task runners under scripts/ (executed via tsx) and their colocated
@@ -12,30 +14,9 @@ const config: KnipConfig = {
     "scripts/**/*.ts",
   ],
   project: ["src/**/*.ts", "scripts/**/*.ts"],
-  ignore: [
-    // Build output and node_modules
-    "dist/**",
-    "node_modules/**",
-    // Temporary files during testing
-    "**/test-temp/**",
-    // Configuration files
-    "tsconfig.json",
-    "vitest.config.ts",
-    ".oxfmtrc.json",
-    ".rulesync/**",
-    "docs/**",
-  ],
   ignoreDependencies: [
     // Dependencies used only in configuration files
     "@secretlint/secretlint-rule-preset-recommend",
-    // Used only in TypeScript configuration
-    "typescript",
-    "@types/node",
-    "@types/js-yaml",
-    // lint-staged is used in git hooks
-    "lint-staged",
-    // Used in docs site
-    "vitepress",
     // Optional peer dependencies of `xsschema` (a transitive dependency via
     // `fastmcp`). They are not imported from our source, so knip reports them as
     // unused, but `xsschema` resolves them through dynamic `import()` and the
@@ -45,9 +26,6 @@ const config: KnipConfig = {
     "sury",
     "@valibot/to-json-schema",
   ],
-  typescript: {
-    config: "tsconfig.json",
-  },
   includeEntryExports: true,
 };
 

--- a/src/features/commands/cline-command.ts
+++ b/src/features/commands/cline-command.ts
@@ -4,7 +4,7 @@ import {
   CLINE_COMMANDS_DIR_PATH,
   CLINE_COMMANDS_GLOBAL_DIR_PATH,
 } from "../../constants/cline-paths.js";
-import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
 import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
@@ -15,8 +15,6 @@ import {
   ToolCommandFromRulesyncCommandParams,
   ToolCommandSettablePaths,
 } from "./tool-command.js";
-
-export type ClineCommandParams = AiFileParams;
 
 export class ClineCommand extends ToolCommand {
   static getSettablePaths({ global }: { global?: boolean } = {}): ToolCommandSettablePaths {

--- a/src/features/commands/geminicli-command.ts
+++ b/src/features/commands/geminicli-command.ts
@@ -66,11 +66,6 @@ function translateGeminiBodyToRulesync(body: string): string {
 
 export type GeminiCliCommandFrontmatter = z.infer<typeof GeminiCliCommandFrontmatterSchema>;
 
-export type GeminiCliCommandParams = {
-  frontmatter: GeminiCliCommandFrontmatter;
-  body: string;
-} & AiFileParams;
-
 export class GeminiCliCommand extends ToolCommand {
   private readonly frontmatter: GeminiCliCommandFrontmatter;
   private readonly body: string;

--- a/src/features/ignore/augmentcode-ignore.ts
+++ b/src/features/ignore/augmentcode-ignore.ts
@@ -8,11 +8,8 @@ import {
   ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
-  ToolIgnoreParams,
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
-
-export type AugmentcodeIgnoreParams = ToolIgnoreParams;
 
 /**
  * AugmentCode Ignore implementation

--- a/src/features/ignore/vibe-ignore.ts
+++ b/src/features/ignore/vibe-ignore.ts
@@ -7,11 +7,8 @@ import {
   ToolIgnoreForDeletionParams,
   ToolIgnoreFromFileParams,
   ToolIgnoreFromRulesyncIgnoreParams,
-  ToolIgnoreParams,
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
-
-export type VibeIgnoreParams = ToolIgnoreParams;
 
 export class VibeIgnore extends ToolIgnore {
   static getSettablePaths(): ToolIgnoreSettablePaths {

--- a/src/features/mcp/copilot-mcp.ts
+++ b/src/features/mcp/copilot-mcp.ts
@@ -14,8 +14,6 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
-export type CopilotMcpParams = ToolMcpParams;
-
 type CopilotMcpConfig = {
   servers?: McpServers;
 };

--- a/src/features/mcp/copilotcli-mcp.ts
+++ b/src/features/mcp/copilotcli-mcp.ts
@@ -19,8 +19,6 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
-export type CopilotcliMcpParams = ToolMcpParams;
-
 type CopilotcliMcpConfig = {
   mcpServers?: Record<string, McpServer & Record<string, unknown>>;
 };

--- a/src/features/mcp/devin-mcp.ts
+++ b/src/features/mcp/devin-mcp.ts
@@ -32,7 +32,6 @@ import {
  * ({ serverUrl | url, headers }), and may carry an optional `disabledTools`
  * array.
  */
-export type DevinMcpParams = ToolMcpParams;
 
 export class DevinMcp extends ToolMcp {
   private readonly json: Record<string, unknown>;

--- a/src/features/mcp/factorydroid-mcp.ts
+++ b/src/features/mcp/factorydroid-mcp.ts
@@ -16,8 +16,6 @@ import {
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
 
-export type FactorydroidMcpParams = ToolMcpParams;
-
 export class FactorydroidMcp extends ToolMcp {
   private readonly json: Record<string, unknown>;
 

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -41,7 +41,6 @@ function parseRovodevMcpJson(
  * Same shape as Cursor: { mcpServers: { ... } }. See Rovodev MCP docs.
  * Project-level MCP is not supported; use --global when generating.
  */
-export type RovodevMcpParams = ToolMcpParams;
 
 export class RovodevMcp extends ToolMcp {
   private readonly json: Record<string, unknown>;

--- a/src/features/permissions/tool-permissions.ts
+++ b/src/features/permissions/tool-permissions.ts
@@ -7,8 +7,6 @@ import { ToolFile } from "../../types/tool-file.js";
 import type { Logger } from "../../utils/logger.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
 
-export type ToolPermissionsParams = AiFileParams;
-
 export type ToolPermissionsFromRulesyncPermissionsParams = Omit<
   AiFileParams,
   "fileContent" | "relativeFilePath" | "relativeDirPath"

--- a/src/features/rules/antigravity-cli-rule.ts
+++ b/src/features/rules/antigravity-cli-rule.ts
@@ -13,13 +13,10 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type AntigravityCliRuleParams = ToolRuleParams;
 
 export type AntigravityCliRuleSettablePaths = ToolRuleSettablePaths & {
   root: {

--- a/src/features/rules/geminicli-rule.ts
+++ b/src/features/rules/geminicli-rule.ts
@@ -12,13 +12,10 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type GeminiCliRuleParams = ToolRuleParams;
 
 export type GeminiCliRuleSettablePaths = ToolRuleSettablePaths & {
   root: {

--- a/src/features/rules/junie-rule.ts
+++ b/src/features/rules/junie-rule.ts
@@ -5,7 +5,7 @@ import {
   JUNIE_LEGACY_RULE_FILE_NAME,
   JUNIE_RULE_FILE_NAME,
 } from "../../constants/junie-paths.js";
-import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
@@ -17,8 +17,6 @@ import {
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type JunieRuleParams = AiFileParams;
 
 export type JunieRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   root: {

--- a/src/features/rules/kilo-rule.ts
+++ b/src/features/rules/kilo-rule.ts
@@ -14,13 +14,10 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   type ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type KiloRuleParams = ToolRuleParams;
 
 export type KiloRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   root: {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -14,13 +14,10 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type KiroRuleParams = ToolRuleParams;
 
 export type KiroRuleSettablePaths =
   | Pick<ToolRuleSettablePaths, "nonRoot">

--- a/src/features/rules/opencode-rule.ts
+++ b/src/features/rules/opencode-rule.ts
@@ -13,13 +13,10 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   type ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type OpenCodeRuleParams = ToolRuleParams;
 
 export type OpenCodeRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   root: {

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -9,12 +9,9 @@ import {
   ToolRuleForDeletionParams,
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
-  ToolRuleParams,
   ToolRuleSettablePaths,
   buildToolPath,
 } from "./tool-rule.js";
-
-export type RooRuleParams = ToolRuleParams;
 
 export type RooRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
   nonRoot: {

--- a/src/features/subagents/roo-subagent.ts
+++ b/src/features/subagents/roo-subagent.ts
@@ -52,8 +52,6 @@ export const RooModesFileSchema = z.looseObject({
   customModes: z.array(RooModeSchema),
 });
 
-export type RooModesFile = z.infer<typeof RooModesFileSchema>;
-
 export type RooSubagentParams = {
   modes: RooMode[];
 } & Omit<AiFileParams, "fileContent">;

--- a/src/lib/apm/apm-lock.ts
+++ b/src/lib/apm/apm-lock.ts
@@ -70,10 +70,6 @@ export function getApmLockPath(projectRoot: string): string {
   return join(projectRoot, APM_LOCKFILE_FILE_NAME);
 }
 
-export async function apmLockExists(projectRoot: string): Promise<boolean> {
-  return fileExists(getApmLockPath(projectRoot));
-}
-
 /**
  * Create an empty lockfile structure. `apm_version` is set to the rulesync
  * compatibility-marker string so downstream tooling can tell this lockfile

--- a/src/lib/apm/apm-manifest.ts
+++ b/src/lib/apm/apm-manifest.ts
@@ -1,9 +1,9 @@
 import { join } from "node:path";
 
-import { dump, load } from "js-yaml";
+import { load } from "js-yaml";
 import { optional, z } from "zod/mini";
 
-import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { fileExists, readFileContent } from "../../utils/file.js";
 
 export const APM_MANIFEST_FILE_NAME = "apm.yml";
 
@@ -107,19 +107,6 @@ export async function readApmManifest(projectRoot: string): Promise<ApmManifest>
   const path = getApmManifestPath(projectRoot);
   const content = await readFileContent(path);
   return parseApmManifest(content);
-}
-
-/**
- * Write an `apm.yml` back to disk. Only used by tests today — the install
- * command itself does not mutate the manifest.
- */
-export async function writeApmManifest(params: {
-  projectRoot: string;
-  manifest: { name?: string; version?: string; dependencies?: unknown[] };
-}): Promise<void> {
-  const path = getApmManifestPath(params.projectRoot);
-  const content = dump(params.manifest, { lineWidth: -1 });
-  await writeFileContent(path, content);
 }
 
 function normalizeDependency(

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -782,6 +782,3 @@ export function formatFetchSummary(summary: FetchSummary): string {
 
   return lines.join("\n");
 }
-
-// Legacy export for backward compatibility during migration
-export { fetchFiles as fetchFromGitHub };

--- a/src/lib/gh/gh-lock.ts
+++ b/src/lib/gh/gh-lock.ts
@@ -58,10 +58,6 @@ export function getGhLockPath(projectRoot: string): string {
   return join(projectRoot, GH_LOCKFILE_FILE_NAME);
 }
 
-export async function ghLockExists(projectRoot: string): Promise<boolean> {
-  return fileExists(getGhLockPath(projectRoot));
-}
-
 /**
  * Create an empty gh lockfile structure. When `existingLock` is provided,
  * top-level looseObject extras are carried forward so unknown fields (added

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -32,12 +32,6 @@ export type GitignoreDestination = z.infer<typeof GitignoreDestinationSchema>;
 // Each tool/feature is responsible for parsing and validating its own keys.
 export type FeatureOptions = Record<string, unknown>;
 
-// Value of a single feature in the per-feature object form:
-// - true: enable with default options
-// - false: disable
-// - object: enable with the given options
-export type FeatureValue = boolean | FeatureOptions | GitignoreDestination;
-
 // Schema for features - supports both array and per-target object formats
 // Array format: ["rules", "ignore", ...] or ["*"]
 // Object format (array per target): { "copilot": ["commands"], "agentsmd": ["rules", "mcp"] }
@@ -84,14 +78,6 @@ export type PerTargetFeaturesValue = Array<FeatureWithWildcard> | PerFeatureConf
 export type PerTargetFeatures = Partial<Record<ToolTarget, PerTargetFeaturesValue>>;
 
 export type RulesyncFeatures = Array<FeatureWithWildcard> | PerTargetFeatures;
-
-/**
- * Type guard: returns true when a per-target features value uses the
- * per-feature object form rather than the array form.
- */
-export const isPerFeatureConfig = (value: PerTargetFeaturesValue): value is PerFeatureConfig => {
-  return !Array.isArray(value);
-};
 
 /**
  * Returns true if a per-feature value enables the feature.

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -14,7 +14,6 @@ export type ConflictStrategy = z.infer<typeof ConflictStrategySchema>;
  * GitHub file type from API response
  */
 export const GitHubFileTypeSchema = z.enum(["file", "dir", "symlink", "submodule"]);
-export type GitHubFileType = z.infer<typeof GitHubFileTypeSchema>;
 
 /**
  * GitHub file/directory entry from contents API

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -18,7 +18,6 @@ export type PermissionAction = z.infer<typeof PermissionActionSchema>;
  * { "*": "ask", "git *": "allow", "rm *": "deny" }
  */
 export const PermissionRulesSchema = z.record(z.string(), PermissionActionSchema);
-export type PermissionRules = z.infer<typeof PermissionRulesSchema>;
 
 /**
  * Permissions configuration.
@@ -43,4 +42,3 @@ export const RulesyncPermissionsFileSchema = z.looseObject({
   $schema: z.optional(z.string()),
   ...PermissionsConfigSchema.shape,
 });
-export type RulesyncPermissionsFile = z.infer<typeof RulesyncPermissionsFileSchema>;

--- a/src/utils/vitest.ts
+++ b/src/utils/vitest.ts
@@ -1,11 +1,3 @@
 export function isEnvTest(): boolean {
   return process.env.NODE_ENV === "test";
 }
-
-export function getVitestWorkerId(): string {
-  const vitestWorkerId = process.env.VITEST_WORKER_ID;
-  if (!vitestWorkerId) {
-    throw new Error("VITEST_WORKER_ID is not set");
-  }
-  return vitestWorkerId;
-}


### PR DESCRIPTION
## Summary

Reviewed the knip setup against knip's official "zero-config / good defaults" guidance and removed the dead code it surfaced.

### knip config (`knip.ts`)

knip itself reported **14 configuration hints** flagging redundant settings. Acted on all of them:

- Removed the entire `ignore` array — every entry (`dist/**`, `node_modules/**`, `tsconfig.json`, `docs/**`, etc.) fell outside the `project` scope (`src/**`, `scripts/**`), so they were no-ops.
- Removed the `src/cli/index.ts` entry — auto-detected from the package.json `bin` field.
- Removed `typescript` / `@types/node` / `@types/js-yaml` / `lint-staged` / `vitepress` from `ignoreDependencies` — resolved automatically by knip plugins.
- Removed the redundant `typescript.config` override — it matched the default.

Kept (with documented reasons): `effect` / `sury` / `@valibot/to-json-schema` (dynamic-import peers of `xsschema` needed by the `bun build` step), `@secretlint/...`, and `includeEntryExports: true`.

After the change, knip reports **0 configuration hints** and **0 unused/unlisted dependencies**.

### Dead code removal

Split knip's 148 findings by repo-wide reference count and removed the **28 that are referenced nowhere**:

- 6 functions/values: `apmLockExists`, `writeApmManifest`, `ghLockExists`, the legacy `fetchFromGitHub` alias, `isPerFeatureConfig`, `getVitestWorkerId`
- 22 unused type aliases (e.g. `JunieRuleParams = AiFileParams` — trivial aliases not used even in their own constructor, unlike `CursorRuleParams` which defines a custom shape)
- plus the imports/comments they orphaned

The remaining findings are intentionally left untouched: per-tool convention exports (`*FrontmatterSchema`, etc.), the public `src/index.ts` API surface, and deliberate duplicate aliases (e.g. `KILO_HOOK_EVENTS = OPENCODE_HOOK_EVENTS`). Pruning those would break the maintained Tool × Feature convention symmetry.

## Test plan

- `pnpm cicheck` — all green (fmt, oxlint, typecheck, **6882 tests pass**, content checks)
- `pnpm knip` — the 28 deletions are gone (unused exports 103 → 97, unused types 45 → 23); no new findings

Note: no associated issue — this is maintainer-initiated cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)