### PR TITLE
chore: release v9.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.2.0";
+const getVersion = () => "9.3.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v9.3.0.

Bumps the version to 9.3.0 in `src/cli/index.ts` and `package.json`.

See the draft release notes for the full changelog.