### PR TITLE
feat(permissions): add a reasonix override for [sandbox]/[agent] plan-mode

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -988,4 +988,18 @@ For JetBrains Junie CLI, this generates the Action Allowlist `rules` object in `
 
 For Reasonix, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in the `[permissions]` table of the shared `reasonix.toml` (project mode) or `~/.reasonix/config.toml` (global mode) — the same TOML file the MCP feature's `[[plugins]]` array-of-tables lives in. The rule syntax mirrors Claude Code's: entries are `Bash(<pattern>)`, `Read(<pattern>)`, `Edit(<pattern>)`, `Write(<pattern>)`, `WebFetch(<pattern>)`, `WebSearch(<pattern>)`, `Grep(<pattern>)`, `Glob(<pattern>)`, `NotebookEdit(<pattern>)`, `Agent(<pattern>)`, etc. (Reasonix's SPEC.md documents these as "Claude Code-style" families; `agent` → `Agent` is the one lower-confidence mapping, since Reasonix's own delegation tool is internally named `task`). `[permissions].mode` (the writer fallback: `ask`/`allow`/`deny`) has no canonical rulesync equivalent and is preserved untouched. The TOML file is shared with the MCP feature, so writes only replace the `permissions` table — every other table (`[[plugins]]`, `[agent]`, `[ui]`, …) is preserved on round-trip, and the file is never deleted. See [SPEC.md §3.7 Permissions](https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/docs/SPEC.md).
 
+> **Reasonix-only override (`reasonix` key):** Reasonix has security axes orthogonal to per-tool allow/ask/deny with no canonical category — the `[sandbox]` enforcement table (`workspace_root`, `allow_write`, `forbid_read`, `bash` = `enforce`/`off`, `network`) and the plan-mode read-only trust lists under `[agent]` (`plan_mode_allowed_tools`, `plan_mode_read_only_commands`). Add a tool-scoped `reasonix` override to author them: `reasonix.sandbox` and `reasonix.agent` are shallow-merged into the matching `reasonix.toml` table at its top level (override keys win, unrelated sibling keys such as `[agent].model` are preserved), while the shared `permission` block keeps driving `[permissions].allow`/`ask`/`deny`. On import, the whole `[sandbox]` table round-trips (it is a dedicated security surface) and only the plan-mode keys are lifted from `[agent]`.
+>
+> ```json
+> {
+>   "permission": { "bash": { "git status*": "allow" } },
+>   "reasonix": {
+>     "sandbox": { "bash": "enforce", "network": false },
+>     "agent": { "plan_mode_read_only_commands": ["gh pr diff"] }
+>   }
+> }
+> ```
+>
+> The `[[plugins]].trusted_read_only_tools` MCP read-only trust list is per-plugin (an array-of-tables shared with the MCP feature) and is not covered by this override.
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -988,4 +988,18 @@ For JetBrains Junie CLI, this generates the Action Allowlist `rules` object in `
 
 For Reasonix, this generates `permissions.allow`, `permissions.ask`, and `permissions.deny` arrays in the `[permissions]` table of the shared `reasonix.toml` (project mode) or `~/.reasonix/config.toml` (global mode) — the same TOML file the MCP feature's `[[plugins]]` array-of-tables lives in. The rule syntax mirrors Claude Code's: entries are `Bash(<pattern>)`, `Read(<pattern>)`, `Edit(<pattern>)`, `Write(<pattern>)`, `WebFetch(<pattern>)`, `WebSearch(<pattern>)`, `Grep(<pattern>)`, `Glob(<pattern>)`, `NotebookEdit(<pattern>)`, `Agent(<pattern>)`, etc. (Reasonix's SPEC.md documents these as "Claude Code-style" families; `agent` → `Agent` is the one lower-confidence mapping, since Reasonix's own delegation tool is internally named `task`). `[permissions].mode` (the writer fallback: `ask`/`allow`/`deny`) has no canonical rulesync equivalent and is preserved untouched. The TOML file is shared with the MCP feature, so writes only replace the `permissions` table — every other table (`[[plugins]]`, `[agent]`, `[ui]`, …) is preserved on round-trip, and the file is never deleted. See [SPEC.md §3.7 Permissions](https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/docs/SPEC.md).
 
