### PR TITLE
refactor(ignore): guard ignore-side Claude settings JSON.parse with try/catch

### DIFF
--- a/src/features/ignore/claudecode-ignore.test.ts
+++ b/src/features/ignore/claudecode-ignore.test.ts
@@ -216,6 +216,26 @@ describe("ClaudecodeIgnore", () => {
       // existing shared settings.json untouched on disk.
       expect(claudecodeIgnore.getRelativeFilePath()).toBe("settings.local.json");
     });
+
+    it("should throw a formatted error when the existing settings.json is malformed", async () => {
+      const claudeDir = join(testDir, ".claude");
+      await ensureDir(claudeDir);
+      await writeFileContent(join(claudeDir, "settings.json"), "{ not valid json");
+
+      const rulesyncIgnore = new RulesyncIgnore({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+        fileContent: "*.log",
+      });
+
+      await expect(
+        ClaudecodeIgnore.fromRulesyncIgnore({
+          outputRoot: testDir,
+          rulesyncIgnore,
+          options: { fileMode: "shared" },
+        }),
+      ).rejects.toThrow(/Failed to parse existing Claude settings at .*settings\.json/);
+    });
   });
 
   describe("isDeletable", () => {

--- a/src/features/ignore/claudecode-ignore.ts
+++ b/src/features/ignore/claudecode-ignore.ts
@@ -9,6 +9,7 @@ import {
 } from "../../constants/claudecode-paths.js";
 import type { ClaudeSettingsJson } from "../../types/claude-settings.js";
 import { FeatureOptions } from "../../types/features.js";
+import { formatError } from "../../utils/error.js";
 import { fileExists, readFileContent } from "../../utils/file.js";
 import {
   applyIgnoreReadDenies,
@@ -143,7 +144,15 @@ export class ClaudecodeIgnore extends ToolIgnore {
     const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const exists = await fileExists(filePath);
     const existingFileContent = exists ? await readFileContent(filePath) : "{}";
-    const existingJsonValue: ClaudeSettingsJson = JSON.parse(existingFileContent);
+    let existingJsonValue: ClaudeSettingsJson;
+    try {
+      existingJsonValue = JSON.parse(existingFileContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse existing Claude settings at ${filePath}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
 
     // The gateway owns the `permissions.deny` merge shared with the permissions
     // feature; here we only state the intent (deny these Read patterns).


### PR DESCRIPTION
## Background

Follow-up from the review of PR #2115 (captured in #2121). Finding 3: the Claude Code **ignore** feature parsed an existing `.claude/settings.json` with a bare `JSON.parse` (`src/features/ignore/claudecode-ignore.ts`), so a corrupted settings file surfaced an unformatted low-level error. The **permissions** side (`claudecode-permissions.ts:127-135`) already wraps the same parse in a try/catch that rethrows a `Failed to parse existing Claude settings at <path>: <detail>` message.

## Changes

- Wrap the ignore-side `JSON.parse` in a try/catch that mirrors the permissions side, using `formatError` for a consistent, actionable message.
- Add a unit test asserting a malformed existing `settings.json` throws the formatted error.

## Scope note

Findings 1 and 2 of #2121 explicitly require no code change:
- **Finding 1** (empty/null `allow`/`ask`/`deny` arrays now normalized away on the ignore path) is a documentation/changelog note — the behavior is intentional and already consistent with the permissions side.
- **Finding 2** (Reasonix DRY) is a conditional future follow-up, only relevant if the same gateway centralization is ever applied to Reasonix.

So this PR resolves the only actionable item and closes the issue.

## Verification

`pnpm cicheck` passes (6753 tests, including the new malformed-input test).

Closes #2121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
