### PR TITLE
chore(release): v9.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.0.2";
+const getVersion = () => "9.1.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### New Features
- Add CLI hook events and Action Allowlist permissions for Junie (#2084)
- Support skill argument-hint frontmatter and preMcpToolCall hook event for Copilot CLI (#2085)
- Add project-scoped Goose MCP via open plugins (#2086)
- Re-target Devin adapters to native Devin Local `.devin/` paths (#2089)
- Support antigravity-cli workflow commands (#2091)
- Add hooks adapter plus global skills/subagents scope for Kiro IDE (#2093)
- Follow Qwen Code per-hook fields (#2094)
- Add Takt MCP transport-allowlist adapter (#2095)
- Support global scope for GitHub Copilot skills (#2098)
- Add permissions, hooks, and commands adapters for Reasonix (#2101)
- Support global scope for commands and subagents in Kiro CLI (#2102)
- Add commands adapter for Rovo Dev CLI saved prompts (#2103)

### Bug Fixes
- Accept documented string forms for skill compatibility and top-level permission in OpenCode (#2096)
- Stop force-writing stale hooks feature flag and preserve granular approval keys in Codex CLI (#2099)
- Emit hooks under Hermes's native `VALID_HOOKS` event keys (#2100)
- Quote `$CLAUDE_PROJECT_DIR`-prefixed hook commands (#2104)

### Maintenance
- Enforce shared-file write order via a declarative step graph (#2081)
- Route npm installs through Takumi Guard (#2083)
- Record SYSTEM.md / APPEND_SYSTEM.md system-prompt surface for Pi (#2088)
- Make the step graph directly testable and harden it (#2105)
- Auto-open Homebrew/core bump PR after npm publish (#2087)

## Contributors
- @dyoshikawa
- @saitota

## Full Changelog
https://github.com/dyoshikawa/rulesync/compare/v9.0.2...v9.1.0
