### PR TITLE
feat(permissions): support OpenCode-scoped permission override key (#2127)

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -829,7 +829,7 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
-> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`, and its own `webfetch`/`websearch` handling). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
+> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
 >
 > ```jsonc
 > {
@@ -840,13 +840,14 @@ For OpenCode, this generates the `permission` object in `opencode.json` / `openc
 >   "opencode": {
 >     "permission": {
 >       "external_directory": "deny",
->       "webfetch": "allow",
 >     },
 >   },
 > }
 > ```
 >
-> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, the all-tools key `*`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+>
+> You may also override a **shared** category for OpenCode specifically (e.g. put `webfetch` under `opencode.permission` to give OpenCode a different value than the shared block sends to other tools). On generate this works as expected, but note the override is not round-trip stable for shared categories: re-importing the generated `opencode.json` classifies a shared category back into the shared block, so prefer expressing OpenCode-only categories here and keeping cross-tool categories in the shared block.
 
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -829,6 +829,25 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
+> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`, and its own `webfetch`/`websearch` handling). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
+>
+> ```jsonc
+> {
+>   "permission": {
+>     "bash": { "git *": "allow", "*": "ask" },
+>   },
+>   // Emitted only into opencode.json's `permission`; never leaks to other tools.
+>   "opencode": {
+>     "permission": {
+>       "external_directory": "deny",
+>       "webfetch": "allow",
+>     },
+>   },
+> }
+> ```
+>
+> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 
 - `bash`: generates one `prefix_rule(...)` per command pattern in `.codex/rules/rulesync.rules` (`allow` → `allow`, `ask` → `prompt`, `deny` → `forbidden`)

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -829,7 +829,7 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
-> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`, and its own `webfetch`/`websearch` handling). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
+> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
 >
 > ```jsonc
 > {
@@ -840,13 +840,14 @@ For OpenCode, this generates the `permission` object in `opencode.json` / `openc
 >   "opencode": {
 >     "permission": {
 >       "external_directory": "deny",
->       "webfetch": "allow",
 >     },
 >   },
 > }
 > ```
 >
-> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, the all-tools key `*`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+>
+> You may also override a **shared** category for OpenCode specifically (e.g. put `webfetch` under `opencode.permission` to give OpenCode a different value than the shared block sends to other tools). On generate this works as expected, but note the override is not round-trip stable for shared categories: re-importing the generated `opencode.json` classifies a shared category back into the shared block, so prefer expressing OpenCode-only categories here and keeping cross-tool categories in the shared block.
 
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -829,6 +829,25 @@ For Claude Code, this generates `permissions.allow`, `permissions.ask`, and `per
 
 For OpenCode, this generates the `permission` object in `opencode.json` / `opencode.jsonc` (project mode) or `.config/opencode/opencode.json` / `.config/opencode/opencode.jsonc` (global mode), preserving other existing OpenCode config fields.
 
+> **OpenCode-only override (`opencode` key):** OpenCode exposes permission categories that other tools do not understand (e.g. `external_directory`, and its own `webfetch`/`websearch` handling). Placing these in the shared `permission` block would push meaningless entries into Claude Code, Codex, etc. To scope them to OpenCode, add a tool-scoped `opencode` override key alongside the shared block — mirroring the tool-scoped override keys used by [hooks](#hooks) (`opencode.hooks`) and rules frontmatter. Categories under `opencode.permission` are merged on top of the shared block **per category** (the override wins) and are emitted **only** into `opencode.json` / `opencode.jsonc`; every other tool ignores them. Each value may be a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax.
+>
+> ```jsonc
+> {
+>   "permission": {
+>     "bash": { "git *": "allow", "*": "ask" },
+>   },
+>   // Emitted only into opencode.json's `permission`; never leaks to other tools.
+>   "opencode": {
+>     "permission": {
+>       "external_directory": "deny",
+>       "webfetch": "allow",
+>     },
+>   },
+> }
+> ```
+>
+> On **import**, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, or an `mcp__*` tool name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools.
+
 For Codex CLI, this generates a `rulesync` named profile in `.codex/config.toml` under `[permissions.rulesync]` and sets `default_permissions = "rulesync"` (project/global depending on mode). It also generates `.codex/rules/rulesync.rules` from `permission.bash` entries using `prefix_rule(...)`. Current Rulesync-to-Codex mapping supports `bash`, `read`, `edit`/`write`, and `webfetch` categories:
 
 - `bash`: generates one `prefix_rule(...)` per command pattern in `.codex/rules/rulesync.rules` (`allow` → `allow`, `ask` → `prompt`, `deny` → `forbidden`)

--- a/src/features/permissions/opencode-permissions.test.ts
+++ b/src/features/permissions/opencode-permissions.test.ts
@@ -140,6 +140,21 @@ describe("OpencodePermissions", () => {
     });
   });
 
