### PR TITLE
release: v9.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.6.0";
+const getVersion = () => "9.6.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v9.6.1 — a maintenance release containing dependency and GitHub Actions updates only. No functional changes.

## What's Changed

- chore(deps): bump the all-dependencies group with 99 updates (#2201)
- ci(deps): bump anomalyco/opencode/github from 1.17.13 to 1.17.18 in the all-actions group (#2200)

## Version

- `getVersion()` in `src/cli/index.ts`: 9.6.0 → 9.6.1
- `package.json` version: 9.6.0 → 9.6.1

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v9.6.0...v9.6.1