### PR TITLE
feat(kiro): model steering `inclusion: auto` with name/description

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -39,8 +39,10 @@ augmentcode: # augmentcode specific parameters
   type: "always_apply" # always_apply, manual, or agent_requested
   description: "When to apply this rule" # (optional) used with "agent_requested" type
 kiro: # kiro specific parameters (steering inclusion)
-  inclusion: "fileMatch" # always, fileMatch, or manual
+  inclusion: "fileMatch" # always, fileMatch, manual, or auto
   fileMatchPattern: ["src/components/**/*.tsx"] # (optional) glob string or array of globs, used when inclusion is "fileMatch"
+  name: "api-design" # (optional) required when inclusion is "auto"; the steering entry key
+  description: "REST API design patterns. Use when creating or modifying API endpoints." # (optional) required when inclusion is "auto"; Kiro auto-includes the file when a request matches this
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -54,7 +56,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 ...
 ```
 
-> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it. In **global** mode (`--global`), steering is written to `~/.kiro/steering/` with the root rule as `~/.kiro/steering/product.md` (Kiro does not read `~/AGENTS.md`, so the project-scope root `AGENTS.md` is not used at the home level), and global MCP is written to `~/.kiro/settings/mcp.json`.
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, `manual`, or `auto` — which auto-includes the file when a request matches its companion `description`, keyed by `name`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is (carrying `name`/`description` through for `auto`); otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it. In **global** mode (`--global`), steering is written to `~/.kiro/steering/` with the root rule as `~/.kiro/steering/product.md` (Kiro does not read `~/AGENTS.md`, so the project-scope root `AGENTS.md` is not used at the home level), and global MCP is written to `~/.kiro/settings/mcp.json`.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -39,8 +39,10 @@ augmentcode: # augmentcode specific parameters
   type: "always_apply" # always_apply, manual, or agent_requested
   description: "When to apply this rule" # (optional) used with "agent_requested" type
 kiro: # kiro specific parameters (steering inclusion)
-  inclusion: "fileMatch" # always, fileMatch, or manual
+  inclusion: "fileMatch" # always, fileMatch, manual, or auto
   fileMatchPattern: ["src/components/**/*.tsx"] # (optional) glob string or array of globs, used when inclusion is "fileMatch"
+  name: "api-design" # (optional) required when inclusion is "auto"; the steering entry key
+  description: "REST API design patterns. Use when creating or modifying API endpoints." # (optional) required when inclusion is "auto"; Kiro auto-includes the file when a request matches this
 takt: # takt specific parameters (optional; emitted under .takt/facets/policies/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
@@ -54,7 +56,7 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 ...
 ```
 
-> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, or `manual`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is; otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it. In **global** mode (`--global`), steering is written to `~/.kiro/steering/` with the root rule as `~/.kiro/steering/product.md` (Kiro does not read `~/AGENTS.md`, so the project-scope root `AGENTS.md` is not used at the home level), and global MCP is written to `~/.kiro/settings/mcp.json`.
+> **Kiro note:** Kiro reads steering files from `.kiro/steering/*.md` and uses an `inclusion` frontmatter block to decide when each is loaded (`always`, `fileMatch` with a `fileMatchPattern`, `manual`, or `auto` — which auto-includes the file when a request matches its companion `description`, keyed by `name`). Rulesync derives this for non-root steering files: an explicit `kiro.inclusion` block round-trips as-is (carrying `name`/`description` through for `auto`); otherwise specific (non-wildcard) `globs` map to `inclusion: fileMatch` (a single glob is written as a string and multiple as a YAML array, both of which Kiro accepts), so the rule applies only to matching files instead of always; otherwise the file stays always-on and is written without a frontmatter block (Kiro's no-frontmatter default). The root overview index is always written plain so Kiro always loads it. In **global** mode (`--global`), steering is written to `~/.kiro/steering/` with the root rule as `~/.kiro/steering/product.md` (Kiro does not read `~/AGENTS.md`, so the project-scope root `AGENTS.md` is not used at the home level), and global MCP is written to `~/.kiro/settings/mcp.json`.
 
 > **Kilo Code note:** Kilo writes the root rule to the auto-loaded `AGENTS.md` and non-root rules to `.kilo/rules/*.md`. Because Kilo v7 does not auto-load files under `.kilo/rules/`, Rulesync also registers each generated non-root rule file in the `instructions` array of the shared `kilo.jsonc` (the root `AGENTS.md` is auto-loaded and is therefore not registered). This merge is non-destructive: existing keys such as `mcp`, `tools`, and `permission` are preserved, and the `instructions` list is deduped and sorted.
 

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -57,6 +57,26 @@ describe("deriveKiroInclusion", () => {
       }),
     ).toEqual({ inclusion: "fileMatch", fileMatchPattern: "explicit/**" });
   });
