### PR TITLE
release: v9.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.6.2";
+const getVersion = () => "9.6.3";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Release v9.6.3

This PR bumps the version to 9.6.3.

### What's Changed

- fix: normalize Codex MCP server names (#2217)
- docs: add adoption case studies for Ripple, VOICEVOX, Effect, AG Grid, and RHDH (#2216)

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v9.6.2...v9.6.3