### PR TITLE
refactor(generate): make the step graph directly testable and harden it

### DIFF
--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -12,7 +12,12 @@ import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
 import { createMockLogger } from "../test-utils/mock-logger.js";
 import { fileExists, readFileContentOrNull } from "../utils/file.js";
-import { checkRulesyncDirExists, generate, resolveExecutionOrder } from "./generate.js";
+import {
+  checkRulesyncDirExists,
+  generate,
+  GENERATION_STEP_GRAPH,
+  resolveExecutionOrder,
+} from "./generate.js";
 
 const logger = createMockLogger();
 
@@ -1146,5 +1151,49 @@ describe("resolveExecutionOrder", () => {
     expect(() =>
       resolveExecutionOrder([step("a", { dependsOn: ["b"] }), step("b", { dependsOn: ["a"] })]),
     ).toThrow(/cyclic/);
+  });
+});
+
+const asRunnableSteps = () =>
+  GENERATION_STEP_GRAPH.map(
+    (meta) => ({ ...meta, run: async () => ({ count: 0, paths: [], hasDiff: false }) }) as never,
+  );
+
+describe("GENERATION_STEP_GRAPH", () => {
+  it("is well-formed: every shared-file writer pair is ordered by dependsOn", () => {
+    expect(() => resolveExecutionOrder(asRunnableSteps())).not.toThrow();
+  });
+
+  it("declares every dependsOn edge for a reason: an overlapping writesSharedFile token, or the known rules->skills value dependency", () => {
+    const byId = new Map(GENERATION_STEP_GRAPH.map((meta) => [meta.id, meta]));
+    const knownValueDependencies = new Set(["rules->skills"]);
+
+    for (const step of GENERATION_STEP_GRAPH) {
+      for (const dep of step.dependsOn ?? []) {
+        const edgeKey = `${step.id}->${dep}`;
+        const depFiles = new Set(byId.get(dep)?.writesSharedFile ?? []);
+        const sharesFile = (step.writesSharedFile ?? []).some((file) => depFiles.has(file));
+
+        expect(
+          sharesFile || knownValueDependencies.has(edgeKey),
+          `dependsOn edge '${edgeKey}' has no overlapping writesSharedFile token and is not a ` +
+            `documented value dependency; either it's stale or the known-value-dependency list ` +
+            `needs updating`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("pins the full execution order of the real generation step graph", () => {
+    expect(resolveExecutionOrder(asRunnableSteps()).map((s) => s.id)).toEqual([
+      "ignore",
+      "commands",
+      "subagents",
+      "skills",
+      "mcp",
+      "hooks",
+      "permissions",
+      "rules",
+    ]);
   });
 });

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -1068,6 +1068,8 @@ describe("generate", () => {
   });
 });
 
+const stubRun = async () => ({ count: 0, paths: [], hasDiff: false });
+
 const executionStep = (
   id: string,
   opts: { writesSharedFile?: string[]; dependsOn?: string[] } = {},
@@ -1075,7 +1077,7 @@ const executionStep = (
   ({
     id,
     ...opts,
-    run: async () => ({ count: 0, paths: [], hasDiff: false }),
+    run: stubRun,
   }) as never;
 
 describe("resolveExecutionOrder", () => {
@@ -1155,9 +1157,7 @@ describe("resolveExecutionOrder", () => {
 });
 
 const asRunnableSteps = () =>
-  GENERATION_STEP_GRAPH.map(
-    (meta) => ({ ...meta, run: async () => ({ count: 0, paths: [], hasDiff: false }) }) as never,
-  );
+  GENERATION_STEP_GRAPH.map((meta) => ({ ...meta, run: stubRun }) as never);
 
 describe("GENERATION_STEP_GRAPH", () => {
   it("is well-formed: every shared-file writer pair is ordered by dependsOn", () => {

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -300,6 +300,89 @@ export function resolveExecutionOrder(steps: GenerationStep[]): GenerationStep[]
   return ordered;
 }
 
+type GenerationStepMeta = Omit<GenerationStep, "run">;
+
+/**
+ * The static shape of the generation step graph: which steps write which shared
+ * (read-modify-write) config files, and the `dependsOn` edges that fix a safe order
+ * for those writers. Exported (separately from the `run` closures, which need a
+ * live `config`/`logger`) so `resolveExecutionOrder`'s ordering guarantee can be
+ * tested directly against the real graph rather than a hand-copied one.
+ */
+export const GENERATION_STEP_GRAPH: GenerationStepMeta[] = [
+  {
+    id: "ignore",
+    writesSharedFile: ["claude-settings", "zed-settings"],
+  },
+  {
+    id: "mcp",
+    writesSharedFile: [
+      "kilo-opencode-config",
+      "zed-settings",
+      "qwencode-settings",
+      "augmentcode-settings",
+      "hermesagent-config",
+      "amp-settings",
+      "codexcli-config",
+      "grokcli-config",
+      "vibe-config",
+      "devin-config",
+      "reasonix-config",
+    ],
+    // Both ignore and mcp write zed-settings; ignore must run first so mcp's
+    // read-modify-write doesn't drop the ignore keys it wrote.
+    dependsOn: ["ignore"],
+  },
+  { id: "commands" },
+  { id: "subagents" },
+  { id: "skills" },
+  {
+    id: "hooks",
+    writesSharedFile: [
+      "claude-settings",
+      "qwencode-settings",
+      "augmentcode-settings",
+      "hermesagent-config",
+      "kiro-agent-config",
+      "codexcli-config",
+      "vibe-config",
+      "devin-config",
+    ],
+    // Shares claude-settings with ignore and several *-config files with mcp;
+    // both must run first so hooks' read-modify-write doesn't drop their keys.
+    dependsOn: ["ignore", "mcp"],
+  },
+  {
+    id: "permissions",
+    writesSharedFile: [
+      "claude-settings",
+      "kilo-opencode-config",
+      "zed-settings",
+      "qwencode-settings",
+      "augmentcode-settings",
+      "hermesagent-config",
+      "kiro-agent-config",
+      "amp-settings",
+      "codexcli-config",
+      "grokcli-config",
+      "vibe-config",
+      "devin-config",
+      "reasonix-config",
+    ],
+    // Shares claude-settings/zed-settings/kilo-opencode-config and several
+    // *-config files with ignore, hooks, and mcp; all three must run first.
+    dependsOn: ["ignore", "hooks", "mcp"],
+  },
+  {
+    id: "rules",
+    writesSharedFile: ["kilo-opencode-config"],
+    // Shares kilo-opencode-config with mcp and permissions (both must run first),
+    // and reads the skills list the skills step produces (a value dependency,
+    // not a shared-file one).
+    dependsOn: ["mcp", "skills", "permissions"],
+  },
+];
+
 /**
  * Generate configuration files for AI tools.
  * @throws Error if generation fails
@@ -313,81 +396,24 @@ export async function generate(params: {
   // Captured by the skills step so the rules step can read the generated skills.
   let skillsResult: Awaited<ReturnType<typeof generateSkillsCore>> | undefined;
 
-  const steps: GenerationStep[] = [
-    {
-      id: "ignore",
-      writesSharedFile: ["claude-settings", "zed-settings"],
-      run: () => generateIgnoreCore({ config, logger }),
+  const runners: Record<GenerationStepId, () => Promise<FeatureGenerateResult>> = {
+    ignore: () => generateIgnoreCore({ config, logger }),
+    mcp: () => generateMcpCore({ config, logger }),
+    commands: () => generateCommandsCore({ config, logger }),
+    subagents: () => generateSubagentsCore({ config, logger }),
+    skills: async () => {
+      skillsResult = await generateSkillsCore({ config, logger });
+      return skillsResult;
     },
-    {
-      id: "mcp",
-      writesSharedFile: [
-        "kilo-opencode-config",
-        "zed-settings",
-        "qwencode-settings",
-        "augmentcode-settings",
-        "hermesagent-config",
-        "amp-settings",
-        "codexcli-config",
-        "grokcli-config",
-        "vibe-config",
-        "devin-config",
-        "reasonix-config",
-      ],
-      dependsOn: ["ignore"],
-      run: () => generateMcpCore({ config, logger }),
-    },
-    { id: "commands", run: () => generateCommandsCore({ config, logger }) },
-    { id: "subagents", run: () => generateSubagentsCore({ config, logger }) },
-    {
-      id: "skills",
-      run: async () => {
-        skillsResult = await generateSkillsCore({ config, logger });
-        return skillsResult;
-      },
-    },
-    {
-      id: "hooks",
-      writesSharedFile: [
-        "claude-settings",
-        "qwencode-settings",
-        "augmentcode-settings",
-        "hermesagent-config",
-        "kiro-agent-config",
-        "codexcli-config",
-        "vibe-config",
-        "devin-config",
-      ],
-      dependsOn: ["ignore", "mcp"],
-      run: () => generateHooksCore({ config, logger }),
-    },
-    {
-      id: "permissions",
-      writesSharedFile: [
-        "claude-settings",
-        "kilo-opencode-config",
-        "zed-settings",
-        "qwencode-settings",
-        "augmentcode-settings",
-        "hermesagent-config",
-        "kiro-agent-config",
-        "amp-settings",
-        "codexcli-config",
-        "grokcli-config",
-        "vibe-config",
-        "devin-config",
-        "reasonix-config",
-      ],
-      dependsOn: ["ignore", "hooks", "mcp"],
-      run: () => generatePermissionsCore({ config, logger }),
-    },
-    {
-      id: "rules",
-      writesSharedFile: ["kilo-opencode-config"],
-      dependsOn: ["mcp", "skills", "permissions"],
-      run: () => generateRulesCore({ config, logger, skills: skillsResult?.skills }),
-    },
-  ];
+    hooks: () => generateHooksCore({ config, logger }),
+    permissions: () => generatePermissionsCore({ config, logger }),
+    rules: () => generateRulesCore({ config, logger, skills: skillsResult?.skills }),
+  };
+
+  const steps: GenerationStep[] = GENERATION_STEP_GRAPH.map((meta) => ({
+    ...meta,
+    run: runners[meta.id],
+  }));
 
   const orderedSteps = resolveExecutionOrder(steps);
 

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -201,9 +201,9 @@ type GenerationStepId =
 type GenerationStep = {
   id: GenerationStepId;
   /** Tokens for on-disk files this step read-modify-writes and shares with other steps. */
-  writesSharedFile?: string[];
+  writesSharedFile?: readonly string[];
   /** Step ids that must run before this one (they write a shared file this step then reads). */
-  dependsOn?: GenerationStepId[];
+  dependsOn?: readonly GenerationStepId[];
   run: () => Promise<FeatureGenerateResult>;
 };
 
@@ -300,16 +300,18 @@ export function resolveExecutionOrder(steps: GenerationStep[]): GenerationStep[]
   return ordered;
 }
 
-type GenerationStepMeta = Omit<GenerationStep, "run">;
+type GenerationStepMeta = Readonly<Omit<GenerationStep, "run">>;
 
 /**
  * The static shape of the generation step graph: which steps write which shared
  * (read-modify-write) config files, and the `dependsOn` edges that fix a safe order
  * for those writers. Exported (separately from the `run` closures, which need a
  * live `config`/`logger`) so `resolveExecutionOrder`'s ordering guarantee can be
- * tested directly against the real graph rather than a hand-copied one.
+ * tested directly against the real graph rather than a hand-copied one. Readonly
+ * so a consumer can't mutate this module-level singleton and affect every
+ * subsequent `generate()` call in the process.
  */
-export const GENERATION_STEP_GRAPH: GenerationStepMeta[] = [
+export const GENERATION_STEP_GRAPH: readonly GenerationStepMeta[] = [
   {
     id: "ignore",
     writesSharedFile: ["claude-settings", "zed-settings"],
@@ -348,8 +350,10 @@ export const GENERATION_STEP_GRAPH: GenerationStepMeta[] = [
       "vibe-config",
       "devin-config",
     ],
-    // Shares claude-settings with ignore and several *-config files with mcp;
-    // both must run first so hooks' read-modify-write doesn't drop their keys.
+    // Shares claude-settings with ignore, and shares qwencode-settings,
+    // augmentcode-settings, hermesagent-config, codexcli-config, vibe-config,
+    // and devin-config with mcp; both must run first so hooks' read-modify-write
+    // doesn't drop their keys.
     dependsOn: ["ignore", "mcp"],
   },
   {
@@ -369,8 +373,9 @@ export const GENERATION_STEP_GRAPH: GenerationStepMeta[] = [
       "devin-config",
       "reasonix-config",
     ],
-    // Shares claude-settings/zed-settings/kilo-opencode-config and several
-    // *-config files with ignore, hooks, and mcp; all three must run first.
+    // Shares claude-settings/zed-settings with ignore, every token hooks writes,
+    // and every token mcp writes; all three must run first so permissions'
+    // read-modify-write doesn't drop their keys.
     dependsOn: ["ignore", "hooks", "mcp"],
   },
   {


### PR DESCRIPTION
## Summary
- Follow-up to #2081 / PR #2081, which refactored `generate()`'s shared-file write ordering into a declarative step graph (`dependsOn` + `writesSharedFile`), topologically sorted and validated by `resolveExecutionOrder`/`assertSharedFilesOrdered`.
- Extracts the graph's static shape (`id`, `writesSharedFile`, `dependsOn`) into an exported `GENERATION_STEP_GRAPH`, separate from the `run` closures that need a live `config`/`logger`. This lets tests exercise `resolveExecutionOrder` against the *real* graph instead of a hand-copied stand-in.
- Restores short rationale comments on each non-obvious `dependsOn` edge, explaining which shared file forces the ordering (the original PR's prose comments were dropped when the graph became declarative).
- Adds a test that walks every `dependsOn` edge and asserts it corresponds to either an actual overlapping `writesSharedFile` token or the one documented value-dependency (`rules` reading the `skills` step's output) — this catches a stale or unjustified edge, and combined with the existing `assertSharedFilesOrdered` runtime check (which catches a *missing* edge for a real overlap), the two together keep the declared edges honest in both directions.
- Adds a test pinning the full execution order of the real graph, so the `mcp` step's position (2nd → 5th after the refactor) — or any future reordering that changes runtime behavior — is caught rather than silently regressing.

## Not addressed (left for a follow-up if needed)
- Fully automated verification that `writesSharedFile` enumerates *every* shared file across all tool targets (proving there's no un-declared overlap) would require cross-referencing each feature's `getSettablePaths()` per tool target, which is a materially larger undertaking than this hardening pass. The new edge-justification test narrows the risk (no stale/incorrect edges) but doesn't fully close this gap.
- The two "effectively unreachable" defensive checks flagged in the original issue (`if (!skillsResult) throw`, `get()`'s missing-result throw) were left as-is — they're a cheap safety net against future graph regressions and only rated `low`/`nit`.

## Test plan
- [x] `pnpm cicheck` passes
- [x] New tests: graph well-formedness, edge-justification, and full execution-order pinning, all run against the real `GENERATION_STEP_GRAPH`
- [x] Existing `generate.test.ts` and `resolveExecutionOrder` tests still pass unmodified

Closes #2082