### PR TITLE
release: v11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "10.1.0";
+const getVersion = () => "11.0.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v11.0.0.

- Bump `getVersion()` to 11.0.0
- Bump `package.json` version to 11.0.0

See the draft release notes for the changes included in this version (main change: PR #2267 — `codexcli.base_permission_profile`, sandbox_mode deprecation, and new Codex CLI generation defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)