### PR TITLE
test(generate): derive shared-file writers from the registry and enforce declarations

### DIFF
--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -7,6 +7,7 @@ import {
   CODEXCLI_HOOKS_FILE_NAME,
   CODEXCLI_MCP_FILE_NAME,
 } from "../../constants/codexcli-paths.js";
+import type { SharedWritePath } from "../../lib/shared-file-derive.js";
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import {
   CODEXCLI_HOOK_EVENTS,
@@ -103,6 +104,12 @@ export class CodexcliHooks extends ToolHooks {
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
     return { relativeDirPath: CODEXCLI_DIR, relativeFilePath: CODEXCLI_HOOKS_FILE_NAME };
+  }
+
+  // Codex CLI enables hooks by also writing `.codex/config.toml`, a file the MCP
+  // and permissions features share. Declared here because it is not a settable path.
+  static getExtraSharedWritePaths(): SharedWritePath[] {
+    return [{ relativeDirPath: CODEXCLI_DIR, relativeFilePath: CODEXCLI_MCP_FILE_NAME }];
   }
 
   static async fromFile({

--- a/src/features/hooks/vibe-hooks.ts
+++ b/src/features/hooks/vibe-hooks.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import * as smolToml from "smol-toml";
 
+import type { SharedWritePath } from "../../lib/shared-file-derive.js";
 import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import {
   CANONICAL_TO_VIBE_EVENT_NAMES,
@@ -254,6 +255,12 @@ export class VibeHooks extends ToolHooks {
 
   static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
     return { relativeDirPath: VIBE_DIR, relativeFilePath: VIBE_HOOKS_FILE_NAME };
+  }
+
+  // Vibe enables hooks by also writing `.vibe/config.toml`, a file the MCP and
+  // permissions features share. Declared here because it is not a settable path.
+  static getExtraSharedWritePaths(): SharedWritePath[] {
+    return [{ relativeDirPath: VIBE_DIR, relativeFilePath: VIBE_CONFIG_FILE_NAME }];
   }
 
   static async fromFile({

--- a/src/features/rules/kilo-rule.ts
+++ b/src/features/rules/kilo-rule.ts
@@ -6,8 +6,10 @@ import {
   KILO_RULE_FILE_NAME,
   KILO_RULES_DIR_NAME,
 } from "../../constants/kilo-paths.js";
+import type { SharedWritePath } from "../../lib/shared-file-derive.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
+import { KiloMcp } from "../mcp/kilo-mcp.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -53,6 +55,14 @@ export class KiloRule extends ToolRule {
         relativeDirPath: buildToolPath(KILO_DIR, KILO_RULES_DIR_NAME, excludeToolDir),
       },
     };
+  }
+
+  // Only project-scope rule generation writes the shared kilo.json (global skips
+  // the MCP instructions registrar).
+  static getExtraSharedWritePaths({
+    global = false,
+  }: { global?: boolean } = {}): SharedWritePath[] {
+    return global ? [] : [KiloMcp.getSettablePaths({ global: false })];
   }
 
   static async fromFile({

--- a/src/features/rules/opencode-rule.ts
+++ b/src/features/rules/opencode-rule.ts
@@ -5,8 +5,10 @@ import {
   OPENCODE_GLOBAL_DIR,
   OPENCODE_RULE_FILE_NAME,
 } from "../../constants/opencode-paths.js";
+import type { SharedWritePath } from "../../lib/shared-file-derive.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { readFileContent } from "../../utils/file.js";
+import { OpencodeMcp } from "../mcp/opencode-mcp.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -52,6 +54,14 @@ export class OpenCodeRule extends ToolRule {
         relativeDirPath: buildToolPath(OPENCODE_DIR, "memories", excludeToolDir),
       },
     };
+  }
+
+  // Only project-scope rule generation writes the shared opencode.json (global
+  // skips the MCP instructions registrar).
+  static getExtraSharedWritePaths({
+    global = false,
+  }: { global?: boolean } = {}): SharedWritePath[] {
+    return global ? [] : [OpencodeMcp.getSettablePaths({ global: false })];
   }
 
   static async fromFile({

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -200,7 +200,7 @@ type GenerationStepId =
 
 type GenerationStep = {
   id: GenerationStepId;
-  /** Tokens for on-disk files this step read-modify-writes and shares with other steps. */
+  /** `dir/file` keys for on-disk files this step read-modify-writes and shares with other steps. */
   writesSharedFile?: readonly string[];
   /** Step ids that must run before this one (they write a shared file this step then reads). */
   dependsOn?: readonly GenerationStepId[];
@@ -314,25 +314,32 @@ type GenerationStepMeta = Readonly<Omit<GenerationStep, "run">>;
 export const GENERATION_STEP_GRAPH: readonly GenerationStepMeta[] = [
   {
     id: "ignore",
-    writesSharedFile: ["claude-settings", "zed-settings"],
+    writesSharedFile: [".claude/settings.json", ".zed/settings.json"],
   },
   {
     id: "mcp",
     writesSharedFile: [
-      "kilo-opencode-config",
-      "zed-settings",
-      "qwencode-settings",
-      "augmentcode-settings",
-      "hermesagent-config",
-      "amp-settings",
-      "codexcli-config",
-      "grokcli-config",
-      "vibe-config",
-      "devin-config",
-      "reasonix-config",
+      ".amp/settings.json",
+      ".augment/settings.json",
+      ".codex/config.toml",
+      ".config/amp/settings.json",
+      ".config/devin/config.json",
+      ".config/opencode/opencode.json",
+      ".config/zed/settings.json",
+      ".devin/config.json",
+      ".grok/config.toml",
+      ".hermes/config.yaml",
+      ".qwen/settings.json",
+      ".reasonix/config.toml",
+      ".takt/config.yaml",
+      ".vibe/config.toml",
+      ".zed/settings.json",
+      "kilo.json",
+      "opencode.json",
+      "reasonix.toml",
     ],
-    // Both ignore and mcp write zed-settings; ignore must run first so mcp's
-    // read-modify-write doesn't drop the ignore keys it wrote.
+    // Both ignore and mcp write .zed/settings.json; ignore must run first so
+    // mcp's read-modify-write doesn't drop the ignore keys it wrote.
     dependsOn: ["ignore"],
   },
   { id: "commands" },
@@ -341,49 +348,52 @@ export const GENERATION_STEP_GRAPH: readonly GenerationStepMeta[] = [
   {
     id: "hooks",
     writesSharedFile: [
-      "claude-settings",
-      "qwencode-settings",
-      "augmentcode-settings",
-      "hermesagent-config",
-      "kiro-agent-config",
-      "codexcli-config",
-      "vibe-config",
-      "devin-config",
+      ".augment/settings.json",
+      ".claude/settings.json",
+      ".codex/config.toml",
+      ".config/devin/config.json",
+      ".hermes/config.yaml",
+      ".kiro/agents/default.json",
+      ".qwen/settings.json",
+      ".vibe/config.toml",
     ],
-    // Shares claude-settings with ignore, and shares qwencode-settings,
-    // augmentcode-settings, hermesagent-config, codexcli-config, vibe-config,
-    // and devin-config with mcp; both must run first so hooks' read-modify-write
-    // doesn't drop their keys.
+    // Shares .claude/settings.json with ignore and several config files with mcp;
+    // both must run first so hooks' read-modify-write doesn't drop their keys.
     dependsOn: ["ignore", "mcp"],
   },
   {
     id: "permissions",
     writesSharedFile: [
-      "claude-settings",
-      "kilo-opencode-config",
-      "zed-settings",
-      "qwencode-settings",
-      "augmentcode-settings",
-      "hermesagent-config",
-      "kiro-agent-config",
-      "amp-settings",
-      "codexcli-config",
-      "grokcli-config",
-      "vibe-config",
-      "devin-config",
-      "reasonix-config",
+      ".amp/settings.json",
+      ".augment/settings.json",
+      ".claude/settings.json",
+      ".codex/config.toml",
+      ".config/amp/settings.json",
+      ".config/devin/config.json",
+      ".config/opencode/opencode.json",
+      ".config/zed/settings.json",
+      ".devin/config.json",
+      ".grok/config.toml",
+      ".hermes/config.yaml",
+      ".kiro/agents/default.json",
+      ".qwen/settings.json",
+      ".reasonix/config.toml",
+      ".takt/config.yaml",
+      ".vibe/config.toml",
+      ".zed/settings.json",
+      "opencode.json",
+      "reasonix.toml",
     ],
-    // Shares claude-settings/zed-settings with ignore, every token hooks writes,
-    // and every token mcp writes; all three must run first so permissions'
-    // read-modify-write doesn't drop their keys.
+    // Shares files with ignore, and with every file hooks and mcp write; all
+    // three must run first so permissions' read-modify-write doesn't drop keys.
     dependsOn: ["ignore", "hooks", "mcp"],
   },
   {
     id: "rules",
-    writesSharedFile: ["kilo-opencode-config"],
-    // Shares kilo-opencode-config with mcp and permissions (both must run first),
-    // and reads the skills list the skills step produces (a value dependency,
-    // not a shared-file one).
+    writesSharedFile: ["kilo.json", "opencode.json"],
+    // Shares kilo.json/opencode.json with mcp and permissions (both must run
+    // first), and reads the skills list the skills step produces (a value
+    // dependency, not a shared-file one).
     dependsOn: ["mcp", "skills", "permissions"],
   },
 ];

--- a/src/lib/shared-file-derive.test.ts
+++ b/src/lib/shared-file-derive.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { Feature } from "../types/features.js";
+import { GENERATION_STEP_GRAPH } from "./generate.js";
+import { deriveSharedFileWriters } from "./shared-file-derive.js";
+
+const declaredWritersByFile = (): Map<string, Set<Feature>> => {
+  const byFile = new Map<string, Set<Feature>>();
+  for (const step of GENERATION_STEP_GRAPH) {
+    for (const key of step.writesSharedFile ?? []) {
+      const writers = byFile.get(key) ?? new Set<Feature>();
+      writers.add(step.id as Feature);
+      byFile.set(key, writers);
+    }
+  }
+  for (const [key, writers] of byFile) {
+    if (writers.size < 2) byFile.delete(key);
+  }
+  return byFile;
+};
+
+const derivedWritersByFile = (): Map<string, Set<Feature>> =>
+  new Map(deriveSharedFileWriters().map((w) => [w.key, new Set(w.features)]));
+
+const sortedFeatures = (writers: Map<string, Set<Feature>>): Record<string, string[]> =>
+  Object.fromEntries(
+    [...writers]
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([key, fs]) => [key, [...fs].toSorted()]),
+  );
+
+describe("shared-file write declarations", () => {
+  it("the generation step graph declares exactly the shared files derived from the registry", () => {
+    expect(sortedFeatures(declaredWritersByFile())).toEqual(sortedFeatures(derivedWritersByFile()));
+  });
+
+  it("declares no shared file that the registry does not actually share", () => {
+    const derived = derivedWritersByFile();
+    const undeclared = [...declaredWritersByFile().keys()].filter((key) => !derived.has(key));
+    expect(undeclared).toEqual([]);
+  });
+
+  it("declares every shared file the registry derives", () => {
+    const declared = declaredWritersByFile();
+    const missing = [...derivedWritersByFile().keys()].filter((key) => !declared.has(key));
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/lib/shared-file-derive.ts
+++ b/src/lib/shared-file-derive.ts
@@ -1,0 +1,135 @@
+import type { Feature } from "../types/features.js";
+import { PROCESSOR_REGISTRY } from "../types/processor-registry.js";
+import type { ToolTarget } from "../types/tool-targets.js";
+
+export type SharedWritePath = {
+  readonly relativeDirPath: string;
+  readonly relativeFilePath: string;
+};
+
+export type SharedFileWriter = {
+  readonly key: string;
+  readonly relativeDirPath: string;
+  readonly relativeFilePath: string;
+  readonly features: ReadonlyArray<Feature>;
+  readonly toolsByFeature: ReadonlyMap<Feature, ReadonlyArray<ToolTarget>>;
+};
+
+const SHARED_WRITE_FEATURES: ReadonlySet<Feature> = new Set([
+  "ignore",
+  "mcp",
+  "hooks",
+  "permissions",
+  "rules",
+]);
+
+// Deprecated aliases; a guard for the day one diverges from its canonical
+// target's paths. A no-op today since they reuse the canonical class and paths.
+const TARGETS_NOT_DERIVED: ReadonlySet<string> = new Set([
+  "augmentcode-legacy",
+  "claudecode-legacy",
+]);
+
+export const sharedFileKey = (path: SharedWritePath): string => {
+  const dir = path.relativeDirPath.replace(/\\/g, "/").replace(/\/$/, "");
+  const file = path.relativeFilePath.replace(/\\/g, "/");
+  return dir === "" || dir === "." ? file : `${dir}/${file}`;
+};
+
+type FactoryClass = {
+  getSettablePaths?: (options?: { global?: boolean }) => unknown;
+  getExtraSharedWritePaths?: (options?: { global?: boolean }) => SharedWritePath[];
+};
+
+type FactoryMap = ReadonlyMap<ToolTarget, { readonly class: FactoryClass }>;
+
+const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWritePath[] => {
+  const paths: SharedWritePath[] = [];
+  let settable:
+    | {
+        relativeDirPath?: string;
+        relativeFilePath?: string;
+        root?: { relativeDirPath: string; relativeFilePath: string };
+        alternativeRoots?: ReadonlyArray<{ relativeDirPath: string; relativeFilePath: string }>;
+      }
+    | undefined;
+  try {
+    settable = cls.getSettablePaths?.({ global }) as typeof settable;
+  } catch {
+    return paths;
+  }
+  if (settable?.relativeFilePath) {
+    paths.push({
+      relativeDirPath: settable.relativeDirPath ?? ".",
+      relativeFilePath: settable.relativeFilePath,
+    });
+  }
+  if (settable?.root) {
+    paths.push(settable.root);
+    for (const alt of settable.alternativeRoots ?? []) paths.push(alt);
+  }
+  for (const path of cls.getExtraSharedWritePaths?.({ global }) ?? []) {
+    if (path.relativeFilePath) paths.push(path);
+  }
+  return paths;
+};
+
+// A shared file may live at a different path per scope (e.g. `opencode.json` vs
+// `.config/opencode/opencode.json`), so a feature's writes are the union across
+// both scopes; the step graph declares that union.
+const collectFactoryPaths = (factory: { class: FactoryClass }): SharedWritePath[] => [
+  ...settablePathsForScope(factory.class, false),
+  ...settablePathsForScope(factory.class, true),
+];
+
+/**
+ * Derive, from the processor registry, every on-disk file that two or more
+ * features read-modify-write. Source of truth the generation step graph's
+ * `writesSharedFile` declarations must match.
+ */
+export const deriveSharedFileWriters = (): SharedFileWriter[] => {
+  const byKey = new Map<string, Map<Feature, Set<ToolTarget>>>();
+  const pathByKey = new Map<string, SharedWritePath>();
+
+  for (const entry of PROCESSOR_REGISTRY) {
+    if (!SHARED_WRITE_FEATURES.has(entry.feature)) continue;
+    const factories = entry.factory as unknown as FactoryMap;
+    for (const [tool, factory] of factories) {
+      if (TARGETS_NOT_DERIVED.has(tool)) continue;
+      for (const path of collectFactoryPaths(factory)) {
+        const key = sharedFileKey(path);
+        if (!pathByKey.has(key)) pathByKey.set(key, path);
+        let features = byKey.get(key);
+        if (!features) {
+          features = new Map();
+          byKey.set(key, features);
+        }
+        let tools = features.get(entry.feature);
+        if (!tools) {
+          tools = new Set();
+          features.set(entry.feature, tools);
+        }
+        tools.add(tool);
+      }
+    }
+  }
+
+  const writers: SharedFileWriter[] = [];
+  for (const [key, features] of byKey) {
+    if (features.size < 2) continue;
+    const path = pathByKey.get(key)!;
+    const toolsByFeature = new Map<Feature, ReadonlyArray<ToolTarget>>();
+    for (const [feature, tools] of features) {
+      toolsByFeature.set(feature, [...tools].toSorted());
+    }
+    writers.push({
+      key,
+      relativeDirPath: path.relativeDirPath,
+      relativeFilePath: path.relativeFilePath,
+      features: [...features.keys()].toSorted(),
+      toolsByFeature,
+    });
+  }
+
+  return writers.toSorted((a, b) => a.key.localeCompare(b.key));
+};


### PR DESCRIPTION
## Background

Which config file each feature read-modify-writes is known in two places. The tool classes know their real write targets through `getSettablePaths()` and their implementations; `GENERATION_STEP_GRAPH` re-declares the same knowledge as opaque tokens (`"reasonix-config"`, ...). Nothing — no type, no test — connects the two: `generate.test.ts` only checks the graph's internal consistency (are `dependsOn` edges justified for duplicated tokens), never whether the token set matches reality.

So `assertSharedFilesOrdered` can only order writers that are declared. An undeclared second writer passes silently and looks safe only while the execution order happens to be correct. And a tool adder has no reason to open `generate.ts`: the code compiles, tests pass, and output is correct under the current order — the drift surfaces only in review (e.g. ab61e383).

## Changes

- Derive the multi-writer set from `PROCESSOR_REGISTRY` × `getSettablePaths` (both scopes) plus a `getExtraSharedWritePaths` contract for writes not visible as settable paths, and assert it matches the graph — a missing declaration now fails CI, not review.
- Replace opaque tokens with real `dir/file` keys so declarations and derivation share one namespace.
- Fixes surfaced by the derivation: register `.takt/config.yaml`; drop permissions from `kilo.json` (it writes `kilo.jsonc`); cover the global-only `.config/devin/config.json` writer.

No change to generated output.

## Test Plan

- `pnpm cicheck` green (6740 tests).

Refs #2081
