### PR TITLE
fix(mcp): harden adapters against prototype pollution

### DIFF
--- a/src/features/mcp/amp-mcp.ts
+++ b/src/features/mcp/amp-mcp.ts
@@ -11,7 +11,7 @@ import {
 import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { isPlainObject, isRecord } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -35,7 +35,9 @@ function parseAmpSettingsJsonc(fileContent: string): Record<string, unknown> {
     throw new Error(`Failed to parse Amp settings: ${details}`);
   }
 
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; the JSONC parser always yields a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error("Amp settings must be a JSON object");
   }
 

--- a/src/features/mcp/augmentcode-mcp.ts
+++ b/src/features/mcp/augmentcode-mcp.ts
@@ -8,7 +8,7 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { isMcpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { isPlainObject } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -37,7 +37,9 @@ function parseAugmentcodeSettings(
       { cause: error },
     );
   }
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; `JSON.parse` always yields a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error(
       `Failed to parse AugmentCode settings at ${configPath}: expected a JSON object`,
     );

--- a/src/features/mcp/cline-mcp.ts
+++ b/src/features/mcp/cline-mcp.ts
@@ -5,7 +5,7 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { isMcpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { isPlainObject } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -33,7 +33,9 @@ function parseClineSettings(
       cause: error,
     });
   }
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; `JSON.parse` always yields a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error(`Failed to parse Cline MCP settings at ${configPath}: expected a JSON object`);
   }
   return parsed;

--- a/src/features/mcp/goose-mcp.test.ts
+++ b/src/features/mcp/goose-mcp.test.ts
@@ -239,6 +239,39 @@ describe("GooseMcp", () => {
         disabled: true,
       });
     });
+
+    it("strips prototype-pollution keys from an extension's envs/headers on import", async () => {
+      const dir = join(testDir, GOOSE_DIR);
+      await ensureDir(dir);
+      await writeFileContent(
+        join(dir, GOOSE_FILE),
+        [
+          "extensions:",
+          "  fetch:",
+          "    name: fetch",
+          "    type: stdio",
+          "    cmd: uvx",
+          "    envs:",
+          "      __proto__: polluted",
+          "      constructor: polluted",
+          "      TOKEN: safe",
+          "  remote:",
+          "    name: remote",
+          "    type: streamable_http",
+          "    uri: https://example.com/mcp",
+          "    headers:",
+          "      __proto__: polluted",
+          "      Authorization: Bearer safe",
+          "",
+        ].join("\n"),
+      );
+
+      const mcp = await GooseMcp.fromFile({ outputRoot: testDir, global: true });
+      const servers = JSON.parse(mcp.toRulesyncMcp().getFileContent()).mcpServers;
+
+      expect(servers.fetch.env).toEqual({ TOKEN: "safe" });
+      expect(servers.remote.headers).toEqual({ Authorization: "Bearer safe" });
+    });
   });
 
   describe("forDeletion", () => {

--- a/src/features/mcp/goose-mcp.test.ts
+++ b/src/features/mcp/goose-mcp.test.ts
@@ -104,6 +104,27 @@ describe("GooseMcp", () => {
       });
     });
 
