### PR TITLE
fix(mcp): map Codex MCP oauth clientId to snake_case client_id

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -695,7 +695,7 @@ client_id = "1601185624273.8899143856786"
 callbackPort = 3118
 ```
 
-An explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
+Only a string `clientId` is duplicated (a non-string value would not be a usable OAuth client id), and an explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
 
 > **Grok CLI note:** MCP servers are written to a `[mcp_servers.<name>]` table in `.grok/config.toml` (project) / `~/.grok/config.toml` (global, via `--global`). The file is treated as shared Grok config: Rulesync only replaces the `mcp_servers` key and preserves every other table on round-trip, and it is never deleted. Unlike Codex CLI, Grok uses a literal `env` table (it does not support the `env_vars` runtime-passthrough list) and has no per-server tool allow/deny lists, so the only field rename is `disabled` (rulesync) ⇄ `enabled = false` (grok); an active server simply omits `enabled`. Servers with no environment variables are emitted without a dangling `[mcp_servers.<name>.env]` table (empty nested tables are stripped), and a server whose entire configuration would be empty is dropped with a warning.
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -684,6 +684,19 @@ env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
 - Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
 - Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined; see the [Codex configuration reference](https://developers.openai.com/codex/config-reference#mcp_serversid-env_vars) (last checked 2026-05-13) for the exact resolution rule.
 
+#### Codex-specific: OAuth client id (`oauth.clientId` → `client_id`)
+
+A server's `oauth` block is preserved in the canonical Claude Code shape (camelCase `clientId`), but Codex CLI reads the OAuth client id from snake_case `oauth.client_id`. Without it, `codex mcp login <server>` falls back to dynamic client registration and fails for providers that do not support it (e.g. Slack). The codex generator therefore **duplicates** `clientId` into a sibling `client_id`, keeping the camelCase key so tools that expect it keep working:
+
+```toml
+[mcp_servers.slack.oauth]
+clientId = "1601185624273.8899143856786"
+client_id = "1601185624273.8899143856786"
+callbackPort = 3118
+```
+
+An explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
+
 > **Grok CLI note:** MCP servers are written to a `[mcp_servers.<name>]` table in `.grok/config.toml` (project) / `~/.grok/config.toml` (global, via `--global`). The file is treated as shared Grok config: Rulesync only replaces the `mcp_servers` key and preserves every other table on round-trip, and it is never deleted. Unlike Codex CLI, Grok uses a literal `env` table (it does not support the `env_vars` runtime-passthrough list) and has no per-server tool allow/deny lists, so the only field rename is `disabled` (rulesync) ⇄ `enabled = false` (grok); an active server simply omits `enabled`. Servers with no environment variables are emitted without a dangling `[mcp_servers.<name>.env]` table (empty nested tables are stripped), and a server whose entire configuration would be empty is dropped with a warning.
 
 ### Goose-specific: MCP servers as `extensions` (global) and open-plugin manifest (project)

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -695,7 +695,7 @@ client_id = "1601185624273.8899143856786"
 callbackPort = 3118
 ```
 
-An explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
+Only a string `clientId` is duplicated (a non-string value would not be a usable OAuth client id), and an explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
 
 > **Grok CLI note:** MCP servers are written to a `[mcp_servers.<name>]` table in `.grok/config.toml` (project) / `~/.grok/config.toml` (global, via `--global`). The file is treated as shared Grok config: Rulesync only replaces the `mcp_servers` key and preserves every other table on round-trip, and it is never deleted. Unlike Codex CLI, Grok uses a literal `env` table (it does not support the `env_vars` runtime-passthrough list) and has no per-server tool allow/deny lists, so the only field rename is `disabled` (rulesync) ⇄ `enabled = false` (grok); an active server simply omits `enabled`. Servers with no environment variables are emitted without a dangling `[mcp_servers.<name>.env]` table (empty nested tables are stripped), and a server whose entire configuration would be empty is dropped with a warning.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -684,6 +684,19 @@ env_vars = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"]
 - Use this for secrets and API keys you do not want literal-encoded into a committed `mcp.json`.
 - Precedence: codex CLI resolves these names from the user's runtime shell environment. If a name is also set in `env` (literal value), the codex CLI behavior is upstream-defined; see the [Codex configuration reference](https://developers.openai.com/codex/config-reference#mcp_serversid-env_vars) (last checked 2026-05-13) for the exact resolution rule.
 
