### PR TITLE
chore: release v8.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.31.0",
+  "version": "8.32.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.31.0";
+const getVersion = () => "8.32.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v8.32.0.

- Bump `getVersion()` in `src/cli/index.ts` to `8.32.0`
- Bump `package.json` version to `8.32.0`

See the draft release notes for the full list of changes:
https://github.com/dyoshikawa/rulesync/compare/v8.31.0...v8.32.0

## Highlights

- New tool/feature support: JetBrains AI Assistant, Hermes Agent, Reasonix MCP, Goose skills, and permissions/global-scope adapters across many tools (takt, grokcli, amp, factorydroid, augmentcode, kiro, opencode, copilot, warp, roo, vibe, cline, claudecode)
- Fixes: prototype-pollution hardening for MCP adapters, root-file ownership corrections, non-root rule folding for codexcli/pi, and more
