### PR TITLE
refactor(rules): consolidate rovodev root-mirror hooks into one contract

### DIFF
--- a/src/features/rules/rovodev-rule.test.ts
+++ b/src/features/rules/rovodev-rule.test.ts
@@ -472,4 +472,68 @@ describe("RovodevRule", () => {
       expect(RovodevRule.isTargetedByRulesyncRule(rulesyncRule)).toBe(true);
     });
   });
+
+  describe("getRootMirror", () => {
+    const primaryRoot = () =>
+      new RovodevRule({
+        outputRoot: testDir,
+        relativeDirPath: ".rovodev",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "root body",
+        validate: true,
+        root: true,
+      });
+
+    it("getMirrorFiles mirrors the primary root to a project-root ./AGENTS.md", () => {
+      const mirrors = RovodevRule.getRootMirror().getMirrorFiles({
+        outputRoot: testDir,
+        rootRule: primaryRoot(),
+        content: "mirrored content",
+      });
+
+      expect(mirrors).toHaveLength(1);
+      const [mirror] = mirrors;
+      expect(mirror).toBeInstanceOf(RovodevRule);
+      expect(mirror?.isRoot()).toBe(true);
+      expect(mirror?.getRelativeDirPath()).toBe(".");
+      expect(mirror?.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(mirror?.getFileContent()).toBe("mirrored content");
+    });
+
+    it("getMirrorFiles returns empty when the rule is not the primary root", () => {
+      const nonPrimary = new RovodevRule({
+        outputRoot: testDir,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        fileContent: "already at root",
+        validate: true,
+        root: true,
+      });
+
+      expect(
+        RovodevRule.getRootMirror().getMirrorFiles({
+          outputRoot: testDir,
+          rootRule: nonPrimary,
+          content: "content",
+        }),
+      ).toEqual([]);
+    });
+
+    it("getMirrorDeletionGlobs points primary at .rovodev/AGENTS.md and mirror at ./AGENTS.md", () => {
+      const globs = RovodevRule.getRootMirror().getMirrorDeletionGlobs({ outputRoot: testDir });
+
+      expect(globs).toEqual({
+        primaryGlob: join(testDir, ".rovodev", "AGENTS.md"),
+        mirrorGlob: join(testDir, "AGENTS.md"),
+      });
+    });
+  });
+
+  describe("getLocalRootDeletionGlob", () => {
+    it("points the separate-local-file glob at the project root, not under .rovodev/", () => {
+      expect(
+        RovodevRule.getLocalRootDeletionGlob({ outputRoot: testDir, fileName: "AGENTS.local.md" }),
+      ).toBe(join(testDir, "AGENTS.local.md"));
+    });
+  });
 });

--- a/src/features/rules/rovodev-rule.ts
+++ b/src/features/rules/rovodev-rule.ts
@@ -329,51 +329,53 @@ export class RovodevRule extends ToolRule {
   }
 
   /**
-   * Mirror the primary `.rovodev/AGENTS.md` root rule to `./AGENTS.md` so project
-   * memory stays discoverable at the repo root. Empty when `rootRule` is not the primary root.
+   * Root-mirror contract: rovodev mirrors its primary `.rovodev/AGENTS.md` root
+   * rule to `./AGENTS.md` so project memory stays discoverable at the repo root.
+   * Generation (`getMirrorFiles`) and deletion (`getMirrorDeletionGlobs`) are
+   * bundled in one object so they cannot drift out of symmetry. The processor
+   * keys off this method's mere presence to decide the tool mirrors at all.
    */
