### PR TITLE
fix: normalize Codex MCP server names

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -325,6 +325,40 @@ args = ["server.js"]
       expect(codexcliMcp.getRelativeFilePath()).toBe("config.toml");
     });
 
+    it("should normalize invalid Codex MCP server names and warn when the last collision wins", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            "Postgres MCP - Production - Read Only": { command: "node" },
+            "My Server": { command: "first" },
+            my_server: { command: "second" },
+            "constructor!": { command: "safe" },
+            "already-valid": { command: "unchanged" },
+          },
+        }),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+      });
+
+      expect(codexcliMcp.getToml().mcp_servers).toEqual({
+        postgres_mcp_production_read_only: { command: "node" },
+        my_server: { command: "second" },
+        "already-valid": { command: "unchanged" },
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'MCP server "constructor!" could not be normalized to a valid Codex MCP server name and was skipped.',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Codex MCP server name collision: "My Server" and "my_server" both normalize to "my_server". Only the last processed server will be used.',
+      );
+    });
+
     it("should preserve existing TOML content when adding MCP servers", async () => {
       // Create existing config.toml with some content
       const existingToml = `[general]

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -74,6 +74,20 @@ function mapOauthFromCodex(oauth: Record<string, unknown>): Record<string, unkno
   return result;
 }
 
+const CODEX_MCP_SERVER_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function normalizeCodexMcpServerName(name: string): string | null {
+  if (PROTOTYPE_POLLUTION_KEYS.has(name)) return null;
+  if (CODEX_MCP_SERVER_NAME_PATTERN.test(name)) return name;
+
+  const normalizedName = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return normalizedName && !PROTOTYPE_POLLUTION_KEYS.has(normalizedName) ? normalizedName : null;
+}
+
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
   const result: McpServers = {};
 
@@ -111,9 +125,17 @@ function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
 
 function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   const result: Record<string, Record<string, unknown>> = {};
+  const originalNames = new Map<string, string>();
 
   for (const [name, config] of Object.entries(mcpServers)) {
-    if (PROTOTYPE_POLLUTION_KEYS.has(name)) continue;
+    const codexName = normalizeCodexMcpServerName(name);
+    if (codexName === null) {
+      warnWithFallback(
+        undefined,
+        `MCP server "${name}" could not be normalized to a valid Codex MCP server name and was skipped.`,
+      );
+      continue;
+    }
     if (!isRecord(config)) continue;
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
@@ -141,7 +163,15 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
       }
     }
 
-    result[name] = converted;
+    const previousName = originalNames.get(codexName);
+    if (previousName !== undefined) {
+      warnWithFallback(
+        undefined,
+        `Codex MCP server name collision: "${previousName}" and "${name}" both normalize to "${codexName}". Only the last processed server will be used.`,
+      );
+    }
+    originalNames.set(codexName, name);
+    result[codexName] = converted;
   }
 
   return result;


### PR DESCRIPTION
## Summary

- normalize invalid MCP server names for Codex CLI
- warn and let the last server win when normalized names collide
- warn and skip names that cannot be normalized safely

## Testing

- pnpm cicheck

Fixes #2215