+> **Reasonix-only override (`reasonix` key):** Reasonix has security axes orthogonal to per-tool allow/ask/deny with no canonical category — the `[sandbox]` enforcement table (`workspace_root`, `allow_write`, `forbid_read`, `bash` = `enforce`/`off`, `network`) and the plan-mode read-only trust lists under `[agent]` (`plan_mode_allowed_tools`, `plan_mode_read_only_commands`). Add a tool-scoped `reasonix` override to author them: `reasonix.sandbox` and `reasonix.agent` are shallow-merged into the matching `reasonix.toml` table at its top level (override keys win, unrelated sibling keys such as `[agent].model` are preserved), while the shared `permission` block keeps driving `[permissions].allow`/`ask`/`deny`. On import, the whole `[sandbox]` table round-trips (it is a dedicated security surface) and only the plan-mode keys are lifted from `[agent]`.
+>
+> ```json
+> {
+>   "permission": { "bash": { "git status*": "allow" } },
+>   "reasonix": {
+>     "sandbox": { "bash": "enforce", "network": false },
+>     "agent": { "plan_mode_read_only_commands": ["gh pr diff"] }
+>   }
+> }
+> ```
+>
+> The `[[plugins]].trusted_read_only_tools` MCP read-only trust list is per-plugin (an array-of-tables shared with the MCP feature) and is not covered by this override.
+
 > **Note: Interaction with ignore feature.** Both the ignore feature and the permissions feature can manage `Read` tool deny entries in `.claude/settings.json`. When both features configure the `Read` tool, the **permissions feature takes precedence** and a warning is emitted. If you only need to restrict file reads based on glob patterns, use the ignore feature (`.rulesync/.aiignore`). Use permissions only when you need fine-grained `allow`/`ask`/`deny` control over the `Read` tool.

--- a/src/features/permissions/reasonix-permissions.test.ts
+++ b/src/features/permissions/reasonix-permissions.test.ts
@@ -267,6 +267,86 @@ describe("ReasonixPermissions", () => {
     });
   });
 