+    it("strips prototype-pollution keys from a server's env table", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        // Authored as raw JSON text so `__proto__`/`constructor`/`prototype`
+        // land as own enumerable keys (an object literal would set the prototype).
+        fileContent:
+          '{"mcpServers":{"fetch":{"command":"uvx",' +
+          '"env":{"__proto__":"polluted","constructor":"polluted","prototype":"polluted","TOKEN":"safe"}}}}',
+      });
+
+      const mcp = await GooseMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const ext = getExtensions(mcp.getFileContent()).fetch;
+
+      expect(ext?.envs).toEqual({ TOKEN: "safe" });
+    });
+
     it("converts a remote http server to a streamable_http extension", async () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",

--- a/src/features/mcp/goose-mcp.ts
+++ b/src/features/mcp/goose-mcp.ts
@@ -7,8 +7,11 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
-import { isRecord, isStringArray } from "../../utils/type-guards.js";
+import {
+  omitPrototypePollutionKeys,
+  PROTOTYPE_POLLUTION_KEYS,
+} from "../../utils/prototype-pollution.js";
+import { isPlainObject, isRecord, isStringArray } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -40,7 +43,9 @@ function parseGooseConfig(
   if (parsed === undefined || parsed === null) {
     return {};
   }
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; a YAML mapping always parses to a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error(`Failed to parse Goose config at ${configPath}: expected a YAML mapping`);
   }
   return parsed;
@@ -106,7 +111,7 @@ function applyGooseStdioFields(
     ext.cmd = command;
     if (isStringArray(config.args)) ext.args = config.args;
   }
-  if (isRecord(config.env)) ext.envs = config.env;
+  if (isPlainObject(config.env)) ext.envs = omitPrototypePollutionKeys(config.env);
 }
 
 /**
@@ -125,7 +130,7 @@ function convertServerToGooseExtension(
     applyGooseStdioFields(ext, config);
   } else if (gooseType === "sse" || gooseType === "streamable_http") {
     if (url !== undefined) ext.uri = url;
-    if (isRecord(config.headers)) ext.headers = config.headers;
+    if (isPlainObject(config.headers)) ext.headers = omitPrototypePollutionKeys(config.headers);
   }
 
   ext.enabled = config.disabled !== true;
@@ -182,9 +187,9 @@ function convertFromGooseFormat(extensions: Record<string, unknown>): McpServers
 
     if (typeof ext.cmd === "string") server.command = ext.cmd;
     if (isStringArray(ext.args)) server.args = ext.args;
-    if (isRecord(ext.envs)) server.env = ext.envs;
+    if (isPlainObject(ext.envs)) server.env = omitPrototypePollutionKeys(ext.envs);
     if (typeof ext.uri === "string") server.url = ext.uri;
-    if (isRecord(ext.headers)) server.headers = ext.headers;
+    if (isPlainObject(ext.headers)) server.headers = omitPrototypePollutionKeys(ext.headers);
     if (ext.enabled === false) server.disabled = true;
     if (typeof ext.timeout === "number") server.timeout = ext.timeout;
 

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -101,6 +101,27 @@ describe("HermesagentMcp", () => {
       });
     });
 
+    it("strips prototype-pollution keys from a server's env table", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        // Authored as raw JSON text so `__proto__`/`constructor`/`prototype`
+        // land as own enumerable keys (an object literal would set the prototype).
+        fileContent:
+          '{"mcpServers":{"fetch":{"command":"uvx",' +
+          '"env":{"__proto__":"polluted","constructor":"polluted","prototype":"polluted","TOKEN":"safe"}}}}',
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.env).toEqual({ TOKEN: "safe" });
+    });
+
     it("converts a remote server to url/headers, dropping the canonical-only type", async () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
@@ -273,6 +294,29 @@ describe("HermesagentMcp", () => {
         disabled: true,
       });
       expect(servers.legacy.enabled).toBeUndefined();
+    });
+
+    it("strips prototype-pollution keys from a server's headers on import", async () => {
+      const dir = join(testDir, HERMES_DIR);
+      await ensureDir(dir);
+      await writeFileContent(
+        join(dir, HERMES_FILE),
+        [
+          "mcp_servers:",
+          "  remote:",
+          "    url: https://example.com/mcp",
+          "    headers:",
+          "      __proto__: polluted",
+          "      constructor: polluted",
+          "      Authorization: Bearer safe",
+          "",
+        ].join("\n"),
+      );
+
+      const mcp = await HermesagentMcp.fromFile({ outputRoot: testDir, global: true });
+      const servers = JSON.parse(mcp.toRulesyncMcp().getFileContent()).mcpServers;
+
+      expect(servers.remote.headers).toEqual({ Authorization: "Bearer safe" });
     });
   });
 

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -10,8 +10,11 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
-import { isRecord, isStringArray } from "../../utils/type-guards.js";
+import {
+  omitPrototypePollutionKeys,
+  PROTOTYPE_POLLUTION_KEYS,
+} from "../../utils/prototype-pollution.js";
+import { isPlainObject, isRecord, isStringArray } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -43,7 +46,9 @@ function parseHermesConfig(
   if (parsed === undefined || parsed === null) {
     return {};
   }
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; a YAML mapping always parses to a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error(`Failed to parse Hermes config at ${configPath}: expected a YAML mapping`);
   }
   return parsed;
@@ -94,10 +99,10 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
       out.command = command;
       if (isStringArray(config.args)) out.args = config.args;
     }
-    if (isRecord(config.env)) out.env = config.env;
+    if (isPlainObject(config.env)) out.env = omitPrototypePollutionKeys(config.env);
   } else if (url !== undefined) {
     out.url = url;
-    if (isRecord(config.headers)) out.headers = config.headers;
+    if (isPlainObject(config.headers)) out.headers = omitPrototypePollutionKeys(config.headers);
   }
 
   // Hermes defaults a server to enabled, so only emit the flag when disabling.
@@ -138,9 +143,9 @@ function convertFromHermesFormat(mcpServers: Record<string, unknown>): McpServer
     const server: Record<string, unknown> = {};
     if (typeof config.command === "string") server.command = config.command;
     if (isStringArray(config.args)) server.args = config.args;
-    if (isRecord(config.env)) server.env = config.env;
+    if (isPlainObject(config.env)) server.env = omitPrototypePollutionKeys(config.env);
     if (typeof config.url === "string") server.url = config.url;
-    if (isRecord(config.headers)) server.headers = config.headers;
+    if (isPlainObject(config.headers)) server.headers = omitPrototypePollutionKeys(config.headers);
     if (config.enabled === false) server.disabled = true;
     if (typeof config.timeout === "number") server.timeout = config.timeout;
 

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -5,7 +5,7 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { isMcpServers } from "../../types/mcp.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { isPlainObject } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
   ToolMcp,
@@ -30,7 +30,9 @@ function parseRovodevMcpJson(
       cause: error,
     });
   }
-  if (!isRecord(parsed)) {
+  // `isPlainObject` (not `isRecord`) rejects class instances for
+  // prototype-pollution hardening; `JSON.parse` always yields a plain object.
+  if (!isPlainObject(parsed)) {
     throw new Error(`Failed to parse Rovodev MCP config at ${configPath}: expected a JSON object`);
   }
   return parsed;

--- a/src/utils/prototype-pollution.test.ts
+++ b/src/utils/prototype-pollution.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPrototypePollutionKey,
+  omitPrototypePollutionKeys,
+  PROTOTYPE_POLLUTION_KEYS,
+} from "./prototype-pollution.js";
+
+describe("PROTOTYPE_POLLUTION_KEYS", () => {
+  it("contains the three prototype-mutating keys", () => {
+    expect([...PROTOTYPE_POLLUTION_KEYS].toSorted()).toEqual([
+      "__proto__",
+      "constructor",
+      "prototype",
+    ]);
+  });
+});
+
+describe("isPrototypePollutionKey", () => {
+  it("flags prototype-pollution keys", () => {
+    expect(isPrototypePollutionKey("__proto__")).toBe(true);
+    expect(isPrototypePollutionKey("constructor")).toBe(true);
+    expect(isPrototypePollutionKey("prototype")).toBe(true);
+  });
+
+  it("passes ordinary keys", () => {
+    expect(isPrototypePollutionKey("TOKEN")).toBe(false);
+    expect(isPrototypePollutionKey("Authorization")).toBe(false);
+  });
+});
+
+describe("omitPrototypePollutionKeys", () => {
+  it("drops prototype-pollution keys while preserving the rest", () => {
+    // Authored as raw JSON text so `__proto__` lands as an own enumerable key
+    // (an object literal would set the prototype instead).
+    const input = JSON.parse(
+      '{"__proto__":"polluted","constructor":"polluted","prototype":"polluted","TOKEN":"safe"}',
+    ) as Record<string, unknown>;
+
+    const result = omitPrototypePollutionKeys(input);
+
+    expect(result).toEqual({ TOKEN: "safe" });
+    expect(Object.keys(result)).toEqual(["TOKEN"]);
+  });
+
+  it("returns a fresh object and leaves an already-clean record's entries intact", () => {
+    const input = { A: "1", B: "2" };
+    const result = omitPrototypePollutionKeys(input);
+
+    expect(result).toEqual({ A: "1", B: "2" });
+    expect(result).not.toBe(input);
+  });
+
+  it("returns an empty object for an empty record", () => {
+    expect(omitPrototypePollutionKeys({})).toEqual({});
+  });
+});

--- a/src/utils/prototype-pollution.ts
+++ b/src/utils/prototype-pollution.ts
@@ -14,3 +14,25 @@ export const PROTOTYPE_POLLUTION_KEYS: ReadonlySet<string> = new Set([
 export function isPrototypePollutionKey(key: string): boolean {
   return PROTOTYPE_POLLUTION_KEYS.has(key);
 }
+
+/**
+ * Returns a shallow copy of a record's own entries with every
+ * prototype-pollution key (`__proto__`, `constructor`, `prototype`) dropped.
+ *
+ * Use when copying a nested, user-supplied string map — an MCP server's `env`
+ * or `headers` table — into freshly generated config. Carrying such a map by
+ * reference, or re-assigning its keys via bracket notation, would let a literal
+ * `__proto__` key ride along (and re-assigning it would mutate the target's
+ * prototype). Walking the entries through this helper severs that path while
+ * preserving every legitimate key.
+ */
+export function omitPrototypePollutionKeys(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+    sanitized[key] = value;
+  }
+  return sanitized;
+}


