### PR TITLE
release/v10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "9.8.0",
+  "version": "10.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "9.8.0";
+const getVersion = () => "10.0.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

Release v10.0.0.

- Update `getVersion()` in `src/cli/index.ts` to 10.0.0
- Update `package.json` version to 10.0.0

MAJOR bump: the deprecated per-server `targets` field in `.rulesync/mcp.json` is now enforced as a filter (previously parsed but ignored), which can change generated output for configs carrying stale `targets` values. See #2259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)