### PR TITLE
feat(hooks): map deepagents preToolUse/postToolUse to tool.use/tool.result

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -132,8 +132,8 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |        —        |        —        |   —   |     ✅      |  ✅   |
 | `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |  ✅  |        —        |        —        |   —   |     ✅      |  ✅   |
 | `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |        —        |        —        |  ✅   |      —      |  ✅   |
-| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
-| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
+| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
+| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
 | `preModelInvocation`   |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postModelInvocation`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postToolUseFailure`   |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -132,8 +132,8 @@ Events present in the shared `hooks` block but unsupported by a given tool are s
 | `sessionStart`         |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |        —        |        —        |   —   |     ✅      |  ✅   |
 | `sessionEnd`           |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |     —     |     ✅     |  ✅  |        —        |        —        |   —   |     ✅      |  ✅   |
 | `beforeSubmitPrompt`   |   ✅   |     ✅      |    —     |  —   |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |        —        |        —        |  ✅   |      —      |  ✅   |
-| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
-| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     —      |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
+| `preToolUse`           |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
+| `postToolUse`          |   ✅   |     ✅      |    ✅    |  ✅  |   ✅    |     ✅      |      ✅       |     ✅     |    ✅     |     ✅     |  ✅  |       ✅        |       ✅        |   —   |     ✅      |  ✅   |
 | `preModelInvocation`   |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postModelInvocation`  |   —    |      —      |    —     |  —   |    —    |      —      |       —       |     —      |     —     |     —      |  —   |       ✅        |       ✅        |   —   |      —      |   —   |
 | `postToolUseFailure`   |   ✅   |     ✅      |    —     |  —   |    —    |     ✅      |       —       |     —      |     —     |     ✅     |  —   |        —        |        —        |   —   |      —      |  ✅   |

--- a/src/features/hooks/deepagents-hooks.test.ts
+++ b/src/features/hooks/deepagents-hooks.test.ts
@@ -151,6 +151,36 @@ describe("DeepagentsHooks", () => {
       expect(entry.command).toEqual(["bash", "-c", "echo needs input"]);
     });
 
+    it("should map the canonical preToolUse/postToolUse events to dcode tool.use/tool.result", () => {
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            preToolUse: [{ type: "command", command: "echo before" }],
+            postToolUse: [{ type: "command", command: "echo after" }],
+          },
+        }),
+      });
+
+      const hooks = DeepagentsHooks.fromRulesyncHooks({ outputRoot: testDir, rulesyncHooks });
+      const parsed = JSON.parse(hooks.getFileContent());
+
+      const useEntry = parsed.hooks.find((h: { events?: string[] }) =>
+        h.events?.includes("tool.use"),
+      );
+      expect(useEntry).toBeDefined();
+      expect(useEntry.command).toEqual(["bash", "-c", "echo before"]);
+
+      const resultEntry = parsed.hooks.find((h: { events?: string[] }) =>
+        h.events?.includes("tool.result"),
+      );
+      expect(resultEntry).toBeDefined();
+      expect(resultEntry.command).toEqual(["bash", "-c", "echo after"]);
+    });
+
     it("should skip prompt-type hooks", () => {
       const rulesyncHooksContent = JSON.stringify({
         version: 1,
@@ -179,8 +209,8 @@ describe("DeepagentsHooks", () => {
       const rulesyncHooksContent = JSON.stringify({
         version: 1,
         hooks: {
-          // preToolUse is NOT in DEEPAGENTS_HOOK_EVENTS
-          preToolUse: [{ type: "command", command: "echo tool" }],
+          // subagentStop is NOT in DEEPAGENTS_HOOK_EVENTS
+          subagentStop: [{ type: "command", command: "echo tool" }],
           sessionStart: [{ type: "command", command: "echo start" }],
         },
       });

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -317,6 +317,8 @@ export const DEEPAGENTS_HOOK_EVENTS: readonly HookEvent[] = [
   "sessionEnd",
   "beforeSubmitPrompt",
   "permissionRequest",
+  "preToolUse",
+  "postToolUse",
   "postToolUseFailure",
   "stop",
   "preCompact",
@@ -890,6 +892,9 @@ export const CANONICAL_TO_DEEPAGENTS_EVENT_NAMES: Record<string, string> = {
   sessionEnd: "session.end",
   beforeSubmitPrompt: "user.prompt",
   permissionRequest: "permission.request",
+  // Tool lifecycle events added upstream in deepagents-code 0.1.32.
+  preToolUse: "tool.use",
+  postToolUse: "tool.result",
   postToolUseFailure: "tool.error",
   stop: "task.complete",
   preCompact: "context.compact",


### PR DESCRIPTION
## Problem

Deep Agents CLI (`deepagents-code`) added two lifecycle hook events, `tool.use` (before a tool call) and `tool.result` (after a tool call), in `v0.1.32`. rulesync mapped only `tool.error` for the deepagents tool lifecycle, so canonical `preToolUse`/`postToolUse` command hooks were silently dropped for the `deepagents` target.

## Fix

- Add `preToolUse` and `postToolUse` to `DEEPAGENTS_HOOK_EVENTS` and map them to `tool.use` / `tool.result` in `CANONICAL_TO_DEEPAGENTS_EVENT_NAMES` (`src/types/hooks.ts`). No schema change — these events carry no matcher, matching the existing matcher-less command-hook path.
- Flip the `deepagents` column to supported for the `preToolUse`/`postToolUse` rows in the hook-event support matrix (`docs/reference/file-formats.md`, auto-synced to `skills/rulesync/`).
- Add positive round-trip coverage and update the "skip unsupported event" test to use a still-unsupported event (`subagentStop`).

Upstream reads `hooks.json` only from `~/.deepagents/hooks.json`, so the deepagents hooks scope stays global-only (unchanged).

Source: https://github.com/langchain-ai/deepagents/releases (deepagents-code 0.1.32).

Closes #2156

🤖 Generated with [Claude Code](https://claude.com/claude-code)