### PR TITLE
fix: align security scan with @openrouter/sdk request shape

### DIFF
--- a/scripts/security-scan-lib.test.ts
+++ b/scripts/security-scan-lib.test.ts
@@ -460,6 +460,17 @@ describe("runSecurityScan", () => {
 
     expect(result).toEqual(scanResult);
     expect(mockClient.chat.send).toHaveBeenCalledOnce();
+    // Lock in the OpenRouter SDK request shape (chatRequest/appTitle), which
+    // the SDK validates at call time and silently breaks the scan if wrong.
+    const sendArg = vi.mocked(mockClient.chat.send).mock.calls[0]?.[0];
+    expect(sendArg).toMatchObject({
+      chatRequest: {
+        model: "test-model",
+        messages: [{ role: "user", content: "analyze this\n\nsome code" }],
+        stream: false,
+      },
+      appTitle: "rulesync security-scan",
+    });
   });
 
   it("should throw when no content returned", async () => {

--- a/scripts/security-scan-lib.ts
+++ b/scripts/security-scan-lib.ts
@@ -94,7 +94,7 @@ export const runSecurityScan = async ({
   prompt: string;
 }): Promise<SecurityScanResult> => {
   const response = await client.chat.send({
-    chatGenerationParams: {
+    chatRequest: {
       model,
       messages: [{ role: "user", content: `${prompt}\n\n${scanContent}` }],
       responseFormat: {
@@ -108,7 +108,7 @@ export const runSecurityScan = async ({
       stream: false as const,
     },
     httpReferer: "https://github.com/dyoshikawa/rulesync",
-    xTitle: "rulesync security-scan",
+    appTitle: "rulesync security-scan",
   });
 
   const content = response.choices?.[0]?.message?.content;
@@ -163,13 +163,13 @@ export const generateOverallSummary = async ({
   const input = buildSummaryInput({ results });
 
   const response = await client.chat.send({
-    chatGenerationParams: {
+    chatRequest: {
       model,
       messages: [{ role: "user", content: `${OVERALL_SUMMARY_PROMPT}\n\n${input}` }],
       stream: false as const,
     },
     httpReferer: "https://github.com/dyoshikawa/rulesync",
-    xTitle: "rulesync security-scan",
+    appTitle: "rulesync security-scan",
   });
 
   const content = response.choices?.[0]?.message?.content;


### PR DESCRIPTION
## Summary

The scheduled Security Scan workflow ([failing run](https://github.com/dyoshikawa/rulesync/actions/runs/28215330012)) failed for every variant with:

```
SDKValidationError: Input validation failed: [
  { "expected": "object", "code": "invalid_type", "path": ["chatRequest"],
    "message": "Invalid input: expected object, received undefined" }
]
```

`@openrouter/sdk` (0.13.7) expects `chat.send` to receive the request body under `chatRequest` and the app display name under `appTitle`, but the code still passed the older `chatGenerationParams` / `xTitle` field names, so the SDK rejected every call and the scan aborted with "All scans failed".

## Changes
- Rename the `chat.send` request fields in `scripts/security-scan-lib.ts` to match the SDK: `chatGenerationParams` -> `chatRequest`, `xTitle` -> `appTitle` (both the scan and the overall-summary calls).
- Assert the request shape in `runSecurityScan` tests so a future field-name drift fails fast instead of only at runtime.

## Test plan
- `pnpm cicheck` passes (lint, typecheck, tests, content checks).