### PR TITLE
feat(aiassistant): add project skills adapter (.agents/skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | Google Antigravity IDE |  ✅   |        | ✅  |    ✅    |           |   ✅   |  ✅   |     ✅      |
 | Google Antigravity CLI |  ✅   |   ✅   | ✅  |          |           |   ✅   |  ✅   |     ✅      |
 | Google Antigravity ⚠️  |  ✅   |        |     |    ✅    |           |   ✅   |       |             |
-| JetBrains AI Assistant |  ✅   |   ✅   |     |          |           |        |       |             |
+| JetBrains AI Assistant |  ✅   |   ✅   |     |          |           |   ✅   |       |             |
 | JetBrains Junie        |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |
 | AugmentCode            |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |
 | Devin Desktop          |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |             |

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -35,7 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
-| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |        |       |             |
+| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |   ✅   |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -35,7 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity IDE | antigravity-ide | ✅ 🌏 |        | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     ✅      |
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |          |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | Google Antigravity ⚠️  | antigravity     |  ✅   |        |          |    ✅    |           | ✅ 🌏  |       |             |
-| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |        |       |             |
+| JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |   ✅   |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |
 | AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |             |

--- a/src/constants/aiassistant-paths.ts
+++ b/src/constants/aiassistant-paths.ts
@@ -1,7 +1,14 @@
 import { join } from "node:path";
 
+import { AGENTSMD_SKILLS_DIR_PATH } from "./agentsmd-paths.js";
+
 export const AIASSISTANT_DIR = ".aiassistant";
 export const AIASSISTANT_RULES_DIR_PATH = join(AIASSISTANT_DIR, "rules");
 // JetBrains AI Assistant shares the JetBrains-wide `.aiignore` filename (the
 // same file Junie uses) at the project root.
 export const AIASSISTANT_IGNORE_FILE_NAME = ".aiignore";
+// JetBrains AI Assistant 2026.1 added a Skill Manager that auto-discovers
+// project-level skills from the committable `.agents/skills/<name>/SKILL.md`
+// directory, following the open Agent Skills standard. The relative path is the
+// same as the agentsskills target. https://agentskills.io/specification
+export const AIASSISTANT_SKILLS_DIR_PATH = AGENTSMD_SKILLS_DIR_PATH;

--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -112,6 +112,10 @@ describe("E2E: skills", () => {
       outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
     },
     {
+      target: "aiassistant",
+      outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
+    },
+    {
       target: "amp",
       outputPath: join(".agents", "skills", "test-skill", "SKILL.md"),
     },
@@ -211,6 +215,7 @@ This is the test skill body content.
     { target: "junie", orphanPath: join(".junie", "skills", "orphan-skill", "SKILL.md") },
     { target: "replit", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
     { target: "agentsskills", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
+    { target: "aiassistant", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
     { target: "pi", orphanPath: join(".pi", "skills", "orphan-skill", "SKILL.md") },
     { target: "zed", orphanPath: join(".agents", "skills", "orphan-skill", "SKILL.md") },
     { target: "factorydroid", orphanPath: join(".factory", "skills", "orphan-skill", "SKILL.md") },
@@ -265,6 +270,7 @@ describe("E2E: skills (import)", () => {
     { target: "antigravity-ide", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
     { target: "antigravity-cli", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
     { target: "junie", sourcePath: join(".junie", "skills", "test-skill", "SKILL.md") },
+    { target: "aiassistant", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
     { target: "replit", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },
     { target: "pi", sourcePath: join(".pi", "skills", "test-skill", "SKILL.md") },
     { target: "zed", sourcePath: join(".agents", "skills", "test-skill", "SKILL.md") },

--- a/src/features/skills/aiassistant-skill.test.ts
+++ b/src/features/skills/aiassistant-skill.test.ts
@@ -1,0 +1,256 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AIASSISTANT_SKILLS_DIR_PATH } from "../../constants/aiassistant-paths.js";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AiassistantSkill } from "./aiassistant-skill.js";
+import { RulesyncSkill } from "./rulesync-skill.js";
+
+describe("AiassistantSkill", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const testSetup = await setupTestDirectory();
+    testDir = testSetup.testDir;
+    cleanup = testSetup.cleanup;
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("getSettablePaths", () => {
+    it("should return .agents/skills as relativeDirPath", () => {
+      const paths = AiassistantSkill.getSettablePaths();
+      expect(paths.relativeDirPath).toBe(AIASSISTANT_SKILLS_DIR_PATH);
+      expect(paths.relativeDirPath).toBe(join(".agents", "skills"));
+    });
+
+    it("should throw in global mode (project scope only)", () => {
+      expect(() => AiassistantSkill.getSettablePaths({ global: true })).toThrow(
+        /does not support global mode/,
+      );
+    });
+  });
+
+  describe("constructor", () => {
+    it("should create instance with valid content", () => {
+      const skill = new AiassistantSkill({
+        outputRoot: testDir,
+        relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "test-skill",
+          description: "Test skill description",
+        },
+        body: "This is the body of the AI Assistant skill.",
+        validate: true,
+      });
+
+      expect(skill).toBeInstanceOf(AiassistantSkill);
+      expect(skill.getBody()).toBe("This is the body of the AI Assistant skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when frontmatter is invalid", () => {
+      expect(
+        () =>
+          new AiassistantSkill({
+            outputRoot: testDir,
+            relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+            dirName: "test-skill",
+            // @ts-expect-error intentionally missing description for validation test
+            frontmatter: {
+              name: "test-skill",
+            },
+            body: "Body",
+            validate: true,
+          }),
+      ).toThrow(/Invalid frontmatter/);
+    });
+  });
+
+  describe("fromDir", () => {
+    it("should create instance from valid skill directory", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "test-skill");
+      await ensureDir(skillDir);
+      const skillContent = `---
+name: test-skill
+description: Test skill description
+---
+
+This is the body of the AI Assistant skill.`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await AiassistantSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "test-skill",
+      });
+
+      expect(skill).toBeInstanceOf(AiassistantSkill);
+      expect(skill.getBody()).toBe("This is the body of the AI Assistant skill.");
+      expect(skill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+
+    it("should throw error when SKILL.md not found", async () => {
+      const skillDir = join(testDir, ".agents", "skills", "empty-skill");
+      await ensureDir(skillDir);
+
+      await expect(
+        AiassistantSkill.fromDir({
+          outputRoot: testDir,
+          dirName: "empty-skill",
+        }),
+      ).rejects.toThrow(/SKILL\.md not found/);
+    });
+  });
+
+  describe("fromRulesyncSkill", () => {
+    it("should create instance from RulesyncSkill", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "test-skill",
+          description: "Test skill description",
+        },
+        body: "Test body content",
+        validate: true,
+      });
+
+      const aiassistantSkill = AiassistantSkill.fromRulesyncSkill({
+        rulesyncSkill,
+        validate: true,
+      });
+
+      expect(aiassistantSkill).toBeInstanceOf(AiassistantSkill);
+      expect(aiassistantSkill.getDirName()).toBe("test-skill");
+      expect(aiassistantSkill.getBody()).toBe("Test body content");
+      expect(aiassistantSkill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test skill description",
+      });
+    });
+  });
+
+  describe("isTargetedByRulesyncSkill", () => {
+    it("should return true when targets includes '*'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "all-targets-skill",
+        frontmatter: {
+          name: "all-targets-skill",
+          description: "Skill for all targets",
+          targets: ["*"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AiassistantSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return true when targets includes 'aiassistant'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "aiassistant-skill",
+        frontmatter: {
+          name: "aiassistant-skill",
+          description: "Skill for aiassistant",
+          targets: ["copilot", "aiassistant"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AiassistantSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(true);
+    });
+
+    it("should return false when targets does not include 'aiassistant'", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "claudecode-only-skill",
+        frontmatter: {
+          name: "claudecode-only-skill",
+          description: "Skill for claudecode only",
+          targets: ["claudecode"],
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      expect(AiassistantSkill.isTargetedByRulesyncSkill(rulesyncSkill)).toBe(false);
+    });
+  });
+
+  describe("toRulesyncSkill", () => {
+    it("should convert to RulesyncSkill", () => {
+      const skill = new AiassistantSkill({
+        outputRoot: testDir,
+        relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+        dirName: "test-skill",
+        frontmatter: {
+          name: "test-skill",
+          description: "Test description",
+        },
+        body: "Test body",
+        validate: true,
+      });
+
+      const rulesyncSkill = skill.toRulesyncSkill();
+
+      expect(rulesyncSkill).toBeInstanceOf(RulesyncSkill);
+      expect(rulesyncSkill.getFrontmatter()).toEqual({
+        name: "test-skill",
+        description: "Test description",
+        targets: ["*"],
+      });
+      expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+  });
+
+  describe("forDeletion", () => {
+    it("should create minimal instance for deletion", () => {
+      const skill = AiassistantSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+      });
+
+      expect(skill.getDirName()).toBe("cleanup");
+      expect(skill.getRelativeDirPath()).toBe(AIASSISTANT_SKILLS_DIR_PATH);
+      expect(skill.getGlobal()).toBe(false);
+      expect(skill.getFrontmatter()).toEqual({
+        name: "",
+        description: "",
+      });
+      expect(skill.getBody()).toBe("");
+    });
+
+    it("should use process.cwd() as default outputRoot", () => {
+      const skill = AiassistantSkill.forDeletion({
+        dirName: "cleanup",
+        relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+      });
+
+      expect(skill).toBeInstanceOf(AiassistantSkill);
+      expect(skill.getOutputRoot()).toBe(testDir);
+    });
+  });
+});

--- a/src/features/skills/aiassistant-skill.ts
+++ b/src/features/skills/aiassistant-skill.ts
@@ -1,0 +1,219 @@
+import { join } from "node:path";
+
+import { z } from "zod/mini";
+
+import { AIASSISTANT_SKILLS_DIR_PATH } from "../../constants/aiassistant-paths.js";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { ValidationResult } from "../../types/ai-dir.js";
+import { formatError } from "../../utils/error.js";
+import { RulesyncSkill, RulesyncSkillFrontmatterInput, SkillFile } from "./rulesync-skill.js";
+import {
+  ToolSkill,
+  ToolSkillForDeletionParams,
+  ToolSkillFromDirParams,
+  ToolSkillFromRulesyncSkillParams,
+  ToolSkillSettablePaths,
+} from "./tool-skill.js";
+
+export const AiassistantSkillFrontmatterSchema = z.looseObject({
+  name: z.string(),
+  description: z.string(),
+});
+
+export type AiassistantSkillFrontmatter = z.infer<typeof AiassistantSkillFrontmatterSchema>;
+
+export type AiassistantSkillParams = {
+  outputRoot?: string;
+  relativeDirPath?: string;
+  dirName: string;
+  frontmatter: AiassistantSkillFrontmatter;
+  body: string;
+  otherFiles?: SkillFile[];
+  validate?: boolean;
+  global?: boolean;
+};
+
+/**
+ * Represents a JetBrains AI Assistant skill directory.
+ *
+ * AI Assistant 2026.1 added a Skill Manager that auto-discovers project-level
+ * skills from the committable `.agents/skills/<name>/SKILL.md` directory (the
+ * open Agent Skills standard, the same convention `agentsskills-skill.ts` emits).
+ * The docs state these project paths "travel with the repository and be shared
+ * through version control".
+ *
+ * Only the project scope is supported: IDE-level/global skill storage is internal
+ * and not a committable path, so there is no global surface to emit.
+ *
+ * @see https://www.jetbrains.com/help/ai-assistant/agent-skills.html
+ */
+export class AiassistantSkill extends ToolSkill {
+  constructor({
+    outputRoot = process.cwd(),
+    relativeDirPath = AIASSISTANT_SKILLS_DIR_PATH,
+    dirName,
+    frontmatter,
+    body,
+    otherFiles = [],
+    validate = true,
+    global = false,
+  }: AiassistantSkillParams) {
+    super({
+      outputRoot,
+      relativeDirPath,
+      dirName,
+      mainFile: {
+        name: SKILL_FILE_NAME,
+        body,
+        frontmatter: { ...frontmatter },
+      },
+      otherFiles,
+      global,
+    });
+
+    if (validate) {
+      const result = this.validate();
+      if (!result.success) {
+        throw result.error;
+      }
+    }
+  }
+
+  static getSettablePaths(options?: { global?: boolean }): ToolSkillSettablePaths {
+    if (options?.global) {
+      // AI Assistant stores user-level skills inside the IDE (not a committable
+      // path), so only the project scope `.agents/skills/` is supported.
+      throw new Error("AiassistantSkill does not support global mode.");
+    }
+    return {
+      relativeDirPath: AIASSISTANT_SKILLS_DIR_PATH,
+    };
+  }
+
+  getFrontmatter(): AiassistantSkillFrontmatter {
+    const result = AiassistantSkillFrontmatterSchema.parse(this.requireMainFileFrontmatter());
+    return result;
+  }
+
+  getBody(): string {
+    return this.mainFile?.body ?? "";
+  }
+
+  validate(): ValidationResult {
+    if (!this.mainFile) {
+      return {
+        success: false,
+        error: new Error(`${this.getDirPath()}: ${SKILL_FILE_NAME} file does not exist`),
+      };
+    }
+
+    const result = AiassistantSkillFrontmatterSchema.safeParse(this.mainFile.frontmatter);
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(
+          `Invalid frontmatter in ${this.getDirPath()}: ${formatError(result.error)}`,
+        ),
+      };
+    }
+
+    return { success: true, error: null };
+  }
+
+  toRulesyncSkill(): RulesyncSkill {
+    const frontmatter = this.getFrontmatter();
+    const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
+      name: frontmatter.name,
+      description: frontmatter.description,
+      targets: ["*"],
+    };
+
+    return new RulesyncSkill({
+      outputRoot: this.outputRoot,
+      relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+      dirName: this.getDirName(),
+      frontmatter: rulesyncFrontmatter,
+      body: this.getBody(),
+      otherFiles: this.getOtherFiles(),
+      validate: true,
+      global: this.global,
+    });
+  }
+
+  static fromRulesyncSkill({
+    outputRoot = process.cwd(),
+    rulesyncSkill,
+    validate = true,
+    global = false,
+  }: ToolSkillFromRulesyncSkillParams): AiassistantSkill {
+    const settablePaths = AiassistantSkill.getSettablePaths({ global });
+    const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+
+    const aiassistantFrontmatter: AiassistantSkillFrontmatter = {
+      name: rulesyncFrontmatter.name,
+      description: rulesyncFrontmatter.description,
+    };
+
+    return new AiassistantSkill({
+      outputRoot,
+      relativeDirPath: settablePaths.relativeDirPath,
+      dirName: rulesyncSkill.getDirName(),
+      frontmatter: aiassistantFrontmatter,
+      body: rulesyncSkill.getBody(),
+      otherFiles: rulesyncSkill.getOtherFiles(),
+      validate,
+      global,
+    });
+  }
+
+  static isTargetedByRulesyncSkill(rulesyncSkill: RulesyncSkill): boolean {
+    const targets = rulesyncSkill.getFrontmatter().targets;
+    return targets.includes("*") || targets.includes("aiassistant");
+  }
+
+  static async fromDir(params: ToolSkillFromDirParams): Promise<AiassistantSkill> {
+    const loaded = await this.loadSkillDirContent({
+      ...params,
+      getSettablePaths: AiassistantSkill.getSettablePaths,
+    });
+
+    const result = AiassistantSkillFrontmatterSchema.safeParse(loaded.frontmatter);
+    if (!result.success) {
+      const skillDirPath = join(loaded.outputRoot, loaded.relativeDirPath, loaded.dirName);
+      throw new Error(
+        `Invalid frontmatter in ${join(skillDirPath, SKILL_FILE_NAME)}: ${formatError(result.error)}`,
+      );
+    }
+
+    return new AiassistantSkill({
+      outputRoot: loaded.outputRoot,
+      relativeDirPath: loaded.relativeDirPath,
+      dirName: loaded.dirName,
+      frontmatter: result.data,
+      body: loaded.body,
+      otherFiles: loaded.otherFiles,
+      validate: true,
+      global: loaded.global,
+    });
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    dirName,
+    global = false,
+  }: ToolSkillForDeletionParams): AiassistantSkill {
+    const settablePaths = AiassistantSkill.getSettablePaths({ global });
+    return new AiassistantSkill({
+      outputRoot,
+      relativeDirPath: relativeDirPath ?? settablePaths.relativeDirPath,
+      dirName,
+      frontmatter: { name: "", description: "" },
+      body: "",
+      otherFiles: [],
+      validate: false,
+      global,
+    });
+  }
+}

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -854,6 +854,7 @@ Content that would fail parsing`;
       expect(new Set(targets)).toEqual(
         new Set([
           "agentsskills",
+          "aiassistant",
           "amp",
           "antigravity",
           "antigravity-cli",
@@ -897,6 +898,7 @@ Content that would fail parsing`;
         new Set([
           "agentsmd",
           "agentsskills",
+          "aiassistant",
           "amp",
           "antigravity",
           "antigravity-cli",
@@ -939,6 +941,7 @@ Content that would fail parsing`;
       expect(new Set(targets)).toEqual(
         new Set([
           "agentsskills",
+          "aiassistant",
           "amp",
           "antigravity",
           "antigravity-cli",

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -13,6 +13,7 @@ import { directoryExists, findFilesByGlobs } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { AgentsmdSkill } from "./agentsmd-skill.js";
 import { AgentsSkillsSkill } from "./agentsskills-skill.js";
+import { AiassistantSkill } from "./aiassistant-skill.js";
 import { AmpSkill } from "./amp-skill.js";
 import { AntigravityCliSkill } from "./antigravity-cli-skill.js";
 import { AntigravityIdeSkill } from "./antigravity-ide-skill.js";
@@ -109,6 +110,17 @@ export const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFa
       // location in addition to project `.agents/skills/`. https://agentskills.io/specification
       class: AgentsSkillsSkill,
       meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
+    },
+  ],
+  [
+    "aiassistant",
+    {
+      // JetBrains AI Assistant 2026.1 auto-discovers committable project skills
+      // from `.agents/skills/<name>/SKILL.md` (the Agent Skills standard). IDE-level
+      // skill storage is internal, so only the project scope is supported.
+      // https://www.jetbrains.com/help/ai-assistant/agent-skills.html
+      class: AiassistantSkill,
+      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: false },
     },
   ],
   [

--- a/src/types/tool-target-tuples.ts
+++ b/src/types/tool-target-tuples.ts
@@ -160,6 +160,7 @@ export const subagentsProcessorToolTargetTuple = [
 export const skillsProcessorToolTargetTuple = [
   "agentsmd",
   "agentsskills",
+  "aiassistant",
   "amp",
   "antigravity",
   "antigravity-cli",


### PR DESCRIPTION
## Summary

JetBrains AI Assistant **2026.1** added a Skill Manager / Skill Repository that auto-discovers project-level skills from the committable `.agents/skills/<name>/SKILL.md` directory (the open [Agent Skills standard](https://agentskills.io/specification), the same convention `agentsskills-skill.ts` already emits). rulesync's `aiassistant` target previously supported only `rules` and `ignore`, so `skills` was `unsupported`.

This PR adds an `AiassistantSkill` adapter and enables the `skills` feature for the `aiassistant` target.

## Changes

- **New adapter `src/features/skills/aiassistant-skill.ts`** — mirrors `junie-skill.ts` / `agentsskills-skill.ts` and writes project skills to `.agents/skills/<name>/SKILL.md`. **Project scope only**: AI Assistant stores user-level skills inside the IDE (not a committable path), so `getSettablePaths({ global: true })` throws, matching the project-only convention used by similar adapters (e.g. Copilot).
- **New constant `AIASSISTANT_SKILLS_DIR_PATH`** in `src/constants/aiassistant-paths.ts` (reuses the `.agents/skills` Agent Skills path).
- **Registration** — added `aiassistant` to `skillsProcessorToolTargetTuple` (`src/types/tool-target-tuples.ts`) and to the factory map in `skills-processor.ts` with `meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: false }`, so `getToolTargets` now reports `aiassistant` for skills.
- **Tests** — added `aiassistant-skill.test.ts` (constructor, `fromDir`, `fromRulesyncSkill`, `toRulesyncSkill`, `isTargetedByRulesyncSkill`, `forDeletion`, project-scope-only `getSettablePaths`), the `aiassistant` happy-path cases (generate, orphan-delete, import) in `e2e-skills.spec.ts`, and updated the target lists in `skills-processor.test.ts`.
- **Generated docs** — regenerated the Supported Tools matrix (`README.md`, `docs/reference/supported-tools.md`) via `pnpm run generate:tables` and synced `skills/rulesync/supported-tools.md`. The Skills column now shows ✅ (project) for JetBrains AI Assistant.

Gitignore needs no manual change: `.agents/skills/` is already derived/listed.

## Verification

`pnpm cicheck` is fully green (301 test files, 6962 tests passing; fmt, lint, typecheck, sync-skill-docs, gitignore, supported-tools, cspell, secretlint all pass).

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
