### PR TITLE
chore: release v9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.4.0";
+const getVersion = () => "9.5.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v9.5.0

Bumps `getVersion()` and `package.json` to 9.5.0.

## What's Changed

### New Features
* Support per-target output roots so `outputRoots` accepts a map of target-specific paths in addition to a shared list (#2055)

### Refactoring
* Unify shared config file writes behind a declared-ownership gateway (#2187)

### CI
* Shorten stale-PR auto-close threshold from 30 to 14 days (#2186)

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v9.4.0...v9.5.0