-  static getRootMirrorFiles({
-    outputRoot,
-    rootRule,
-    content,
-  }: {
-    outputRoot: string;
-    rootRule: ToolRule;
-    content: string;
-  }): RovodevRule[] {
-    if (!(rootRule instanceof RovodevRule)) {
-      return [];
-    }
-    const primary = this.getSettablePaths({ global: false }).root;
-    if (
-      rootRule.getRelativeDirPath() !== primary.relativeDirPath ||
-      rootRule.getRelativeFilePath() !== primary.relativeFilePath
-    ) {
-      return [];
-    }
-    return [
-      new RovodevRule({
-        outputRoot,
-        relativeDirPath: ".",
-        relativeFilePath: ROVODEV_RULE_FILE_NAME,
-        fileContent: content,
-        validate: true,
-        root: true,
-      }),
-    ];
-  }
-
-  /**
-   * Globs for mirror deletion: the `./AGENTS.md` mirror (`mirrorGlob`) is deleted
-   * only when the primary `.rovodev/AGENTS.md` (`primaryGlob`) still exists.
-   */
-  static getRootMirrorDeletionGlobs({ outputRoot }: { outputRoot: string }): {
-    primaryGlob: string;
-    mirrorGlob: string;
+  static getRootMirror(): {
+    getMirrorFiles(params: {
+      outputRoot: string;
+      rootRule: ToolRule;
+      content: string;
+    }): RovodevRule[];
+    getMirrorDeletionGlobs(params: { outputRoot: string }): {
+      primaryGlob: string;
+      mirrorGlob: string;
+    };
   } {
     return {
-      primaryGlob: join(outputRoot, ROVODEV_DIR, ROVODEV_RULE_FILE_NAME),
-      mirrorGlob: join(outputRoot, ROVODEV_RULE_FILE_NAME),
+      // Empty when `rootRule` is not the primary root.
+      getMirrorFiles: ({ outputRoot, rootRule, content }) => {
+        if (!(rootRule instanceof RovodevRule)) {
+          return [];
+        }
+        const primary = RovodevRule.getSettablePaths({ global: false }).root;
+        if (
+          rootRule.getRelativeDirPath() !== primary.relativeDirPath ||
+          rootRule.getRelativeFilePath() !== primary.relativeFilePath
+        ) {
+          return [];
+        }
+        return [
+          new RovodevRule({
+            outputRoot,
+            relativeDirPath: ".",
+            relativeFilePath: ROVODEV_RULE_FILE_NAME,
+            fileContent: content,
+            validate: true,
+            root: true,
+          }),
+        ];
+      },
+      // The `./AGENTS.md` mirror (`mirrorGlob`) is deleted only when the primary
+      // `.rovodev/AGENTS.md` (`primaryGlob`) still exists.
+      getMirrorDeletionGlobs: ({ outputRoot }) => ({
+        primaryGlob: join(outputRoot, ROVODEV_DIR, ROVODEV_RULE_FILE_NAME),
+        mirrorGlob: join(outputRoot, ROVODEV_RULE_FILE_NAME),
+      }),
     };
   }
 

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -208,16 +208,24 @@ type ToolRuleFactory = {
     getSettablePaths(options?: {
       global?: boolean;
     }): ToolRuleSettablePaths | ToolRuleSettablePathsGlobal;
-    /** Set alongside `meta.mirrorsRootToAgentsMd`. See {@link RovodevRule.getRootMirrorFiles}. */
-    getRootMirrorFiles?(params: {
-      outputRoot: string;
-      rootRule: ToolRule;
-      content: string;
-    }): ToolRule[];
-    /** Set alongside `meta.mirrorsRootToAgentsMd`. See {@link RovodevRule.getRootMirrorDeletionGlobs}. */
-    getRootMirrorDeletionGlobs?(params: { outputRoot: string }): {
-      primaryGlob: string;
-      mirrorGlob: string;
+    /**
+     * When present, this tool mirrors its generated root rule to a project-root
+     * `AGENTS.md` (project scope only). Presence of this single method — not a
+     * separate `meta` flag — is the source of truth for "this tool mirrors": it
+     * returns one contract that bundles the mirror's generation and deletion so
+     * the two cannot drift out of symmetry (a tool cannot define one without the
+     * other). See {@link RovodevRule.getRootMirror}.
+     */
+    getRootMirror?(): {
+      getMirrorFiles(params: {
+        outputRoot: string;
+        rootRule: ToolRule;
+        content: string;
+      }): ToolRule[];
+      getMirrorDeletionGlobs(params: { outputRoot: string }): {
+        primaryGlob: string;
+        mirrorGlob: string;
+      };
     };
     /**
      * Override where the `separate-local-file` deletion glob points when the tool
@@ -251,8 +259,6 @@ type ToolRuleFactory = {
     localRootMode?: LocalRootMode;
     /** File name for the `separate-local-file` local-root file. */
     localRootFileName?: string;
-    /** Mirror the generated root rule to a project-root `AGENTS.md` (project scope only). */
-    mirrorsRootToAgentsMd?: boolean;
   };
 };
 
@@ -672,7 +678,6 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
         },
         localRootMode: "separate-local-file",
         localRootFileName: "AGENTS.local.md",
