### PR TITLE
fix(hooks): quote $CLAUDE_PROJECT_DIR-substituted hook path

### DIFF
--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -204,6 +205,46 @@ describe("ClaudecodeHooks", () => {
       expect(sessionStartEntry.hooks[1].command).toBe("npx prettier --write ./src/hooks/format.ts");
     });
 
+    it("should quote the $CLAUDE_PROJECT_DIR-prefixed path so it survives spaces in the project path (#2097)", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "./x.sh" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const content = claudecodeHooks.getFileContent();
+      const parsed = JSON.parse(content);
+      const command = parsed.hooks.SessionStart[0].hooks[0].command;
+      expect(command).toBe('"$CLAUDE_PROJECT_DIR/x.sh"');
+
+      // Simulate how Claude Code invokes hooks: `/bin/sh -c "<command>"`. Without quoting,
+      // a project path containing a space (e.g. "/Volumes/Crucial X9/...") would word-split
+      // and fail with `/bin/sh: /Volumes/Crucial: No such file or directory`.
+      const projectDir = "/Volumes/Crucial X9/project";
+      const shCommand = command.replace("$CLAUDE_PROJECT_DIR", projectDir);
+      const result = execFileSync("/bin/sh", ["-c", `printf %s ${shCommand}`], {
+        encoding: "utf8",
+      });
+      expect(result).toBe(`${projectDir}/x.sh`);
+    });
+
     it("should merge config.claudecode.hooks on top of shared hooks", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
@@ -337,6 +378,28 @@ describe("ClaudecodeHooks", () => {
       expect(json.hooks.sessionStart).toHaveLength(1);
       expect(json.hooks.sessionStart?.[0]?.command).toContain("echo.sh");
       expect(json.hooks.stop).toHaveLength(1);
+    });
+
+    it("should strip a quoted $CLAUDE_PROJECT_DIR prefix back to a ./-relative command (#2097)", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR/x.sh"' }],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("./x.sh");
     });
   });
 

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -98,9 +98,16 @@ function applyCommandPrefix({
     !trimmedCommand.startsWith("$") &&
     (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
 
-  return shouldPrefix && typeof trimmedCommand === "string"
-    ? `${converterConfig.projectDirVar}/${trimmedCommand.replace(/^\.\//, "")}`
-    : def.command;
+  if (!shouldPrefix || typeof trimmedCommand !== "string") {
+    return def.command;
+  }
+  const withoutDotPrefix = trimmedCommand.replace(/^\.\//, "");
+  const spaceIndex = withoutDotPrefix.indexOf(" ");
+  const pathToken = spaceIndex === -1 ? withoutDotPrefix : withoutDotPrefix.slice(0, spaceIndex);
+  const rest = spaceIndex === -1 ? "" : withoutDotPrefix.slice(spaceIndex);
+  // Quote only the substituted path token so commands invoked via `sh -c` survive
+  // project paths containing spaces; trailing args are left unquoted and intact.
+  return `"${converterConfig.projectDirVar}/${pathToken}"${rest}`;
 }
 
 /**
@@ -211,10 +218,12 @@ function stripCommandPrefix({
     typeof cmd === "string" &&
     cmd.includes(`${converterConfig.projectDirVar}/`)
   ) {
-    return cmd.replace(
-      new RegExp(`^${converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\/?`),
-      "./",
-    );
+    const escapedVar = converterConfig.projectDirVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const quotedMatch = cmd.match(new RegExp(`^"${escapedVar}\\/([^"]*)"(.*)$`));
+    if (quotedMatch) {
+      return `./${quotedMatch[1]}${quotedMatch[2]}`;
+    }
+    return cmd.replace(new RegExp(`^${escapedVar}\\/?`), "./");
   }
   return cmd;
 }


### PR DESCRIPTION
## Summary
- Closes #2097. When generating `.claude/settings.json`, rulesync rewrites relative hook commands like `./x.sh` into `$CLAUDE_PROJECT_DIR/x.sh` but did not quote the substitution. Claude Code runs hooks via `/bin/sh -c "<command>"`, so on a project whose absolute path contains a space, the unquoted expansion word-splits and the hook fails with `/bin/sh: /Volumes/Crucial: No such file or directory`.
- Only the substituted `$CLAUDE_PROJECT_DIR/<path>` token is quoted, so any trailing arguments on the command are preserved unquoted.
- The reverse conversion (`settings.json` -> canonical rulesync hooks) now also strips the quotes back off, so existing unquoted configs and newly-quoted ones both round-trip correctly.

### Before
```json
{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.rulesync/hooks/session-start.sh" }
```

### After
```json
{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.rulesync/hooks/session-start.sh\"" }
```

## Test plan
- [x] Added a regression test asserting a hook command `./x.sh` generates the quoted `"$CLAUDE_PROJECT_DIR/x.sh"`, and verifies via `sh -c` that it survives a project path containing a space (simulating how Claude Code invokes hooks).
- [x] Added a round-trip test confirming the quoted command is stripped back to `./x.sh` when reading an existing `settings.json`.
- [x] `pnpm test` (unit tests) - all hooks-related tests pass (298 test files run; unrelated pre-existing failures are local sandbox EPERM issues on MCP/subagents file writes, unaffected by this change).
- [x] `pnpm typecheck`, `pnpm oxlint`, `pnpm fmt:check`, `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
