### PR TITLE
release: v9.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.0.1";
+const getVersion = () => "9.0.2";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v9.0.2.

## What's Changed

### Bug Fixes
- Align the security scan with the `@openrouter/sdk` request shape (#2062)

### Maintenance
- Switch the security scan output from TOON to repomix XML (#2060)
- Switch the publish-assets workflow from TOON to repomix XML
- Bump the all-actions group with 4 updates (#2063)

## Full Changelog
https://github.com/dyoshikawa/rulesync/compare/v9.0.1...v9.0.2