### PR TITLE
feat(junie): round-trip hook blockOnError/async fields (#2153)

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -123,7 +123,8 @@ Example:
 - `type` (optional): Either `"command"` (default) or `"prompt"`. Not all tools support `prompt`; see notes below.
 - `matcher` (optional): Regex used by tools that scope hooks to specific tool names (e.g. `preToolUse`, `postToolUse`, `notification`). Ignored by events that do not take a matcher (e.g. `sessionStart`, `worktreeCreate`, `worktreeRemove`).
 - `timeout` (optional): Per-hook timeout in seconds, forwarded to tools that support it.
-- `failClosed` (optional): Cursor-specific boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json`.
+- `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
+- `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
 
 Events present in the shared `hooks` block but unsupported by a given tool are skipped for that tool (a warning is logged at generate time). The canonical `notification` event maps to deepagents-cli's `input.required` (human-in-the-loop interrupt).
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -123,7 +123,8 @@ Example:
 - `type` (optional): Either `"command"` (default) or `"prompt"`. Not all tools support `prompt`; see notes below.
 - `matcher` (optional): Regex used by tools that scope hooks to specific tool names (e.g. `preToolUse`, `postToolUse`, `notification`). Ignored by events that do not take a matcher (e.g. `sessionStart`, `worktreeCreate`, `worktreeRemove`).
 - `timeout` (optional): Per-hook timeout in seconds, forwarded to tools that support it.
-- `failClosed` (optional): Cursor-specific boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json`.
+- `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
+- `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
 
 Events present in the shared `hooks` block but unsupported by a given tool are skipped for that tool (a warning is logged at generate time). The canonical `notification` event maps to deepagents-cli's `input.required` (human-in-the-loop interrupt).
 

--- a/src/features/hooks/junie-hooks.test.ts
+++ b/src/features/hooks/junie-hooks.test.ts
@@ -163,6 +163,46 @@ describe("JunieHooks", () => {
       expect(parsed.hooks.SessionStart).toBeDefined();
     });
 
+    it("should emit blockOnError/async from canonical failClosed/async", async () => {
+      await ensureDir(join(testDir, ".junie"));
+      await writeFileContent(join(testDir, ".junie", "config.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [
+            {
+              type: "command",
+              command: ".rulesync/hooks/session-start.sh",
+              failClosed: true,
+              async: false,
+            },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const junieHooks = await JunieHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(junieHooks.getFileContent());
+      const hook = parsed.hooks.SessionStart[0].hooks[0];
+      // Canonical failClosed → Junie blockOnError; async stays async.
+      expect(hook.blockOnError).toBe(true);
+      expect(hook.async).toBe(false);
+      // The canonical field name must not leak into the Junie output.
+      expect(hook.failClosed).toBeUndefined();
+    });
+
     it("should throw error with descriptive message when existing config.json contains invalid JSON", async () => {
       await ensureDir(join(testDir, ".junie"));
       await writeFileContent(join(testDir, ".junie", "config.json"), "invalid json {");
@@ -232,6 +272,39 @@ describe("JunieHooks", () => {
       const json = rulesyncHooks.getJson();
       expect(json.hooks.sessionStart).toHaveLength(1);
       expect(json.hooks.sessionStart?.[0]?.command).toContain("session-start.sh");
+    });
+
+    it("should import blockOnError/async back into canonical failClosed/async", () => {
+      const junieHooks = new JunieHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".junie",
+        relativeFilePath: "config.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: "session-start.sh",
+                    blockOnError: true,
+                    async: false,
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = junieHooks.toRulesyncHooks();
+      const def = rulesyncHooks.getJson().hooks.sessionStart?.[0];
+      // Junie blockOnError → canonical failClosed; async stays async.
+      expect(def?.failClosed).toBe(true);
+      expect(def?.async).toBe(false);
+      // The Junie field name must not survive into the canonical model.
+      expect((def as Record<string, unknown>).blockOnError).toBeUndefined();
     });
 
     it("should throw error with descriptive message when content contains invalid JSON", () => {

--- a/src/features/hooks/junie-hooks.ts
+++ b/src/features/hooks/junie-hooks.ts
@@ -37,6 +37,14 @@ const JUNIE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   // hooks so generation matches the declared capability.
   supportedHookTypes: new Set(["command"]),
   noMatcherEvents: JUNIE_NO_MATCHER_EVENTS,
+  // Junie hook objects support `blockOnError` (block the action on hook failure)
+  // and `async` (run in the background). `blockOnError` maps onto the canonical
+  // `failClosed` field (shared with Cursor's identical semantics); `async` maps
+  // onto the canonical `async` field. https://junie.jetbrains.com/docs/junie-cli-hooks.html
+  booleanPassthroughFields: [
+    { canonical: "failClosed", tool: "blockOnError" },
+    { canonical: "async", tool: "async" },
+  ],
 };
 
 export class JunieHooks extends ToolHooks {

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -27,6 +27,17 @@ export type ToolHooksConverterConfig = {
   supportedHookTypes?: ReadonlySet<"command" | "prompt" | "http">;
   passthroughFields?: ReadonlyArray<"name" | "description">;
   /**
+   * Per-hook boolean fields to carry through the round-trip, each mapping a
+   * canonical {@link HookDefinitionSchema} boolean field to its tool-side field
+   * name (which may differ — e.g. Junie's `blockOnError` ↔ canonical
+   * `failClosed`). Only boolean values are emitted on export and imported back;
+   * any other value is ignored so a malformed field can't leak through.
+   */
+  booleanPassthroughFields?: ReadonlyArray<{
+    readonly canonical: "failClosed" | "async";
+    readonly tool: string;
+  }>;
+  /**
    * When true, only dot-relative commands (e.g. ./script.sh, ../script.sh, .rulesync/hooks/x.sh)
    * are prefixed with projectDirVar. Bare executable commands like `npx prettier ...` are left intact.
    */
@@ -107,6 +118,43 @@ function applyCommandPrefix({
 }
 
 /**
+ * Emit the configured boolean passthrough fields on the tool side, mapping each
+ * canonical field name to its (possibly renamed) tool field name. Only boolean
+ * values are carried through.
+ */
+function emitBooleanPassthroughFields({
+  def,
+  converterConfig,
+}: {
+  def: HooksConfig["hooks"][string][number];
+  converterConfig: ToolHooksConverterConfig;
+}): Record<string, boolean> {
+  return Object.fromEntries(
+    (converterConfig.booleanPassthroughFields ?? [])
+      .filter(({ canonical }) => typeof def[canonical] === "boolean")
+      .map(({ canonical, tool }) => [tool, def[canonical] as boolean]),
+  );
+}
+
+/**
+ * Import the configured boolean passthrough fields back into canonical fields,
+ * reversing {@link emitBooleanPassthroughFields}. Only boolean values are read.
+ */
+function importBooleanPassthroughFields({
+  h,
+  converterConfig,
+}: {
+  h: Record<string, unknown>;
+  converterConfig: ToolHooksConverterConfig;
+}): Record<string, boolean> {
+  return Object.fromEntries(
+    (converterConfig.booleanPassthroughFields ?? [])
+      .filter(({ tool }) => typeof h[tool] === "boolean")
+      .map(({ canonical, tool }) => [canonical, h[tool] as boolean]),
+  );
+}
+
+/**
  * Convert the definitions of a single matcher group into tool hook entries,
  * honoring supported hook types and passthrough fields.
  */
@@ -135,6 +183,7 @@ function buildToolHooks({
       ...(converterConfig.passthroughFields?.includes("description") &&
         def.description !== undefined &&
         def.description !== null && { description: def.description }),
+      ...emitBooleanPassthroughFields({ def, converterConfig }),
     });
   }
   return hooks;
@@ -248,6 +297,7 @@ function toolHookToCanonical({
       typeof h.name === "string" && { name: h.name }),
     ...(converterConfig.passthroughFields?.includes("description") &&
       typeof h.description === "string" && { description: h.description }),
+    ...importBooleanPassthroughFields({ h, converterConfig }),
     ...(rawEntry.matcher !== undefined &&
       rawEntry.matcher !== null &&
       rawEntry.matcher !== "" && { matcher: rawEntry.matcher }),

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -173,6 +173,10 @@ function buildToolHooks({
     }
     const command = applyCommandPrefix({ def, converterConfig });
     hooks.push({
+      // Spread the boolean passthrough fields first so the explicitly-handled
+      // core fields below always win: a misconfigured `tool` name (e.g. mapping
+      // onto "type"/"command") can never silently shadow them.
+      ...emitBooleanPassthroughFields({ def, converterConfig }),
       type: hookType,
       ...(command !== undefined && command !== null && { command }),
       ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
@@ -183,7 +187,6 @@ function buildToolHooks({
       ...(converterConfig.passthroughFields?.includes("description") &&
         def.description !== undefined &&
         def.description !== null && { description: def.description }),
-      ...emitBooleanPassthroughFields({ def, converterConfig }),
     });
   }
   return hooks;


### PR DESCRIPTION
## Summary

JetBrains Junie's hook objects support two per-hook control flags, `blockOnError` and `async`, but rulesync's shared hooks converter never modeled or emitted them, so they were silently dropped on generate and lost on import round-trip.

Per the maintainer decision recorded on the issue, `blockOnError` is unified onto the **existing** canonical `failClosed` field (identical semantics, already used by Cursor) rather than introducing a separate Junie-specific field, keeping the canonical hooks model from fragmenting. `async` already exists canonically (added for Qwen Code), so it only needed wiring.

## Changes

- **`tool-hooks-converter.ts`** — add a rename-capable `booleanPassthroughFields` mechanism: each entry maps a canonical `HookDefinition` boolean field (`failClosed` / `async`) to its tool-side field name (which may differ). Only boolean values are emitted on export and imported back. Extracted `emitBooleanPassthroughFields` / `importBooleanPassthroughFields` helpers so the change stays within the existing complexity budget. The feature is opt-in per converter config, so no other tool's behavior changes.
- **`junie-hooks.ts`** — wire `JUNIE_CONVERTER_CONFIG` with `blockOnError` ⇄ `failClosed` and `async` ⇄ `async`.
- **`junie-hooks.test.ts`** — round-trip coverage for both directions (canonical → Junie and Junie → canonical), asserting the tool-side / canonical field names don't leak across.
- **`file-formats.md`** (+ synced `skills/rulesync/`) — document `failClosed`'s Junie `blockOnError` passthrough and the `async` field.

## Testing

- `pnpm cicheck` — all green (6884 unit tests, fmt, oxlint, typecheck, cspell, secretlint, drift checks).
- `pnpm test:e2e` `e2e-hooks.spec.ts` — 60 passed (shared converter change is backward-compatible).

Closes #2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
