### PR TITLE
fix(generate): make shared-write ownership guard reachable and harden derivation (#2189)

### DIFF
--- a/src/features/shared/shared-config-gateway.test.ts
+++ b/src/features/shared/shared-config-gateway.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { deriveSharedFileWriters } from "../../lib/shared-file-derive.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import type { ClaudeSettingsJson } from "../../types/claude-settings.js";
+import * as sharedConfigGateway from "./shared-config-gateway.js";
 import {
   applyIgnoreReadDenies,
   applyPermissions,
@@ -209,6 +210,23 @@ describe("SHARED_CONFIG_OWNERSHIP", () => {
       (key) => SHARED_CONFIG_OWNERSHIP[key] !== undefined || !derivedKeys.has(key),
     );
     expect(stale, "remove these entries from GATEWAY_PENDING_SHARED_FILES").toEqual([]);
+  });
+
+  it("resolves every custom policyFunction name to an exported function", () => {
+    // The `custom` policy references its implementation by string name; a rename
+    // that misses the declaration would otherwise stale silently. Pin the names
+    // so they must resolve to a real exported function of this module.
+    const exports = sharedConfigGateway as Record<string, unknown>;
+    for (const [fileKey, declaration] of Object.entries(SHARED_CONFIG_OWNERSHIP)) {
+      for (const [feature, policy] of Object.entries(declaration.features)) {
+        if (policy?.kind !== "custom") continue;
+        expect(
+          typeof exports[policy.policyFunction],
+          `policyFunction '${policy.policyFunction}' declared for feature '${feature}' on ` +
+            `'${fileKey}' does not resolve to an exported function in shared-config-gateway.ts`,
+        ).toBe("function");
+      }
+    }
   });
 });
 

