### PR TITLE
chore: release v9.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.1.0";
+const getVersion = () => "9.1.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v9.1.1

## What's Changed

### Maintenance
- Move Rovo Dev root-mirror quirk from the hub into a spoke hook (#2109)
- Move the Rovo Dev local-root deletion glob into a spoke hook (#2108)
- Derive shared-file writers from the registry and enforce declarations in tests (#2108)

## Full Changelog
https://github.com/dyoshikawa/rulesync/compare/v9.1.0...v9.1.1