### PR TITLE
refactor(rules): move rovodev quirks from hub to spoke hooks

### DIFF
--- a/src/features/rules/rovodev-rule.ts
+++ b/src/features/rules/rovodev-rule.ts
@@ -376,4 +376,15 @@ export class RovodevRule extends ToolRule {
       mirrorGlob: join(outputRoot, ROVODEV_RULE_FILE_NAME),
     };
   }
+
+  /** Glob for the `separate-local-file` deletion; rovodev writes it at project root, not under `.rovodev/`. */
+  static getLocalRootDeletionGlob({
+    outputRoot,
+    fileName,
+  }: {
+    outputRoot: string;
+    fileName: string;
+  }): string {
+    return join(outputRoot, fileName);
+  }
 }

--- a/src/features/rules/rovodev-rule.ts
+++ b/src/features/rules/rovodev-rule.ts
@@ -327,4 +327,53 @@ export class RovodevRule extends ToolRule {
       toolTarget: "rovodev",
     });
   }
+
+  /**
+   * Mirror the primary `.rovodev/AGENTS.md` root rule to `./AGENTS.md` so project
+   * memory stays discoverable at the repo root. Empty when `rootRule` is not the primary root.
+   */
+  static getRootMirrorFiles({
+    outputRoot,
+    rootRule,
+    content,
+  }: {
+    outputRoot: string;
+    rootRule: ToolRule;
+    content: string;
+  }): RovodevRule[] {
+    if (!(rootRule instanceof RovodevRule)) {
+      return [];
+    }
+    const primary = this.getSettablePaths({ global: false }).root;
+    if (
+      rootRule.getRelativeDirPath() !== primary.relativeDirPath ||
+      rootRule.getRelativeFilePath() !== primary.relativeFilePath
+    ) {
+      return [];
+    }
+    return [
+      new RovodevRule({
+        outputRoot,
+        relativeDirPath: ".",
+        relativeFilePath: ROVODEV_RULE_FILE_NAME,
+        fileContent: content,
+        validate: true,
+        root: true,
+      }),
+    ];
+  }
+
+  /**
+   * Globs for mirror deletion: the `./AGENTS.md` mirror (`mirrorGlob`) is deleted
+   * only when the primary `.rovodev/AGENTS.md` (`primaryGlob`) still exists.
+   */
+  static getRootMirrorDeletionGlobs({ outputRoot }: { outputRoot: string }): {
+    primaryGlob: string;
+    mirrorGlob: string;
+  } {
+    return {
+      primaryGlob: join(outputRoot, ROVODEV_DIR, ROVODEV_RULE_FILE_NAME),
+      mirrorGlob: join(outputRoot, ROVODEV_RULE_FILE_NAME),
+    };
+  }
 }

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -218,6 +218,11 @@ type ToolRuleFactory = {
       primaryGlob: string;
       mirrorGlob: string;
     };
+    /**
+     * Override where the `separate-local-file` deletion glob points when the tool
+     * writes its local file outside its root dir. See {@link RovodevRule.getLocalRootDeletionGlob}.
+     */
+    getLocalRootDeletionGlob?(params: { outputRoot: string; fileName: string }): string;
   };
   meta: {
     /** File extension for the rule file */
@@ -1421,9 +1426,10 @@ As this project's AI coding tool, you must follow the additional conventions bel
         }
         const fileName = factory.meta.localRootFileName;
 
