### PR TITLE
feat(init): use deepwiki and rulesync MCP servers in init sample

### DIFF
--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -118,29 +118,18 @@ globs: ["**/*"]
     content: `{
   "$schema": "${RULESYNC_MCP_SCHEMA_URL}",
   "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp",
       "env": {}
     },
-    "context7": {
+    "rulesync": {
       "type": "stdio",
-      "command": "npx",
+      "command": "pnpm",
       "args": [
-        "-y",
-        "@upstash/context7-mcp"
+        "dlx",
+        "rulesync",
+        "mcp"
       ],
       "env": {}
     }


### PR DESCRIPTION
## Summary

Update the sample `mcp.json` generated by `rulesync init` to ship a more relevant starter set of MCP servers.

Previously `rulesync init` wrote `serena` and `context7` sample servers. This changes the template to:

```json
{
  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
  "mcpServers": {
    "deepwiki": {
      "type": "http",
      "url": "https://mcp.deepwiki.com/mcp",
      "env": {}
    },
    "rulesync": {
      "type": "stdio",
      "command": "pnpm",
      "args": ["dlx", "rulesync", "mcp"],
      "env": {}
    }
  }
}
```

- `deepwiki` — HTTP MCP server for AI-powered repository documentation.
- `rulesync` — stdio MCP server run via `pnpm dlx rulesync mcp`.

## Changes

- `src/lib/init.ts`: replace the `serena`/`context7` sample servers with `deepwiki`/`rulesync` in `sampleMcpFile`.

## Notes

The generic `.rulesync/mcp.json` format examples in `docs/reference/file-formats.md` continue to use `serena`/`context7` as illustrative examples; they are not tied to the init template and were left unchanged.

## Verification

- `pnpm cicheck` passes (code + content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
