### PR TITLE
Release v9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.0.0";
+const getVersion = () => "9.0.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v9.0.1

This PR bumps the version to 9.0.1 in preparation for the release.

## Changes since v9.0.0

All changes are internal chores and refactoring with no user-facing behavior changes.

- chore: resolve all knip findings (#2058)
- chore: migrate from tsup to tsdown and drop ignoreDeprecations (#2057)
- chore: use pnpm dlx instead of npx for ccstatusline statusline command (#2056)
- refactor(rules): align GooseRuleSettablePaths with grokcli and drop unused excludeToolDir (#2054)

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v9.0.0...v9.0.1