### PR TITLE
feat: add goal-release command that drafts a release and merges the release PR

### DIFF
--- a/.rulesync/commands/goal-release.md
+++ b/.rulesync/commands/goal-release.md
@@ -18,10 +18,12 @@ the PR's CI checks to pass, and then runs `/merge-pr` to merge it.
 
 ## 1. Draft the Release
 
-Run the `/draft-release` command with `new_version`.
+Run the `draft-release` skill (`/draft-release`) with `new_version`.
 
-- If `new_version` is provided (e.g. `v1.2.3` or `1.2.3`), pass it through
-  unchanged; `/draft-release` normalizes the `v` prefix itself.
+- If `new_version` is provided (e.g. `v1.2.3` or `1.2.3`), it must match the
+  semver shape `^v?\d+\.\d+\.\d+$` — if it does not, stop and report instead
+  of passing it on. Pass a valid value through unchanged; `/draft-release`
+  normalizes the `v` prefix itself.
 - If `new_version` is empty, pass no argument; `/draft-release` determines the
   next version automatically via the `release-dry-run` skill.
 
@@ -31,9 +33,14 @@ When `/draft-release` finishes, it has:
 - opened a pull request against `main`, and
 - created a draft GitHub release `v<version>` with the release notes.
 
+If `/draft-release` failed partway (e.g. the PR exists but the draft release
+was not created, or it stopped before opening the PR), stop here and report
+the partial state to the user instead of continuing.
+
 ## 2. Resolve the Release PR
 
-Identify the pull request created in Step 1 from the current
+Use the PR number or URL that `/draft-release`'s `gh pr create` printed in
+Step 1 when available. Otherwise, identify the pull request from the current
 `release/v<version>` branch:
 
 ```bash
@@ -52,18 +59,34 @@ Wait for the release PR's GitHub Actions checks to finish:
 gh pr checks <pr_number> --watch
 ```
 
+If the watch reports that no checks are registered yet, wait a moment and
+retry — checks can take a few seconds to appear right after the PR is opened.
+
 - If every check passes, proceed to Step 4.
 - If a check fails, investigate and fix the failure on the release branch
   (run `pnpm cicheck` locally, commit, and push), then wait for the re-run.
   Never proceed to the merge while any check is `fail` or `pending`.
+- Fixes must legitimately resolve the failure. Never make a check green by
+  skipping or deleting tests, weakening lint or type-check configuration, or
+  editing GitHub Actions workflows.
 - Set a safety cap of **3** fix attempts. If CI is still red after the cap,
   stop and report the failing checks to the user instead of merging.
+
+If any fix commit beyond `/draft-release`'s own version-bump commits was
+pushed, stop before merging and report the extra commits to the user for
+confirmation. The release PR must reach the merge step containing only
+reviewed, expected content.
 
 ## 4. Merge the Release PR
 
 Run the `/merge-pr` command with the release PR number. It re-verifies the PR
 state and CI status, merges with `gh pr merge --admin --merge`, posts a
 thank-you comment, and cleans up the local branch.
+
+Note: `/goal-pr` tells agents not to auto-merge PRs that touch `package.json`
+or release configuration. That restriction does not apply here — merging the
+version-bump release PR is this command's explicit purpose, and the user opted
+into it by invoking `/goal-release`.
 
 ## 5. Final Report
 

--- a/.rulesync/commands/goal-release.md
+++ b/.rulesync/commands/goal-release.md
@@ -1,0 +1,75 @@
+---
+targets:
+  - "*"
+description: >-
+  Cut a release end to end: run /draft-release to open the release PR and
+  draft GitHub release, wait for CI to turn green, then run /merge-pr to merge
+  the release PR. Use when the user wants to draft and merge a release in one
+  go, or triggers on "/goal-release".
+---
+
+# Goal Release Command
+
+new_version = $ARGUMENTS
+
+This command drives a release all the way to merge. It runs `/draft-release` to
+open the release pull request (and create the draft GitHub release), waits for
+the PR's CI checks to pass, and then runs `/merge-pr` to merge it.
+
+## 1. Draft the Release
+
+Run the `/draft-release` command with `new_version`.
+
+- If `new_version` is provided (e.g. `v1.2.3` or `1.2.3`), pass it through
+  unchanged; `/draft-release` normalizes the `v` prefix itself.
+- If `new_version` is empty, pass no argument; `/draft-release` determines the
+  next version automatically via the `release-dry-run` skill.
+
+When `/draft-release` finishes, it has:
+
+- created a `release/v<version>` branch with the version-bump commits,
+- opened a pull request against `main`, and
+- created a draft GitHub release `v<version>` with the release notes.
+
+## 2. Resolve the Release PR
+
+Identify the pull request created in Step 1 from the current
+`release/v<version>` branch:
+
+```bash
+gh pr view --json number,title,state,headRefName
+```
+
+Confirm that `headRefName` matches the `release/v<version>` branch created in
+Step 1. This command must only ever merge that release PR — if the resolved PR
+is a different one, stop and report to the user instead of merging.
+
+## 3. Wait for CI
+
+Wait for the release PR's GitHub Actions checks to finish:
+
+```bash
+gh pr checks <pr_number> --watch
+```
+
+- If every check passes, proceed to Step 4.
+- If a check fails, investigate and fix the failure on the release branch
+  (run `pnpm cicheck` locally, commit, and push), then wait for the re-run.
+  Never proceed to the merge while any check is `fail` or `pending`.
+- Set a safety cap of **3** fix attempts. If CI is still red after the cap,
+  stop and report the failing checks to the user instead of merging.
+
+## 4. Merge the Release PR
+
+Run the `/merge-pr` command with the release PR number. It re-verifies the PR
+state and CI status, merges with `gh pr merge --admin --merge`, posts a
+thank-you comment, and cleans up the local branch.
+
+## 5. Final Report
+
+Report to the user:
+
+- The merged release PR number and title.
+- The new version and a link to the draft GitHub release (publishing the
+  release is intentionally left as a manual follow-up step).
+- Any CI fixes that were needed along the way.


### PR DESCRIPTION
## Summary

Adds a new `/goal-release` command (`.rulesync/commands/goal-release.md`) that cuts a release end to end in one invocation:

1. Runs `/draft-release` to open the `release/v<version>` PR and create the draft GitHub release (auto-determining the version via the `release-dry-run` skill when no argument is given).
2. Resolves the release PR and verifies its head branch is the one just created.
3. Waits for the PR's CI checks with `gh pr checks --watch`, fixing failures on the release branch (capped at 3 attempts).
4. Runs `/merge-pr` to merge the release PR, then reports the merged PR, the new version, and the draft release link.

The command file was authored through the rulesync MCP server workflow and generated for all configured targets (copilot, claudecode, opencode, takt).

## Notes

- Safety rails: only ever merges the release PR created in step 1, and never merges while any check is `fail` or `pending`.
- Publishing the draft GitHub release remains a manual follow-up step, unchanged from `/draft-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)