### PR TITLE
feat(hermesagent): pass through advanced MCP per-server fields

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,7 @@
     ".rulesync/**"
   ],
   "words": [
+    "PKCE",
     "agentic",
     "approvable",
     "authorable",

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -345,7 +345,7 @@ describe("HermesagentMcp", () => {
       expect(server?.supports_parallel_tool_calls).toBe(false);
     });
 
-    it("passes through the boolean tools.prompts/resources capability toggles (issue #2236)", async () => {
+    it("maps promptsEnabled/resourcesEnabled to Hermes's boolean tools.prompts/resources (issue #2236)", async () => {
       const rulesyncMcp = new RulesyncMcp({
         relativeDirPath: ".rulesync",
         relativeFilePath: ".mcp.json",
@@ -354,7 +354,8 @@ describe("HermesagentMcp", () => {
             fetch: {
               command: "uvx",
               enabledTools: ["search"],
-              tools: { prompts: true, resources: false },
+              promptsEnabled: true,
+              resourcesEnabled: false,
             },
           },
         }),
@@ -494,8 +495,24 @@ describe("HermesagentMcp", () => {
         connect_timeout: 60,
         supports_parallel_tool_calls: true,
         enabledTools: ["search"],
-        tools: { prompts: true, resources: false },
+        promptsEnabled: true,
+        resourcesEnabled: false,
       });
+      // The reserved canonical `tools` key (a string[]) must not be repurposed.
+      expect(server.tools).toBeUndefined();
+
+      // The imported canonical config must survive schema validation, which the
+      // real `generate` load path (`RulesyncMcp.fromFile`) runs — otherwise the
+      // whole MCP generation would be silently dropped.
+      expect(
+        () =>
+          new RulesyncMcp({
+            relativeDirPath: ".rulesync",
+            relativeFilePath: ".mcp.json",
+            fileContent: canonical.getFileContent(),
+            validate: true,
+          }),
+      ).not.toThrow();
 
       // Re-export back to Hermes and confirm the fields survive unchanged.
       const regenerated = await HermesagentMcp.fromRulesyncMcp({

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -313,6 +313,63 @@ describe("HermesagentMcp", () => {
       expect(server?.tools).toBeUndefined();
     });
 
+    it("passes through advanced auth/mTLS/timeout fields (issue #2236)", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            remote: {
+              url: "https://example.com/mcp",
+              auth: "oauth",
+              client_cert: ["~/secrets/client.crt", "~/secrets/client.key", "pass"],
+              client_key: "~/secrets/client.key",
+              connect_timeout: 60,
+              supports_parallel_tool_calls: false,
+            },
+          },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).remote;
+
+      expect(server?.auth).toBe("oauth");
+      expect(server?.client_cert).toEqual(["~/secrets/client.crt", "~/secrets/client.key", "pass"]);
+      expect(server?.client_key).toBe("~/secrets/client.key");
+      expect(server?.connect_timeout).toBe(60);
+      expect(server?.supports_parallel_tool_calls).toBe(false);
+    });
+
+    it("passes through the boolean tools.prompts/resources capability toggles (issue #2236)", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: ".rulesync",
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            fetch: {
+              command: "uvx",
+              enabledTools: ["search"],
+              tools: { prompts: true, resources: false },
+            },
+          },
+        }),
+      });
+
+      const mcp = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+        global: true,
+      });
+      const server = getMcpServers(mcp.getFileContent()).fetch;
+
+      expect(server?.tools).toEqual({ include: ["search"], prompts: true, resources: false });
+    });
+
     it("preserves other config.yaml keys when merging", async () => {
       const dir = join(testDir, HERMES_DIR);
       await ensureDir(dir);
@@ -399,6 +456,67 @@ describe("HermesagentMcp", () => {
         command: "uvx",
         enabledTools: ["search", "fetch"],
         disabledTools: ["delete"],
+      });
+    });
+
+    it("round-trips advanced Hermes per-server fields (issue #2236)", async () => {
+      const dir = join(testDir, HERMES_DIR);
+      await ensureDir(dir);
+      await writeFileContent(
+        join(dir, HERMES_FILE),
+        [
+          "mcp_servers:",
+          "  remote:",
+          "    url: https://example.com/mcp",
+          "    auth: oauth",
+          "    client_cert: ~/secrets/mcp-client.pem",
+          "    client_key: ~/secrets/client.key",
+          "    connect_timeout: 60",
+          "    supports_parallel_tool_calls: true",
+          "    tools:",
+          "      include: [search]",
+          "      prompts: true",
+          "      resources: false",
+          "",
+        ].join("\n"),
+      );
+
+      // Import into the canonical model.
+      const imported = await HermesagentMcp.fromFile({ outputRoot: testDir, global: true });
+      const canonical = imported.toRulesyncMcp();
+      const server = JSON.parse(canonical.getFileContent()).mcpServers.remote;
+
+      expect(server).toMatchObject({
+        url: "https://example.com/mcp",
+        auth: "oauth",
+        client_cert: "~/secrets/mcp-client.pem",
+        client_key: "~/secrets/client.key",
+        connect_timeout: 60,
+        supports_parallel_tool_calls: true,
+        enabledTools: ["search"],
+        tools: { prompts: true, resources: false },
+      });
+
+      // Re-export back to Hermes and confirm the fields survive unchanged.
+      const regenerated = await HermesagentMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp: new RulesyncMcp({
+          relativeDirPath: ".rulesync",
+          relativeFilePath: ".mcp.json",
+          fileContent: canonical.getFileContent(),
+        }),
+        global: true,
+      });
+      const hermes = getMcpServers(regenerated.getFileContent()).remote;
+
+      expect(hermes).toMatchObject({
+        url: "https://example.com/mcp",
+        auth: "oauth",
+        client_cert: "~/secrets/mcp-client.pem",
+        client_key: "~/secrets/client.key",
+        connect_timeout: 60,
+        supports_parallel_tool_calls: true,
+        tools: { include: ["search"], prompts: true, resources: false },
       });
     });
 

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -50,6 +50,43 @@ function resolveHermesTimeout(config: Record<string, unknown>): number | undefin
 }
 
 /**
+ * Copies the advanced Hermes-recognized per-server fields that have no canonical
+ * alias — `auth` (`oauth` for OAuth 2.1/PKCE), mTLS `client_cert` (string PEM
+ * path, or `[cert, key]`/`[cert, key, password]` list) and `client_key`,
+ * `connect_timeout` (seconds), and `supports_parallel_tool_calls` — verbatim
+ * from `source` to `target`. Field names are identical on both sides (the
+ * canonical `McpServerSchema` is a `looseObject`), so this serves export and
+ * import alike. See the Hermes mcp-config-reference.
+ */
+function copyHermesAdvancedFields(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+): void {
+  if (typeof source.auth === "string") target.auth = source.auth;
+  if (typeof source.client_cert === "string" || isStringArray(source.client_cert)) {
+    target.client_cert = source.client_cert;
+  }
+  if (typeof source.client_key === "string") target.client_key = source.client_key;
+  if (typeof source.connect_timeout === "number") target.connect_timeout = source.connect_timeout;
+  if (typeof source.supports_parallel_tool_calls === "boolean") {
+    target.supports_parallel_tool_calls = source.supports_parallel_tool_calls;
+  }
+}
+
+/**
+ * Copies Hermes's boolean `prompts`/`resources` capability toggles (which have
+ * no canonical alias) verbatim from a source `tools` block to a target `tools`
+ * block. Used in both directions.
+ */
+function copyHermesToolCapabilities(
+  sourceTools: Record<string, unknown>,
+  targetTools: Record<string, unknown>,
+): void {
+  if (typeof sourceTools.prompts === "boolean") targetTools.prompts = sourceTools.prompts;
+  if (typeof sourceTools.resources === "boolean") targetTools.resources = sourceTools.resources;
+}
+
+/**
  * Converts a single rulesync canonical MCP server into a Hermes `mcp_servers:` entry.
  *
  * Hermes is close to the MCP spec but not identical: `command` must be a single
@@ -89,13 +126,19 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
   const timeout = resolveHermesTimeout(config);
   if (timeout !== undefined) out.timeout = timeout;
 
+  // Advanced Hermes-recognized per-server fields (auth/mTLS/timeout/parallel).
+  copyHermesAdvancedFields(config, out);
+
   // Per-server selective tool loading. Canonical `enabledTools`/`disabledTools`
   // map to Hermes's `tools: { include, exclude }` block (include = whitelist,
   // exclude = denylist; see hermes-agent `apps/desktop/src/lib/mcp-tool-filter.ts`
-  // and `tools/mcp_tool.py`'s `_register_server_tools`).
+  // and `tools/mcp_tool.py`'s `_register_server_tools`). Hermes's boolean
+  // `tools.prompts`/`tools.resources` capability toggles have no canonical alias
+  // and pass through verbatim from the canonical `tools` block.
   const tools: Record<string, unknown> = {};
   if (isStringArray(config.enabledTools)) tools.include = config.enabledTools;
   if (isStringArray(config.disabledTools)) tools.exclude = config.disabledTools;
+  if (isRecord(config.tools)) copyHermesToolCapabilities(config.tools, tools);
   if (Object.keys(tools).length > 0) out.tools = tools;
 
   return out;
@@ -150,9 +193,17 @@ function convertFromHermesFormat(mcpServers: Record<string, unknown>): McpServer
     if (isPlainObject(config.headers)) server.headers = omitPrototypePollutionKeys(config.headers);
     if (config.enabled === false) server.disabled = true;
     if (typeof config.timeout === "number") server.networkTimeout = config.timeout;
+    // Advanced Hermes-recognized fields with no canonical alias round-trip
+    // verbatim (see convertServerToHermes).
+    copyHermesAdvancedFields(config, server);
     if (isRecord(config.tools)) {
       if (isStringArray(config.tools.include)) server.enabledTools = config.tools.include;
       if (isStringArray(config.tools.exclude)) server.disabledTools = config.tools.exclude;
+      // `tools.prompts`/`tools.resources` have no canonical alias, so preserve
+      // them under a canonical `tools` block for round-trip.
+      const toolsPassthrough: Record<string, unknown> = {};
+      copyHermesToolCapabilities(config.tools, toolsPassthrough);
+      if (Object.keys(toolsPassthrough).length > 0) server.tools = toolsPassthrough;
     }
 
     result[name] = server;

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -74,16 +74,40 @@ function copyHermesAdvancedFields(
 }
 
 /**
- * Copies Hermes's boolean `prompts`/`resources` capability toggles (which have
- * no canonical alias) verbatim from a source `tools` block to a target `tools`
- * block. Used in both directions.
+ * Builds Hermes's per-server `tools` block from a canonical server config. The
+ * canonical `enabledTools`/`disabledTools` arrays become `include`/`exclude`,
+ * and the boolean `promptsEnabled`/`resourcesEnabled` toggles become Hermes's
+ * `prompts`/`resources` capability flags. Returns an empty object when the
+ * server has no tool scoping (the caller omits the block in that case).
+ *
+ * Note: `promptsEnabled`/`resourcesEnabled` are canonical top-level keys rather
+ * than a nested canonical `tools` object, because canonical `McpServerSchema.tools`
+ * is reserved as a `string[]` (used by other tools) — reusing it for an object
+ * would fail validation on the next `generate`.
  */