+#### Codex-specific: OAuth client id (`oauth.clientId` → `client_id`)
+
+A server's `oauth` block is preserved in the canonical Claude Code shape (camelCase `clientId`), but Codex CLI reads the OAuth client id from snake_case `oauth.client_id`. Without it, `codex mcp login <server>` falls back to dynamic client registration and fails for providers that do not support it (e.g. Slack). The codex generator therefore **duplicates** `clientId` into a sibling `client_id`, keeping the camelCase key so tools that expect it keep working:
+
+```toml
+[mcp_servers.slack.oauth]
+clientId = "1601185624273.8899143856786"
+client_id = "1601185624273.8899143856786"
+callbackPort = 3118
+```
+
+An explicit `client_id` already present in the source is left untouched. On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
+
 > **Grok CLI note:** MCP servers are written to a `[mcp_servers.<name>]` table in `.grok/config.toml` (project) / `~/.grok/config.toml` (global, via `--global`). The file is treated as shared Grok config: Rulesync only replaces the `mcp_servers` key and preserves every other table on round-trip, and it is never deleted. Unlike Codex CLI, Grok uses a literal `env` table (it does not support the `env_vars` runtime-passthrough list) and has no per-server tool allow/deny lists, so the only field rename is `disabled` (rulesync) ⇄ `enabled = false` (grok); an active server simply omits `enabled`. Servers with no environment variables are emitted without a dangling `[mcp_servers.<name>.env]` table (empty nested tables are stripped), and a server whose entire configuration would be empty is dropped with a warning.
 
 ### Goose-specific: MCP servers as `extensions` (global) and open-plugin manifest (project)

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -1836,6 +1836,77 @@ callbackPort = 3118
       });
     });
 
