### PR TITLE
fix(skills): emit Devin global skills to ~/.config/devin/skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,7 +238,7 @@ rulesync.local.jsonc
 **/.augment-guidelines
 **/.agents/skills/
 **/.rovodev/prompts.yml
-**/.codeium/windsurf/skills/
+**/.config/devin/skills/
 **/.copilot/agents/
 **/.copilot/mcp-config.json
 **/.copilot/hooks/

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -118,7 +118,7 @@ describe("registry derivation", () => {
       // Shared trees and global-scope outputs (emitted under the home dir).
       "rovodev::skills::**/.agents/skills/",
       "rovodev::commands::**/.rovodev/prompts.yml",
-      "devin::skills::**/.codeium/windsurf/skills/",
+      "devin::skills::**/.config/devin/skills/",
       "copilotcli::subagents::**/.copilot/agents/",
       "copilotcli::mcp::**/.copilot/mcp-config.json",
       "copilotcli::hooks::**/.copilot/hooks/",

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -83,7 +83,7 @@ export const HAND_MAINTAINED_GITIGNORE_ENTRIES: ReadonlyArray<GitignoreEntryTag>
   // not `getSettablePaths` (only the sibling `.rovodev/prompts/` content-file
   // directory is derived automatically), so it needs a hand-maintained entry.
   { target: "rovodev", feature: "commands", entry: "**/.rovodev/prompts.yml" },
-  { target: "devin", feature: "skills", entry: "**/.codeium/windsurf/skills/" },
+  { target: "devin", feature: "skills", entry: "**/.config/devin/skills/" },
   { target: "copilotcli", feature: "subagents", entry: "**/.copilot/agents/" },
   { target: "copilotcli", feature: "mcp", entry: "**/.copilot/mcp-config.json" },
   { target: "copilotcli", feature: "hooks", entry: "**/.copilot/hooks/" },

--- a/src/constants/devin-paths.ts
+++ b/src/constants/devin-paths.ts
@@ -15,11 +15,15 @@ export const DEVIN_GLOBAL_CONFIG_DIR_PATH = join(".config", "devin");
 // `~/.config/devin/agents/` (NOT `.devin/agents/` under the home directory).
 // https://docs.devin.ai/cli/subagents
 export const DEVIN_GLOBAL_AGENTS_DIR_PATH = join(DEVIN_GLOBAL_CONFIG_DIR_PATH, "agents");
+// Devin Local global skills live under `~/.config/devin/skills/` — the
+// Devin-native (XDG) directory, consistent with the global agents/rules paths.
+// The legacy `~/.codeium/<channel>/skills/` location is channel-dependent and no
+// longer emitted. https://docs.devin.ai/cli/extensibility/skills
+export const DEVIN_GLOBAL_SKILLS_DIR_PATH = join(DEVIN_GLOBAL_CONFIG_DIR_PATH, "skills");
 export const CODEIUM_WINDSURF_GLOBAL_WORKFLOWS_DIR_PATH = join(
   CODEIUM_WINDSURF_DIR,
   "global_workflows",
 );
-export const CODEIUM_WINDSURF_SKILLS_DIR_PATH = join(CODEIUM_WINDSURF_DIR, "skills");
 // Native Devin Local config file. Holds `mcpServers`, `permissions`, and (in
 // global mode) `hooks`. Project: `.devin/config.json`; user:
 // `~/.config/devin/config.json`. https://docs.devin.ai/cli/extensibility/configuration

--- a/src/e2e/e2e-skills.spec.ts
+++ b/src/e2e/e2e-skills.spec.ts
@@ -402,7 +402,7 @@ const skillsGlobalTargets = [
   },
   {
     target: "devin",
-    outputPath: join(".codeium", "windsurf", "skills", "test-skill", "SKILL.md"),
+    outputPath: join(".config", "devin", "skills", "test-skill", "SKILL.md"),
   },
   {
     target: "warp",

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -711,7 +711,7 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
         supportsGlobal: true,
         ruleDiscoveryMode: "auto",
         // No additionalConventions.skills needed: Devin auto-discovers skills
-        // from .devin/skills/ and ~/.codeium/windsurf/skills/ directories.
+        // from .devin/skills/ (project) and ~/.config/devin/skills/ (global).
       },
     },
   ],

--- a/src/features/skills/devin-skill.test.ts
+++ b/src/features/skills/devin-skill.test.ts
@@ -31,9 +31,9 @@ describe("DevinSkill", () => {
       expect(paths.relativeDirPath).toBe(join(".devin", "skills"));
     });
 
-    it("should return .codeium/windsurf/skills as relativeDirPath for global mode", () => {
+    it("should return .config/devin/skills as relativeDirPath for global mode", () => {
       const paths = DevinSkill.getSettablePaths({ global: true });
-      expect(paths.relativeDirPath).toBe(join(".codeium", "windsurf", "skills"));
+      expect(paths.relativeDirPath).toBe(join(".config", "devin", "skills"));
     });
   });
 