+  describe("reasonix override (sandbox / agent plan-mode)", () => {
+    it("merges sandbox and agent plan-mode tables from the override", async () => {
+      const instance = await ReasonixPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({
+            permission: { bash: { "git *": "allow" } },
+            reasonix: {
+              sandbox: { bash: "enforce", network: false, allow_write: ["/tmp"] },
+              agent: { plan_mode_read_only_commands: ["gh pr diff"] },
+            },
+          }),
+        }),
+      });
+
+      const parsed = smolToml.parse(instance.getFileContent()) as any;
+      expect(parsed.sandbox).toEqual({ bash: "enforce", network: false, allow_write: ["/tmp"] });
+      expect(parsed.agent.plan_mode_read_only_commands).toEqual(["gh pr diff"]);
+      expect(parsed.permissions.allow).toContain("Bash(git *)");
+    });
+
+    it("preserves unrelated [agent] keys while the override sets plan-mode lists", async () => {
+      await writeFileContent(
+        join(testDir, "reasonix.toml"),
+        smolToml.stringify({ agent: { model: "reasonix-pro", plan_mode_allowed_tools: ["old"] } }),
+      );
+
+      const instance = await ReasonixPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({
+            permission: { bash: { "git *": "allow" } },
+            reasonix: { agent: { plan_mode_allowed_tools: ["custom_reader"] } },
+          }),
+        }),
+      });
+
+      const parsed = smolToml.parse(instance.getFileContent()) as any;
+      // Unrelated `model` preserved; plan_mode_allowed_tools overridden.
+      expect(parsed.agent).toEqual({
+        model: "reasonix-pro",
+        plan_mode_allowed_tools: ["custom_reader"],
+      });
+    });
+
+    it("routes sandbox and agent plan-mode lists back into the reasonix override on import", () => {
+      const instance = new ReasonixPermissions({
+        relativeDirPath: ".",
+        relativeFilePath: "reasonix.toml",
+        fileContent: smolToml.stringify({
+          permissions: { allow: ["Bash(git *)"] },
+          sandbox: { bash: "enforce", network: false },
+          agent: { model: "reasonix-pro", plan_mode_read_only_commands: ["gh pr diff"] },
+        }),
+      });
+
+      const json = instance.toRulesyncPermissions().getJson();
+      expect(json.permission.bash?.["git *"]).toBe("allow");
+      // Whole sandbox table + only the plan-mode agent keys (not `model`).
+      expect(json.reasonix).toEqual({
+        sandbox: { bash: "enforce", network: false },
+        agent: { plan_mode_read_only_commands: ["gh pr diff"] },
+      });
+    });
+
+    it("does not emit a reasonix override when no sandbox/agent settings are present", () => {
+      const instance = new ReasonixPermissions({
+        relativeDirPath: ".",
+        relativeFilePath: "reasonix.toml",
+        fileContent: smolToml.stringify({ permissions: { allow: ["Bash(git *)"] } }),
+      });
+
+      expect(instance.toRulesyncPermissions().getJson().reasonix).toBeUndefined();
+    });
+  });
+
   describe("toRulesyncPermissions", () => {
     it("should convert Reasonix Tool(specifier) entries to rulesync canonical format", () => {
       const instance = new ReasonixPermissions({

--- a/src/features/permissions/reasonix-permissions.test.ts
+++ b/src/features/permissions/reasonix-permissions.test.ts
@@ -316,6 +316,28 @@ describe("ReasonixPermissions", () => {
       });
     });
 
+    it("clears an existing plan-mode list when the override supplies an empty array", async () => {
+      await writeFileContent(
+        join(testDir, "reasonix.toml"),
+        smolToml.stringify({ agent: { plan_mode_allowed_tools: ["old"] } }),
+      );
+
+      const instance = await ReasonixPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({
+            permission: { bash: { "git *": "allow" } },
+            reasonix: { agent: { plan_mode_allowed_tools: [] } },
+          }),
+        }),
+      });
+
+      const parsed = smolToml.parse(instance.getFileContent()) as any;
+      expect(parsed.agent.plan_mode_allowed_tools).toEqual([]);
+    });
+
     it("routes sandbox and agent plan-mode lists back into the reasonix override on import", () => {
       const instance = new ReasonixPermissions({
         relativeDirPath: ".",

--- a/src/features/permissions/reasonix-permissions.test.ts
+++ b/src/features/permissions/reasonix-permissions.test.ts
@@ -290,6 +290,29 @@ describe("ReasonixPermissions", () => {
       expect(parsed.permissions.allow).toContain("Bash(git *)");
     });
 
+    it("preserves unrelated [sandbox] keys while the override sets its own", async () => {
+      await writeFileContent(
+        join(testDir, "reasonix.toml"),
+        smolToml.stringify({ sandbox: { workspace_root: "/repo", bash: "off" } }),
+      );
+
+      const instance = await ReasonixPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({
+            permission: { bash: { "git *": "allow" } },
+            reasonix: { sandbox: { bash: "enforce" } },
+          }),
+        }),
+      });
+
+      const parsed = smolToml.parse(instance.getFileContent()) as any;
+      // Sibling `workspace_root` preserved; `bash` overridden.
+      expect(parsed.sandbox).toEqual({ workspace_root: "/repo", bash: "enforce" });
+    });
+
     it("preserves unrelated [agent] keys while the override sets plan-mode lists", async () => {
       await writeFileContent(
         join(testDir, "reasonix.toml"),

--- a/src/features/permissions/reasonix-permissions.ts
+++ b/src/features/permissions/reasonix-permissions.ts
@@ -122,6 +122,30 @@ function toPermissionsTable(value: unknown): Record<string, unknown> {
   return { ...(value as Record<string, unknown>) };
 }
 
+// The `[agent]` sub-keys the `reasonix` override authors and round-trips. The
+// whole `[sandbox]` table is a dedicated security surface, so it round-trips in
+// full; `[agent]` also holds unrelated settings, so only the plan-mode read-only
+// trust lists are extracted on import.
+const REASONIX_OVERRIDE_AGENT_KEYS = [
+  "plan_mode_allowed_tools",
+  "plan_mode_read_only_commands",
+] as const;
+
+function asReasonixRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickReasonixKeys(source: unknown, keys: readonly string[]): Record<string, unknown> {
+  const record = asReasonixRecord(source);
+  const picked: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (record[key] !== undefined) picked[key] = record[key];
+  }
+  return picked;
+}
+
 export class ReasonixPermissions extends ToolPermissions {
   private readonly toml: ReasonixConfig;
 
@@ -243,6 +267,21 @@ export class ReasonixPermissions extends ToolPermissions {
     // Preserve every other top-level key (MCP `[[plugins]]`, `[agent]`, `[ui]`,
     // …) exactly like `reasonix-mcp.ts`'s read-modify-write TOML merge.
     const merged: ReasonixConfig = { ...parsed, permissions: mergedPermissions };
+
+    // Overlay the Reasonix-scoped override's `[sandbox]`/`[agent]` tables. Shallow
+    // merged at the table's top level, so the override's keys win while unrelated
+    // sibling keys the user set directly (e.g. `[agent].model`) are preserved.
+    const override = config.reasonix;
+    if (override?.sandbox !== undefined) {
+      merged.sandbox = {
+        ...asReasonixRecord(parsed.sandbox),
+        ...asReasonixRecord(override.sandbox),
+      };
+    }
+    if (override?.agent !== undefined) {
+      merged.agent = { ...asReasonixRecord(parsed.agent), ...asReasonixRecord(override.agent) };
+    }
+
     const fileContent = smolToml.stringify(merged);
 
     return new ReasonixPermissions({
@@ -262,8 +301,23 @@ export class ReasonixPermissions extends ToolPermissions {
       deny: toStringArray(permissions.deny),
     });
 
+    // Route Reasonix's security tables into the `reasonix` override — they have
+    // no canonical category. The `[sandbox]` table is dedicated, so it
+    // round-trips in full; only the plan-mode trust lists are lifted from
+    // `[agent]` (which also carries unrelated settings).
+    const sandbox = asReasonixRecord(this.toml.sandbox);
+    const agentPlanMode = pickReasonixKeys(this.toml.agent, REASONIX_OVERRIDE_AGENT_KEYS);
+    const reasonixOverride: Record<string, unknown> = {};
+    if (Object.keys(sandbox).length > 0) reasonixOverride.sandbox = sandbox;
+    if (Object.keys(agentPlanMode).length > 0) reasonixOverride.agent = agentPlanMode;
+
+    const result: Record<string, unknown> = { ...config };
+    if (Object.keys(reasonixOverride).length > 0) {
+      result.reasonix = reasonixOverride;
+    }
+
     return this.toRulesyncPermissionsDefault({
-      fileContent: JSON.stringify(config, null, 2),
+      fileContent: JSON.stringify(result, null, 2),
     });
   }
 

--- a/src/features/permissions/reasonix-permissions.ts
+++ b/src/features/permissions/reasonix-permissions.ts
@@ -304,7 +304,10 @@ export class ReasonixPermissions extends ToolPermissions {
     // Route Reasonix's security tables into the `reasonix` override — they have
     // no canonical category. The `[sandbox]` table is dedicated, so it
     // round-trips in full; only the plan-mode trust lists are lifted from
-    // `[agent]` (which also carries unrelated settings).
+    // `[agent]` (which also carries unrelated settings). Note the merge is
+    // shallow on generate but the extract is whole-table for `[sandbox]`, so an
+    // existing `[sandbox]` key the override did not author is pulled into the
+    // override on the next import.
     const sandbox = asReasonixRecord(this.toml.sandbox);
     const agentPlanMode = pickReasonixKeys(this.toml.agent, REASONIX_OVERRIDE_AGENT_KEYS);
     const reasonixOverride: Record<string, unknown> = {};

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -176,14 +176,33 @@ const QwencodePermissionsOverrideSchema = z.looseObject({
 export type QwencodePermissionsOverride = z.infer<typeof QwencodePermissionsOverrideSchema>;
 
 /**
+ * Tool-scoped override block for Reasonix. Reasonix has security axes orthogonal
+ * to per-tool allow/ask/deny with no canonical category — the `[sandbox]`
+ * enforcement table (`workspace_root`, `allow_write`, `forbid_read`, `bash`,
+ * `network`) and plan-mode read-only trust lists under `[agent]`
+ * (`plan_mode_allowed_tools`, `plan_mode_read_only_commands`). Fields placed here
+ * are merged into the matching `reasonix.toml` table and emitted only for
+ * Reasonix, while the shared `permission` block continues to drive
+ * `[permissions].allow`/`ask`/`deny`. Kept `looseObject` (verbatim passthrough).
+ *
+ * @example
+ * { "sandbox": { "bash": "enforce", "network": false }, "agent": { "plan_mode_read_only_commands": ["gh pr diff"] } }
+ */
+const ReasonixPermissionsOverrideSchema = z.looseObject({
+  sandbox: z.optional(z.looseObject({})),
+  agent: z.optional(z.looseObject({})),
+});
+export type ReasonixPermissionsOverride = z.infer<typeof ReasonixPermissionsOverrideSchema>;
+
+/**
  * Permissions configuration.
  * Keys are tool category names (e.g., "bash", "edit", "read", "webfetch").
  * Values are pattern-to-action mappings for that tool category.
  *
  * The optional `opencode`/`hermes`/`cline`/`kilo`/`claudecode`/`vibe`/`cursor`/
- * `qwencode` keys are tool-scoped overrides consumed only by their respective
- * translator (see the matching `*PermissionsOverrideSchema`); every other tool
- * reads the shared `permission` block and ignores them.
+ * `qwencode`/`reasonix` keys are tool-scoped overrides consumed only by their
+ * respective translator (see the matching `*PermissionsOverrideSchema`); every
+ * other tool reads the shared `permission` block and ignores them.
  *
  * @example
  * {
@@ -201,6 +220,7 @@ const PermissionsConfigSchema = z.looseObject({
   vibe: z.optional(VibePermissionsOverrideSchema),
   cursor: z.optional(CursorPermissionsOverrideSchema),
   qwencode: z.optional(QwencodePermissionsOverrideSchema),
+  reasonix: z.optional(ReasonixPermissionsOverrideSchema),
 });
 export type PermissionsConfig = z.infer<typeof PermissionsConfigSchema>;
 

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -184,6 +184,9 @@ export type QwencodePermissionsOverride = z.infer<typeof QwencodePermissionsOver
  * are merged into the matching `reasonix.toml` table and emitted only for
  * Reasonix, while the shared `permission` block continues to drive
  * `[permissions].allow`/`ask`/`deny`. Kept `looseObject` (verbatim passthrough).
+ * Note: the whole `[sandbox]` table round-trips, but only the plan-mode keys are
+ * re-extracted from `[agent]` on import — other `agent` keys authored here reach
+ * `reasonix.toml` on generate but are not re-extracted back into the override.
  *
  * @example
  * { "sandbox": { "bash": "enforce", "network": false }, "agent": { "plan_mode_read_only_commands": ["gh pr diff"] } }


### PR DESCRIPTION
## Problem

Reasonix has security axes orthogonal to per-tool allow/ask/deny with no canonical category — the `[sandbox]` enforcement table (`workspace_root`, `allow_write`, `forbid_read`, `bash` = `enforce`/`off`, `network`) and the plan-mode read-only trust lists under `[agent]` (`plan_mode_allowed_tools`, `plan_mode_read_only_commands`). They could not be driven from rulesync.

## Fix

Add a tool-scoped `reasonix` override namespace (per #2127):

```json
{
  "permission": { "bash": { "git status*": "allow" } },
  "reasonix": { "sandbox": { "bash": "enforce", "network": false }, "agent": { "plan_mode_read_only_commands": ["gh pr diff"] } }
}
```

- `reasonix.sandbox` / `reasonix.agent` are shallow-merged into the matching `reasonix.toml` table at its top level (override keys win, unrelated siblings like `[agent].model` preserved), while the shared `permission` block keeps driving `[permissions].allow`/`ask`/`deny`.
- On import, the whole `[sandbox]` table round-trips (dedicated security surface) and only the plan-mode keys are lifted from `[agent]`.

### Scope / verification
SPEC keys verified against [DeepSeek-Reasonix SPEC.md (main-v2)](https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/docs/SPEC.md). The per-plugin `[[plugins]].trusted_read_only_tools` list (an array-of-tables shared with the MCP feature) is left out of scope (design-laden, per-plugin).

Closes #2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)