### PR TITLE
feat(mcp): map Hermes per-server tool filters (tools.include/exclude)

### DIFF
--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -258,6 +258,44 @@ describe("HermesagentMcp", () => {
       expect(server?.tools).toEqual({ include: ["search", "fetch"], exclude: ["delete"] });
     });
 
+    it("emits only include when only enabledTools is set", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { fetch: { command: "uvx", enabledTools: ["search"] } },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.tools).toEqual({ include: ["search"] });
+    });
+
+    it("emits only exclude when only disabledTools is set", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: { fetch: { command: "uvx", disabledTools: ["delete"] } },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.tools).toEqual({ exclude: ["delete"] });
+    });
+
     it("omits the tools block when no tool filters are set", async () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -233,6 +233,48 @@ describe("HermesagentMcp", () => {
       expect(server?.disabled).toBeUndefined();
     });
 
+    it("maps canonical enabledTools/disabledTools to the Hermes tools block", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            fetch: {
+              command: "uvx",
+              enabledTools: ["search", "fetch"],
+              disabledTools: ["delete"],
+            },
+          },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.tools).toEqual({ include: ["search", "fetch"], exclude: ["delete"] });
+    });
+
+    it("omits the tools block when no tool filters are set", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: { fetch: { command: "uvx" } } }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.tools).toBeUndefined();
+    });
+
     it("preserves other config.yaml keys when merging", async () => {
       const dir = join(testDir, HERMES_DIR);
       await ensureDir(dir);
@@ -294,6 +336,32 @@ describe("HermesagentMcp", () => {
         disabled: true,
       });
       expect(servers.legacy.enabled).toBeUndefined();
+    });
+
+    it("maps the Hermes tools block back to canonical enabledTools/disabledTools", async () => {
+      const dir = join(testDir, HERMES_DIR);
+      await ensureDir(dir);
+      await writeFileContent(
+        join(dir, HERMES_FILE),
+        [
+          "mcp_servers:",
+          "  fetch:",
+          "    command: uvx",
+          "    tools:",
+          "      include: [search, fetch]",
+          "      exclude: [delete]",
+          "",
+        ].join("\n"),
+      );
+
+      const mcp = await HermesagentMcp.fromFile({ outputRoot: testDir, global: true });
+      const servers = JSON.parse(mcp.toRulesyncMcp().getFileContent()).mcpServers;
+
+      expect(servers.fetch).toMatchObject({
+        command: "uvx",
+        enabledTools: ["search", "fetch"],
+        disabledTools: ["delete"],
+      });
     });
 
     it("strips prototype-pollution keys from a server's headers on import", async () => {

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -86,7 +86,9 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
   if (timeout !== undefined) out.timeout = timeout;
 
   // Per-server selective tool loading. Canonical `enabledTools`/`disabledTools`
-  // map to Hermes's `tools: { include, exclude }` block (see hermes-agent mcp.md).
+  // map to Hermes's `tools: { include, exclude }` block (include = whitelist,
+  // exclude = denylist; see hermes-agent `apps/desktop/src/lib/mcp-tool-filter.ts`
+  // and `tools/mcp_tool.py`'s `_register_server_tools`).
   const tools: Record<string, unknown> = {};
   if (isStringArray(config.enabledTools)) tools.include = config.enabledTools;
   if (isStringArray(config.disabledTools)) tools.exclude = config.disabledTools;

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -50,10 +50,12 @@ function resolveHermesTimeout(config: Record<string, unknown>): number | undefin
  *
  * Hermes is close to the MCP spec but not identical: `command` must be a single
  * executable string (an array's tail folds into `args`), a server is disabled
- * via `enabled: false` (not the canonical `disabled: true`), and remote servers
- * use `url`/`headers`. Only fields Hermes understands are emitted, so the shared
- * `config.yaml` is not polluted with canonical-only aliases (`type`, `transport`,
- * `httpUrl`, `networkTimeout`, tool-filter keys, ...).
+ * via `enabled: false` (not the canonical `disabled: true`), remote servers use
+ * `url`/`headers`, and per-server tool scoping lives under a `tools: { include,
+ * exclude }` block (from the canonical `enabledTools`/`disabledTools`). Only
+ * fields Hermes understands are emitted, so the shared `config.yaml` is not
+ * polluted with canonical-only aliases (`type`, `transport`, `httpUrl`,
+ * `networkTimeout`, ...).
  */
 function convertServerToHermes(config: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -82,6 +84,13 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
 
   const timeout = resolveHermesTimeout(config);
   if (timeout !== undefined) out.timeout = timeout;
+
+  // Per-server selective tool loading. Canonical `enabledTools`/`disabledTools`
+  // map to Hermes's `tools: { include, exclude }` block (see hermes-agent mcp.md).
+  const tools: Record<string, unknown> = {};
+  if (isStringArray(config.enabledTools)) tools.include = config.enabledTools;
+  if (isStringArray(config.disabledTools)) tools.exclude = config.disabledTools;
+  if (Object.keys(tools).length > 0) out.tools = tools;
 
   return out;
 }
@@ -135,6 +144,10 @@ function convertFromHermesFormat(mcpServers: Record<string, unknown>): McpServer
     if (isPlainObject(config.headers)) server.headers = omitPrototypePollutionKeys(config.headers);
     if (config.enabled === false) server.disabled = true;
     if (typeof config.timeout === "number") server.networkTimeout = config.timeout;
+    if (isRecord(config.tools)) {
+      if (isStringArray(config.tools.include)) server.enabledTools = config.tools.include;
+      if (isStringArray(config.tools.exclude)) server.disabledTools = config.tools.exclude;
+    }
 
     result[name] = server;
   }


### PR DESCRIPTION
## Problem

Hermes Agent documents a per-MCP-server `tools: { include, exclude }` block for selective tool loading, but rulesync's Hermes MCP adapter emitted only `command/args/env/url/headers/enabled/timeout` and discarded the canonical tool-filter keys. A user who scoped a server's tools lost that scoping on generate — Hermes then loaded all of the server's tools.

## Fix

- `convertServerToHermes` now maps canonical `enabledTools` -> `tools.include` and `disabledTools` -> `tools.exclude`, emitting the `tools` block only when at least one filter is set.
- `convertFromHermesFormat` reverses it on import (`tools.include` -> `enabledTools`, `tools.exclude` -> `disabledTools`).
- Added round-trip coverage for both directions.

Hermes MCP remains global-only (`~/.hermes/config.yaml`), unchanged.

Source: https://github.com/NousResearch/hermes-agent/blob/main/mcp.md

Closes #2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)