### PR TITLE
fix(goose): fold non-root rules into root .goosehints; document skills path decision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,7 +263,6 @@ rulesync.local.jsonc
 **/GEMINI.md
 **/.gemini/memories/
 **/.goosehints
-**/.goose/memories/
 **/.hermes.md
 **/.junie/AGENTS.md
 **/.junie/guidelines.md

--- a/src/constants/goose-paths.ts
+++ b/src/constants/goose-paths.ts
@@ -15,7 +15,16 @@ export const GOOSE_HOOKS_FILE_NAME = "hooks.json";
 // containing a SKILL.md with `name`+`description` frontmatter. rulesync emits
 // only this Goose-specific project path; Goose's portable global skills location
 // (`~/.agents/skills/`) is already served by the agentsskills target.
+//
+// Upstream now recommends `.agents/skills/` (project) and `~/.agents/skills/`
+// (global) as the standard, discovering `.goose/skills/` (and `.claude/skills/`)
+// only "for backward compatibility". We deliberately keep this legacy
+// project path: it is still discovered by current Goose, the recommended
+// `.agents/skills/` location is already the canonical Goose skill target via
+// `agentsskills`, and migrating the dedicated `goose` target would only
+// duplicate that output. See the agentsskills target for the recommended path.
 // @see https://block.github.io/goose/docs/mcp/skills-mcp/
+// @see https://block.github.io/goose/docs/guides/context-engineering/using-skills/
 export const GOOSE_SKILLS_DIR_PATH = join(GOOSE_DIR, "skills");
 
 // Recipes are reusable YAML workflow files. Goose discovers project recipes in

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -151,6 +151,45 @@ globs: ["src/**/*"]
     expect(await fileExists(join(testDir, ".agents", "memories", "detail.md"))).toBe(false);
   });
 
