### PR TITLE
chore: release v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "8.32.0",
+  "version": "9.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "8.32.0";
+const getVersion = () => "9.0.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v9.0.0.

### Breaking Changes
- Remove deprecated features: `baseDirs`, the object form of `features`, the `antigravity` alias target, and the `geminicli` tool target (#2052)

### Bug Fixes
- fix(goose): fold non-root rules into root `.goosehints` instead of inert `.goose/memories` (#2049)

### Documentation
- docs(release-dry-run): prefer MAJOR bump on feature removal or behavior change (#2050)

## Changes
- Bump `getVersion()` in `src/cli/index.ts` to 9.0.0
- Bump `package.json` version to 9.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)