-        // rovodev writes its local file at the project root, not under its root dir.
-        if (factory.class === RovodevRule) {
-          const filePaths = await findFilesByGlobs(join(this.outputRoot, fileName));
+        if (factory.class.getLocalRootDeletionGlob) {
+          const filePaths = await findFilesByGlobs(
+            factory.class.getLocalRootDeletionGlob({ outputRoot: this.outputRoot, fileName }),
+          );
           return buildDeletionRulesFromPaths(filePaths);
         }
 

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -4,7 +4,6 @@ import { encode } from "@toon-format/toon";
 import { z } from "zod/mini";
 
 import { SKILL_FILE_NAME } from "../../constants/general.js";
-import { ROVODEV_DIR, ROVODEV_RULE_FILE_NAME } from "../../constants/rovodev-paths.js";
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { FeatureProcessor } from "../../types/feature-processor.js";
 import type { FeatureOptions } from "../../types/features.js";
@@ -208,6 +207,17 @@ type ToolRuleFactory = {
     getSettablePaths(options?: {
       global?: boolean;
     }): ToolRuleSettablePaths | ToolRuleSettablePathsGlobal;
+    /** Set alongside `meta.mirrorsRootToAgentsMd`. See {@link RovodevRule.getRootMirrorFiles}. */
+    getRootMirrorFiles?(params: {
+      outputRoot: string;
+      rootRule: ToolRule;
+      content: string;
+    }): ToolRule[];
+    /** Set alongside `meta.mirrorsRootToAgentsMd`. See {@link RovodevRule.getRootMirrorDeletionGlobs}. */
+    getRootMirrorDeletionGlobs?(params: { outputRoot: string }): {
+      primaryGlob: string;
+      mirrorGlob: string;
+    };
   };
   meta: {
     /** File extension for the rule file */
@@ -844,7 +854,7 @@ export class RulesProcessor extends FeatureProcessor {
 
     const extraFiles = await this.buildMcpInstructionFiles({ toolRules, meta });
 
-    this.applyRootRuleSections({ toolRules, meta });
+    this.applyRootRuleSections({ toolRules, factory });
 
     return [...toolRules, ...extraFiles];
   }
@@ -953,63 +963,33 @@ export class RulesProcessor extends FeatureProcessor {
    */
   private applyRootRuleSections({
     toolRules,
-    meta,
+    factory,
   }: {
     toolRules: ToolRule[];
-    meta: ToolRuleFactory["meta"];
+    factory: ToolRuleFactory;
   }): void {
+    const { meta } = factory;
     const rootRule = toolRules.find((rule) => rule.isRoot());
     if (!rootRule) {
       return;
     }
 
-    // Generate reference section based on meta configuration
     const referenceSection = this.generateReferenceSectionFromMeta(meta, toolRules);
 
-    // Generate additional conventions section (only if not creating a separate rule)
     const conventionsSection =
       !meta.createsSeparateConventionsRule && meta.additionalConventions
         ? this.generateAdditionalConventionsSectionFromMeta(meta)
         : "";
 
-    // Prepend sections to root rule content
     const newContent = referenceSection + conventionsSection + rootRule.getFileContent();
     rootRule.setFileContent(newContent);
 
-    if (meta.mirrorsRootToAgentsMd && !this.global) {
-      this.mirrorRootRuleToAgentsMd({ toolRules, rootRule, content: newContent });
-    }
-  }
-
-  /**
-   * Mirror the primary root rule to a project-root `AGENTS.md` for tools whose
-   * primary root lives in a subdirectory (rovodev: `.rovodev/AGENTS.md`).
-   */
-  private mirrorRootRuleToAgentsMd({
-    toolRules,
-    rootRule,
-    content,
-  }: {
-    toolRules: ToolRule[];
-    rootRule: ToolRule;
-    content: string;
-  }): void {
-    if (!(rootRule instanceof RovodevRule)) {
-      return;
-    }
-    const primary = RovodevRule.getSettablePaths({ global: false }).root;
-    if (
-      rootRule.getRelativeDirPath() === primary.relativeDirPath &&
-      rootRule.getRelativeFilePath() === primary.relativeFilePath
-    ) {
+    if (meta.mirrorsRootToAgentsMd && !this.global && factory.class.getRootMirrorFiles) {
       toolRules.push(
-        new RovodevRule({
+        ...factory.class.getRootMirrorFiles({
           outputRoot: this.outputRoot,
-          relativeDirPath: ".",
-          relativeFilePath: "AGENTS.md",
-          fileContent: content,
-          validate: true,
-          root: true,
+          rootRule,
+          content: newContent,
         }),
       );
     }
@@ -1466,17 +1446,18 @@ As this project's AI coding tool, you must follow the additional conventions bel
           !forDeletion ||
           this.global ||
           !factory.meta.mirrorsRootToAgentsMd ||
-          factory.class !== RovodevRule
+          !factory.class.getRootMirrorDeletionGlobs
         ) {
           return [];
         }
-        const primaryPaths = await findFilesByGlobs(
-          join(this.outputRoot, ROVODEV_DIR, ROVODEV_RULE_FILE_NAME),
-        );
+        const { primaryGlob, mirrorGlob } = factory.class.getRootMirrorDeletionGlobs({
+          outputRoot: this.outputRoot,
+        });
+        const primaryPaths = await findFilesByGlobs(primaryGlob);
         if (primaryPaths.length === 0) {
           return [];
         }
-        const mirrorPaths = await findFilesByGlobs(join(this.outputRoot, "AGENTS.md"));
+        const mirrorPaths = await findFilesByGlobs(mirrorGlob);
         return buildDeletionRulesFromPaths(mirrorPaths);
       })();
 


### PR DESCRIPTION
## Description

`mirrorsRootToAgentsMd` was cited as a single-tool (rovodev) quirk whose interpretation lived in the hub (`rules-processor.ts`) rather than the spoke. The hub hardcoded `instanceof RovodevRule` / `=== RovodevRule` checks and rovodev path constants across the generate and delete paths, leaking tool-specific knowledge into code shared by all 34 tools.

## Changes

- Move the root-mirror quirk to optional spoke hooks on `RovodevRule` (`getRootMirrorFiles`, `getRootMirrorDeletionGlobs`), following the existing `getAuxiliaryFiles` / `fromRulesyncSubagents` hook pattern used by other features.
- Move the `separate-local-file` deletion glob to a `getLocalRootDeletionGlob` hook, so the hub no longer branches on `=== RovodevRule` for it.
- The `mirrorsRootToAgentsMd` meta flag stays as a pure dispatch declaration; rovodev-specific paths and `instanceof` checks now live entirely in `RovodevRule`.

## Test Plan

- [x] `pnpm run typecheck`, `pnpm run fmt:check`, `pnpm run oxlint` — clean.
- [x] `rules-processor.test.ts` / `rovodev-rule.test.ts` — 112 pass (root-mirror generate/delete and local-root deletion covered).
