### PR TITLE
fix(opencode): translate permission `agent` category to `task`

### DIFF
--- a/src/features/permissions/opencode-permissions.test.ts
+++ b/src/features/permissions/opencode-permissions.test.ts
@@ -122,7 +122,6 @@ describe("OpencodePermissions", () => {
         permission: {
           bash: { "git *": "allow" },
           external_directory: "deny",
-          task: "ask",
         },
       }),
     );
@@ -136,8 +135,77 @@ describe("OpencodePermissions", () => {
     // OpenCode-only categories move under the override, preserving their shape.
     expect(rulesync.opencode?.permission).toEqual({
       external_directory: "deny",
-      task: "ask",
     });
+  });
+
+  it("should translate OpenCode's `task` key into the canonical `agent` category on import (issue #2230)", async () => {
+    await writeFileContent(
+      join(testDir, "opencode.json"),
+      JSON.stringify({
+        permission: {
+          bash: { "git *": "allow" },
+          task: "deny",
+        },
+      }),
+    );
+
+    const instance = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = instance.toRulesyncPermissions().getJson();
+
+    // OpenCode's `task` key is the subagent-launch permission; it maps to the
+    // canonical `agent` category in the shared block (not the override).
+    expect(rulesync.permission.agent).toEqual({ "*": "deny" });
+    expect(rulesync.permission.task).toBeUndefined();
+    expect(rulesync.opencode).toBeUndefined();
+  });
+
+  it("should translate the canonical `agent` category into OpenCode's `task` key on export (issue #2230)", async () => {
+    await writeFileContent(join(testDir, "opencode.json"), JSON.stringify({ model: "x" }));
+    const rulesyncPermissions = new RulesyncPermissions({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+      fileContent: JSON.stringify({
+        permission: {
+          agent: { "*": "deny" },
+        },
+      }),
+    });
+
+    const instance = await OpencodePermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions,
+    });
+    const json = JSON.parse(instance.getFileContent());
+
+    // The canonical `agent` category is written under OpenCode's real `task`
+    // key, and never leaks the non-existent `agent` key into opencode.json.
+    expect(json.permission.task).toEqual({ "*": "deny" });
+    expect(json.permission.agent).toBeUndefined();
+  });
+
+  it("should round-trip the canonical `agent`/OpenCode `task` category (issue #2230)", async () => {
+    await writeFileContent(join(testDir, "opencode.json"), JSON.stringify({}));
+    const rulesyncPermissions = new RulesyncPermissions({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+      fileContent: JSON.stringify({
+        permission: { agent: { "*": "deny" } },
+      }),
+    });
+
+    const generated = await OpencodePermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions,
+    });
+    await writeFileContent(join(testDir, "opencode.json"), generated.getFileContent());
+
+    const imported = await OpencodePermissions.fromFile({ outputRoot: testDir });
+    const rulesync = imported.toRulesyncPermissions().getJson();
+
+    expect(rulesync.permission).toEqual({ agent: { "*": "deny" } });
+    expect(rulesync.opencode).toBeUndefined();
   });
 
   it("should keep the all-tools wildcard category in the shared block on import", async () => {

--- a/src/features/permissions/opencode-permissions.ts
+++ b/src/features/permissions/opencode-permissions.ts
@@ -52,6 +52,33 @@ const CANONICAL_PERMISSION_CATEGORIES = new Set([
   "agent",
 ]);
 
+/**
+ * Translate between rulesync's canonical permission category names and
+ * OpenCode's native permission keys. OpenCode has no `agent` key — subagent
+ * launches are gated by the `task` key (see the documented key list at
+ * https://opencode.ai/docs/permissions/). Without this translation a canonical
+ * `agent: deny` would be written verbatim into `opencode.json` and silently
+ * ignored by OpenCode. Unknown names pass through unchanged.
+ */
+const CANONICAL_TO_OPENCODE_PERMISSION_KEYS: Record<string, string> = {
+  agent: "task",
+};
+
+const OPENCODE_TO_CANONICAL_PERMISSION_KEYS: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_OPENCODE_PERMISSION_KEYS).map(([canonical, opencode]) => [
+    opencode,
+    canonical,
+  ]),
+);
+
+function toOpencodePermissionKey(canonical: string): string {
+  return CANONICAL_TO_OPENCODE_PERMISSION_KEYS[canonical] ?? canonical;
+}
+
+function toCanonicalPermissionKey(opencodeKey: string): string {
+  return OPENCODE_TO_CANONICAL_PERMISSION_KEYS[opencodeKey] ?? opencodeKey;
+}
+
 function isSharedPermissionCategory(category: string): boolean {
   // `"*"` is OpenCode's all-tools key and carries a cross-tool meaning in the
   // canonical rulesync model (the string form `"permission": "allow"` normalizes
@@ -161,6 +188,14 @@ export class OpencodePermissions extends ToolPermissions {
     // replaces the shared entry without affecting other tools' outputs.
     const overridePermission = rulesyncJson.opencode?.permission ?? {};
 
+    // Translate canonical category names into OpenCode's native permission keys
+    // (`agent` → `task`) before emitting them, so subagent-launch gating is
+    // written under the key OpenCode actually reads.
+    const sharedPermission: Record<string, unknown> = {};
+    for (const [category, value] of Object.entries(rulesyncJson.permission ?? {})) {
+      sharedPermission[toOpencodePermissionKey(category)] = value;
+    }
+
     return new OpencodePermissions({
       outputRoot,
       relativeDirPath: basePaths.relativeDirPath,
@@ -169,7 +204,7 @@ export class OpencodePermissions extends ToolPermissions {
         fileKey: sharedConfigFileKey(basePaths),
         feature: "permissions",
         existingContent: fileContent ?? "",
-        patch: { permission: { ...rulesyncJson.permission, ...overridePermission } },
+        patch: { permission: { ...sharedPermission, ...overridePermission } },
         filePath: join(jsonDir, relativeFilePath),
       }),
       validate: true,
@@ -196,8 +231,12 @@ export class OpencodePermissions extends ToolPermissions {
     const shared: PermissionsConfig["permission"] = {};
     const overrideOnly: NonNullable<OpencodePermissionsOverride["permission"]> = {};
     for (const [category, value] of Object.entries(rawPermission)) {
-      if (isSharedPermissionCategory(category)) {
-        shared[category] = typeof value === "string" ? { "*": value } : value;
+      // Translate OpenCode's native permission keys back into canonical category
+      // names (`task` → `agent`) so subagent-launch gating lands in the shared
+      // block instead of being treated as an OpenCode-only override.
+      const canonicalCategory = toCanonicalPermissionKey(category);
+      if (isSharedPermissionCategory(canonicalCategory)) {
+        shared[canonicalCategory] = typeof value === "string" ? { "*": value } : value;
       } else {
         overrideOnly[category] = value;
       }


### PR DESCRIPTION
## Background

OpenCode's documented permission keys do not include `agent`; the subagent-launch permission is gated by the `task` key (see https://opencode.ai/docs/permissions/). rulesync's canonical `agent` category was written verbatim into `opencode.json`'s `permission` block with no translation, so a rulesync `agent: deny` was silently ignored by OpenCode.

## Change

- On export, translate the canonical `agent` category to OpenCode's real `task` key.
- On import, translate `task` back to the canonical `agent` category so it lands in the shared block (not the OpenCode-only override).
- Mirrors the existing tool-name translation pattern in `zed-permissions.ts`.
- Added unit tests covering both directions plus a round-trip; existing round-trip tests and the permissions e2e still pass.

Primary source: https://opencode.ai/docs/permissions/ (documented keys include `task`, not `agent`).

Closes #2230