+  it("should keep the all-tools wildcard category in the shared block on import", async () => {
+    await writeFileContent(
+      join(testDir, "opencode.json"),
+      JSON.stringify({ permission: { "*": "ask" } }),
+    );
+
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    // `"*"` is the all-tools key: it must stay shared (matching the string form
+    // `"permission": "ask"`), not be routed into the OpenCode-only override.
+    expect(rulesync.permission).toEqual({ "*": { "*": "ask" } });
+    expect(rulesync.opencode).toBeUndefined();
+  });
+
   it("should omit the opencode override when there are no OpenCode-only categories", async () => {
     await writeFileContent(
       join(testDir, "opencode.json"),

--- a/src/features/permissions/opencode-permissions.test.ts
+++ b/src/features/permissions/opencode-permissions.test.ts
@@ -81,6 +81,103 @@ describe("OpencodePermissions", () => {
     expect(rulesync.permission).toEqual({ "*": { "*": "allow" } });
   });
 
+  it("should merge the opencode override on top of the shared block (override wins per category)", async () => {
+    await writeFileContent(join(testDir, "opencode.json"), JSON.stringify({ model: "x" }));
+    const rulesyncPermissions = new RulesyncPermissions({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+      fileContent: JSON.stringify({
+        permission: {
+          bash: { "*": "ask", "git *": "allow" },
+          webfetch: { "*": "ask" },
+        },
+        opencode: {
+          permission: {
+            external_directory: "deny",
+            webfetch: "allow",
+          },
+        },
+      }),
+    });
+
+    const instance = await OpencodePermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions,
+    });
+    const json = JSON.parse(instance.getFileContent());
+
+    // Shared block carried over untouched.
+    expect(json.permission.bash).toEqual({ "*": "ask", "git *": "allow" });
+    // OpenCode-only category emitted.
+    expect(json.permission.external_directory).toBe("deny");
+    // Override wins per category over the shared value.
+    expect(json.permission.webfetch).toBe("allow");
+  });
+
+  it("should route OpenCode-only categories into the opencode override on import", async () => {
+    await writeFileContent(
+      join(testDir, "opencode.json"),
+      JSON.stringify({
+        permission: {
+          bash: { "git *": "allow" },
+          external_directory: "deny",
+          task: "ask",
+        },
+      }),
+    );
+
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    // Shared canonical category stays in the shared block.
+    expect(rulesync.permission.bash).toEqual({ "git *": "allow" });
+    expect(rulesync.permission.external_directory).toBeUndefined();
+    // OpenCode-only categories move under the override, preserving their shape.
+    expect(rulesync.opencode?.permission).toEqual({
+      external_directory: "deny",
+      task: "ask",
+    });
+  });
+
+  it("should omit the opencode override when there are no OpenCode-only categories", async () => {
+    await writeFileContent(
+      join(testDir, "opencode.json"),
+      JSON.stringify({ permission: { bash: { "git *": "allow" } } }),
+    );
+
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission.bash).toEqual({ "git *": "allow" });
+    expect(rulesync.opencode).toBeUndefined();
+  });
+
+  it("should round-trip an opencode override stably (generate → import)", async () => {
+    await writeFileContent(join(testDir, "opencode.json"), JSON.stringify({}));
+    const rulesyncPermissions = new RulesyncPermissions({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+      fileContent: JSON.stringify({
+        permission: { bash: { "git *": "allow" } },
+        opencode: { permission: { external_directory: "deny" } },
+      }),
+    });
+
+    const generated = await OpencodePermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions,
+    });
+    await writeFileContent(join(testDir, "opencode.json"), generated.getFileContent());
+
+    const imported = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = imported.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission).toEqual({ bash: { "git *": "allow" } });
+    expect(rulesync.opencode?.permission).toEqual({ external_directory: "deny" });
+  });
+
   it("should support global mode file resolution", async () => {
     await ensureDir(join(testDir, ".config", "opencode"));
     await writeFileContent(

--- a/src/features/permissions/opencode-permissions.ts
+++ b/src/features/permissions/opencode-permissions.ts
@@ -52,7 +52,15 @@ const CANONICAL_PERMISSION_CATEGORIES = new Set([
 ]);
 
 function isSharedPermissionCategory(category: string): boolean {
-  return CANONICAL_PERMISSION_CATEGORIES.has(category) || category.startsWith("mcp__");
+  // `"*"` is OpenCode's all-tools key and carries a cross-tool meaning in the
+  // canonical rulesync model (the string form `"permission": "allow"` normalizes
+  // to the same `{ "*": { "*": action } }` shape), so it must stay in the shared
+  // block rather than being routed into the OpenCode-only override.
+  return (
+    category === "*" ||
+    CANONICAL_PERMISSION_CATEGORIES.has(category) ||
+    category.startsWith("mcp__")
+  );
 }
 
 const OpencodePermissionsConfigSchema = z.looseObject({

--- a/src/features/permissions/opencode-permissions.ts
+++ b/src/features/permissions/opencode-permissions.ts
@@ -10,7 +10,11 @@ import {
 } from "../../constants/opencode-paths.js";
 import type { AiFileParams } from "../../types/ai-file.js";
 import { ValidationResult } from "../../types/ai-file.js";
-import type { PermissionsConfig } from "../../types/permissions.js";
+import type {
+  OpencodePermissionsOverride,
+  PermissionAction,
+  PermissionsConfig,
+} from "../../types/permissions.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -26,6 +30,30 @@ const OpencodePermissionSchema = z.union([
   z.enum(["allow", "ask", "deny"]),
   z.record(z.string(), z.enum(["allow", "ask", "deny"])),
 ]);
+
+/**
+ * Canonical rulesync permission categories that carry a cross-tool meaning (see
+ * the "Supported tool categories" list in `docs/reference/file-formats.md`).
+ * On import, any OpenCode category outside this set — plus MCP tool names — is
+ * treated as OpenCode-only and routed into the `opencode` override block so a
+ * subsequent `rulesync generate` does not leak it into other tools' configs.
+ */
+const CANONICAL_PERMISSION_CATEGORIES = new Set([
+  "bash",
+  "read",
+  "edit",
+  "write",
+  "webfetch",
+  "websearch",
+  "grep",
+  "glob",
+  "notebookedit",
+  "agent",
+]);
+
+function isSharedPermissionCategory(category: string): boolean {
+  return CANONICAL_PERMISSION_CATEGORIES.has(category) || category.startsWith("mcp__");
+}
 
 const OpencodePermissionsConfigSchema = z.looseObject({
   // OpenCode accepts either a per-tool object OR a bare top-level string that
@@ -118,9 +146,15 @@ export class OpencodePermissions extends ToolPermissions {
     }
 
     const parsed = parseJsonc(fileContent ?? "{}");
+    const rulesyncJson = rulesyncPermissions.getJson();
+    // Merge the shared canonical block with the OpenCode-only override. The
+    // override wins per category, so an OpenCode-specific value (e.g. an
+    // `external_directory` deny, or a `webfetch` value tuned only for OpenCode)
+    // replaces the shared entry without affecting other tools' outputs.
+    const overridePermission = rulesyncJson.opencode?.permission ?? {};
     const nextJson = {
       ...parsed,
-      permission: rulesyncPermissions.getJson().permission,
+      permission: { ...rulesyncJson.permission, ...overridePermission },
     };
 
     return new OpencodePermissions({
@@ -133,9 +167,39 @@ export class OpencodePermissions extends ToolPermissions {
   }
 
   toRulesyncPermissions(): RulesyncPermissions {
-    const permission = this.normalizePermission(this.json.permission);
+    const rawPermission = this.json.permission;
+
+    // Top-level uniform string form (`"permission": "allow"`) or an empty config:
+    // keep the existing all-tools wildcard behavior, with nothing to route into
+    // the OpenCode override.
+    if (rawPermission === undefined || typeof rawPermission === "string") {
+      const permission = this.normalizePermission(rawPermission);
+      return this.toRulesyncPermissionsDefault({
+        fileContent: JSON.stringify({ permission }, null, 2),
+      });
+    }
+
+    // Object form: split categories into the shared canonical block and the
+    // OpenCode-only override. Shared categories are normalized into the canonical
+    // pattern-to-action shape; OpenCode-only categories keep their original shape
+    // (bare action string or pattern map) so the round-trip stays stable.
+    const shared: PermissionsConfig["permission"] = {};
+    const overrideOnly: NonNullable<OpencodePermissionsOverride["permission"]> = {};
+    for (const [category, value] of Object.entries(rawPermission)) {
+      if (isSharedPermissionCategory(category)) {
+        shared[category] = typeof value === "string" ? { "*": value } : value;
+      } else {
+        overrideOnly[category] = value;
+      }
+    }
+
+    const json: PermissionsConfig =
+      Object.keys(overrideOnly).length > 0
+        ? { permission: shared, opencode: { permission: overrideOnly } }
+        : { permission: shared };
+
     return this.toRulesyncPermissionsDefault({
-      fileContent: JSON.stringify({ permission }, null, 2),
+      fileContent: JSON.stringify(json, null, 2),
     });
   }
 
@@ -169,8 +233,14 @@ export class OpencodePermissions extends ToolPermissions {
     });
   }
 
+  /**
+   * Normalize the uniform/undefined forms of OpenCode's `permission` field into
+   * the canonical rulesync shape. The object form is handled directly in
+   * `toRulesyncPermissions` (it needs to split shared vs OpenCode-only
+   * categories), so this only covers the two remaining cases.
+   */
   private normalizePermission(
-    permission: OpencodePermissionsConfig["permission"] | undefined,
+    permission: PermissionAction | undefined,
   ): PermissionsConfig["permission"] {
     if (!permission) {
       return {};
@@ -180,15 +250,6 @@ export class OpencodePermissions extends ToolPermissions {
     // it to every tool. The canonical rulesync model represents "all tools /
     // all inputs" with the wildcard tool key `"*"` and the wildcard glob `"*"`,
     // matching how OpenCode's own object syntax uses `"*"` as the all-tools key.
-    if (typeof permission === "string") {
-      return { "*": { "*": permission } };
-    }
-
-    return Object.fromEntries(
-      Object.entries(permission).map(([tool, value]) => [
-        tool,
-        typeof value === "string" ? { "*": value } : value,
-      ]),
-    );
+    return { "*": { "*": permission } };
   }
 }

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -20,9 +20,39 @@ export type PermissionAction = z.infer<typeof PermissionActionSchema>;
 const PermissionRulesSchema = z.record(z.string(), PermissionActionSchema);
 
 /**
+ * OpenCode-specific permission value. Unlike the shared canonical block, which
+ * only accepts a pattern-to-action map, OpenCode also allows a bare action
+ * string that applies to the whole category (e.g. `"external_directory": "deny"`).
+ * This mirrors OpenCode's own permission schema in `opencode-permissions.ts`.
+ */
+const OpencodeOverridePermissionValueSchema = z.union([
+  PermissionActionSchema,
+  PermissionRulesSchema,
+]);
+
+/**
+ * Tool-scoped override block for OpenCode. Permission categories placed here
+ * (e.g. OpenCode-only categories such as `external_directory`) are emitted only
+ * into OpenCode's config and never leak into other tools' permission files. It
+ * also lets a shared category be overridden with an OpenCode-specific value.
+ * Kept `looseObject` so future OpenCode categories are accepted.
+ *
+ * @example
+ * { "permission": { "external_directory": "deny", "webfetch": "allow" } }
+ */
+const OpencodePermissionsOverrideSchema = z.looseObject({
+  permission: z.optional(z.record(z.string(), OpencodeOverridePermissionValueSchema)),
+});
+export type OpencodePermissionsOverride = z.infer<typeof OpencodePermissionsOverrideSchema>;
+
+/**
  * Permissions configuration.
  * Keys are tool category names (e.g., "bash", "edit", "read", "webfetch").
  * Values are pattern-to-action mappings for that tool category.
+ *
+ * The optional `opencode` key is a tool-scoped override that is consumed only by
+ * the OpenCode translator (see `OpencodePermissionsOverrideSchema`); every other
+ * tool reads the shared `permission` block and ignores it.
  *
  * @example
  * {
@@ -32,6 +62,7 @@ const PermissionRulesSchema = z.record(z.string(), PermissionActionSchema);
  */
 const PermissionsConfigSchema = z.looseObject({
   permission: z.record(z.string(), PermissionRulesSchema),
+  opencode: z.optional(OpencodePermissionsOverrideSchema),
 });
 export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;
 


### PR DESCRIPTION
## Summary

Adds an optional tool-scoped `opencode` override key to `.rulesync/permissions.json`, so OpenCode-specific permission categories can be configured without leaking into other tools' permission files.

This follows the same tool-scoped override convention already used by hooks (`opencode.hooks`) and rules frontmatter.

Closes #2127

## Changes

- **Schema (`src/types/permissions.ts`)**: extend the permissions config with an optional `opencode: { permission: {...} }` override key. Values accept either a bare action string (`"deny"`) or a pattern map (`{ "*": "ask" }`), matching OpenCode's own permission syntax. Kept `looseObject` so future OpenCode categories are accepted.
- **OpenCode translator (`fromRulesyncPermissions`)**: merge the shared `permission` block with `opencode.permission` **per category** (the override wins) before writing `opencode.json` / `opencode.jsonc`.
- **Import round-trip (`toRulesyncPermissions`)**: on import, any OpenCode category that is not a shared canonical rulesync category (`bash`, `read`, `edit`, `write`, `webfetch`, `websearch`, `grep`, `glob`, `notebookedit`, `agent`, or an `mcp__*` name) is routed into the `opencode` override rather than the shared block, so a subsequent `rulesync generate` does not leak it into other tools. OpenCode-only categories preserve their original shape for a stable round-trip.
- **Other tools**: unchanged — they read only the shared `permission` block and ignore the `opencode` key.
- **Docs**: documented the override in the OpenCode permissions section of `docs/reference/file-formats.md` (synced to `skills/rulesync/`). The generated `permissions-schema.json` (gitignored build artifact) picks up the new key automatically.
- **Tests**: added cases for the override merge (override wins per category), the import split into the override, override omission when there are no OpenCode-only categories, and a generate → import round-trip.

## Notes

- Verified the OpenCode-supported permission category names against the [OpenCode permissions docs](https://opencode.ai/docs/permissions/): `external_directory` / `webfetch` / `websearch` exist, but **`codesearch` does not** — so it was dropped from the implementation and examples.
- **Kilo (open question from the issue)**: deferred. Kilo is an OpenCode fork sharing the same permission shape, so an equivalent `kilo` override key could be added in a follow-up. Keeping this PR scoped to OpenCode as the issue title specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