### PR DESCRIPTION
## Background

Follow-up to the review findings tracked in #2020 (from PR #2019, Hermes Agent support). This PR resolves the **items 6–7 security-hardening** slice, which the maintainer asked be done as a single cross-cutting MCP-adapter pass rather than Hermes-only.

## What changed

- **Shared helper** — `omitPrototypePollutionKeys` in `src/utils/prototype-pollution.ts` returns a shallow copy of a record with `__proto__` / `constructor` / `prototype` keys dropped, for safely copying nested user-supplied `env` / `headers` maps into generated config.
- **Item 7 (nested `env`/`headers`)** — Hermes Agent and Goose now filter prototype-pollution keys out of a server's `env` / `headers` table on both export and import, instead of carrying the map through by reference.
- **Item 6 (`isRecord` → `isPlainObject`)** — the untrusted-config parse guards across the MCP adapters (`amp`, `augmentcode`, `cline`, `goose`, `hermesagent`, `rovodev`) now use `isPlainObject`, which rejects class instances per the codebase prototype-pollution convention. `grokcli` / `codexcli` already used `isPlainObject` and per-key filtering.

These are defense-in-depth changes: js-yaml v4 and `JSON.parse` are already safe and parsed config is always a plain object, so output for legitimate configs is unchanged.

## Disposition of the other #2020 items

- **Item 1** (YAML serialize→deserialize round-trip in Hermes `fromRulesyncMcp`) — left as-is: the merged config must still be `dump()`-ed to produce the file content, so removing the re-parse only saves a cheap `load()` at the cost of complicating the constructor contract. No correctness impact.
- **Item 2** (inline comment for `_relativeFilePath`) — already present in `hermesagent-rule.ts` (`fromFile`).
- **Item 3** (constant for `~/.hermes/SOUL.md`) — intentionally skipped: an unused export would fail `knip`, and the path is documented in the file header.
- **Item 4** (e2e matrix alphabetical ordering) — cosmetic; not changed to avoid churn in the happy-path matrix.
- **Item 5** (Hermes `timeout`/`networkTimeout` passthrough) — already implemented in #2023.

## Tests

- New `src/utils/prototype-pollution.test.ts` covering the helper.
- New cases in `hermesagent-mcp.test.ts` / `goose-mcp.test.ts` asserting `env`/`headers` pollution keys are stripped on export and import.
- `pnpm cicheck` green (6891 tests, lint, typecheck, content checks).

Closes #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
