### PR TITLE
chore: update Homebrew formula to v12.0.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "9.8.0"
+  version "12.0.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "f1e51045fcc976542d8a6b7061c7d5b04a7908da0f676185a4ed06632530eccd"
+      sha256 "351c977a6c75567675b63a50b1131cec7b97337b37ba4f0c105450656c29de5b"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "09f0ccc6b581f0198708f8f072031576116d33185d964b8dfe840e81beb34820"
+      sha256 "f31affd01216e80f78bf6dd79c48e605186fcf989f2e16bb58964bd1ca00c11a"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "594da40d1b96d087302559d62b3880e14cb31bd1ee19e2686a0dbb70c9b5fdf7"
+      sha256 "8d044240afff1b45af3a708bdf1b005694aec404fc8d540715fcca93fdf08ace"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "f7ca7be64ec39385579b61fc8834886dfa947b374901afd7992381080dd42636"
+      sha256 "a433ee666c6c10e7cbde6ac090224ccc43f81ccfcd9a3fb652acbcce1938fb94"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v12.0.0 release.