### PR TITLE
refactor(lib): harden shared-file-writer derivation against drift

### DIFF
--- a/src/lib/shared-file-derive.test.ts
+++ b/src/lib/shared-file-derive.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import type { Feature } from "../types/features.js";
+import { ALL_FEATURES, type Feature } from "../types/features.js";
 import { GENERATION_STEP_GRAPH } from "./generate.js";
 import {
   deriveSharedFileWriters,
   deriveSharedWriteSteps,
+  NON_SHARED_WRITE_FEATURES,
   SHARED_WRITE_FEATURE_ORDER,
+  settablePathsForScope,
 } from "./shared-file-derive.js";
 
 const graphWritersByFile = (): Map<string, Set<Feature>> => {
@@ -51,6 +53,34 @@ describe("shared-file write derivation", () => {
     // evaluates at module load), so an unordered writer fails loudly at runtime,
     // not just here.
     expect(() => deriveSharedWriteSteps()).not.toThrow();
+  });
+
+  it("classifies every Feature as either a shared writer or an explicit non-shared-writer", () => {
+    // Guards #2110 mid#1: SHARED_WRITE_FEATURE_ORDER is hand-maintained, so a
+    // feature that later starts writing a shared file could be silently
+    // forgotten. Requiring the two lists to partition ALL_FEATURES exactly means
+    // adding a Feature forces classifying it in one of them (a duplicate would
+    // make `classified` longer than ALL_FEATURES, so this also rejects overlap).
+    const classified = [...SHARED_WRITE_FEATURE_ORDER, ...NON_SHARED_WRITE_FEATURES].toSorted();
+    expect(classified).toEqual([...ALL_FEATURES].toSorted());
+  });
+
+  it("collects getExtraSharedWritePaths even when getSettablePaths throws", () => {
+    // Guards #2110 mid#2: the two hooks are independent, so a throwing
+    // getSettablePaths must not suppress a tool's (possibly scope-only) extra
+    // shared path.
+    const cls = {
+      getSettablePaths: () => {
+        throw new Error("boom");
+      },
+      getExtraSharedWritePaths: () => [
+        { relativeDirPath: ".config/example", relativeFilePath: "example.json" },
+      ],
+    };
+
+    expect(settablePathsForScope(cls, true)).toEqual([
+      { relativeDirPath: ".config/example", relativeFilePath: "example.json" },
+    ]);
   });
 
   it("orders every writer pair of every shared file by dependsOn edges", () => {

--- a/src/lib/shared-file-derive.test.ts
+++ b/src/lib/shared-file-derive.test.ts
@@ -78,7 +78,7 @@ describe("shared-file write derivation", () => {
       ],
     };
 
-    expect(settablePathsForScope(cls, true)).toEqual([
+    expect(settablePathsForScope({ cls, global: true })).toEqual([
       { relativeDirPath: ".config/example", relativeFilePath: "example.json" },
     ]);
   });

--- a/src/lib/shared-file-derive.ts
+++ b/src/lib/shared-file-derive.ts
@@ -34,6 +34,26 @@ export const SHARED_WRITE_FEATURE_ORDER = [
   "rules",
 ] as const satisfies readonly Feature[];
 
+/**
+ * Features that deliberately never participate in shared read-modify-write
+ * config files: each writes its own dedicated per-item artifact, never a file
+ * another feature also writes.
+ *
+ * - `commands`: standalone per-command files (e.g. `.claude/commands/*.md`).
+ * - `skills`: standalone per-skill directories (e.g. `.claude/skills/<name>/`).
+ *
+ * Kept as an explicit list — not an implicit "everything not in
+ * {@link SHARED_WRITE_FEATURE_ORDER}" — so that adding a new `Feature` forces a
+ * conscious classification: the exhaustiveness test in
+ * `shared-file-derive.test.ts` fails until the new feature is placed in either
+ * this list or `SHARED_WRITE_FEATURE_ORDER`. That closes the drift where a
+ * feature which later starts writing a shared file is silently forgotten.
+ */
+export const NON_SHARED_WRITE_FEATURES = [
+  "commands",
+  "skills",
+] as const satisfies readonly Feature[];
+
 // Deprecated aliases; a guard for the day one diverges from its canonical
 // target's paths. A no-op today since they reuse the canonical class and paths.
 const TARGETS_NOT_DERIVED: ReadonlySet<string> = new Set([
@@ -54,7 +74,7 @@ type FactoryClass = {
 
 type FactoryMap = ReadonlyMap<ToolTarget, { readonly class: FactoryClass }>;
 
-const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWritePath[] => {
+export const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWritePath[] => {
   const paths: SharedWritePath[] = [];
   let settable:
     | {
@@ -67,7 +87,12 @@ const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWriteP
   try {
     settable = cls.getSettablePaths?.({ global }) as typeof settable;
   } catch {
-    return paths;
+    // Fail-open (see the extra-paths note below), but do NOT early-return: the
+    // two hooks are independent, so a throwing getSettablePaths must not also
+    // suppress this tool's getExtraSharedWritePaths — otherwise a tool whose
+    // global getSettablePaths throws while it has a global-only extra shared
+    // path would silently drop that path from the write order.
+    settable = undefined;
   }
   if (settable?.relativeFilePath) {
     paths.push({
@@ -85,11 +110,11 @@ const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWriteP
   // trade-off is that a broken getExtraSharedWritePaths silently drops that
   // tool's extra shared paths from the write order — acceptable because every
   // current implementation returns a static constant that cannot throw.
-  let extra: SharedWritePath[];
+  let extra: SharedWritePath[] = [];
   try {
     extra = cls.getExtraSharedWritePaths?.({ global }) ?? [];
   } catch {
-    return paths;
+    extra = [];
   }
   for (const path of extra) {
     if (path.relativeFilePath) paths.push(path);

--- a/src/lib/shared-file-derive.ts
+++ b/src/lib/shared-file-derive.ts
@@ -74,7 +74,13 @@ type FactoryClass = {
 
 type FactoryMap = ReadonlyMap<ToolTarget, { readonly class: FactoryClass }>;
 
-export const settablePathsForScope = (cls: FactoryClass, global: boolean): SharedWritePath[] => {
+export const settablePathsForScope = ({
+  cls,
+  global,
+}: {
+  cls: FactoryClass;
+  global: boolean;
+}): SharedWritePath[] => {
   const paths: SharedWritePath[] = [];
   let settable:
     | {
@@ -126,8 +132,8 @@ export const settablePathsForScope = (cls: FactoryClass, global: boolean): Share
 // `.config/opencode/opencode.json`), so a feature's writes are the union across
 // both scopes; the step graph declares that union.
 const collectFactoryPaths = (factory: { class: FactoryClass }): SharedWritePath[] => [
-  ...settablePathsForScope(factory.class, false),
-  ...settablePathsForScope(factory.class, true),
+  ...settablePathsForScope({ cls: factory.class, global: false }),
+  ...settablePathsForScope({ cls: factory.class, global: true }),
 ];
 
 /**


### PR DESCRIPTION
## Summary

Addresses the two `mid` follow-ups from the PR #2109 review captured in #2110, hardening `src/lib/shared-file-derive.ts` against future drift. Refs #2081.

## Changes

### mid #1 — exhaustiveness for the shared-write feature classification
`SHARED_WRITE_FEATURE_ORDER` is hand-maintained. If `commands`/`subagents`/`skills` later start writing shared config files and someone forgets to account for them, the drift this derivation is meant to prevent could silently re-appear.

- Added an explicit `NON_SHARED_WRITE_FEATURES` exclusion list (`commands`, `skills`), each documented with *why* it is excluded (both write their own dedicated per-item artifacts — command files / skill directories — never a file another feature also writes).
- Added a test asserting `SHARED_WRITE_FEATURE_ORDER ∪ NON_SHARED_WRITE_FEATURES` partitions `ALL_FEATURES` exactly. Adding a new `Feature` now fails the test until it is consciously classified as a shared writer or an excluded one. (A duplicate makes the classified list longer than `ALL_FEATURES`, so the single partition assertion also rejects overlap — no redundant case.)

### mid #2 — `getExtraSharedWritePaths` no longer swallowed by a throwing `getSettablePaths`
`settablePathsForScope` early-returned from the `getSettablePaths` `catch`, which skipped the subsequent `getExtraSharedWritePaths` collection. Currently harmless with existing tools, but a tool whose global `getSettablePaths` throws while it also has a global-only extra shared path would silently drop that path.

- The two hooks are now collected independently: a throwing `getSettablePaths` leaves `settable` undefined and falls through to the extra-path collection instead of returning early. Both hooks remain fail-open individually (the derivation runs at module load, so a throwing tool must not take down every `generate`).
- Exported `settablePathsForScope` and added a test that a throwing `getSettablePaths` still yields the tool's `getExtraSharedWritePaths` entries.

## Notes
- The `low` items (#3 base-class default for `getExtraSharedWritePaths`, #4 type-guard for the `settable` shape, #5 test-case-subsumption comment) and item #6 (confirm the intended Kilo `kilo.json`/`kilo.jsonc` split) are out of scope for this PR and left for the maintainer.

Full `pnpm cicheck` is green (typecheck, lint, 6926 tests, content checks).

Closes #2110