-        mirrorsRootToAgentsMd: true,
       },
     },
   ],
@@ -1005,9 +1010,10 @@ export class RulesProcessor extends FeatureProcessor {
     const newContent = referenceSection + conventionsSection + rootRule.getFileContent();
     rootRule.setFileContent(newContent);
 
-    if (meta.mirrorsRootToAgentsMd && !this.global && factory.class.getRootMirrorFiles) {
+    const rootMirror = factory.class.getRootMirror?.();
+    if (rootMirror && !this.global) {
       toolRules.push(
-        ...factory.class.getRootMirrorFiles({
+        ...rootMirror.getMirrorFiles({
           outputRoot: this.outputRoot,
           rootRule,
           content: newContent,
@@ -1464,15 +1470,11 @@ As this project's AI coding tool, you must follow the additional conventions bel
       );
 
       const rootMirrorDeletionRules = await (async () => {
-        if (
-          !forDeletion ||
-          this.global ||
-          !factory.meta.mirrorsRootToAgentsMd ||
-          !factory.class.getRootMirrorDeletionGlobs
-        ) {
+        const rootMirror = factory.class.getRootMirror?.();
+        if (!forDeletion || this.global || !rootMirror) {
           return [];
         }
-        const { primaryGlob, mirrorGlob } = factory.class.getRootMirrorDeletionGlobs({
+        const { primaryGlob, mirrorGlob } = rootMirror.getMirrorDeletionGlobs({
           outputRoot: this.outputRoot,
         });
         const primaryPaths = await findFilesByGlobs(primaryGlob);

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -460,7 +460,7 @@ function computeRootFileOwnership(params: {
     // be attributed to the target too, otherwise ownership/skip decisions invert.
     // (For rovodev this overlaps its `alternativeRoots` today; the explicit
     // block keeps ownership correct even if that alt root is ever removed.)
-    if (!params.global && factory.meta.mirrorsRootToAgentsMd) {
+    if (!params.global && factory.class.getRootMirror) {
       register(".", AGENTSMD_RULE_FILE_NAME, target);
     }
   }


### PR DESCRIPTION
## Summary

Follow-up from PR #2108 (the `mid` item in #2111): the `meta.mirrorsRootToAgentsMd` flag was coupled to **two independent optional hooks** on the tool class — `getRootMirrorFiles` (generation) and `getRootMirrorDeletionGlobs` (deletion). Before PR #2108 both were bound to a single `factory.class === RovodevRule` condition, so they were symmetric. After the refactor they became independent optional methods, so a future tool that set `mirrorsRootToAgentsMd: true` but implemented only one hook would silently get asymmetric "mirror is generated but never cleaned up on deletion" behavior — guarded only by a JSDoc "Set alongside" comment.

## Changes

- Removed the `meta.mirrorsRootToAgentsMd` flag and the two separate `getRootMirrorFiles` / `getRootMirrorDeletionGlobs` hooks.
- Introduced a single optional `getRootMirror()` contract that bundles both halves:
  - `getMirrorFiles({ outputRoot, rootRule, content })`
  - `getMirrorDeletionGlobs({ outputRoot })`
- **The method's mere presence is now the single source of truth** for "this tool mirrors its root to `./AGENTS.md`". Generation (`rules-processor.ts`), mirror deletion (`rules-processor.ts`), and ownership registration (`generate.ts`) all key off `factory.class.getRootMirror`, so the generation/deletion pair cannot drift out of symmetry — a tool cannot define one half without the other.
- Added direct unit tests (the `low` item in #2111) for `getRootMirror` (both halves) and `getLocalRootDeletionGlob`, which were previously covered only indirectly via `rules-processor.test.ts` integration tests.

`getLocalRootDeletionGlob` is intentionally left as a standalone hook: it is gated by `localRootMode: "separate-local-file"` (a different mechanism) and has no generation/deletion partner, so it carries no symmetry footgun.

Behavior is preserved — rovodev is the only tool that mirrors, and it always returns the contract, so all three gate sites remain equivalent to the previous flag-based checks. Verified by the unchanged Tool × Feature e2e rules matrix (`e2e-rules.spec.ts`, 105 tests) plus the new unit tests; full `pnpm cicheck` is green.

Closes #2111
