### PR TITLE
ci: shorten stale-PR auto-close threshold from 30 to 14 days

### DIFF
--- a/.github/workflows/auto-close-stale-prs.yml
+++ b/.github/workflows/auto-close-stale-prs.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Close pull requests inactive for more than 30 days
+      - name: Close pull requests inactive for more than 14 days
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const STALE_DAYS = 30;
+            const STALE_DAYS = 14;
             const staleThresholdMs = STALE_DAYS * 24 * 60 * 60 * 1000;
             const now = Date.now();
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary

Shortens the inactivity window before a stale PR is auto-closed by `.github/workflows/auto-close-stale-prs.yml` from `STALE_DAYS = 30` (~1 month) to `14` (2 weeks), per #2160. Keeps the PR queue tidier and gives contributors quicker feedback (they can always reopen or file a new PR).

- `const STALE_DAYS = 30;` → `14`.
- Step name `Close pull requests inactive for more than 30 days` → `14 days`.
- The comment body posted to PRs already interpolates `${STALE_DAYS}`, so no hardcoded strings needed updating; no README/docs reference the policy.

The issue's item 4 ("consider whether draft PRs should be treated the same") is a separate policy question left unchanged — current behavior closes both drafts and ready PRs.

## ⚠️ Manual merge required

This PR edits a **GitHub Actions workflow**, so per the autonomous-batch safety policy it is **not auto-merged** — please review and merge it manually. CI is green.

Closes #2160