### PR TITLE
Release v9.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.6.3",
+  "version": "9.7.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.6.3";
+const getVersion = () => "9.7.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### New Features

- **Homebrew tap distribution**: rulesync can now be installed via a self-contained Homebrew tap. (#2221)
- **init sample MCP servers**: The `init` sample now configures the DeepWiki and Rulesync MCP servers out of the box. (#2228)

### Bug Fixes

- **Resilient security scan**: The security scan is now resilient to empty or stalled OpenRouter responses. A timeout is applied to the summary call, scan gaps fail the run, and run success is decided solely by files that failed all retries. (#2222)

### Refactoring

- **Shared-config ownership gateway**: The JSON, JSONC, and TOML shared-config writers now route through the ownership gateway for consistent write handling. (#2223, #2224)

### Chores

- Remove the Serena MCP server from the project. (#2229)

## Contributors

Thanks to the following contributors for this release:

- @dyoshikawa
- @saitota

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v9.6.3...v9.7.0
