### PR TITLE
feat(hooks): map Devin postCompact hook event

### DIFF
--- a/src/features/hooks/devin-hooks.test.ts
+++ b/src/features/hooks/devin-hooks.test.ts
@@ -269,6 +269,34 @@ describe("DevinHooks", () => {
       expect(parsed.hooks).toEqual(config.hooks);
     });
 
+    it("should round-trip the postCompact event via the PostCompaction key", async () => {
+      const config = {
+        version: 1,
+        hooks: {
+          // Devin's post-context-compaction event; matcher-less lifecycle event.
+          postCompact: [{ type: "command", command: "compact.sh" }],
+        },
+      };
+      const rulesyncHooks = makeRulesyncHooks(config);
+
+      const devinHooks = await DevinHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      // Emitted under Devin's PascalCase `PostCompaction` key (not `PostCompact`),
+      // with no matcher.
+      const generated = JSON.parse(devinHooks.getFileContent());
+      expect(generated.PostCompaction).toEqual([
+        { hooks: [{ type: "command", command: "compact.sh" }] },
+      ]);
+
+      // And it maps back to the canonical `postCompact` event.
+      const parsed = JSON.parse(devinHooks.toRulesyncHooks().getFileContent());
+      expect(parsed.hooks).toEqual(config.hooks);
+    });
+
     it("should throw on invalid JSON content", () => {
       const devinHooks = new DevinHooks({
         outputRoot: testDir,

--- a/src/features/hooks/devin-hooks.ts
+++ b/src/features/hooks/devin-hooks.ts
@@ -33,14 +33,16 @@ import {
  *
  * Devin matches `matcher` against the event's `tool_name`, which is only
  * meaningful for the tool/permission lifecycle events
- * (`PreToolUse`/`PostToolUse`/`PermissionRequest`). The session and turn events
- * are matcher-less; any matcher defined on them is dropped with a warning.
+ * (`PreToolUse`/`PostToolUse`/`PermissionRequest`). The session, turn, and
+ * compaction events are matcher-less; any matcher defined on them is dropped
+ * with a warning.
  */
 const DEVIN_NO_MATCHER_EVENTS: ReadonlySet<string> = new Set([
   "sessionStart",
   "sessionEnd",
   "stop",
   "beforeSubmitPrompt",
+  "postCompact",
 ]);
 
 const DEVIN_CONVERTER_CONFIG: ToolHooksConverterConfig = {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -194,10 +194,13 @@ export const CLAUDE_HOOK_EVENTS: readonly HookEvent[] = [
  * Hook events supported by Devin Local (native `.devin/` hooks).
  *
  * Devin Local adopts a Claude-Code-style lifecycle hooks surface. It documents
- * seven events: `PreToolUse`, `PostToolUse`, `PermissionRequest`,
- * `UserPromptSubmit`, `Stop`, `SessionStart`, and `SessionEnd`. The
+ * eight events: `PreToolUse`, `PostToolUse`, `PermissionRequest`,
+ * `UserPromptSubmit`, `Stop`, `SessionStart`, `SessionEnd`, and
+ * `PostCompaction` (fires after context compaction; added in the Devin CLI
+ * stable changelog — https://docs.devin.ai/cli/changelog/stable). The
  * tool/permission events (`PreToolUse`/`PostToolUse`/`PermissionRequest`) carry
- * a `matcher` (regex against `tool_name`); the session/turn events do not.
+ * a `matcher` (regex against `tool_name`); the session/turn/compaction events
+ * do not.
  *
  * Hooks live in `.devin/hooks.v1.json` (project, standalone — the hooks object
  * is the entire file) or under the `"hooks"` key of `.devin/config.json` /
@@ -213,6 +216,7 @@ export const DEVIN_HOOK_EVENTS: readonly HookEvent[] = [
   "beforeSubmitPrompt",
   "stop",
   "permissionRequest",
+  "postCompact",
 ];
 
 /** Hook events supported by OpenCode. */
@@ -672,6 +676,9 @@ export const CANONICAL_TO_DEVIN_EVENT_NAMES: Record<string, string> = {
   beforeSubmitPrompt: "UserPromptSubmit",
   stop: "Stop",
   permissionRequest: "PermissionRequest",
+  // Devin's post-context-compaction event uses the `PostCompaction` PascalCase
+  // key (not `PostCompact`). https://docs.devin.ai/cli/changelog/stable
+  postCompact: "PostCompaction",
 };
 
 /**


### PR DESCRIPTION
## Background
Devin's CLI added a hook event that fires after context compaction (see the stable changelog: https://docs.devin.ai/cli/changelog/stable). rulesync did not map it, so canonical `postCompact` hooks were dropped when generating Devin config.

## Change
- Add `postCompact` to `DEVIN_HOOK_EVENTS`.
- Map canonical `postCompact` to Devin's PascalCase `PostCompaction` key in `CANONICAL_TO_DEVIN_EVENT_NAMES` (Devin uses `PostCompaction`, not `PostCompact`).
- Treat `postCompact` as a matcher-less lifecycle event in `DEVIN_NO_MATCHER_EVENTS`.
- Add a round-trip unit test.

Primary source: https://docs.devin.ai/cli/changelog/stable

Closes #2208