### PR TITLE
feat(permissions): round-trip Factory Droid autonomy override keys

### DIFF
--- a/src/features/permissions/factorydroid-permissions.test.ts
+++ b/src/features/permissions/factorydroid-permissions.test.ts
@@ -237,6 +237,23 @@ describe("FactorydroidPermissions", () => {
       });
     });
 
+    it("routes the autonomy keys (subagentAutonomyLevel, mcpAutonomyOverrides) into the override on import", () => {
+      const instance = new FactorydroidPermissions({
+        relativeDirPath: ".factory",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          subagentAutonomyLevel: "medium",
+          mcpAutonomyOverrides: { "some-server": "high" },
+        }),
+      });
+
+      const config = JSON.parse(instance.toRulesyncPermissions().getFileContent());
+      expect(config.factorydroid).toEqual({
+        subagentAutonomyLevel: "medium",
+        mcpAutonomyOverrides: { "some-server": "high" },
+      });
+    });
+
     it("does not emit a factorydroid override when no Factory-specific keys are present", () => {
       const instance = new FactorydroidPermissions({
         relativeDirPath: ".factory",

--- a/src/features/permissions/factorydroid-permissions.ts
+++ b/src/features/permissions/factorydroid-permissions.ts
@@ -38,14 +38,19 @@ type FactorydroidSettingsJson = {
 // hard-block tier (distinct from an approvable canonical `deny`); the rest are
 // autonomy/sandbox/network/MCP controls with no canonical slot. rulesync still
 // fully owns `commandAllowlist`/`commandDenylist` via the shared block.
+// `subagentAutonomyLevel` scopes the autonomy granted to spawned subagents and
+// `mcpAutonomyOverrides` configures autonomy levels for individual MCP tools;
+// both are Factory-specific autonomy controls with no canonical slot.
 const FACTORYDROID_OVERRIDE_KEYS = [
   "commandBlocklist",
   "networkPolicy",
   "sandbox",
   "mcpPolicy",
+  "mcpAutonomyOverrides",
   "enableDroidShield",
   "sessionDefaultSettings",
   "maxAutonomyLevel",
+  "subagentAutonomyLevel",
   "interactionMode",
 ] as const;
 

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -202,9 +202,11 @@ export type ReasonixPermissionsOverride = z.infer<typeof ReasonixPermissionsOver
  * exposes security controls with no canonical per-command allow/ask/deny slot —
  * `commandBlocklist` (a hard-block tier that can never be approved, distinct from
  * an approvable `deny`), `networkPolicy` (`allowedIps`), `sandbox`
- * (`enabled`/`mode`/`filesystem`/`network`), `mcpPolicy`, `enableDroidShield`,
+ * (`enabled`/`mode`/`filesystem`/`network`), `mcpPolicy`,
+ * `mcpAutonomyOverrides` (per-MCP-tool autonomy levels), `enableDroidShield`,
  * and autonomy settings (`sessionDefaultSettings`, `maxAutonomyLevel`,
- * `interactionMode`). Fields placed here are merged into `settings.json` and
+ * `subagentAutonomyLevel`, `interactionMode`). Fields placed here are merged
+ * into `settings.json` and
  * emitted only for Factory Droid, while the shared `permission` block continues
  * to drive `commandAllowlist`/`commandDenylist`. Kept `looseObject` passthrough.
  *


### PR DESCRIPTION
Adds `subagentAutonomyLevel` and `mcpAutonomyOverrides` to the Factory Droid permissions override namespace so both round-trip faithfully instead of being dropped on import.

## Background

Factory Droid's settings.json exposes two autonomy controls with no canonical per-command allow/ask/deny slot:
- subagentAutonomyLevel — scopes autonomy granted to spawned subagents (enum inherit/off/low/medium/high).
- mcpAutonomyOverrides — configures autonomy levels for individual MCP tools (v0.109.3).

Both were preserved on export via the override spread, but dropped on import because FACTORYDROID_OVERRIDE_KEYS did not list them. This adds them to the key list so import lifts them into the factorydroid override, closing the round-trip gap. The override schema is already looseObject passthrough, so no schema change is needed.

## Changes
- Add both keys to FACTORYDROID_OVERRIDE_KEYS.
- Update the override schema doc comment.
- Add a round-trip import test for the two keys.

Closes #2209