+
+  it("carries name/description through for inclusion: auto", () => {
+    expect(
+      deriveKiroInclusion({
+        kiro: {
+          inclusion: "auto",
+          name: "api-design",
+          description: "REST API design patterns. Use when creating or modifying API endpoints.",
+        },
+      }),
+    ).toEqual({
+      inclusion: "auto",
+      name: "api-design",
+      description: "REST API design patterns. Use when creating or modifying API endpoints.",
+    });
+  });
+
+  it("emits inclusion: auto without companions when they are omitted", () => {
+    expect(deriveKiroInclusion({ kiro: { inclusion: "auto" } })).toEqual({ inclusion: "auto" });
+  });
 });
 
 describe("KiroRule", () => {
@@ -440,6 +460,57 @@ describe("KiroRule", () => {
         fileMatchPattern: ["**/*.ts", "**/*.tsx"],
       });
       expect(roundTrip.getBody()).toContain("# Authored");
+    });
+
+    it("imports a hand-authored auto-inclusion steering file, round-tripping name/description", async () => {
+      const steeringDir = join(testDir, ".kiro/steering");
+      await ensureDir(steeringDir);
+      await writeFileContent(
+        join(steeringDir, "api-design.md"),
+        "---\ninclusion: auto\nname: api-design\ndescription: REST API design patterns. Use when creating or modifying API endpoints.\n---\n# API Design\n",
+      );
+
+      const kiroRule = await KiroRule.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "api-design.md",
+      });
+      const roundTrip = kiroRule.toRulesyncRule();
+
+      expect(roundTrip.getFrontmatter().globs).toEqual([]);
+      expect(roundTrip.getFrontmatter().kiro).toEqual({
+        inclusion: "auto",
+        name: "api-design",
+        description: "REST API design patterns. Use when creating or modifying API endpoints.",
+      });
+      expect(roundTrip.getBody()).toContain("# API Design");
+    });
+
+    it("emits inclusion: auto with name/description from the kiro override", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "api-design.md",
+        frontmatter: {
+          root: false,
+          targets: ["kiro"],
+          description: "",
+          globs: [],
+          kiro: {
+            inclusion: "auto",
+            name: "api-design",
+            description: "REST API design patterns. Use when creating or modifying API endpoints.",
+          },
+        },
+        body: "# API Design",
+      });
+
+      const generated = KiroRule.fromRulesyncRule({ outputRoot: testDir, rulesyncRule });
+      const content = generated.getFileContent();
+
+      expect(content).toContain("inclusion: auto");
+      expect(content).toContain("name: api-design");
+      expect(content).toContain(
+        "description: REST API design patterns. Use when creating or modifying API endpoints.",
+      );
     });
 
     it("should use custom outputRoot", () => {

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -30,6 +30,8 @@ export type KiroRuleSettablePaths =
  *   is present, so rulesync omits the block in this case).
  * - `fileMatch` — loaded only when the open file matches `fileMatchPattern`.
  * - `manual` — loaded on demand via `#steering-file-name`.
+ * - `auto` — auto-included when a request matches `description` (skill-like);
+ *   requires companion `name` and `description` fields.
  *
  * @see https://kiro.dev/docs/steering/
  */
@@ -38,6 +40,9 @@ export type KiroSteeringInclusion = {
   // A single glob is emitted as a string; multiple globs as a YAML array, both of
   // which Kiro accepts for `fileMatchPattern`.
   fileMatchPattern?: string | string[];
+  // Companion fields Kiro requires for `inclusion: auto` (ignored otherwise).
+  name?: string;
+  description?: string;
 };
 
 const WILDCARD_GLOBS = new Set(["**/*", "**", "*"]);
@@ -59,7 +64,8 @@ function toFileMatchPattern(globs: string[]): string | string[] | undefined {
  *
  * Precedence:
  * 1. An explicit `kiro.inclusion` block round-trips as-is (with `fileMatchPattern`
- *    taken from the block, or derived from `globs` when omitted for `fileMatch`).
+ *    taken from the block, or derived from `globs` when omitted for `fileMatch`;
+ *    and with the companion `name`/`description` carried through for `auto`).
  * 2. Otherwise specific (non-wildcard) globs map to `fileMatch`, scoping the rule
  *    to matching files instead of leaving it implicitly always-on.
  * 3. Otherwise the rule stays `always` — represented by omitting the block so the
@@ -71,7 +77,12 @@ export function deriveKiroInclusion({
   kiro,
   globs,
 }: {
-  kiro?: { inclusion?: string; fileMatchPattern?: string | string[] };
+  kiro?: {
+    inclusion?: string;
+    fileMatchPattern?: string | string[];
+    name?: string;
+    description?: string;
+  };
   globs?: string[];
 }): KiroSteeringInclusion | undefined {
   const specificGlobs = (globs ?? []).filter((g) => !WILDCARD_GLOBS.has(g));
@@ -82,6 +93,15 @@ export function deriveKiroInclusion({
       return fileMatchPattern
         ? { inclusion: "fileMatch", fileMatchPattern }
         : { inclusion: "fileMatch" };
+    }
+    // `auto` relies on the companion `name`/`description` to decide relevance, so
+    // carry them through when present.
+    if (kiro.inclusion === "auto") {
+      return {
+        inclusion: "auto",
+        ...(kiro.name !== undefined ? { name: kiro.name } : {}),
+        ...(kiro.description !== undefined ? { description: kiro.description } : {}),
+      };
     }
     return { inclusion: kiro.inclusion };
   }
@@ -223,6 +243,12 @@ export class KiroRule extends ToolRule {
           : [fileMatchPattern];
     const globs = inclusion === "fileMatch" ? patternGlobs : [];
 
+    // `auto` mode carries companion `name`/`description` fields that Kiro uses to
+    // decide relevance; round-trip them so re-generating reproduces the file.
+    const name = typeof frontmatter.name === "string" ? frontmatter.name : undefined;
+    const description =
+      typeof frontmatter.description === "string" ? frontmatter.description : undefined;
+
     return new RulesyncRule({
       outputRoot: process.cwd(),
       relativeDirPath: RulesyncRule.getSettablePaths().recommended.relativeDirPath,
@@ -231,7 +257,12 @@ export class KiroRule extends ToolRule {
         root: false,
         targets: ["*"],
         globs,
-        kiro: { inclusion, ...(fileMatchPattern !== undefined ? { fileMatchPattern } : {}) },
+        kiro: {
+          inclusion,
+          ...(fileMatchPattern !== undefined ? { fileMatchPattern } : {}),
+          ...(inclusion === "auto" && name !== undefined ? { name } : {}),
+          ...(inclusion === "auto" && description !== undefined ? { description } : {}),
+        },
       },
       body,
     });

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -73,11 +73,15 @@ export const RulesyncRuleFrontmatterSchema = z.object({
   ),
   kiro: z.optional(
     z.looseObject({
-      // Steering inclusion mode: always | fileMatch | manual (string for forward compat).
+      // Steering inclusion mode: always | fileMatch | manual | auto (string for forward compat).
       inclusion: z.optional(z.string()),
       // Glob(s) used when `inclusion: fileMatch`. Kiro accepts a single string or
       // a YAML array of globs.
       fileMatchPattern: z.optional(z.union([z.string(), z.array(z.string())])),
+      // Companion fields required by `inclusion: auto`: Kiro auto-includes the
+      // steering file when a request matches `description` (skill-like), keyed by `name`.
+      name: z.optional(z.string()),
+      description: z.optional(z.string()),
     }),
   ),
   takt: z.optional(


### PR DESCRIPTION
## Summary

Kiro steering now documents a fourth inclusion mode, `inclusion: auto`, which auto-includes a steering file when a request matches its companion `description` (skill-like), keyed by `name` ([kiro.dev/docs/steering](https://kiro.dev/docs/steering/)). Previously rulesync passed `inclusion: auto` through verbatim but dropped the required `name`/`description`, producing a non-functional auto-steering file. On import the fields were also lost. This affected both `kiro-cli` and `kiro-ide` (they share `KiroRule`).

## Changes

- Add optional `name`/`description` to the `kiro` frontmatter schema (`rulesync-rule.ts`) and to the `KiroSteeringInclusion` type.
- In `deriveKiroInclusion`, emit `{ inclusion: "auto", name, description }` from the `kiro` override block; round-trip both fields in `toRulesyncRule`.
- Update the `KiroRule` docstring and `docs/reference/file-formats.md` (synced to `skills/rulesync/`) to list the `auto` mode.
- Add `kiro-rule.test.ts` coverage: `deriveKiroInclusion` auto cases, an import round-trip, and an emit test.

A single change to the shared `KiroRule` covers both `kiro-cli` and `kiro-ide`.

## Verification

- `pnpm cicheck` — green (code + content).
- `npx vitest run --config vitest.e2e.config.ts src/e2e/e2e-rules.spec.ts` — 103 passed.

Closes #2152