### PR TITLE
chore: release v9.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.7.0";
+const getVersion = () => "9.8.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## What's Changed

### New Features

- **Grok CLI hooks adapter**: Added a hooks adapter for Grok CLI, honoring the Grok matcher on all tool-name events (#2250)
- **Grok CLI project-scoped permissions**: Support project-scoped Grok CLI `[permission]` rules, writing the `[ui] permission_mode` in global scope only
- **Codex CLI permission enums**: Type Codex CLI approval/sandbox override keys as enums, and accept the legacy `on-failure` alias for the approval policy (#2251)
- **Factory Droid autonomy**: Round-trip Factory Droid autonomy override keys (#2239)
- **Qwen Code**: Map four additional Qwen Code hook events (#2242) and round-trip `permissions.autoMode` via the qwencode override (#2245)
- **Reasonix hooks**: Map Reasonix `Notification` and `PreCompact` hook events (#2241)
- **Devin hooks**: Map the Devin `postCompact` hook event (#2240)
- **AugmentCode hooks**: Map the AugmentCode `Notification` hook event (#2243)
- **HermesAgent MCP**: Pass through advanced MCP per-server fields and store prompts/resources toggles as top-level canonical keys (#2246)

### Bug Fixes

- **opencode**: Translate the permission `agent` category to `task` (#2244)
- **shared config**: Cover the TOML gateway path and harden codexcli-mcp TOML parsing (#2247)

## Contributors

- @dyoshikawa

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v9.7.0...v9.8.0