+    it("does not duplicate a non-string clientId", async () => {
+      const jsonData = {
+        mcpServers: {
+          slack: {
+            type: "http",
+            url: "https://mcp.slack.com/mcp",
+            oauth: {
+              // A non-string client id is not a usable OAuth client id, so it is
+              // left as-is rather than duplicated into `client_id`.
+              clientId: 12345,
+            },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: false,
+      });
+
+      const oauth = (codexcliMcp.getToml().mcp_servers as any).slack.oauth;
+      expect(oauth.clientId).toBe(12345);
+      expect("client_id" in oauth).toBe(false);
+    });
+
+    it("keeps a full generate → import round-trip stable", async () => {
+      const jsonData = {
+        mcpServers: {
+          slack: {
+            type: "http",
+            url: "https://mcp.slack.com/mcp",
+            oauth: {
+              clientId: "1601185624273.8899143856786",
+              callbackPort: 3118,
+            },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      // Generate the codex config, then re-parse it as a CodexcliMcp and convert
+      // back to the canonical shape — the OAuth block must collapse back to just
+      // the camelCase clientId.
+      const generated = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: false,
+      });
+      const reimported = new CodexcliMcp({
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: generated.getFileContent(),
+      });
+
+      const json = JSON.parse(reimported.toRulesyncMcp().getFileContent());
+      expect(json.mcpServers.slack.oauth).toEqual({
+        clientId: "1601185624273.8899143856786",
+        callbackPort: 3118,
+      });
+    });
+
     it("prefers canonical clientId and drops client_id when both are present on import", () => {
       const tomlContent = `[mcp_servers.slack.oauth]
 clientId = "camel-value"

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -1750,4 +1750,105 @@ enabled_tools = ["search"]
       expect(mcpServers["local-server"].enabled_tools).toEqual(["search"]);
     });
   });
+
+  describe("oauth client id mapping (#2158)", () => {
+    it("duplicates oauth.clientId to snake_case client_id on outbound conversion", async () => {
+      const jsonData = {
+        mcpServers: {
+          slack: {
+            type: "http",
+            url: "https://mcp.slack.com/mcp",
+            oauth: {
+              clientId: "1601185624273.8899143856786",
+              callbackPort: 3118,
+            },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: false,
+      });
+
+      const oauth = (codexcliMcp.getToml().mcp_servers as any).slack.oauth;
+      // Both keys are emitted: camelCase for tools that read it, and snake_case
+      // for Codex CLI's login flow.
+      expect(oauth.client_id).toBe("1601185624273.8899143856786");
+      expect(oauth.clientId).toBe("1601185624273.8899143856786");
+      expect(oauth.callbackPort).toBe(3118);
+    });
+
+    it("does not overwrite an existing client_id", async () => {
+      const jsonData = {
+        mcpServers: {
+          slack: {
+            type: "http",
+            url: "https://mcp.slack.com/mcp",
+            oauth: {
+              clientId: "camel-value",
+              client_id: "snake-value",
+            },
+          },
+        },
+      };
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify(jsonData),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: false,
+      });
+
+      const oauth = (codexcliMcp.getToml().mcp_servers as any).slack.oauth;
+      expect(oauth.client_id).toBe("snake-value");
+    });
+
+    it("collapses client_id back to canonical clientId on inbound conversion", () => {
+      const tomlContent = `[mcp_servers.slack]
+type = "http"
+url = "https://mcp.slack.com/mcp"
+
+[mcp_servers.slack.oauth]
+client_id = "1601185624273.8899143856786"
+callbackPort = 3118
+`;
+      const codexcliMcp = new CodexcliMcp({
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const json = JSON.parse(codexcliMcp.toRulesyncMcp().getFileContent());
+      expect(json.mcpServers.slack.oauth).toEqual({
+        clientId: "1601185624273.8899143856786",
+        callbackPort: 3118,
+      });
+    });
+
+    it("prefers canonical clientId and drops client_id when both are present on import", () => {
+      const tomlContent = `[mcp_servers.slack.oauth]
+clientId = "camel-value"
+client_id = "camel-value"
+`;
+      const codexcliMcp = new CodexcliMcp({
+        relativeDirPath: ".codex",
+        relativeFilePath: "config.toml",
+        fileContent: tomlContent,
+      });
+
+      const json = JSON.parse(codexcliMcp.toRulesyncMcp().getFileContent());
+      expect(json.mcpServers.slack.oauth).toEqual({ clientId: "camel-value" });
+    });
+  });
 });

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -33,6 +33,46 @@ const RULESYNC_TO_CODEX_FIELD_MAP: Record<string, string> = {
 
 const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
 
+/**
+ * Translate a server's `oauth` table from the canonical rulesync shape (Claude
+ * Code style camelCase) into the shape Codex CLI understands. Codex expects the
+ * OAuth client id under snake_case `client_id`; without it `codex mcp login`
+ * falls back to dynamic client registration and fails for providers that do not
+ * support it (e.g. Slack, see #2158). The canonical `clientId` is kept alongside
+ * the added `client_id` so tools that read the camelCase shape keep working and
+ * the round-trip stays stable.
+ */
+function mapOauthToCodex(oauth: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(oauth)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+    result[key] = value;
+  }
+  if (typeof oauth["clientId"] === "string" && !("client_id" in result)) {
+    result["client_id"] = oauth["clientId"];
+  }
+  return result;
+}
+
+/**
+ * Reverse of {@link mapOauthToCodex}: collapse Codex's `oauth.client_id` back to
+ * the canonical `clientId` on import. When both keys are present (the shape
+ * rulesync itself emits) the canonical `clientId` wins and `client_id` is
+ * dropped so a subsequent generate does not accumulate duplicates.
+ */
+function mapOauthFromCodex(oauth: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(oauth)) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+    if (key === "client_id") {
+      if (!("clientId" in oauth)) result["clientId"] = value;
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
@@ -46,6 +86,8 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
         if (value === false) {
           converted["disabled"] = true;
         }
+      } else if (key === "oauth" && isRecord(value)) {
+        converted[key] = mapOauthFromCodex(value);
       } else if (Object.hasOwn(CODEX_TO_RULESYNC_FIELD_MAP, key)) {
         const mappedKey = CODEX_TO_RULESYNC_FIELD_MAP[key];
         if (mappedKey) {
@@ -79,6 +121,8 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
         if (value === true) {
           converted["enabled"] = false;
         }
+      } else if (key === "oauth" && isRecord(value)) {
+        converted[key] = mapOauthToCodex(value);
       } else if (Object.hasOwn(RULESYNC_TO_CODEX_FIELD_MAP, key)) {
         const mappedKey = RULESYNC_TO_CODEX_FIELD_MAP[key];
         if (mappedKey) {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -7,7 +7,10 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { warnWithFallback } from "../../utils/logger.js";
-import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
+import {
+  omitPrototypePollutionKeys,
+  PROTOTYPE_POLLUTION_KEYS,
+} from "../../utils/prototype-pollution.js";
 import { isPlainObject, isRecord, isStringArray } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
@@ -43,11 +46,9 @@ const MAX_REMOVE_EMPTY_ENTRIES_DEPTH = 32;
  * the round-trip stays stable.
  */
 function mapOauthToCodex(oauth: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(oauth)) {
-    if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
-    result[key] = value;
-  }
+  const result = omitPrototypePollutionKeys(oauth);
+  // Only a string client id is duplicated: Codex's `client_id` must be a bare
+  // string, and a non-string value would not be a usable OAuth client id anyway.
   if (typeof oauth["clientId"] === "string" && !("client_id" in result)) {
     result["client_id"] = oauth["clientId"];
   }


### PR DESCRIPTION
## Problem

Rulesync preserved MCP server OAuth config in the canonical Claude Code shape (camelCase `clientId`), but the Codex CLI reads the OAuth client id from snake_case `oauth.client_id`. As a result `codex mcp login <server>` fell back to dynamic client registration and failed for providers that do not support it (e.g. Slack).

## Fix

- The codex MCP generator now duplicates `oauth.clientId` into a sibling `client_id` in `.codex/config.toml`, keeping the camelCase key so tools that expect it keep working. An explicit `client_id` already present in the source is left untouched.
- On import, `client_id` collapses back to the canonical `clientId` (and is dropped when both are present) so the round-trip stays stable.
- Documented under "Codex-specific: OAuth client id" in `docs/reference/file-formats.md` (auto-synced to `skills/rulesync/`).
- Added round-trip unit tests.

Note: this nested `oauth.client_id` field is not in OpenAI's published config reference; the mapping is based on the reporter's empirical verification with codex-cli 0.142.5. Duplicating (rather than renaming) keeps existing consumers working.

Closes #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)