### PR TITLE
fix(hermesagent): emit hooks under Hermes's native VALID_HOOKS event keys

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
     "isinstance",
     "kwargs",
     "pathlib",
+    "shlex",
     "subagent",
     "subagents",
     "toolsets",

--- a/src/e2e/e2e-hooks.spec.ts
+++ b/src/e2e/e2e-hooks.spec.ts
@@ -636,16 +636,21 @@ describe("E2E: hooks (global mode)", () => {
     const projectDir = getProjectDir();
     const homeDir = getHomeDir();
 
-    // Hermes Agent has no project-scoped hooks location; hooks are merged under
-    // the `hooks.rulesync` key of the shared global ~/.hermes/config.yaml (YAML,
-    // global only).
+    // Hermes Agent has no project-scoped hooks location; hooks are merged into
+    // the shared global ~/.hermes/config.yaml (YAML, global only) under
+    // Hermes's real `VALID_HOOKS` event keys — NOT a `hooks.rulesync` blob,
+    // which Hermes would silently ignore.
     const hooksContent = JSON.stringify(
       {
         version: 1,
         root: true,
         hooks: {
           sessionStart: [{ type: "command", command: ".rulesync/hooks/session-start.sh" }],
-          stop: [{ command: ".rulesync/hooks/audit.sh" }],
+          preToolUse: [
+            { type: "command", command: ".rulesync/hooks/audit.sh", matcher: "terminal" },
+          ],
+          // Not part of Hermes's VALID_HOOKS mapping table — must be dropped.
+          worktreeCreate: [{ command: ".rulesync/hooks/wt.sh" }],
         },
       },
       null,
@@ -660,11 +665,15 @@ describe("E2E: hooks (global mode)", () => {
       env: { HOME_DIR: homeDir },
     });
 
-    // The config is YAML; assert the canonical hook command paths survive
-    // generation under the nested `hooks.rulesync` block.
+    // The config is YAML; assert the canonical hooks survive generation under
+    // Hermes's real, functioning event keys.
     const generatedContent = await readFileContent(join(homeDir, ".hermes", "config.yaml"));
-    expect(generatedContent).toContain("rulesync");
+    expect(generatedContent).not.toContain("rulesync:");
+    expect(generatedContent).toContain("on_session_start");
+    expect(generatedContent).toContain("pre_tool_call");
     expect(generatedContent).toContain(".rulesync/hooks/session-start.sh");
     expect(generatedContent).toContain(".rulesync/hooks/audit.sh");
+    expect(generatedContent).toContain("matcher: terminal");
+    expect(generatedContent).not.toContain(".rulesync/hooks/wt.sh");
   });
 });

--- a/src/features/hooks/hermesagent-hooks.test.ts
+++ b/src/features/hooks/hermesagent-hooks.test.ts
@@ -1,50 +1,342 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { parseHermesConfig } from "../hermes-config.js";
 import { HermesagentHooks } from "./hermesagent-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 
