### PR TITLE
docs(cursor): document .cursorindexingignore as an intentional non-goal

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -732,6 +732,17 @@ writes it). Claude Code is the exception: it does not
 read a separate ignore file, so Rulesync writes the deny list into Claude
 Code's settings file as `permissions.deny` entries (`Read(<pattern>)`).
 
+For Cursor, Rulesync emits only `.cursorignore` — the file that **blocks access
+entirely** (semantic search, Tab, Agent, Inline Edit, and `@`-mentions). Cursor
+also supports a second file, `.cursorindexingignore`, which excludes files from
+**indexing only** while keeping them accessible to the AI on demand. These two
+files mean _different_ things, and Rulesync's `ignore` feature models a single
+canonical ignore list per tool with no per-pattern distinction between
+"block access" and "exclude from indexing only". Emitting the same patterns to
+both files would be incorrect, so `.cursorindexingignore` is intentionally **not
+generated** (an intentional non-goal). Author it by hand if you need
+indexing-only excludes.
+
 By default, Claude Code's deny list is written to the **shared**
 `.claude/settings.json` so that the policy can be committed and reviewed by
 the team. This is intentional (see issue #1094), but it means that running

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -732,6 +732,17 @@ writes it). Claude Code is the exception: it does not
 read a separate ignore file, so Rulesync writes the deny list into Claude
 Code's settings file as `permissions.deny` entries (`Read(<pattern>)`).
 
+For Cursor, Rulesync emits only `.cursorignore` — the file that **blocks access
+entirely** (semantic search, Tab, Agent, Inline Edit, and `@`-mentions). Cursor
+also supports a second file, `.cursorindexingignore`, which excludes files from
+**indexing only** while keeping them accessible to the AI on demand. These two
+files mean _different_ things, and Rulesync's `ignore` feature models a single
+canonical ignore list per tool with no per-pattern distinction between
+"block access" and "exclude from indexing only". Emitting the same patterns to
+both files would be incorrect, so `.cursorindexingignore` is intentionally **not
+generated** (an intentional non-goal). Author it by hand if you need
+indexing-only excludes.
+
 By default, Claude Code's deny list is written to the **shared**
 `.claude/settings.json` so that the policy can be committed and reviewed by
 the team. This is intentional (see issue #1094), but it means that running

--- a/src/features/ignore/cursor-ignore.ts
+++ b/src/features/ignore/cursor-ignore.ts
@@ -12,6 +12,24 @@ import {
   ToolIgnoreSettablePaths,
 } from "./tool-ignore.js";
 
+/**
+ * Cursor ignore adapter.
+ *
+ * Cursor documents two ignore files with different semantics:
+ * - `.cursorignore` — blocks access entirely (semantic search, Tab, Agent,
+ *   Inline Edit, `@`-mentions).
+ * - `.cursorindexingignore` — excludes from indexing only; files stay accessible
+ *   to the AI on demand.
+ *
+ * rulesync's `ignore` feature models a single canonical ignore list per tool,
+ * with no per-pattern way to distinguish "block access" from "exclude from
+ * indexing only". Emitting the same patterns to both files would be wrong (they
+ * mean different things), so this adapter writes only `.cursorignore`;
+ * `.cursorindexingignore` is an intentional non-goal (see issue #1923). Authors
+ * who need indexing-only excludes should maintain that file by hand.
+ *
+ * @see https://cursor.com/docs/reference/ignore-file
+ */
 export class CursorIgnore extends ToolIgnore {
   static getSettablePaths(): ToolIgnoreSettablePaths {
     return {


### PR DESCRIPTION
## Background

Follow-up to #1923. Cursor documents two ignore files with **different** semantics ([docs](https://cursor.com/docs/reference/ignore-file)):

- `.cursorignore` — blocks access entirely (semantic search, Tab, Agent, Inline Edit, `@`-mentions).
- `.cursorindexingignore` — excludes from indexing only; files stay accessible to the AI on demand.

rulesync's `ignore` feature models a single canonical ignore list per tool, with no per-pattern way to distinguish "block access" from "exclude from indexing only". Emitting the same patterns to both files would be wrong.

Per the maintainer decision on this design question, `.cursorindexingignore` is treated as an **intentional non-goal** and documented as such.

## What changed

- Added a class-level doc comment to `src/features/ignore/cursor-ignore.ts` explaining the two-semantics impedance mismatch and that only `.cursorignore` is emitted.
- Added a paragraph to `docs/reference/file-formats.md` (synced to `skills/rulesync/`) documenting that `.cursorindexingignore` is intentionally not generated and should be hand-authored if needed.

No behavior change; documentation only.

Closes #1923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