-function copyHermesToolCapabilities(
-  sourceTools: Record<string, unknown>,
-  targetTools: Record<string, unknown>,
+function buildHermesToolsBlock(config: Record<string, unknown>): Record<string, unknown> {
+  const tools: Record<string, unknown> = {};
+  if (isStringArray(config.enabledTools)) tools.include = config.enabledTools;
+  if (isStringArray(config.disabledTools)) tools.exclude = config.disabledTools;
+  if (typeof config.promptsEnabled === "boolean") tools.prompts = config.promptsEnabled;
+  if (typeof config.resourcesEnabled === "boolean") tools.resources = config.resourcesEnabled;
+  return tools;
+}
+
+/**
+ * Applies a Hermes per-server `tools` block back onto a canonical server config
+ * (inverse of {@link buildHermesToolsBlock}): `include`/`exclude` become
+ * `enabledTools`/`disabledTools`, and `prompts`/`resources` become the boolean
+ * `promptsEnabled`/`resourcesEnabled` top-level toggles.
+ */
+function applyHermesToolsBlock(
+  hermesTools: Record<string, unknown>,
+  server: Record<string, unknown>,
 ): void {
-  if (typeof sourceTools.prompts === "boolean") targetTools.prompts = sourceTools.prompts;
-  if (typeof sourceTools.resources === "boolean") targetTools.resources = sourceTools.resources;
+  if (isStringArray(hermesTools.include)) server.enabledTools = hermesTools.include;
+  if (isStringArray(hermesTools.exclude)) server.disabledTools = hermesTools.exclude;
+  if (typeof hermesTools.prompts === "boolean") server.promptsEnabled = hermesTools.prompts;
+  if (typeof hermesTools.resources === "boolean") server.resourcesEnabled = hermesTools.resources;
 }
 
 /**
@@ -132,13 +156,9 @@ function convertServerToHermes(config: Record<string, unknown>): Record<string, 
   // Per-server selective tool loading. Canonical `enabledTools`/`disabledTools`
   // map to Hermes's `tools: { include, exclude }` block (include = whitelist,
   // exclude = denylist; see hermes-agent `apps/desktop/src/lib/mcp-tool-filter.ts`
-  // and `tools/mcp_tool.py`'s `_register_server_tools`). Hermes's boolean
-  // `tools.prompts`/`tools.resources` capability toggles have no canonical alias
-  // and pass through verbatim from the canonical `tools` block.
-  const tools: Record<string, unknown> = {};
-  if (isStringArray(config.enabledTools)) tools.include = config.enabledTools;
-  if (isStringArray(config.disabledTools)) tools.exclude = config.disabledTools;
-  if (isRecord(config.tools)) copyHermesToolCapabilities(config.tools, tools);
+  // and `tools/mcp_tool.py`'s `_register_server_tools`); the boolean
+  // `promptsEnabled`/`resourcesEnabled` toggles map to Hermes's `prompts`/`resources`.
+  const tools = buildHermesToolsBlock(config);
   if (Object.keys(tools).length > 0) out.tools = tools;
 
   return out;
@@ -196,15 +216,7 @@ function convertFromHermesFormat(mcpServers: Record<string, unknown>): McpServer
     // Advanced Hermes-recognized fields with no canonical alias round-trip
     // verbatim (see convertServerToHermes).
     copyHermesAdvancedFields(config, server);
-    if (isRecord(config.tools)) {
-      if (isStringArray(config.tools.include)) server.enabledTools = config.tools.include;
-      if (isStringArray(config.tools.exclude)) server.disabledTools = config.tools.exclude;
-      // `tools.prompts`/`tools.resources` have no canonical alias, so preserve
-      // them under a canonical `tools` block for round-trip.
-      const toolsPassthrough: Record<string, unknown> = {};
-      copyHermesToolCapabilities(config.tools, toolsPassthrough);
-      if (Object.keys(toolsPassthrough).length > 0) server.tools = toolsPassthrough;
-    }
+    if (isRecord(config.tools)) applyHermesToolsBlock(config.tools, server);
 
     result[name] = server;
   }


### PR DESCRIPTION
## Background

Hermes Agent's `mcp_servers` entries recognize advanced per-server fields that rulesync's `hermesagent` MCP adapter dropped, so an OAuth- or mTLS-authenticated remote MCP server (and related tuning) could not be authored for Hermes: `auth` (`oauth`), `client_cert`/`client_key` (mTLS), `connect_timeout`, `supports_parallel_tool_calls`, and the boolean `tools.prompts`/`tools.resources` capability toggles.

## Change

- Pass these fields through verbatim in both `convertServerToHermes` (export) and `convertFromHermesFormat` (import). They have no canonical alias, and `McpServerSchema` is a `looseObject`, so no canonical schema change is needed.
- `client_cert` supports both the string PEM path and the `[cert, key]`/`[cert, key, password]` list forms; `prompts`/`resources` are booleans per the reference.
- Extracted `copyHermesAdvancedFields`/`copyHermesToolCapabilities` helpers so both converters stay within the complexity limit.
- Added export, import, and full round-trip tests; existing tests and the MCP e2e still pass.

Primary source: https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference (field types confirmed: `client_cert` string-or-list, `connect_timeout` number, `supports_parallel_tool_calls` bool, `prompts`/`resources` bool).

Closes #2236