### PR TITLE
chore(release): v9.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.5.0";
+const getVersion = () => "9.6.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Release v9.6.0

Version bump and release preparation for v9.6.0.

### Highlights
- Add Reasonix support with rules/skills adapters, expanded hook events, and MCP plugin timeout fields (#2193)
- Add codexcli/kiro/augmentcode-scoped permission override namespaces (#2196, #2195, #2194)
- Round-trip Junie hook `blockOnError`/`async` fields (#2192)
- Migrate to js-yaml v5 (#2197)

Full Changelog: https://github.com/dyoshikawa/rulesync/compare/v9.5.0...v9.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
