### PR TITLE
feat(augmentcode): support project-scope MCP via workspace settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,7 @@ rulesync.local.jsonc
 **/.takt/facets/personas/
 **/.vibe/agents/
 **/.agents/mcp_config.json
+**/.augment/settings.json
 **/.mcp.json
 **/.codex/config.toml
 **/.vscode/mcp.json
@@ -367,7 +368,6 @@ rulesync.local.jsonc
 **/.kiro/agents/default.json
 **/.kiro/hooks/rulesync.json
 **/.devin/hooks.v1.json
-**/.augment/settings.json
 **/.vibe/hooks.toml
 **/.reasonix/settings.json
 **/.cline/command-permissions.json

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -35,7 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |   ✅   |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |    ✅ 🌏    |
-| AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
+| AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Warp                   | warp            |  ✅   |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
 | Replit                 | replit          |  ✅   |        |          |          |           | ✅ 🌏  |       |             |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -35,7 +35,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Google Antigravity CLI | antigravity-cli | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |           | ✅ 🌏  | ✅ 🌏 |     🌏      |
 | JetBrains AI Assistant | aiassistant     |  ✅   |   ✅   |          |          |           |   ✅   |       |             |
 | JetBrains Junie        | junie           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  |  🌏   |    ✅ 🌏    |
-| AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |    🌏    |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
+| AugmentCode            | augmentcode     | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Devin Desktop          | devin           | ✅ 🌏 |   ✅   | ✅ 🌏 🔧 |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |
 | Warp                   | warp            |  ✅   |   ✅   |  ✅ 🌏   |          |           | ✅ 🌏  |       |     🌏      |
 | Replit                 | replit          |  ✅   |        |          |          |           | ✅ 🌏  |       |             |

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -24,6 +24,7 @@ import {
 
 // Native MCP tools that emit "test-server" (takt writes a transport allowlist instead).
 const mcpGenerateTargets = [
+  { target: "augmentcode", outputPath: join(".augment", "settings.json") },
   { target: "amp", outputPath: join(".amp", "settings.json") },
   { target: "claudecode", outputPath: ".mcp.json" },
   { target: "cursor", outputPath: join(".cursor", "mcp.json") },

--- a/src/e2e/e2e-mcp.spec.ts
+++ b/src/e2e/e2e-mcp.spec.ts
@@ -417,6 +417,7 @@ describe("E2E: mcp (import)", () => {
   const { getTestDir } = useTestDirectory();
 
   it.each([
+    { target: "augmentcode", sourcePath: join(".augment", "settings.json") },
     { target: "claudecode", sourcePath: ".mcp.json" },
     { target: "cursor", sourcePath: join(".cursor", "mcp.json") },
     // copilot MCP uses VS Code-specific format — excluded from import test

--- a/src/features/mcp/augmentcode-mcp.test.ts
+++ b/src/features/mcp/augmentcode-mcp.test.ts
@@ -49,16 +49,31 @@ describe("AugmentcodeMcp", () => {
   });
 
   describe("fromRulesyncMcp", () => {
-    it("should throw in non-global mode", async () => {
+    it("should merge mcpServers into the workspace settings.json at project scope", async () => {
+      await writeFileContent(
+        settingsPath(),
+        JSON.stringify({ toolPermissions: [{ "tool-name": "shell", permission: "allow" }] }),
+      );
+
       const rulesyncMcp = new RulesyncMcp({
         outputRoot: testDir,
         relativeDirPath: ".rulesync",
         relativeFilePath: ".mcp.json",
-        fileContent: JSON.stringify({ mcpServers: {} }),
+        fileContent: JSON.stringify({ mcpServers: { fs: { command: "fs" } } }),
       });
-      await expect(
-        AugmentcodeMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp, global: false }),
-      ).rejects.toThrow(/global-only/);
+
+      const mcp = await AugmentcodeMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: false,
+      });
+
+      // Project-scope MCP is written to the same shared workspace file, keeping
+      // the committed toolPermissions intact.
+      expect(mcp.getJson().toolPermissions).toEqual([
+        { "tool-name": "shell", permission: "allow" },
+      ]);
+      expect(mcp.getJson().mcpServers).toEqual({ fs: { command: "fs" } });
     });
 
     it("should merge mcpServers preserving hooks and permissions keys", async () => {
@@ -119,12 +134,6 @@ describe("AugmentcodeMcp", () => {
   });
 
   describe("fromFile", () => {
-    it("should throw in non-global mode", async () => {
-      await expect(AugmentcodeMcp.fromFile({ outputRoot: testDir, global: false })).rejects.toThrow(
-        /global-only/,
-      );
-    });
-
     it("should read existing settings and surface mcpServers", async () => {
       await writeFileContent(
         settingsPath(),
@@ -138,6 +147,36 @@ describe("AugmentcodeMcp", () => {
     it("should default to empty mcpServers when file is missing", async () => {
       const mcp = await AugmentcodeMcp.fromFile({ outputRoot: testDir, global: true });
       expect(mcp.getJson()).toEqual({ mcpServers: {} });
+    });
+
+    it("should overlay settings.local.json on top of settings.json at project scope", async () => {
+      await writeFileContent(
+        settingsPath(),
+        JSON.stringify({ mcpServers: { base: { command: "base" } } }),
+      );
+      await writeFileContent(
+        join(testDir, ".augment", "settings.local.json"),
+        JSON.stringify({ mcpServers: { local: { command: "local" } } }),
+      );
+
+      const mcp = await AugmentcodeMcp.fromFile({ outputRoot: testDir, global: false });
+      // `mcpServers` is a replace-key: the higher-precedence local file wins
+      // wholesale over the base workspace settings.
+      expect(mcp.getJson().mcpServers).toEqual({ local: { command: "local" } });
+    });
+
+    it("should not overlay settings.local.json in global mode", async () => {
+      await writeFileContent(
+        settingsPath(),
+        JSON.stringify({ mcpServers: { base: { command: "base" } } }),
+      );
+      await writeFileContent(
+        join(testDir, ".augment", "settings.local.json"),
+        JSON.stringify({ mcpServers: { local: { command: "local" } } }),
+      );
+
+      const mcp = await AugmentcodeMcp.fromFile({ outputRoot: testDir, global: true });
+      expect(mcp.getJson().mcpServers).toEqual({ base: { command: "base" } });
     });
   });
 

--- a/src/features/mcp/augmentcode-mcp.ts
+++ b/src/features/mcp/augmentcode-mcp.ts
@@ -6,8 +6,9 @@ import {
 } from "../../constants/augmentcode-paths.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { isMcpServers } from "../../types/mcp.js";
+import { readAugmentcodeSettingsWithLocalOverlay } from "../../utils/augmentcode-settings.js";
 import { formatError } from "../../utils/error.js";
-import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import { readOrInitializeFileContent } from "../../utils/file.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 import {
@@ -18,9 +19,6 @@ import {
   ToolMcpParams,
   ToolMcpSettablePaths,
 } from "./tool-mcp.js";
-
-const AUGMENTCODE_GLOBAL_ONLY_MESSAGE =
-  "AugmentCode MCP is global-only; use --global to sync ~/.augment/settings.json";
 
 function parseAugmentcodeSettings(
   fileContent: string,
@@ -50,13 +48,15 @@ function parseAugmentcodeSettings(
 /**
  * AugmentCode (Auggie CLI) MCP servers.
  *
- * MCP servers are persisted in the shared user settings file
- * `~/.augment/settings.json` (global only — the docs do not document a
- * project-level MCP location). That same file also holds `hooks` and
+ * MCP servers are persisted in the shared settings file `.augment/settings.json`
+ * at either scope: the committed workspace file for team-shared servers (project)
+ * or `~/.augment/settings.json` (global). That same file also holds `hooks` and
  * `toolPermissions`, so generation merges the `mcpServers` block into the
- * existing settings instead of overwriting it, and the file is never deleted.
+ * existing settings instead of overwriting it, and the file is never deleted. On
+ * project-scope import the gitignored `.augment/settings.local.json` overrides
+ * file is overlaid on top (the same layering the hooks/permissions adapters use).
  *
- * @see https://docs.augmentcode.com/cli/integrations
+ * @see https://docs.augmentcode.com/cli/config
  */
 export class AugmentcodeMcp extends ToolMcp {
   private readonly json: Record<string, unknown>;
@@ -97,17 +97,19 @@ export class AugmentcodeMcp extends ToolMcp {
     validate = true,
     global = false,
   }: ToolMcpFromFileParams): Promise<AugmentcodeMcp> {
-    if (!global) {
-      throw new Error(AUGMENTCODE_GLOBAL_ONLY_MESSAGE);
-    }
-    // No `settings.local.json` overlay here: AugmentCode MCP is global-only
-    // (this method throws above for project mode), and the layered
-    // `settings.local.json` overrides file exists ONLY at the project
-    // (workspace) level — there is no global `~/.augment/settings.local.json`.
-    // So there is nothing to overlay in the only mode this import path supports.
     const paths = this.getSettablePaths({ global });
-    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
-    const fileContent = (await readFileContentOrNull(filePath)) ?? "{}";
+    // On project-scope import, overlay the gitignored
+    // `.augment/settings.local.json` ON TOP of `settings.json` so machine-local
+    // MCP overrides are picked up. The overrides file is project-only (there is
+    // no global `~/.augment/settings.local.json`), so it is skipped in global
+    // mode.
+    const fileContent = await readAugmentcodeSettingsWithLocalOverlay({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      baseFileName: paths.relativeFilePath,
+      baseFallbackContent: "{}",
+      includeLocalOverlay: !global,
+    });
     const json = parseAugmentcodeSettings(
       fileContent,
       paths.relativeDirPath,
@@ -131,9 +133,6 @@ export class AugmentcodeMcp extends ToolMcp {
     validate = true,
     global = false,
   }: ToolMcpFromRulesyncMcpParams): Promise<AugmentcodeMcp> {
-    if (!global) {
-      throw new Error(AUGMENTCODE_GLOBAL_ONLY_MESSAGE);
-    }
     const paths = this.getSettablePaths({ global });
 
     const fileContent = await readOrInitializeFileContent(

--- a/src/features/mcp/mcp-field-stripping.test.ts
+++ b/src/features/mcp/mcp-field-stripping.test.ts
@@ -22,8 +22,8 @@ import { RulesyncMcp } from "./rulesync-mcp.js";
  * scope), per the testing guidelines.
  */
 
-// `getHomeDirectory()` must be mocked so global-only tools (e.g. augmentcode)
-// resolve their config under the test directory instead of the real home dir.
+// `getHomeDirectory()` must be mocked so tools whose config lives under the home
+// dir in global mode resolve it under the test directory instead of the real home dir.
 const { getHomeDirectoryMock } = vi.hoisted(() => {
   return { getHomeDirectoryMock: vi.fn() };
 });

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -124,13 +124,13 @@ export const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>(
   [
     "augmentcode",
     {
-      // AugmentCode (Auggie CLI) persists MCP servers in the shared user
-      // settings file `~/.augment/settings.json`. The docs only document a
-      // global location, so MCP is global-only here.
-      // https://docs.augmentcode.com/cli/integrations
+      // AugmentCode (Auggie CLI) persists MCP servers in the shared settings
+      // file `.augment/settings.json` at either scope: the committed workspace
+      // file for team-shared servers (project) or `~/.augment/settings.json`
+      // (global). https://docs.augmentcode.com/cli/config
       class: AugmentcodeMcp,
       meta: {
-        supportsProject: false,
+        supportsProject: true,
         supportsGlobal: true,
         supportsEnabledTools: false,
         supportsDisabledTools: false,


### PR DESCRIPTION
## Summary

AugmentCode's layered settings model accepts an `mcpServers` block in the committed workspace file `.augment/settings.json` — described in the docs as "Best for team-shared project configuration, such as shared MCP servers or tool permissions" ([docs.augmentcode.com/cli/config](https://docs.augmentcode.com/cli/config)). rulesync's `augmentcode` MCP adapter was global-only and hard-threw on project scope, so a project `--features "*"` run emitted no MCP file; only `--global` wrote `~/.augment/settings.json`.

## Changes

- Drop the `!global` guards in `augmentcode-mcp.ts`; merge `mcpServers` into the shared workspace `.augment/settings.json` at project scope, exactly as the AugmentCode hooks and permissions adapters already do for that same file (other keys like `hooks`/`toolPermissions` are preserved; the file is never deleted).
- Overlay the gitignored `.augment/settings.local.json` on project-scope import via the shared `readAugmentcodeSettingsWithLocalOverlay` helper (skipped in global mode, which has no local overrides file).
- Flip the MCP factory meta to `supportsProject: true`; regenerate the supported-tools tables (mcp cell `🌏` → `✅ 🌏`) and `.gitignore`.
- Add a project-scope MCP e2e case plus `settings.local` overlay unit tests; refresh the outdated "global only" doc-comments and bump the docs reference to `cli/config`.

## Verification

- `pnpm cicheck` — green (code + content, incl. gitignore / supported-tools drift checks).
- `npx vitest run --config vitest.e2e.config.ts src/e2e/e2e-mcp.spec.ts` — 98 passed.

Note: the plugin/marketplace surface flagged in the issue's "Non-dimension note" is intentionally out of scope (no corresponding rulesync feature dimension).

Closes #2150