### PR TITLE
docs: add adoption case studies for Ripple, VOICEVOX, Effect, AG Grid, and RHDH

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -373,6 +373,7 @@
     "Classmethod",
     "Asoview",
     "KAKEHASHI",
+    "VOICEVOX",
     "redirs",
     "symref",
     "TOCTOU",

--- a/docs/guide/case-studies.md
+++ b/docs/guide/case-studies.md
@@ -6,3 +6,8 @@ Rulesync is trusted by leading companies and recognized by the industry:
 - **Asoview Inc.**: [Adopting Rulesync for unified AI development rules](https://tech.asoview.co.jp/entry/2025/12/06/100000)
 - **KAKEHASHI Tech Blog**: [Building multilingual systems for the LLM era with a monorepo and a "living specification"](https://kakehashi-dev.hatenablog.com/entry/2025/12/08/110000)
 - **Cloudflare**: [Adopting Rulesync for AI coding assistant configuration](https://github.com/cloudflare/cloudflare-docs/pull/28232)
+- **Ripple**: [Migrating agent rule management to Rulesync](https://github.com/Ripple-TS/ripple/commit/114bcf791c957ab5d43fcc6369515b59b866ce80)
+- **VOICEVOX**: [Adding Rulesync to unify AI coding assistant rules](https://github.com/VOICEVOX/voicevox/pull/2918)
+- **Effect**: [Managing agent rules with Rulesync](https://github.com/Effect-TS/effect-smol/pull/986)
+- **AG Grid**: [Syncing shared AI rules via Rulesync](https://github.com/ag-grid/ag-grid/pull/13044)
+- **Red Hat Developer Hub**: [Adding Rulesync to synchronize AI Assistant rules](https://github.com/redhat-developer/rhdh/pull/3707)

--- a/skills/rulesync/case-studies.md
+++ b/skills/rulesync/case-studies.md
@@ -6,3 +6,8 @@ Rulesync is trusted by leading companies and recognized by the industry:
 - **Asoview Inc.**: [Adopting Rulesync for unified AI development rules](https://tech.asoview.co.jp/entry/2025/12/06/100000)
 - **KAKEHASHI Tech Blog**: [Building multilingual systems for the LLM era with a monorepo and a "living specification"](https://kakehashi-dev.hatenablog.com/entry/2025/12/08/110000)
 - **Cloudflare**: [Adopting Rulesync for AI coding assistant configuration](https://github.com/cloudflare/cloudflare-docs/pull/28232)
+- **Ripple**: [Migrating agent rule management to Rulesync](https://github.com/Ripple-TS/ripple/commit/114bcf791c957ab5d43fcc6369515b59b866ce80)
+- **VOICEVOX**: [Adding Rulesync to unify AI coding assistant rules](https://github.com/VOICEVOX/voicevox/pull/2918)
+- **Effect**: [Managing agent rules with Rulesync](https://github.com/Effect-TS/effect-smol/pull/986)
+- **AG Grid**: [Syncing shared AI rules via Rulesync](https://github.com/ag-grid/ag-grid/pull/13044)
+- **Red Hat Developer Hub**: [Adding Rulesync to synchronize AI Assistant rules](https://github.com/redhat-developer/rhdh/pull/3707)


### PR DESCRIPTION
## Summary

Adds five notable open-source projects to `docs/guide/case-studies.md`, each linked to the pull request (or commit) where the project adopted Rulesync to manage its AI coding assistant rules:

- **Ripple** — [commit `114bcf79`](https://github.com/Ripple-TS/ripple/commit/114bcf791c957ab5d43fcc6369515b59b866ce80) (adopted via a direct commit to `main`, not a PR)
- **VOICEVOX** — [#2918](https://github.com/VOICEVOX/voicevox/pull/2918)
- **Effect** — [#986](https://github.com/Effect-TS/effect-smol/pull/986)
- **AG Grid** — [#13044](https://github.com/ag-grid/ag-grid/pull/13044)
- **Red Hat Developer Hub** — [#3707](https://github.com/redhat-developer/rhdh/pull/3707)

The `skills/rulesync/case-studies.md` mirror is regenerated by `scripts/sync-skill-docs.ts`, and `VOICEVOX` is added to the cspell dictionary.

## Notes

- Ripple has no adoption PR; it migrated to Rulesync in a direct commit to `main`, so the entry links to that commit as agreed.
- Effect (`effect-smol`) later removed Rulesync in [#1934](https://github.com/Effect-TS/effect-smol/pull/1934); the entry links to the original adoption PR #986 per the maintainer's decision.

## Test plan

- [x] `pnpm cicheck:content`
- [x] `pnpm cicheck:code`
