### PR TITLE
chore: remove Serena MCP server from the project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,9 +11,7 @@
       "Bash(rm -rf ~/**)",
       "Read(.env*)"
     ],
-    "allow": [
-      "mcp__serena"
-    ],
+    "allow": [],
     "defaultMode": "auto"
   },
   "statusLine": {

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,22 +1,5 @@
 {
   "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
-      "env": {}
-    },
     "deepwiki": {
       "type": "sse",
       "url": "https://mcp.deepwiki.com/sse",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,8 +30,6 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - You must not use here documents because it causes a sandbox error.
   - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.
   - When creating a PR, you should include a link in the PR description that associates the PR with its issue.
-- When you read or search the codebase:
-  - You should check Serena MCP server tools, and use those actively.
 - About the `skills/` directory at the repository root:
   - This directory contains official skills that are distributed for users to install via the `rulesync fetch` command (e.g., `npx rulesync fetch dyoshikawa/rulesync --features skills`).
   - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.

--- a/.rulesync/commands/batch-all-issues.md
+++ b/.rulesync/commands/batch-all-issues.md
@@ -82,8 +82,8 @@ in `/resolve-scrap-issues` Step 4. Combine three angles:
   non-trivial claims against at least one primary source. Capture exact URLs and
   version numbers so they can be cited. Run independent searches in parallel.
 - **Codebase inspection:** Check whether the issue is already resolved,
-  partially handled, or contradicted by the current code. Prefer the Serena MCP
-  symbol tools over reading whole files. Apply the project rules in `CLAUDE.md`,
+  partially handled, or contradicted by the current code. Prefer targeted
+  symbol and search tools over reading whole files. Apply the project rules in `CLAUDE.md`,
   `.claude/rules/**`, and `docs/**`.
 - **Issue discussion:** Honor any maintainer decision already recorded in the
   comments (e.g., "won't do", "superseded by #N").

--- a/.rulesync/commands/batch-all-scrap-issues.md
+++ b/.rulesync/commands/batch-all-scrap-issues.md
@@ -81,8 +81,8 @@ in `/resolve-scrap-issues` Step 4. Combine three angles:
   non-trivial claims against at least one primary source. Capture exact URLs and
   version numbers so they can be cited. Run independent searches in parallel.
 - **Codebase inspection:** Check whether the issue is already resolved,
-  partially handled, or contradicted by the current code. Prefer the Serena MCP
-  symbol tools over reading whole files. Apply the project rules in `CLAUDE.md`,
+  partially handled, or contradicted by the current code. Prefer targeted
+  symbol and search tools over reading whole files. Apply the project rules in `CLAUDE.md`,
   `.claude/rules/**`, and `docs/**`.
 - **Issue discussion:** Honor any maintainer decision already recorded in the
   comments (e.g., "won't do", "superseded by #N").

--- a/.rulesync/commands/create-issue-with-websearch.md
+++ b/.rulesync/commands/create-issue-with-websearch.md
@@ -51,7 +51,7 @@ With the web findings in hand, investigate the relevant parts of this repository
 - How do existing, analogous features handle the same concerns (scope, frontmatter, generated output, tests)?
 - Which project-specific rules apply (see `CLAUDE.md`, `.claude/rules/**`, `docs/**`)?
 
-Prefer the Serena MCP symbol tools over reading whole files.
+Prefer targeted symbol and search tools over reading whole files.
 
 ## Step 4: Synthesize the Specification
 

--- a/.rulesync/commands/draft-issue-to-external-repository.md
+++ b/.rulesync/commands/draft-issue-to-external-repository.md
@@ -47,7 +47,7 @@ Ground the proposal in primary sources before writing anything opinionated.
 If the proposal implies work on our side (e.g., a new target, a new integrator, a new feature), inspect this repository's state so the draft is accurate:
 
 - Which features / directories / schemas exist here and will need to map to the target's concepts?
-- Prefer Serena MCP symbol tools (`mcp__serena__find_symbol`, `mcp__serena__get_symbols_overview`) over reading whole files.
+- Prefer targeted symbol and search tools over reading whole files.
 - If the proposal includes popularity / adoption claims, verify the numbers before writing them down. For npm downloads: `curl -s "https://api.npmjs.org/downloads/point/<start>:<end>/<package>"`. For stars/forks: `gh repo view <owner/repo> --json stargazerCount,forkCount`.
 
 ## Step 4: Align with the User on Scope and Tone

--- a/.rulesync/commands/porting-another-repository.md
+++ b/.rulesync/commands/porting-another-repository.md
@@ -30,7 +30,7 @@ All artifacts in this run go under `${out}/`. Do not recompute the timestamp per
 
 ## Step 1: Analyze the Source (This Repository)
 
-Understand exactly what is being ported. Prefer Serena MCP symbol tools (`mcp__serena__get_symbols_overview`, `mcp__serena__find_symbol`, `mcp__serena__find_referencing_symbols`) over reading whole files.
+Understand exactly what is being ported. Prefer targeted symbol and search tools over reading whole files.
 
 Identify, for the requested `scope`:
 
@@ -45,7 +45,7 @@ Write the result to `${out}/01-source-analysis.md`.
 
 Understand the target's conventions so the port fits in naturally.
 
-- If `target_repo` is a local path, inspect it directly (Serena/grep/read).
+- If `target_repo` is a local path, inspect it directly (grep/read).
 - If it is `owner/repo` or a URL, use `gh repo view`, `gh api repos/<owner/repo>/contents/<path>`, and the deepwiki MCP (`mcp__deepwiki__ask_question`, `mcp__deepwiki__read_wiki_contents`) to learn its structure.
 
 Capture:

--- a/.rulesync/commands/research-tool-updates.md
+++ b/.rulesync/commands/research-tool-updates.md
@@ -70,8 +70,8 @@ avoid overload; launch the next wave as earlier ones finish.
     project/global scope, new hook events, new MCP transports, metadata fields,
     format changes, or deprecated surfaces that rulesync still emits.
   - Ground every claim in rulesync's actual implementation. Inspect the
-    relevant `src/**` adapters and processor gates (prefer the Serena MCP
-    symbol tools over reading whole files), and validate the generated output
+    relevant `src/**` adapters and processor gates (prefer targeted symbol
+    and search tools over reading whole files), and validate the generated output
     with a dry-run:
 
     ```bash

--- a/.rulesync/commands/resolve-scrap-issues.md
+++ b/.rulesync/commands/resolve-scrap-issues.md
@@ -48,7 +48,7 @@ Keep each summary concise and focused. Present the issues in the order returned 
 Decide, per issue, whether it still describes a real, actionable problem. Combine three angles:
 
 - **Web research (`WebSearch` / `WebFetch`):** Verify any claim that depends on external facts — a tool's current file format, config schema, default location, scope support, deprecation, or recent behavior change. Prefer primary sources (official docs, release notes, source code) over blog posts, and cross-check non-trivial claims against at least one primary source. Capture exact URLs and version numbers; they will be cited. Run independent searches in parallel.
-- **Codebase inspection:** Check whether the issue is already resolved, partially handled, or contradicted by the current code. Prefer the Serena MCP symbol tools over reading whole files. Apply the project rules in `CLAUDE.md`, `.claude/rules/**`, and `docs/**` (for example, the feature-change and frontmatter conventions).
+- **Codebase inspection:** Check whether the issue is already resolved, partially handled, or contradicted by the current code. Prefer targeted symbol and search tools over reading whole files. Apply the project rules in `CLAUDE.md`, `.claude/rules/**`, and `docs/**` (for example, the feature-change and frontmatter conventions).
 - **Issue discussion:** Honor any maintainer decision already recorded in the comments (e.g., "won't do", "superseded by #N").
 
 Classify each issue into exactly one bucket:

--- a/.rulesync/mcp.json
+++ b/.rulesync/mcp.json
@@ -1,23 +1,6 @@
 {
   "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/mcp-schema.json",
   "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
-      "env": {}
-    },
     "deepwiki": {
       "type": "http",
       "url": "https://mcp.deepwiki.com/mcp",

--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -26,8 +26,6 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
   - You must not use here documents because it causes a sandbox error.
   - You must not use `--no-verify` option because it skips pre-commit checks and causes serious security issues.
   - When creating a PR, you should include a link in the PR description that associates the PR with its issue.
-- When you read or search the codebase:
-  - You should check Serena MCP server tools, and use those actively.
 - About the `skills/` directory at the repository root:
   - This directory contains official skills that are distributed for users to install via the `rulesync fetch` command (e.g., `npx rulesync fetch dyoshikawa/rulesync --features skills`).
   - It is NOT the same as `.rulesync/skills/`, which holds the project's own skill definitions used during generation.

--- a/opencode.json
+++ b/opencode.json
@@ -33,24 +33,6 @@
     }
   },
   "mcp": {
-    "serena": {
-      "type": "local",
-      "command": [
-        "uvx",
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "false",
-        "--project",
-        "."
-      ],
-      "enabled": true,
-      "environment": {}
-    },
     "deepwiki": {
       "type": "remote",
       "url": "https://mcp.deepwiki.com/mcp",


### PR DESCRIPTION
## Summary

Removes the Serena MCP server integration that was configured for local development of this project.

Serena was wired in as a dev-time MCP server (semantic code navigation) via `.rulesync/mcp.json`, and agent instructions told contributors to prefer its symbol tools. This PR removes that integration end to end.

## Changes

- **MCP server config**: drop the `serena` server from `.rulesync/mcp.json`, which regenerates `.mcp.json` (untracked) and `opencode.json` without it. Also removes it from the non-generated `.gemini/settings.json`.
- **Permission**: remove the `mcp__serena` allow entry from `.claude/settings.json`.
- **Rule instruction**: drop the "You should check Serena MCP server tools" guidance from `.rulesync/rules/overview.md`, which regenerates `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`.
- **Command guidance**: reword the seven `.rulesync/commands/*.md` files that named Serena MCP symbol tools (e.g. `mcp__serena__find_symbol`) to tool-agnostic wording ("targeted symbol and search tools").

## Notes

- The `.gitignore` (`.serena/`) and `.oxfmtrc.json` (`.serena/project.yml`) entries are intentionally **kept**. They guard against accidentally committing or format-failing on any leftover local `.serena/` artifacts that may still exist on contributor machines mid-migration; they are harmless once Serena is fully gone.
- Serena appearing in `docs/reference/file-formats.md`, `skills/rulesync/file-formats.md`, and the `src/**` tests is **example/fixture data** demonstrating rulesync's MCP feature, not this project's own Serena config, so it is left untouched.

## Verification

`pnpm cicheck` passes (formatting, oxlint, typecheck, 6936 tests, cspell, secretlint).