+  it("should fold goose non-root rules into the root .goosehints", async () => {
+    const testDir = getTestDir();
+
+    const rootRuleContent = `---
+root: true
+targets: ["goose"]
+description: "Root rule"
+globs: ["**/*"]
+---
+
+# Goose Root Rule
+`;
+    const nonRootRuleContent = `---
+targets: ["goose"]
+description: "Detail rule"
+globs: ["src/**/*"]
+---
+
+# Goose Detail Rule
+`;
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+      rootRuleContent,
+    );
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "detail.md"),
+      nonRootRuleContent,
+    );
+
+    await runGenerate({ target: "goose", features: "rules" });
+
+    // Both bodies land in the single root .goosehints; the inert
+    // .goose/memories tree (which Goose never loads as context) is not emitted.
+    const rootContent = await readFileContent(join(testDir, ".goosehints"));
+    expect(rootContent).toContain("Goose Root Rule");
+    expect(rootContent).toContain("Goose Detail Rule");
+    expect(await fileExists(join(testDir, ".goose", "memories", "detail.md"))).toBe(false);
+  });
+
   it("should generate qwencode non-root rules into .qwen/rules with paths frontmatter", async () => {
     const testDir = getTestDir();
 

--- a/src/features/rules/goose-rule.test.ts
+++ b/src/features/rules/goose-rule.test.ts
@@ -28,16 +28,16 @@ describe("GooseRule", () => {
   describe("constructor", () => {
     it("should create a GooseRule with basic parameters", () => {
       const params: GooseRuleParams = {
-        relativeDirPath: ".goose",
-        relativeFilePath: "test-rule.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Test Goose Rule\n\nThis is a test goose rule.",
       };
 
       const gooseRule = new GooseRule(params);
 
       expect(gooseRule).toBeInstanceOf(GooseRule);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose");
-      expect(gooseRule.getRelativeFilePath()).toBe("test-rule.md");
+      expect(gooseRule.getRelativeDirPath()).toBe(".");
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
       expect(gooseRule.getFileContent()).toBe("# Test Goose Rule\n\nThis is a test goose rule.");
       expect(gooseRule.isRoot()).toBe(false);
     });
@@ -56,23 +56,10 @@ describe("GooseRule", () => {
       expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
     });
 
-    it("should create a GooseRule with root parameter set to false", () => {
-      const params: GooseRuleParams = {
-        relativeDirPath: ".goose/memories",
-        relativeFilePath: "memory.md",
-        fileContent: "# Memory Rule\n\nThis is a memory rule.",
-        root: false,
-      };
-
-      const gooseRule = new GooseRule(params);
-
-      expect(gooseRule.isRoot()).toBe(false);
-    });
-
     it("should default root to false when not provided", () => {
       const params: GooseRuleParams = {
-        relativeDirPath: ".goose",
-        relativeFilePath: "test.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Test\n\nContent",
       };
 
@@ -84,21 +71,21 @@ describe("GooseRule", () => {
     it("should create a GooseRule with custom outputRoot", () => {
       const params: GooseRuleParams = {
         outputRoot: "/custom/path",
-        relativeDirPath: ".goose",
-        relativeFilePath: "custom.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Custom Rule",
       };
 
       const gooseRule = new GooseRule(params);
 
-      expect(gooseRule.getFilePath()).toBe("/custom/path/.goose/custom.md");
+      expect(gooseRule.getFilePath()).toBe("/custom/path/.goosehints");
     });
 
     it("should pass all parameters to parent ToolRule", () => {
       const params: GooseRuleParams = {
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
-        relativeFilePath: "test.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Test Content",
         validate: false,
         root: true,
@@ -107,8 +94,8 @@ describe("GooseRule", () => {
       const gooseRule = new GooseRule(params);
 
       expect(gooseRule.getOutputRoot()).toBe(testDir);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
-      expect(gooseRule.getRelativeFilePath()).toBe("test.md");
+      expect(gooseRule.getRelativeDirPath()).toBe(".");
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
       expect(gooseRule.getFileContent()).toBe("# Test Content");
       expect(gooseRule.isRoot()).toBe(true);
     });
@@ -131,22 +118,19 @@ describe("GooseRule", () => {
       expect(gooseRule.getFilePath()).toBe(join(testDir, ".goosehints"));
     });
 
-    it("should create GooseRule from memory file in .goose/memories", async () => {
-      const memoryContent = "# Memory File\n\nThis is a memory file.";
-      const memoriesDir = join(testDir, ".goose/memories");
-      await ensureDir(memoriesDir);
-      await writeFileContent(join(memoriesDir, "test-memory.md"), memoryContent);
+    it("should always read the root .goosehints regardless of the requested file", async () => {
+      const gooseContent = "# Root Goose Hints";
+      await writeFileContent(join(testDir, ".goosehints"), gooseContent);
 
       const gooseRule = await GooseRule.fromFile({
         outputRoot: testDir,
-        relativeFilePath: "test-memory.md",
+        relativeFilePath: "memory.md",
       });
 
-      expect(gooseRule.isRoot()).toBe(false);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
-      expect(gooseRule.getRelativeFilePath()).toBe("test-memory.md");
-      expect(gooseRule.getFileContent()).toBe(memoryContent);
-      expect(gooseRule.getFilePath()).toBe(join(testDir, ".goose/memories/test-memory.md"));
+      expect(gooseRule.isRoot()).toBe(true);
+      expect(gooseRule.getRelativeDirPath()).toBe(".");
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
+      expect(gooseRule.getFileContent()).toBe(gooseContent);
     });
 
     it("should use default outputRoot (process.cwd()) when not provided", async () => {
@@ -174,11 +158,11 @@ describe("GooseRule", () => {
       expect(gooseRule).toBeInstanceOf(GooseRule);
     });
 
-    it("should throw error when file does not exist", async () => {
+    it("should throw error when root file does not exist", async () => {
       await expect(
         GooseRule.fromFile({
           outputRoot: testDir,
-          relativeFilePath: "nonexistent.md",
+          relativeFilePath: ".goosehints",
         }),
       ).rejects.toThrow();
     });
@@ -196,6 +180,23 @@ describe("GooseRule", () => {
       expect(gooseRule.isRoot()).toBe(true);
       expect(gooseRule.getRelativeDirPath()).toBe(join(".config", "goose"));
       expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
+    });
+
+    it("should read the global root .goosehints regardless of the requested file", async () => {
+      const globalDir = join(testDir, ".config", "goose");
+      await ensureDir(globalDir);
+      const gooseContent = "# Global Goose Hints";
+      await writeFileContent(join(globalDir, ".goosehints"), gooseContent);
+
+      const gooseRule = await GooseRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "memory.md",
+        global: true,
+      });
+
+      expect(gooseRule.isRoot()).toBe(true);
+      expect(gooseRule.getRelativeDirPath()).toBe(join(".config", "goose"));
+      expect(gooseRule.getFileContent()).toBe(gooseContent);
     });
   });
 
@@ -225,13 +226,13 @@ describe("GooseRule", () => {
       expect(gooseRule.isRoot()).toBe(true);
     });
 
-    it("should create GooseRule from RulesyncRule for memory file", () => {
+    it("should write a non-root rule to the root .goosehints (folded)", () => {
       const frontmatter: RulesyncRuleFrontmatterInput = {
         description: "Test memory rule",
       };
 
       const rulesyncRule = new RulesyncRule({
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "memory.md",
         frontmatter,
         body: "# Memory Rule\n\nMemory content",
@@ -242,11 +243,14 @@ describe("GooseRule", () => {
         rulesyncRule,
       });
 
+      // Non-root rules share the root path so the RulesProcessor folds their
+      // bodies into the single .goosehints.
       expect(gooseRule).toBeInstanceOf(GooseRule);
       expect(gooseRule.getOutputRoot()).toBe(testDir);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
-      expect(gooseRule.getRelativeFilePath()).toBe("memory.md");
+      expect(gooseRule.getRelativeDirPath()).toBe(".");
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
       expect(gooseRule.isRoot()).toBe(false);
+      expect(gooseRule.getFileContent()).toBe("# Memory Rule\n\nMemory content");
     });
 
     it("should use default outputRoot (process.cwd()) when not provided", () => {
@@ -312,14 +316,37 @@ describe("GooseRule", () => {
       expect(gooseRule).toBeInstanceOf(GooseRule);
       expect(gooseRule.isRoot()).toBe(true);
       expect(gooseRule.getRelativeDirPath()).toBe(join(".config", "goose"));
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
+    });
+
+    it("should write a non-root rule to the global root path (folded)", () => {
+      const frontmatter: RulesyncRuleFrontmatterInput = {
+        description: "Global memory rule",
+      };
+
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "memory.md",
+        frontmatter,
+        body: "# Memory",
+      });
+
+      const gooseRule = GooseRule.fromRulesyncRule({
+        outputRoot: testDir,
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(gooseRule.getRelativeDirPath()).toBe(join(".config", "goose"));
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
     });
   });
 
   describe("toRulesyncRule", () => {
-    it("should convert GooseRule to RulesyncRule", () => {
+    it("should convert non-root GooseRule to RulesyncRule", () => {
       const gooseRule = new GooseRule({
-        relativeDirPath: ".goose/memories",
-        relativeFilePath: "test.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Test Rule\n\nTest content",
       });
 
@@ -327,7 +354,6 @@ describe("GooseRule", () => {
 
       expect(rulesyncRule).toBeInstanceOf(RulesyncRule);
       expect(rulesyncRule.getRelativeDirPath()).toBe(RULESYNC_RULES_RELATIVE_DIR_PATH);
-      expect(rulesyncRule.getRelativeFilePath()).toBe("test.md");
       expect(rulesyncRule.getBody()).toBe("# Test Rule\n\nTest content");
     });
 
@@ -351,8 +377,8 @@ describe("GooseRule", () => {
   describe("validate", () => {
     it("should always return success true", () => {
       const gooseRule = new GooseRule({
-        relativeDirPath: ".goose",
-        relativeFilePath: "test.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Test",
       });
 
@@ -364,8 +390,8 @@ describe("GooseRule", () => {
 
     it("should return success true even with empty content", () => {
       const gooseRule = new GooseRule({
-        relativeDirPath: ".goose",
-        relativeFilePath: "empty.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "",
       });
 
@@ -390,38 +416,8 @@ describe("GooseRule", () => {
     });
   });
 
-  describe("file path handling", () => {
-    it("should correctly identify .goosehints as root file in fromFile", async () => {
-      const content = "# Root File";
-      await writeFileContent(join(testDir, ".goosehints"), content);
-
-      const gooseRule = await GooseRule.fromFile({
-        outputRoot: testDir,
-        relativeFilePath: ".goosehints",
-      });
-
-      expect(gooseRule.isRoot()).toBe(true);
-      expect(gooseRule.getRelativeDirPath()).toBe(".");
-    });
-
-    it("should correctly handle non-root files in fromFile", async () => {
-      const content = "# Memory File";
-      const memoriesDir = join(testDir, ".goose/memories");
-      await ensureDir(memoriesDir);
-      await writeFileContent(join(memoriesDir, "memory.md"), content);
-
-      const gooseRule = await GooseRule.fromFile({
-        outputRoot: testDir,
-        relativeFilePath: "memory.md",
-      });
-
-      expect(gooseRule.isRoot()).toBe(false);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose/memories");
-    });
-  });
-
   describe("getSettablePaths", () => {
-    it("should return correct paths for root and nonRoot", () => {
+    it("should return a root-only project path (non-root folds into root)", () => {
       const paths = GooseRule.getSettablePaths();
 
       expect(paths.root).toEqual({
@@ -429,9 +425,7 @@ describe("GooseRule", () => {
         relativeFilePath: ".goosehints",
       });
 
-      expect(paths.nonRoot).toEqual({
-        relativeDirPath: ".goose/memories",
-      });
+      expect(paths.nonRoot).toBeUndefined();
     });
 
     it("should return correct paths for global mode", () => {
@@ -443,16 +437,6 @@ describe("GooseRule", () => {
       });
 
       expect(paths.nonRoot).toBeUndefined();
-    });
-
-    it("should have consistent paths structure", () => {
-      const paths = GooseRule.getSettablePaths();
-
-      expect(paths).toHaveProperty("root");
-      expect(paths).toHaveProperty("nonRoot");
-      expect(paths.root).toHaveProperty("relativeDirPath");
-      expect(paths.root).toHaveProperty("relativeFilePath");
-      expect(paths.nonRoot).toHaveProperty("relativeDirPath");
     });
   });
 
@@ -469,7 +453,7 @@ describe("GooseRule", () => {
       expect(gooseRule.getFileContent()).toBe("");
     });
 
-    it("should create a GooseRule for deletion of non-root file", () => {
+    it("should create a non-root deletion stub when path does not match root", () => {
       const gooseRule = GooseRule.forDeletion({
         outputRoot: testDir,
         relativeDirPath: ".goose/memories",
@@ -486,7 +470,7 @@ describe("GooseRule", () => {
     it("should return true for rules targeting goose", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
           targets: ["goose"],
@@ -500,7 +484,7 @@ describe("GooseRule", () => {
     it("should return true for rules targeting all tools (*)", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
           targets: ["*"],
@@ -514,7 +498,7 @@ describe("GooseRule", () => {
     it("should return false for rules not targeting goose", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
           targets: ["cursor", "copilot"],
@@ -528,7 +512,7 @@ describe("GooseRule", () => {
     it("should return false for empty targets", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
           targets: [],
@@ -542,7 +526,7 @@ describe("GooseRule", () => {
     it("should handle mixed targets including goose", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {
           targets: ["cursor", "goose", "copilot"],
@@ -556,7 +540,7 @@ describe("GooseRule", () => {
     it("should handle undefined targets in frontmatter", () => {
       const rulesyncRule = new RulesyncRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose/memories",
+        relativeDirPath: ".rulesync/rules",
         relativeFilePath: "test.md",
         frontmatter: {},
         body: "Test content",
@@ -570,16 +554,16 @@ describe("GooseRule", () => {
     it("should inherit all ToolRule functionality", () => {
       const gooseRule = new GooseRule({
         outputRoot: testDir,
-        relativeDirPath: ".goose",
-        relativeFilePath: "integration.md",
+        relativeDirPath: ".",
+        relativeFilePath: ".goosehints",
         fileContent: "# Integration Test",
       });
 
       expect(gooseRule.getOutputRoot()).toBe(testDir);
-      expect(gooseRule.getRelativeDirPath()).toBe(".goose");
-      expect(gooseRule.getRelativeFilePath()).toBe("integration.md");
+      expect(gooseRule.getRelativeDirPath()).toBe(".");
+      expect(gooseRule.getRelativeFilePath()).toBe(".goosehints");
       expect(gooseRule.getFileContent()).toBe("# Integration Test");
-      expect(gooseRule.getFilePath()).toBe(join(testDir, ".goose/integration.md"));
+      expect(gooseRule.getFilePath()).toBe(join(testDir, ".goosehints"));
     });
   });
 });

--- a/src/features/rules/goose-rule.ts
+++ b/src/features/rules/goose-rule.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { GOOSE_DIR, GOOSE_GLOBAL_DIR, GOOSE_RULE_FILE_NAME } from "../../constants/goose-paths.js";
+import { GOOSE_GLOBAL_DIR, GOOSE_RULE_FILE_NAME } from "../../constants/goose-paths.js";
 import { readFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
@@ -9,30 +9,43 @@ import {
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
-  ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
-  buildToolPath,
 } from "./tool-rule.js";
 
 export type GooseRuleParams = ToolRuleParams;
 
-export type GooseRuleSettablePaths = ToolRuleSettablePaths & {
+export type GooseRuleSettablePaths = {
   root: {
     relativeDirPath: string;
     relativeFilePath: string;
   };
+  nonRoot?: undefined;
 };
 
 export type GooseRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
 
 /**
- * Represents a rule file for Goose
- * Goose uses plain markdown files (.goosehints) without frontmatter
+ * Represents a rule file for Goose.
+ *
+ * Goose loads instruction context only from the `.goosehints` / `AGENTS.md`
+ * family (the configured `CONTEXT_FILE_NAMES`), discovered by walking from the
+ * working directory up to the repository root plus any nested directories Goose
+ * touches during a session. The separate `.goose/memories/` tree is the Memory
+ * extension's storage and is NOT auto-loaded as session context.
+ * (Verified against the official docs:
+ * https://block.github.io/goose/docs/guides/context-engineering/using-goosehints/)
+ *
+ * rulesync's topic-based non-root rules have no project subdirectory to map onto,
+ * so writing them under `.goose/memories/` made them effectively invisible to
+ * Goose. Their bodies are instead folded into the single root `.goosehints` by
+ * the RulesProcessor (there is no separate non-root output location — `nonRoot`
+ * is `undefined`). This mirrors the grokcli, warp, and deepagents targets.
+ *
+ * Goose uses plain markdown files (.goosehints) without frontmatter.
  */
 export class GooseRule extends ToolRule {
   static getSettablePaths({
     global,
-    excludeToolDir,
   }: {
     global?: boolean;
     excludeToolDir?: boolean;
@@ -50,50 +63,27 @@ export class GooseRule extends ToolRule {
         relativeDirPath: ".",
         relativeFilePath: GOOSE_RULE_FILE_NAME,
       },
-      nonRoot: {
-        relativeDirPath: buildToolPath(GOOSE_DIR, "memories", excludeToolDir),
-      },
     };
   }
 
   static async fromFile({
     outputRoot = process.cwd(),
-    relativeFilePath,
+    relativeFilePath: _relativeFilePath,
     validate = true,
     global = false,
   }: ToolRuleFromFileParams): Promise<GooseRule> {
     const paths = this.getSettablePaths({ global });
-    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+    const fileContent = await readFileContent(
+      join(outputRoot, paths.root.relativeDirPath, paths.root.relativeFilePath),
+    );
 
-    if (isRoot) {
-      const relativePath = paths.root.relativeFilePath;
-      const fileContent = await readFileContent(
-        join(outputRoot, paths.root.relativeDirPath, relativePath),
-      );
-
-      return new GooseRule({
-        outputRoot,
-        relativeDirPath: paths.root.relativeDirPath,
-        relativeFilePath: paths.root.relativeFilePath,
-        fileContent,
-        validate,
-        root: true,
-      });
-    }
-
-    if (!paths.nonRoot) {
-      throw new Error(`nonRoot path is not set for ${relativeFilePath}`);
-    }
-
-    const relativePath = join(paths.nonRoot.relativeDirPath, relativeFilePath);
-    const fileContent = await readFileContent(join(outputRoot, relativePath));
     return new GooseRule({
       outputRoot,
-      relativeDirPath: paths.nonRoot.relativeDirPath,
-      relativeFilePath,
+      relativeDirPath: paths.root.relativeDirPath,
+      relativeFilePath: paths.root.relativeFilePath,
       fileContent,
       validate,
-      root: false,
+      root: true,
     });
   }
 
@@ -104,15 +94,16 @@ export class GooseRule extends ToolRule {
     global = false,
   }: ToolRuleFromRulesyncRuleParams): GooseRule {
     const paths = this.getSettablePaths({ global });
-    return new GooseRule(
-      this.buildToolRuleParamsDefault({
-        outputRoot,
-        rulesyncRule,
-        validate,
-        rootPath: paths.root,
-        nonRootPath: paths.nonRoot,
-      }),
-    );
+    const isRoot = rulesyncRule.getFrontmatter().root ?? false;
+
+    return new GooseRule({
+      outputRoot,
+      relativeDirPath: paths.root.relativeDirPath,
+      relativeFilePath: paths.root.relativeFilePath,
+      fileContent: rulesyncRule.getBody(),
+      validate,
+      root: isRoot,
+    });
   }
 
   toRulesyncRule(): RulesyncRule {
@@ -132,7 +123,9 @@ export class GooseRule extends ToolRule {
     global = false,
   }: ToolRuleForDeletionParams): GooseRule {
     const paths = this.getSettablePaths({ global });
-    const isRoot = relativeFilePath === paths.root.relativeFilePath;
+    const isRoot =
+      relativeFilePath === paths.root.relativeFilePath &&
+      (relativeDirPath === "." || relativeDirPath === paths.root.relativeDirPath);
 
     return new GooseRule({
       outputRoot,

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -480,11 +480,18 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
   [
     "goose",
     {
+      // Goose reads the `.goosehints` / `AGENTS.md` instruction-file family
+      // natively (working dir up to the repo root plus nested directories it
+      // touches) but never the `.goose/memories/` tree, which belongs to the
+      // separate Memory extension and is not auto-loaded as session context.
+      // Non-root rules are therefore folded into the single root `.goosehints`
+      // below (same handling as grokcli / warp / deepagents).
       class: GooseRule,
       meta: {
         extension: "md",
         supportsGlobal: true,
-        ruleDiscoveryMode: "toon",
+        ruleDiscoveryMode: "auto",
+        foldsNonRootIntoRoot: true,
       },
     },
   ],


### PR DESCRIPTION
## Summary

Resolves the two Goose surface divergences reported in #2038. Each was verified against the current code and the cited upstream docs before changing behavior.

## Finding 1 (primary, fixed): non-root rules written to an inert directory

rulesync routed detail/scoped (non-root) Goose rules to `.goose/memories/*.md`. Per Goose's hints doc, session context is loaded only from the `.goosehints` / `AGENTS.md` family (the configured `CONTEXT_FILE_NAMES`) — discovered from the working directory up to the repo root plus nested directories Goose touches. `.goose/memories/` is the separate Memory extension's storage and is **not** auto-loaded as context, so those non-root rules were effectively invisible to Goose.

**Fix:** Switch the goose rules target to the fold-into-root pattern already used by `grokcli` / `warp` / `deepagents`. The `nonRoot` settable path is removed, and the convention now uses `ruleDiscoveryMode: "auto"` + `foldsNonRootIntoRoot: true`, so every non-root rule body is merged into the single root `.goosehints` that Goose actually reads. Root-rule behavior is unchanged.

I chose folding over emitting nested `.goosehints` files because rulesync's topic-based non-root rules have no project subdirectory to map onto (they are not subproject rules), so there is no nested directory for Goose's hierarchical loader to pick them up from. Folding guarantees the content is loaded, mirrors the existing handling for analogous AGENTS.md-family tools, and avoids a large architectural change. This matches the established precedent comment on the grokcli target.

- `src/features/rules/goose-rule.ts`: `getSettablePaths` is now root-only (`nonRoot: undefined`); `fromFile` / `fromRulesyncRule` / `forDeletion` updated accordingly, with a doc comment citing the loader behavior.
- `src/features/rules/rules-processor.ts`: goose meta switched to `auto` + `foldsNonRootIntoRoot`.
- Updated `goose-rule.test.ts` and added a goose fold happy-path case to `src/e2e/e2e-rules.spec.ts`.
- Regenerated `.gitignore` (drops the now-unemitted `**/.goose/memories/`).

## Finding 2 (low severity): skills emit the legacy `.goose/skills/` path

Upstream now recommends `.agents/skills/` (project) and `~/.agents/skills/` (global), discovering `.goose/skills/` only for backward compatibility. rulesync's `goose` skill target writes the legacy `.goose/skills/` and throws on `--global` (delegating global to `agentsskills`).

**Decision: left as-is (the smaller, safer change).** The legacy path is still discovered by current Goose, the recommended `.agents/skills/` location is already the canonical Goose skill target via `agentsskills`, and migrating the dedicated `goose` target would only duplicate that output for no functional gain. The rationale is now documented in `src/constants/goose-paths.ts` so users land on the recommended location via `agentsskills`.

## Verification

`pnpm cicheck` is green: fmt, oxlint, typecheck, 6947 unit tests, sync-skill-docs, gitignore, supported-tools, cspell, and secretlint all pass. Goose rules e2e (root + global + fold) pass.

Closes #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)
