### PR TITLE
docs(release-dry-run): prefer MAJOR bump on feature removal or behavior change

### DIFF
--- a/.rulesync/skills/release-dry-run/SKILL.md
+++ b/.rulesync/skills/release-dry-run/SKILL.md
@@ -51,6 +51,8 @@ This is a dry run command for release. It will summarize the changes since the l
      - Internal refactoring without API changes
      - Dependency updates (unless they cause breaking changes)
 
+   **Important**: Whenever the changes include any feature removal or a change in the behavior of an existing feature, do not hesitate to choose a MAJOR version bump. Prioritize protecting users from unexpected breakage over keeping the version number low.
+
 5. Output the final recommendation in the following format:
 
    ```


### PR DESCRIPTION
## Summary

Add explicit guidance to the `release-dry-run` skill so that it chooses a **MAJOR** version bump without hesitation whenever the changes include a feature removal or a behavior change of an existing feature. This prioritizes protecting users from unexpected breakage over keeping the version number low.

## Changes

- Updated `.rulesync/skills/release-dry-run/SKILL.md` to add an `Important` note under the version bump rules.
- Regenerated tool outputs via rulesync (gitignored, not tracked).

## Test plan

- `pnpm cicheck:content` passes.
- Pre-commit hook (`pnpm dev generate`, secretlint) passes.