### PR TITLE
chore: release v9.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.3.0";
+const getVersion = () => "9.4.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### New Features
* Model Kiro steering `inclusion: auto` with name/description (#2181)
* Support project-scope MCP for AugmentCode via workspace `settings.json` (#2182)
* Author Takt `step_permission_overrides` and `provider_options` via a `takt` override (#2183)
* Author Amp non-command matchers, `guardedFiles`, and `dangerouslyAllowAll` via an `amp` override (#2184)
* Author Antigravity CLI `toolPermission` and `enableTerminalSandbox` via an override (#2185)

### Bug Fixes
* Order merged `amp.permissions` fail-closed so authored rejects lead (#2184)
* Merge Takt `provider_options` per-provider to preserve sibling keys (#2183)

### Tests
* Cover AugmentCode project-scope MCP import and fix a stale global-only comment (#2182)

## Contributors

* @dyoshikawa

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v9.3.0...v9.4.0
