### PR TITLE
test(shared): cover TOML gateway path; harden codexcli-mcp TOML parsing

### DIFF
--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -136,7 +136,7 @@ NODE_ENV = "development"
       }).not.toThrow();
     });
 
-    it("should throw error for invalid TOML content", () => {
+    it("should throw a path-annotated error for invalid TOML content", () => {
       const invalidTomlContent = "[invalid toml\nkey = ";
 
       expect(() => {
@@ -145,7 +145,7 @@ NODE_ENV = "development"
           relativeFilePath: "config.toml",
           fileContent: invalidTomlContent,
         });
-      }).toThrow();
+      }).toThrow(/Failed to parse Codex CLI config at .*config\.toml/);
     });
 
     it("should preserve existing TOML content structure", () => {
@@ -271,6 +271,21 @@ args = ["server.js"]
   });
 
   describe("fromRulesyncMcp", () => {
+    it("should throw a path-annotated error when the existing config.toml is malformed", async () => {
+      await ensureDir(join(testDir, ".codex"));
+      await writeFileContent(join(testDir, ".codex/config.toml"), "[invalid toml\nkey = ");
+
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: { fs: { command: "node" } } }),
+      });
+
+      await expect(
+        CodexcliMcp.fromRulesyncMcp({ outputRoot: testDir, rulesyncMcp, global: false }),
+      ).rejects.toThrow(/Failed to parse existing Codex CLI config at .*config\.toml/);
+    });
+
     it("should create instance from RulesyncMcp in local mode with new file", async () => {
       const jsonData = {
         mcpServers: {

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -5,6 +5,7 @@ import * as smolToml from "smol-toml";
 import { CODEXCLI_DIR, CODEXCLI_MCP_FILE_NAME } from "../../constants/codexcli-paths.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
+import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { warnWithFallback } from "../../utils/logger.js";
 import {
@@ -187,7 +188,16 @@ export class CodexcliMcp extends ToolMcp {
       validate: false,
     });
 
-    this.toml = smolToml.parse(this.fileContent);
+    let toml: smolToml.TomlTable;
+    try {
+      toml = smolToml.parse(this.fileContent);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Codex CLI config at ${this.getFilePath()}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
+    this.toml = toml;
 
     if (rest.validate) {
       const result = this.validate();
@@ -248,7 +258,15 @@ export class CodexcliMcp extends ToolMcp {
     const configTomlFilePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const configTomlFileContent = (await readFileContentOrNull(configTomlFilePath)) ?? "";
 
-    const configToml = smolToml.parse(configTomlFileContent || smolToml.stringify({}));
+    let configToml: smolToml.TomlTable;
+    try {
+      configToml = smolToml.parse(configTomlFileContent || smolToml.stringify({}));
+    } catch (error) {
+      throw new Error(
+        `Failed to parse existing Codex CLI config at ${configTomlFilePath}: ${formatError(error)}`,
+        { cause: error },
+      );
+    }
 
     const strippedMcpServers = rulesyncMcp.getMcpServers();
     const rawMcpServers = rulesyncMcp.getJson().mcpServers;

--- a/src/features/shared/shared-config-gateway.test.ts
+++ b/src/features/shared/shared-config-gateway.test.ts
@@ -24,6 +24,7 @@ describe("parseSharedConfig", () => {
     expect(parseSharedConfig({ format: "yaml", fileContent: "  \n" })).toEqual({});
     expect(parseSharedConfig({ format: "json", fileContent: "" })).toEqual({});
     expect(parseSharedConfig({ format: "jsonc", fileContent: "" })).toEqual({});
+    expect(parseSharedConfig({ format: "toml", fileContent: "  \n" })).toEqual({});
   });
 
   it("parses each format into a plain document", () => {
@@ -34,6 +35,9 @@ describe("parseSharedConfig", () => {
     expect(
       parseSharedConfig({ format: "jsonc", fileContent: '{\n  // comment\n  "a": 1,\n}' }),
     ).toEqual({ a: 1 });
+    expect(parseSharedConfig({ format: "toml", fileContent: 'model = "hermes-3"' })).toEqual({
+      model: "hermes-3",
+    });
   });
 
   it("coerces a non-mapping root to an empty document by default", () => {
@@ -111,6 +115,13 @@ describe("stringifySharedConfig", () => {
 
   it("emits 2-space JSON without a trailing newline", () => {
     expect(stringifySharedConfig({ format: "json", document: { a: 1 } })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("emits TOML matching smol-toml's stringify shape", () => {
+    const toml = stringifySharedConfig({ format: "toml", document: { model: "hermes-3" } });
+    expect(toml).toBe('model = "hermes-3"\n');
+    // Round-trips back through the toml codec.
+    expect(parseSharedConfig({ format: "toml", fileContent: toml })).toEqual({ model: "hermes-3" });
   });
 });
 
@@ -206,6 +217,21 @@ describe("applySharedConfigPatch", () => {
     expect(parseSharedConfig({ format: "yaml", fileContent: result })).toEqual({
       model: "hermes-large",
       hooks: { pre_tool_call: [] },
+    });
+  });
+
+  it("retracts an owned key whose patch value is undefined (replace-owned-keys)", () => {
+    // A feature retracts a key it owns by setting that key to `undefined` in the
+    // patch (e.g. a regeneration that yields no entries). The key is removed from
+    // the merged document, while unowned user keys are preserved untouched.
+    const result = applySharedConfigPatch({
+      fileKey: HERMES_CONFIG_SHARED_FILE_KEY,
+      feature: "hooks",
+      existingContent: "model: hermes-large\nhooks:\n  stale: true\n",
+      patch: { hooks: undefined },
+    });
+    expect(parseSharedConfig({ format: "yaml", fileContent: result })).toEqual({
+      model: "hermes-large",
     });
   });
 


### PR DESCRIPTION
## Background

Follow-ups from PR #2224 (the TOML shared-config gateway). Three additive/mechanical items.

## Change

1. **TOML gateway test coverage** — `shared-config-gateway.test.ts` tested `format: yaml/json/jsonc` for the empty-input, parse, and stringify cases but had no `format: "toml"` case, despite the gateway having a real `smol-toml` codec branch. Added symmetric toml cases.
2. **Retraction-via-undefined** — added an explicit test proving that an owned key set to `undefined` in a `replace-owned-keys` patch is removed from the merged document (the way a feature retracts a key it owns). The behavior was already commented in `shared-config-gateway.ts`.
3. **codexcli-mcp TOML parse hardening** — `codexcli-mcp.ts` called `smolToml.parse` in the constructor and in `fromRulesyncMcp` with no try/catch, unlike the sibling `codexcli-hooks.ts` writer. Wrapped both in try/catch that includes the config file path in the thrown error via `formatError`, so a malformed `config.toml` produces an actionable message.

Added unit tests for both new error paths; existing tests and the MCP e2e still pass.

Closes #2227