+const logger = createMockLogger();
+
+function rulesyncHooksFrom(config: Record<string, unknown>): RulesyncHooks {
+  return new RulesyncHooks({
+    relativeDirPath: ".rulesync",
+    relativeFilePath: "hooks.json",
+    fileContent: JSON.stringify(config),
+    validate: false,
+  });
+}
+
 describe("HermesagentHooks", () => {
-  it("preserves existing Hermes config when writing hooks", async () => {
-    const rulesyncHooks = new RulesyncHooks({
-      relativeDirPath: ".rulesync",
-      relativeFilePath: "hooks.json",
-      fileContent: JSON.stringify({
+  describe("getSettablePaths", () => {
+    it("returns the shared global config.yaml path", () => {
+      expect(HermesagentHooks.getSettablePaths()).toEqual({
+        relativeDirPath: ".hermes",
+        relativeFilePath: "config.yaml",
+      });
+    });
+  });
+
+  describe("fromRulesyncHooks", () => {
+    it("maps preToolUse/postToolUse to pre_tool_call/post_tool_call with matcher", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
         hooks: {
-          preToolUse: {
-            command: "pnpm lint",
+          preToolUse: [{ type: "command", command: "guard.sh", matcher: "terminal" }],
+          postToolUse: [{ type: "command", command: "format.sh" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "guard.sh", matcher: "terminal" }],
+        post_tool_call: [{ command: "format.sh" }],
+      });
+    });
+
+    it("maps sessionStart/sessionEnd to on_session_start/on_session_end", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          sessionStart: [{ command: "init.sh" }],
+          sessionEnd: [{ command: "cleanup.sh" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        on_session_start: [{ command: "init.sh" }],
+        on_session_end: [{ command: "cleanup.sh" }],
+      });
+    });
+
+    it("maps preModelInvocation/postModelInvocation to pre_llm_call/post_llm_call", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preModelInvocation: [{ command: "inject-context.sh" }],
+          postModelInvocation: [{ command: "sync.sh" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_llm_call: [{ command: "inject-context.sh" }],
+        post_llm_call: [{ command: "sync.sh" }],
+      });
+    });
+
+    it("maps subagentStart/subagentStop to subagent_start/subagent_stop", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          subagentStart: [{ command: "log-start.sh" }],
+          subagentStop: [{ command: "log-stop.sh" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        subagent_start: [{ command: "log-start.sh" }],
+        subagent_stop: [{ command: "log-stop.sh" }],
+      });
+    });
+
+    it("passes through timeout", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preToolUse: [{ command: "guard.sh", timeout: 5 }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "guard.sh", timeout: 5 }],
+      });
+    });
+
+    it("drops events with no native Hermes equivalent", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preToolUse: [{ command: "guard.sh" }],
+          // Not part of Hermes's VALID_HOOKS mapping table.
+          stop: [{ command: "audit.sh" }],
+          worktreeCreate: [{ command: "wt.sh" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "guard.sh" }],
+      });
+    });
+
+    it("drops prompt/http hook types (only type: command is supported)", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", command: "guard.sh" },
+            { type: "prompt", prompt: "Should I proceed?" },
+            { type: "http", url: "https://example.com/hook" },
+          ],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "guard.sh" }],
+      });
+    });
+
+    it("drops matcher (with a warning) on events other than pre_tool_call/post_tool_call", async () => {
+      const warnSpy = vi.spyOn(logger, "warn");
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          sessionStart: [{ command: "init.sh", matcher: "ignored" }],
+        },
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+        logger,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        on_session_start: [{ command: "init.sh" }],
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('matcher "ignored" on "sessionStart" hook will be ignored'),
+      );
+    });
+
+    it("merges the hermesagent override block on top of shared hooks", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preToolUse: [{ command: "shared.sh" }],
+        },
+        hermesagent: {
+          hooks: {
+            preToolUse: [{ command: "hermes-override.sh" }],
+            postToolUse: [{ command: "post.sh" }],
           },
         },
-      }),
+      });
+
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "hermes-override.sh" }],
+        post_tool_call: [{ command: "post.sh" }],
+      });
     });
 
