### PR TITLE
refactor(rules): tidy GooseRule paths type and drop dead excludeToolDir

### DIFF
--- a/src/features/rules/goose-rule.ts
+++ b/src/features/rules/goose-rule.ts
@@ -9,12 +9,13 @@ import {
   ToolRuleFromFileParams,
   ToolRuleFromRulesyncRuleParams,
   ToolRuleParams,
+  ToolRuleSettablePaths,
   ToolRuleSettablePathsGlobal,
 } from "./tool-rule.js";
 
 export type GooseRuleParams = ToolRuleParams;
 
-export type GooseRuleSettablePaths = {
+export type GooseRuleSettablePaths = Pick<ToolRuleSettablePaths, "root"> & {
   root: {
     relativeDirPath: string;
     relativeFilePath: string;
@@ -48,7 +49,6 @@ export class GooseRule extends ToolRule {
     global,
   }: {
     global?: boolean;
-    excludeToolDir?: boolean;
   } = {}): GooseRuleSettablePaths | GooseRuleSettablePathsGlobal {
     if (global) {
       return {


### PR DESCRIPTION
## Background

Follow-up to the PR #2049 review, which switched the goose rules target to the fold-into-root pattern. Three low-severity, non-blocking findings were captured in #2051. This PR resolves the two concrete refactoring findings (Findings 2 and 3).

## Changes

- **Finding 2** — Define `GooseRuleSettablePaths` via `Pick<ToolRuleSettablePaths, "root">`, matching the `grokcli` precedent it documents itself as mirroring, so future refactors of `ToolRuleSettablePaths` propagate consistently.
- **Finding 3** — Drop the now-dead `excludeToolDir` option from `GooseRule.getSettablePaths`. Goose folds non-root rules into the root `.goosehints` and no longer calls `buildToolPath`, so the parameter was unused.

## On Finding 1 (stale `.goose/memories` migration footgun)

Intentionally not addressed here. The issue itself concluded this is "acceptable and consistent with precedent" — `grokcli`/`warp`/`deepagents` share the exact same behavior and none clean their legacy memories dirs. A cross-tool cleanup mechanism would be a separate design decision, out of scope for this cosmetic cleanup.

## Verification

`pnpm cicheck` passes (6546 tests, lint, typecheck, content checks).

Closes #2051