@@ -133,7 +133,7 @@ Missing description field.`;
     });
 
     it("should create instance from global skill directory", async () => {
-      const skillDir = join(testDir, ".codeium", "windsurf", "skills", "global-skill");
+      const skillDir = join(testDir, ".config", "devin", "skills", "global-skill");
       await ensureDir(skillDir);
       const skillContent = `---
 name: Global Skill
@@ -155,7 +155,7 @@ Global skill body content.`;
         name: "Global Skill",
         description: "A global devin skill",
       });
-      expect(skill.getRelativeDirPath()).toBe(join(".codeium", "windsurf", "skills"));
+      expect(skill.getRelativeDirPath()).toBe(join(".config", "devin", "skills"));
     });
   });
 
@@ -205,7 +205,7 @@ Global skill body content.`;
         global: true,
       });
 
-      expect(devinSkill.getRelativeDirPath()).toBe(join(".codeium", "windsurf", "skills"));
+      expect(devinSkill.getRelativeDirPath()).toBe(join(".config", "devin", "skills"));
     });
   });
 
@@ -326,11 +326,11 @@ Global skill body content.`;
     it("should use global path when global is true", () => {
       const skill = DevinSkill.forDeletion({
         dirName: "cleanup",
-        relativeDirPath: join(".codeium", "windsurf", "skills"),
+        relativeDirPath: join(".config", "devin", "skills"),
         global: true,
       });
 
-      expect(skill.getRelativeDirPath()).toBe(join(".codeium", "windsurf", "skills"));
+      expect(skill.getRelativeDirPath()).toBe(join(".config", "devin", "skills"));
       expect(skill.getGlobal()).toBe(true);
     });
   });

--- a/src/features/skills/devin-skill.ts
+++ b/src/features/skills/devin-skill.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { z } from "zod/mini";
 
 import {
-  CODEIUM_WINDSURF_SKILLS_DIR_PATH,
+  DEVIN_GLOBAL_SKILLS_DIR_PATH,
   DEVIN_SKILLS_DIR_PATH,
 } from "../../constants/devin-paths.js";
 import { SKILL_FILE_NAME } from "../../constants/general.js";
@@ -41,8 +41,9 @@ export type DevinSkillParams = {
  * Represents a Devin (now Devin Desktop) skill directory.
  * Devin supports skills in both project mode under .devin/skills/
  * (preferred since the Devin Desktop rebrand; .devin/skills/ is the legacy
- * fallback the tool still reads) and global mode under ~/.codeium/windsurf/skills/
- * (unchanged by the rebrand).
+ * fallback the tool still reads) and global mode under the Devin-native
+ * ~/.config/devin/skills/ (consistent with Devin's global agents/rules paths;
+ * the legacy channel-dependent ~/.codeium/<channel>/skills/ is no longer emitted).
  */
 export class DevinSkill extends ToolSkill {
   constructor({
@@ -80,10 +81,10 @@ export class DevinSkill extends ToolSkill {
     // Devin skills use different paths for project and global modes:
     // - Project mode: {process.cwd()}/.devin/skills/ (preferred since the Devin
     //   Desktop rebrand; .devin/skills/ is the legacy fallback)
-    // - Global mode: {getHomeDirectory()}/.codeium/windsurf/skills/
+    // - Global mode: {getHomeDirectory()}/.config/devin/skills/ (Devin-native)
     if (global) {
       return {
-        relativeDirPath: CODEIUM_WINDSURF_SKILLS_DIR_PATH,
+        relativeDirPath: DEVIN_GLOBAL_SKILLS_DIR_PATH,
       };
     }
     return {


### PR DESCRIPTION
## Problem

Devin global-scope skills were emitted to the legacy Codeium path (`~/.codeium/windsurf/skills/`) instead of the Devin-native config dir. This is inconsistent with rulesync's own global mappings for Devin's other features (subagents -> `~/.config/devin/agents/`, rules -> `~/.config/devin/AGENTS.md`). `~/.config/devin/skills/` is the primary XDG/Devin-native skill directory per the docs.

## Fix

- Add `DEVIN_GLOBAL_SKILLS_DIR_PATH` = `.config/devin/skills` and switch the global branch of `DevinSkill.getSettablePaths` to emit there (mirroring `DevinSubagent`). The project `.devin/skills/` path is unchanged.
- Remove the now-unused legacy constant, update the hand-maintained gitignore entry (`**/.config/devin/skills/`) and regenerate `.gitignore`.
- Update the Devin global-scope skill tests, the gitignore justified-exceptions snapshot, and the skills e2e global-mode output path.

Source: https://docs.devin.ai/cli/extensibility/skills

Closes #2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)