### PR TITLE
chore: use pnpm dlx instead of npx for ccstatusline statusline command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "npx -y ccstatusline@latest",
+    "command": "pnpm dlx ccstatusline@latest",
     "padding": 0
   },
   "env": {


### PR DESCRIPTION
## Summary

Switch the Claude Code status line command in `.claude/settings.json` from `npx -y ccstatusline@latest` to `pnpm dlx ccstatusline@latest`.

This keeps the tooling consistent with the project's package manager (pnpm), avoiding mixing `npx` with the pnpm-managed environment.

## Test plan

- `pnpm cicheck` passes (code style, type safety, tests, content checks).