### PR TITLE
fix(hooks): quote $CLAUDE_PROJECT_DIR-prefixed hook commands

### DIFF
--- a/src/e2e/e2e-hooks.spec.ts
+++ b/src/e2e/e2e-hooks.spec.ts
@@ -83,7 +83,7 @@ describe("E2E: hooks", () => {
         expect(parsed.hooks).toBeDefined();
         expect(parsed.hooks.SessionStart).toBeDefined();
         expect(parsed.hooks.Stop).toBeDefined();
-        expect(JSON.stringify(parsed.hooks)).toContain("$CLAUDE_PROJECT_DIR/");
+        expect(parsed.hooks.SessionStart[0].hooks[0].command).toContain('"$CLAUDE_PROJECT_DIR"/');
       } else if (target === "cursor") {
         // Cursor uses camelCase event names
         expect(parsed.hooks).toBeDefined();

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -204,7 +204,7 @@ describe("ClaudecodeHooks", () => {
       expect(sessionStartEntry.hooks[1].command).toBe("npx prettier --write ./src/hooks/format.ts");
     });
 
-    it("should quote the $CLAUDE_PROJECT_DIR-prefixed command so it survives word-splitting on project paths with spaces", async () => {
+    it("should quote only the $CLAUDE_PROJECT_DIR variable so it survives word-splitting on project paths with spaces", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
 
@@ -230,7 +230,37 @@ describe("ClaudecodeHooks", () => {
 
       const parsed = JSON.parse(claudecodeHooks.getFileContent());
       expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
-        '"$CLAUDE_PROJECT_DIR/.rulesync/hooks/session-start.sh"',
+        '"$CLAUDE_PROJECT_DIR"/.rulesync/hooks/session-start.sh',
+      );
+    });
+
+    it("should keep trailing arguments outside the quotes so they still split as separate words", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "./scripts/format.sh --fix --quiet" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
+        '"$CLAUDE_PROJECT_DIR"/scripts/format.sh --fix --quiet',
       );
     });
 
@@ -377,7 +407,7 @@ describe("ClaudecodeHooks", () => {
         fileContent: JSON.stringify({
           hooks: {
             SessionStart: [
-              { hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR/echo.sh"' }] },
+              { hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR"/echo.sh' }] },
             ],
           },
         }),
@@ -387,6 +417,33 @@ describe("ClaudecodeHooks", () => {
       const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
       const json = rulesyncHooks.getJson();
       expect(json.hooks.sessionStart?.[0]?.command).toBe("./echo.sh");
+    });
+
+    it("should strip the quoted $CLAUDE_PROJECT_DIR prefix while preserving trailing arguments", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: '"$CLAUDE_PROJECT_DIR"/scripts/format.sh --fix --quiet',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("./scripts/format.sh --fix --quiet");
     });
   });
 

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -204,6 +204,36 @@ describe("ClaudecodeHooks", () => {
       expect(sessionStartEntry.hooks[1].command).toBe("npx prettier --write ./src/hooks/format.ts");
     });
 
+    it("should quote the $CLAUDE_PROJECT_DIR-prefixed command so it survives word-splitting on project paths with spaces", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "./.rulesync/hooks/session-start.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
+        '"$CLAUDE_PROJECT_DIR/.rulesync/hooks/session-start.sh"',
+      );
+    });
+
     it("should merge config.claudecode.hooks on top of shared hooks", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
@@ -337,6 +367,26 @@ describe("ClaudecodeHooks", () => {
       expect(json.hooks.sessionStart).toHaveLength(1);
       expect(json.hooks.sessionStart?.[0]?.command).toContain("echo.sh");
       expect(json.hooks.stop).toHaveLength(1);
+    });
+
+    it("should strip the quoted $CLAUDE_PROJECT_DIR prefix back to a ./-relative command", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [
+              { hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR/echo.sh"' }] },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("./echo.sh");
     });
   });
 

--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -101,6 +101,37 @@ describe("FactorydroidHooks", () => {
       expect(sessionStartEntry.hooks[0].command).toContain(".rulesync/hooks/session-start.sh");
     });
 
+    it("should quote only the $FACTORY_PROJECT_DIR variable, keeping trailing arguments outside the quotes", async () => {
+      await ensureDir(join(testDir, ".factory"));
+      await writeFileContent(join(testDir, ".factory", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "./scripts/format.sh --fix --quiet" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = factorydroidHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(
+        '"$FACTORY_PROJECT_DIR"/scripts/format.sh --fix --quiet',
+      );
+    });
+
     it("should not prefix commands that already start with $", async () => {
       await ensureDir(join(testDir, ".factory"));
       await writeFileContent(join(testDir, ".factory", "settings.json"), JSON.stringify({}));
@@ -414,6 +445,33 @@ describe("FactorydroidHooks", () => {
       const rulesyncHooks = factorydroidHooks.toRulesyncHooks();
       const json = rulesyncHooks.getJson();
       expect(json.hooks.sessionStart?.[0]?.command).toBe("./.rulesync/hooks/start.sh");
+    });
+
+    it("should strip the quoted $FACTORY_PROJECT_DIR prefix while preserving trailing arguments", () => {
+      const factorydroidHooks = new FactorydroidHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".factory",
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: '"$FACTORY_PROJECT_DIR"/scripts/format.sh --fix --quiet',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = factorydroidHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("./scripts/format.sh --fix --quiet");
     });
 
     it("should preserve matcher from entries", () => {

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -99,7 +99,7 @@ function applyCommandPrefix({
     (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
 
   return shouldPrefix && typeof trimmedCommand === "string"
-    ? `${converterConfig.projectDirVar}/${trimmedCommand.replace(/^\.\//, "")}`
+    ? `"${converterConfig.projectDirVar}/${trimmedCommand.replace(/^\.\//, "")}"`
     : def.command;
 }
 
@@ -206,15 +206,16 @@ function stripCommandPrefix({
   converterConfig: ToolHooksConverterConfig;
 }): string | undefined {
   const cmd = typeof command === "string" ? command : undefined;
-  if (
-    converterConfig.projectDirVar !== "" &&
-    typeof cmd === "string" &&
-    cmd.includes(`${converterConfig.projectDirVar}/`)
-  ) {
-    return cmd.replace(
-      new RegExp(`^${converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/?`),
-      "./",
-    );
+  if (converterConfig.projectDirVar === "" || typeof cmd !== "string") {
+    return cmd;
+  }
+  const escapedVar = converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const quotedMatch = cmd.match(new RegExp(`^"${escapedVar}\\/(.*)"$`));
+  if (quotedMatch) {
+    return `./${quotedMatch[1]}`;
+  }
+  if (cmd.includes(`${converterConfig.projectDirVar}/`)) {
+    return cmd.replace(new RegExp(`^${escapedVar}\\/?`), "./");
   }
   return cmd;
 }

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -98,8 +98,11 @@ function applyCommandPrefix({
     !trimmedCommand.startsWith("$") &&
     (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
 
+  // Only the variable itself is quoted (not the whole command) so a project path
+  // containing a space can't be word-split by the shell, while any trailing
+  // arguments after the script path stay outside the quotes and still split normally.
   return shouldPrefix && typeof trimmedCommand === "string"
-    ? `"${converterConfig.projectDirVar}/${trimmedCommand.replace(/^\.\//, "")}"`
+    ? `"${converterConfig.projectDirVar}"/${trimmedCommand.replace(/^\.\//, "")}`
     : def.command;
 }
 
@@ -209,12 +212,12 @@ function stripCommandPrefix({
   if (converterConfig.projectDirVar === "" || typeof cmd !== "string") {
     return cmd;
   }
-  const escapedVar = converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const quotedMatch = cmd.match(new RegExp(`^"${escapedVar}\\/(.*)"$`));
-  if (quotedMatch) {
-    return `./${quotedMatch[1]}`;
+  const quotedPrefix = `"${converterConfig.projectDirVar}"/`;
+  if (cmd.startsWith(quotedPrefix)) {
+    return `./${cmd.slice(quotedPrefix.length)}`;
   }
   if (cmd.includes(`${converterConfig.projectDirVar}/`)) {
+    const escapedVar = converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     return cmd.replace(new RegExp(`^${escapedVar}\\/?`), "./");
   }
   return cmd;


### PR DESCRIPTION
## Summary
- Claude Code (and Factory Droid, which shares the same converter) execute hook commands via `/bin/sh -c "<command>"`. The `./` → `$CLAUDE_PROJECT_DIR/`-style rewrite emitted an unquoted substitution, so a project path containing a space gets word-split and the hook fails with `No such file or directory`.
- Wrap the generated `$CLAUDE_PROJECT_DIR/...` (and `$FACTORY_PROJECT_DIR/...`) substitution in double quotes at export time.
- Teach the import-side `stripCommandPrefix` to recognize both the new quoted form and the legacy unquoted form, so round-tripping existing generated files keeps working.
- Manually-authored override commands that already start with `$` are left untouched, as before.

## Test plan
- [x] `pnpm cicheck` (full lint/typecheck/test/docs/gitignore/schema/spelling/secrets suite) passes
- [x] Added a unit test asserting the exact quoted output for Claude Code
- [x] Added a unit test asserting the quoted form round-trips back to a `./`-relative command on import
- [x] Existing Claude Code / Factory Droid hook tests and the hooks E2E spec still pass

Closes #2097