--- a/src/lib/shared-file-derive.test.ts
+++ b/src/lib/shared-file-derive.test.ts
@@ -32,9 +32,22 @@ const sortedFeatures = (writers: Map<string, Set<Feature>>): Record<string, stri
 
 describe("shared-file write derivation", () => {
   it("every feature that writes a shared file has a position in SHARED_WRITE_FEATURE_ORDER", () => {
+    // deriveSharedFileWriters considers every feature (not just the ordered
+    // ones), so a feature that starts returning a shared path surfaces here and
+    // must get an explicit precedence decision, not a silent arbitrary order.
+    // This asserts the property directly rather than relying only on the throw,
+    // which was unreachable while writers were pre-filtered by the order set.
+    const ordered = [...SHARED_WRITE_FEATURE_ORDER];
+    for (const writer of deriveSharedFileWriters()) {
+      for (const feature of writer.features) {
+        expect(
+          ordered,
+          `feature '${feature}' writes shared file '${writer.key}' but has no position in SHARED_WRITE_FEATURE_ORDER`,
+        ).toContain(feature);
+      }
+    }
     // deriveSharedWriteSteps throws when a shared-file writer feature is not
-    // ordered — a new feature entering the shared-write set must get an
-    // explicit precedence decision, not a silent arbitrary order.
+    // ordered; with the pre-filter gone this guard is now genuinely reachable.
     expect(() => deriveSharedWriteSteps()).not.toThrow();
   });
 

--- a/src/lib/shared-file-derive.test.ts
+++ b/src/lib/shared-file-derive.test.ts
@@ -35,8 +35,9 @@ describe("shared-file write derivation", () => {
     // deriveSharedFileWriters considers every feature (not just the ordered
     // ones), so a feature that starts returning a shared path surfaces here and
     // must get an explicit precedence decision, not a silent arbitrary order.
-    // This asserts the property directly rather than relying only on the throw,
-    // which was unreachable while writers were pre-filtered by the order set.
+    // Assert the property directly for a clear failure message; before the
+    // pre-filter was removed this could never fail because writers were
+    // restricted to the order set.
     const ordered = [...SHARED_WRITE_FEATURE_ORDER];
     for (const writer of deriveSharedFileWriters()) {
       for (const feature of writer.features) {
@@ -46,8 +47,9 @@ describe("shared-file write derivation", () => {
         ).toContain(feature);
       }
     }
-    // deriveSharedWriteSteps throws when a shared-file writer feature is not
-    // ordered; with the pre-filter gone this guard is now genuinely reachable.
+    // The same guard also throws inside deriveSharedWriteSteps (which generate.ts
+    // evaluates at module load), so an unordered writer fails loudly at runtime,
+    // not just here.
     expect(() => deriveSharedWriteSteps()).not.toThrow();
   });
 

--- a/src/lib/shared-file-derive.ts
+++ b/src/lib/shared-file-derive.ts
@@ -79,6 +79,12 @@ const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWriteP
     paths.push(settable.root);
     for (const alt of settable.alternativeRoots ?? []) paths.push(alt);
   }
+  // Deliberately fail-open here, mirroring the getSettablePaths() catch above:
+  // this derivation runs at module load (SHARED_WRITE_STEPS in generate.ts), so
+  // a throwing tool implementation must not take down every generate. The
+  // trade-off is that a broken getExtraSharedWritePaths silently drops that
+  // tool's extra shared paths from the write order — acceptable because every
+  // current implementation returns a static constant that cannot throw.
   let extra: SharedWritePath[];
   try {
     extra = cls.getExtraSharedWritePaths?.({ global }) ?? [];

--- a/src/lib/shared-file-derive.ts
+++ b/src/lib/shared-file-derive.ts
@@ -34,8 +34,6 @@ export const SHARED_WRITE_FEATURE_ORDER = [
   "rules",
 ] as const satisfies readonly Feature[];
 
-const SHARED_WRITE_FEATURES: ReadonlySet<Feature> = new Set(SHARED_WRITE_FEATURE_ORDER);
-
 // Deprecated aliases; a guard for the day one diverges from its canonical
 // target's paths. A no-op today since they reuse the canonical class and paths.
 const TARGETS_NOT_DERIVED: ReadonlySet<string> = new Set([
@@ -81,7 +79,13 @@ const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWriteP
     paths.push(settable.root);
     for (const alt of settable.alternativeRoots ?? []) paths.push(alt);
   }
-  for (const path of cls.getExtraSharedWritePaths?.({ global }) ?? []) {
+  let extra: SharedWritePath[];
+  try {
+    extra = cls.getExtraSharedWritePaths?.({ global }) ?? [];
+  } catch {
+    return paths;
+  }
+  for (const path of extra) {
     if (path.relativeFilePath) paths.push(path);
   }
   return paths;
@@ -104,8 +108,12 @@ export const deriveSharedFileWriters = (): SharedFileWriter[] => {
   const byKey = new Map<string, Map<Feature, Set<ToolTarget>>>();
   const pathByKey = new Map<string, SharedWritePath>();
 
+  // Consider every feature, not just those already in SHARED_WRITE_FEATURE_ORDER:
+  // a feature that starts returning a shared path (2+ writers of the same file)
+  // must surface here so deriveSharedWriteSteps can reject it for lacking an
+  // explicit precedence position, instead of being silently dropped from the
+  // write order. Files a single feature writes are excluded below (features < 2).
   for (const entry of PROCESSOR_REGISTRY) {
-    if (!SHARED_WRITE_FEATURES.has(entry.feature)) continue;
     const factories = entry.factory as unknown as FactoryMap;
     for (const [tool, factory] of factories) {
       if (TARGETS_NOT_DERIVED.has(tool)) continue;


### PR DESCRIPTION
## Summary

Follow-up cleanups from PR #2187 (shared-config gateway refactor), addressing the review findings captured in the issue.

### 1. [mid] Unreachable ownership guard + vacuous test — `src/lib/shared-file-derive.ts`

`deriveSharedFileWriters()` pre-filtered registry entries with `if (!SHARED_WRITE_FEATURES.has(entry.feature)) continue;`, so `writer.features` was always a subset of `SHARED_WRITE_FEATURE_ORDER`. That made the ownership `throw` in `deriveSharedWriteSteps()` **dead code** and the `expect(() => deriveSharedWriteSteps()).not.toThrow()` test **vacuous** — a future feature (e.g. `commands`/`skills`) that started returning a shared path would be silently excluded from the write order instead of forcing an explicit precedence decision.

**Fix:** drop the pre-filter so every feature is considered. Single-writer files are still excluded (`features < 2`), so the derived writer set is unchanged — the inline snapshot test confirms this — while the guard is now genuinely reachable. The test now asserts the property directly (every writer feature has a position in the order) rather than relying only on the throw.

### 2. [low] `getExtraSharedWritePaths()` not try/catch protected — `src/lib/shared-file-derive.ts`

Wrapped the `getExtraSharedWritePaths()` call in try/catch, mirroring the sibling `getSettablePaths()` call, so a future tool whose implementation throws cannot break module load of `generate.ts` (`SHARED_WRITE_STEPS` is evaluated at load time).

### 4. [low] `policyFunction` strings unverified — `src/features/shared/shared-config-gateway.ts`

Added a test pinning every `custom` `policyFunction` name in `SHARED_CONFIG_OWNERSHIP` to a real exported function, so a rename cannot silently stale the declaration.

### Not addressed (informational per the issue)

- **#3** (takt `config.yaml` YAML-anchor expansion) — a documented behavior note, not a defect; no action required.
- **#5** (jsonc nested `__proto__` bypasses sanitize) — a pre-existing limitation, not a regression, on a read-only path (`opencode.json`) that is not in the gateway deep-merge set; deferred as defensive-only.

## Testing

- `pnpm cicheck` — all green (6882 unit tests, fmt, oxlint, typecheck, cspell, secretlint, gitignore/supported-tools/sync-skill-docs drift).
- Affected unit tests pass, including the unchanged writer snapshot and the strengthened guard test.

Closes #2189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