-    const hooks = await HermesagentHooks.fromRulesyncHooks({
-      outputRoot: ".",
-      rulesyncHooks,
-    });
+    it("preserves existing Hermes config when writing hooks", async () => {
+      const rulesyncHooks = rulesyncHooksFrom({
+        version: 1,
+        hooks: {
+          preToolUse: [{ command: "pnpm lint" }],
+        },
+      });
 
-    hooks.setFileContent(`model: hermes-3
+      const hooks = await HermesagentHooks.fromRulesyncHooks({
+        outputRoot: ".",
+        rulesyncHooks,
+      });
+
+      hooks.setFileContent(`model: hermes-3
 mcp_servers:
   docs:
     url: https://example.com/mcp
 hooks:
-  rulesync:
-    stale: true
+  pre_tool_call:
+    - command: stale.sh
 `);
 
-    const config = parseHermesConfig(hooks.getFileContent());
-    expect(config.model).toBe("hermes-3");
-    expect(config.mcp_servers).toEqual({
-      docs: { url: "https://example.com/mcp" },
+      const config = parseHermesConfig(hooks.getFileContent());
+      expect(config.model).toBe("hermes-3");
+      expect(config.mcp_servers).toEqual({
+        docs: { url: "https://example.com/mcp" },
+      });
+      // The freshly computed hooks block replaces the stale on-disk hooks,
+      // the same way HermesagentPermissions/HermesagentMcp recompute their
+      // managed keys from canonical rulesync state on every generation.
+      expect(config.hooks).toEqual({
+        pre_tool_call: [{ command: "pnpm lint" }],
+      });
     });
-    expect(config.hooks).toEqual({
-      rulesync: {
-        hooks: {
-          preToolUse: {
-            command: "pnpm lint",
-          },
-        },
-      },
+  });
+
+  describe("toRulesyncHooks", () => {
+    it("round-trips native VALID_HOOKS event keys back to canonical event names", () => {
+      const hooks = new HermesagentHooks({
+        outputRoot: ".",
+        fileContent: `hooks:
+  pre_tool_call:
+    - command: guard.sh
+      matcher: terminal
+  post_tool_call:
+    - command: format.sh
+  pre_llm_call:
+    - command: inject.sh
+  post_llm_call:
+    - command: sync.sh
+  on_session_start:
+    - command: init.sh
+  on_session_end:
+    - command: cleanup.sh
+  subagent_start:
+    - command: log-start.sh
+  subagent_stop:
+    - command: log-stop.sh
+`,
+      });
+
+      const json = hooks.toRulesyncHooks().getJson();
+      expect(json.hooks.preToolUse).toEqual([
+        { type: "command", command: "guard.sh", matcher: "terminal" },
+      ]);
+      expect(json.hooks.postToolUse).toEqual([{ type: "command", command: "format.sh" }]);
+      expect(json.hooks.preModelInvocation).toEqual([{ type: "command", command: "inject.sh" }]);
+      expect(json.hooks.postModelInvocation).toEqual([{ type: "command", command: "sync.sh" }]);
+      expect(json.hooks.sessionStart).toEqual([{ type: "command", command: "init.sh" }]);
+      expect(json.hooks.sessionEnd).toEqual([{ type: "command", command: "cleanup.sh" }]);
+      expect(json.hooks.subagentStart).toEqual([{ type: "command", command: "log-start.sh" }]);
+      expect(json.hooks.subagentStop).toEqual([{ type: "command", command: "log-stop.sh" }]);
+    });
+
+    it("drops native events with no canonical equivalent (pre_verify, transform_*, ...)", () => {
+      const hooks = new HermesagentHooks({
+        outputRoot: ".",
+        fileContent: `hooks:
+  pre_tool_call:
+    - command: guard.sh
+  pre_verify:
+    - command: verify.sh
+  transform_tool_result:
+    - command: redact.sh
+`,
+      });
+
+      const json = hooks.toRulesyncHooks().getJson();
+      expect(json.hooks.preToolUse).toEqual([{ type: "command", command: "guard.sh" }]);
+      expect(json.hooks.pre_verify).toBeUndefined();
+      expect(json.hooks.transform_tool_result).toBeUndefined();
+      expect(Object.keys(json.hooks)).toEqual(["preToolUse"]);
+    });
+
+    it("returns an empty canonical hooks map when no hooks key is present", () => {
+      const hooks = new HermesagentHooks({
+        outputRoot: ".",
+        fileContent: "model: hermes-3\n",
+      });
+
+      const json = hooks.toRulesyncHooks().getJson();
+      expect(json.hooks).toEqual({});
+    });
+  });
+
+  describe("isDeletable", () => {
+    it("returns false because config.yaml is shared with other Hermes settings", () => {
+      const hooks = new HermesagentHooks({
+        outputRoot: ".",
+        fileContent: "hooks: {}\n",
+      });
+      expect(hooks.isDeletable()).toBe(false);
     });
   });
 });

--- a/src/features/hooks/hermesagent-hooks.ts
+++ b/src/features/hooks/hermesagent-hooks.ts
@@ -3,12 +3,184 @@ import {
   HERMESAGENT_GLOBAL_DIR,
 } from "../../constants/hermesagent-paths.js";
 import { type AiFileParams, ValidationResult } from "../../types/ai-file.js";
+import {
+  CANONICAL_TO_HERMESAGENT_EVENT_NAMES,
+  HERMESAGENT_HOOK_EVENTS,
+  HERMESAGENT_TO_CANONICAL_EVENT_NAMES,
+  type HookDefinition,
+  type HooksConfig,
+} from "../../types/hooks.js";
+import type { Logger } from "../../utils/logger.js";
+import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
 import { mergeHermesConfig, parseHermesConfig, stringifyHermesConfig } from "../hermes-config.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 import { ToolHooks, type ToolHooksFromRulesyncHooksParams } from "./tool-hooks.js";
 
 type HermesagentHooksParams = Omit<AiFileParams, "relativeDirPath" | "relativeFilePath">;
 
+/** One serialized entry of a Hermes `hooks.<event>` array. */
+type HermesHookEntry = {
+  command: string;
+  matcher?: string;
+  timeout?: number;
+};
+
+/**
+ * Canonical events that map to a Hermes tool-call event (`pre_tool_call` /
+ * `post_tool_call`) and therefore carry a `matcher`. Every other supported
+ * canonical event maps to a Hermes lifecycle event, which never accepts a
+ * `matcher`.
+ * @see https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md
+ */
+const HERMESAGENT_MATCHER_EVENTS: ReadonlySet<string> = new Set(["preToolUse", "postToolUse"]);
+
+/**
+ * Filter the shared canonical hooks to the events Hermes understands and merge
+ * the `hermesagent`-specific override block on top.
+ */
+function buildEffectiveHooks(
+  config: HooksConfig,
+  toolOverrideHooks: HooksConfig["hooks"] | undefined,
+): HooksConfig["hooks"] {
+  const supported: Set<string> = new Set(HERMESAGENT_HOOK_EVENTS);
+  const shared: HooksConfig["hooks"] = {};
+  for (const [event, defs] of Object.entries(config.hooks)) {
+    if (supported.has(event)) {
+      shared[event] = defs;
+    }
+  }
+  return { ...shared, ...toolOverrideHooks };
+}
+
+/**
+ * Convert the canonical hooks config into Hermes's native
+ * `hooks: { <event>: [{ matcher?, command, timeout? }] }` shape.
+ *
+ * Only `type: "command"` canonical hooks are emitted — Hermes shell hooks run
+ * via `shlex.split`/`shell=False`, so `prompt`/`http` hooks have no native
+ * equivalent and are skipped (the shared `HooksProcessor` already warns about
+ * unsupported hook types centrally). `matcher` is only carried through for
+ * `pre_tool_call`/`post_tool_call`; on any other event it is dropped with a
+ * warning, mirroring how other adapters (e.g. AugmentCode) handle
+ * matcher-less lifecycle events.
+ */
+function canonicalToHermesHooks({
+  config,
+  toolOverrideHooks,
+  logger,
+}: {
+  config: HooksConfig;
+  toolOverrideHooks: HooksConfig["hooks"] | undefined;
+  logger?: Logger;
+}): Record<string, HermesHookEntry[]> {
+  const effectiveHooks = buildEffectiveHooks(config, toolOverrideHooks);
+  const result: Record<string, HermesHookEntry[]> = {};
+
+  for (const [canonicalEvent, defs] of Object.entries(effectiveHooks)) {
+    const nativeEvent = CANONICAL_TO_HERMESAGENT_EVENT_NAMES[canonicalEvent];
+    if (!nativeEvent) {
+      continue;
+    }
+
+    const supportsMatcher = HERMESAGENT_MATCHER_EVENTS.has(canonicalEvent);
+    const entries: HermesHookEntry[] = [];
+    for (const def of defs) {
+      const hookType = def.type ?? "command";
+      if (hookType !== "command") {
+        continue;
+      }
+      if (typeof def.command !== "string" || def.command === "") {
+        continue;
+      }
+
+      const entry: HermesHookEntry = { command: def.command };
+      if (typeof def.matcher === "string" && def.matcher !== "") {
+        if (supportsMatcher) {
+          entry.matcher = def.matcher;
+        } else {
+          logger?.warn(
+            `matcher "${def.matcher}" on "${canonicalEvent}" hook will be ignored — Hermes Agent only supports matchers on pre_tool_call/post_tool_call`,
+          );
+        }
+      }
+      if (typeof def.timeout === "number") {
+        entry.timeout = def.timeout;
+      }
+      entries.push(entry);
+    }
+
+    if (entries.length > 0) {
+      result[nativeEvent] = entries;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Reverse {@link canonicalToHermesHooks}: parse Hermes's native
+ * `hooks: { <event>: [...] }` map back into a canonical event → definition[]
+ * record. Native events with no canonical equivalent (`pre_verify`,
+ * `transform_tool_result`, ...) are skipped since there is nothing to round
+ * -trip them into.
+ */
+function hermesHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
+  const canonical: HooksConfig["hooks"] = {};
+  if (hooks === null || typeof hooks !== "object" || Array.isArray(hooks)) {
+    return canonical;
+  }
+
+  for (const [nativeEvent, entries] of Object.entries(hooks as Record<string, unknown>)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(nativeEvent) || !Array.isArray(entries)) {
+      continue;
+    }
+    const canonicalEvent = HERMESAGENT_TO_CANONICAL_EVENT_NAMES[nativeEvent];
+    if (!canonicalEvent) {
+      continue;
+    }
+
+    const defs: HookDefinition[] = [];
+    for (const raw of entries) {
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+        continue;
+      }
+      const entry = raw as Record<string, unknown>;
+      if (typeof entry.command !== "string") {
+        continue;
+      }
+      const def: HookDefinition = { type: "command", command: entry.command };
+      if (typeof entry.matcher === "string" && entry.matcher !== "") {
+        def.matcher = entry.matcher;
+      }
+      if (typeof entry.timeout === "number") {
+        def.timeout = entry.timeout;
+      }
+      defs.push(def);
+    }
+
+    if (defs.length > 0) {
+      canonical[canonicalEvent] = defs;
+    }
+  }
+
+  return canonical;
+}
+
+/**
+ * Hermes Agent shell hooks.
+ *
+ * Hermes Agent registers shell-command hooks under the `hooks:` key of the
+ * shared user config file `~/.hermes/config.yaml` (the HERMES_HOME directory;
+ * global only — Hermes has no project-scoped hooks location). Hermes only runs
+ * hooks declared under its fixed `VALID_HOOKS` event keys (`pre_tool_call`,
+ * `post_tool_call`, `pre_llm_call`, `post_llm_call`, `on_session_start`,
+ * `on_session_end`, `subagent_start`, `subagent_stop`, ...); any other key is
+ * silently ignored. Generation therefore maps canonical events onto the real
+ * `VALID_HOOKS` keys and merges the resulting `hooks:` block into the existing
+ * config instead of overwriting it, since that file also holds other Hermes
+ * settings (model, `mcp_servers`, `command_allowlist`, ...).
+ * @see https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md
+ */
 export class HermesagentHooks extends ToolHooks {
   static getSettablePaths() {
     return {
@@ -28,6 +200,13 @@ export class HermesagentHooks extends ToolHooks {
     return { success: true, error: null };
   }
 
+  override isDeletable(): boolean {
+    // config.yaml holds other Hermes settings (model, mcp_servers,
+    // command_allowlist, ...), so it must never be removed wholesale; clearing
+    // hooks happens via an in-place merge instead.
+    return false;
+  }
+
   shouldMergeExistingFileContent(): boolean {
     return true;
   }
@@ -38,27 +217,28 @@ export class HermesagentHooks extends ToolHooks {
 
   toRulesyncHooks(): RulesyncHooks {
     const config = parseHermesConfig(this.getFileContent());
-    const hooks =
-      config.hooks && typeof config.hooks === "object"
-        ? (config.hooks as Record<string, unknown>).rulesync
-        : {};
-    return new RulesyncHooks({
-      relativeDirPath: "",
-      relativeFilePath: ".rulesync/hooks.json",
-      fileContent: JSON.stringify(hooks ?? {}, null, 2),
+    const hooks = hermesHooksToCanonical(config.hooks);
+    return this.toRulesyncHooksDefault({
+      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
     });
   }
 
   static fromRulesyncHooks({
     outputRoot,
     rulesyncHooks,
-  }: ToolHooksFromRulesyncHooksParams): HermesagentHooks {
+    logger,
+  }: ToolHooksFromRulesyncHooksParams & { logger?: Logger }): HermesagentHooks {
+    const config = rulesyncHooks.getJson();
+    const hermesHooks = canonicalToHermesHooks({
+      config,
+      toolOverrideHooks: config.hermesagent?.hooks,
+      logger,
+    });
+
     return new HermesagentHooks({
       outputRoot,
       fileContent: stringifyHermesConfig({
-        hooks: {
-          rulesync: rulesyncHooks.getJson(),
-        },
+        hooks: hermesHooks,
       }),
     });
   }

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -14,6 +14,7 @@ import {
   DEVIN_HOOK_EVENTS,
   FACTORYDROID_HOOK_EVENTS,
   GOOSE_HOOK_EVENTS,
+  HERMESAGENT_HOOK_EVENTS,
   JUNIE_HOOK_EVENTS,
   KILO_HOOK_EVENTS,
   KIRO_HOOK_EVENTS,
@@ -283,8 +284,14 @@ export const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFac
     {
       class: HermesagentHooks,
       meta: { supportsProject: false, supportsGlobal: true, supportsImport: true },
-      supportedEvents: CLAUDE_HOOK_EVENTS,
-      supportedHookTypes: ["command", "prompt", "http"],
+      // Hermes validates hooks against a fixed `VALID_HOOKS` event set and only
+      // runs shell commands (shlex.split, shell=False) — `prompt`/`http` hooks
+      // and unmapped canonical events have no native equivalent.
+      // https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md
+      supportedEvents: HERMESAGENT_HOOK_EVENTS,
+      supportedHookTypes: ["command"],
+      // `matcher` is only valid on pre_tool_call/post_tool_call; the adapter
+      // itself drops it (with a warning) on the other supported events.
       supportsMatcher: true,
     },
   ],

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -492,6 +492,55 @@ export const QWENCODE_HOOK_EVENTS: readonly HookEvent[] = [
   "todoCompleted",
 ];
 
+/**
+ * Hook events supported by Hermes Agent's native Shell Hooks system.
+ *
+ * Hermes validates hook events against a fixed `VALID_HOOKS` set:
+ * `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
+ * `pre_verify`, `on_session_start`, `on_session_end`, `on_session_finalize`,
+ * `on_session_reset`, `subagent_start`, `subagent_stop`, `pre_gateway_dispatch`,
+ * `pre_approval_request`, `post_approval_response`, `transform_tool_result`,
+ * `transform_terminal_output`, `transform_llm_output`. Only the events with a
+ * clean 1:1 canonical equivalent are mapped here; the remaining `VALID_HOOKS`
+ * entries (`pre_verify`, `on_session_finalize`, `on_session_reset`,
+ * `pre_gateway_dispatch`, `pre_approval_request`, `post_approval_response`, the
+ * `transform_*` result-rewriting hooks) have no canonical rulesync equivalent,
+ * so no canonical event maps to them.
+ * @see https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md
+ */
+export const HERMESAGENT_HOOK_EVENTS: readonly HookEvent[] = [
+  "sessionStart",
+  "sessionEnd",
+  "preToolUse",
+  "postToolUse",
+  "preModelInvocation",
+  "postModelInvocation",
+  "subagentStart",
+  "subagentStop",
+];
+
+/**
+ * Map canonical camelCase event names to Hermes Agent's native `VALID_HOOKS`
+ * snake_case keys under the `hooks:` block of `~/.hermes/config.yaml`.
+ */
+export const CANONICAL_TO_HERMESAGENT_EVENT_NAMES: Record<string, string> = {
+  sessionStart: "on_session_start",
+  sessionEnd: "on_session_end",
+  preToolUse: "pre_tool_call",
+  postToolUse: "post_tool_call",
+  preModelInvocation: "pre_llm_call",
+  postModelInvocation: "post_llm_call",
+  subagentStart: "subagent_start",
+  subagentStop: "subagent_stop",
+};
+
+/**
+ * Map Hermes Agent's native `VALID_HOOKS` keys back to canonical camelCase.
+ */
+export const HERMESAGENT_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_HERMESAGENT_EVENT_NAMES).map(([k, v]) => [v, k]),
+);
+
 const hooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema));
 
 /**
@@ -517,6 +566,7 @@ export const HooksConfigSchema = z.looseObject({
   augmentcode: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   "antigravity-ide": z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   "antigravity-cli": z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
+  hermesagent: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   junie: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   vibe: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   qwencode: z.optional(


### PR DESCRIPTION
## Summary

**Bug fix** for #2036. `hermesagent-hooks.ts` was previously shipped writing the canonical hooks JSON verbatim under an INVALID key (`hooks: { rulesync: <canonical JSON> } }`). Hermes Agent only recognizes hooks registered under its fixed `VALID_HOOKS` event keys, so `rulesync` is not one of them — Hermes silently ignored the entire block and generated hooks NEVER fired. This is a functional-no-op bug in previously-merged code.

## Root cause \& fix
Fetched the primary source (raw hooks.md from NousResearch/hermes-agent) directly rather than trusting a stale issue-comment event list (which contained a fabricated `pre_api_request`/`post_api_request` pair). Confirmed the real `VALID_HOOKS` set and entry shape (`{ matcher?, command, timeout? }`, `shlex.split`/`shell=False`, timeout default 60/cap 300).

### Event mapping (only documented 1:1 canonical matches; everything else intentionally left unmapped rather than guessed)
| Canonical | Hermes native |
|---|---|
| preToolUse | pre_tool_call |
| postToolUse | post_tool_call |
| preModelInvocation | pre_llm_call |
| postModelInvocation | post_llm_call |
| sessionStart | on_session_start |
| sessionEnd | on_session_end |
| subagentStart | subagent_start |
| subagentStop | subagent_stop |

- `matcher` emitted only on `pre_tool_call`/`post_tool_call` (dropped elsewhere with a warning).
- Only `type: "command"` hooks emitted — Hermes runs shlex-split commands with no shell, so `prompt`/`http` types are unsupported and dropped with a warning.
- Import (`toRulesyncHooks`) rewritten to round-trip from the real native keys instead of the old `hooks.rulesync` blob.
- Merged into the shared global `~/.hermes/config.yaml`, same pattern as `HermesagentMcp`/`HermesagentPermissions`.
- `hooks-processor.ts` factory entry corrected: was declaring `CLAUDE_HOOK_EVENTS` + `["command","prompt","http"]` (copy-paste artifact), now declares the real `HERMESAGENT_HOOK_EVENTS` + `["command"]`.

## Deferred (secondary, out of scope)
The issue also flagged a secondary rules/`nonRoot` gap (nested per-directory context files). Not implemented: Hermes's progressive per-directory loading only watches for `AGENTS.md`/`CLAUDE.md`/`.cursorrules` in subdirectories, not nested `.hermes.md`; wiring `nonRoot` as-is would repeat this exact bug pattern (write files Hermes never reads). Left for a follow-up design.

## Verification
`pnpm cicheck` fully green: 298 test files, 6639 tests. e2e hermesagent-hooks cases pass (7/7). One pre-existing unrelated e2e-convert.spec.ts failure verified present on unmodified main via git stash — not caused by this change.

## References
- https://raw.githubusercontent.com/NousResearch/hermes-agent/main/website/docs/user-guide/features/hooks.md

Closes #2036