### PR TITLE
fix: narrow Codex CLI gitignore entry to .codex/rules/rulesync.rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,7 +245,7 @@ rulesync.local.jsonc
 **/.deepagents/hooks.json
 **/.roomodes
 **/.codexignore
-**/.codex/rules/
+**/.codex/rules/rulesync.rules
 **/AGENTS.md
 **/.agents/memories/
 **/.aiassistant/rules/

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -154,8 +154,9 @@ describe("registry derivation", () => {
       "roo::subagents::**/.roomodes",
       "codexcli::ignore::**/.codexignore",
       // Codex CLI's `.codex/rules/rulesync.rules` bash-permission file is written
-      // by createCodexcliBashRulesFile, outside getSettablePaths.
-      "codexcli::permissions::**/.codex/rules/",
+      // by createCodexcliBashRulesFile, outside getSettablePaths. Only the
+      // rulesync-owned file is ignored, not the whole user-authorable directory.
+      "codexcli::permissions::**/.codex/rules/rulesync.rules",
       // Shared trees and global-scope outputs (emitted under the home dir).
       "rovodev::skills::**/.agents/skills/",
       "rovodev::commands::**/.rovodev/prompts.yml",

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -4,7 +4,7 @@ import {
   CLAUDECODE_MEMORIES_DIR_NAME,
   CLAUDECODE_SETTINGS_LOCAL_FILE_NAME,
 } from "../../constants/claudecode-paths.js";
-import { CODEXCLI_DIR } from "../../constants/codexcli-paths.js";
+import { CODEXCLI_BASH_RULES_FILE_NAME, CODEXCLI_DIR } from "../../constants/codexcli-paths.js";
 import { RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import {
   ALL_FEATURES_WITH_WILDCARD,
@@ -96,11 +96,17 @@ export const HAND_MAINTAINED_GITIGNORE_ENTRIES: ReadonlyArray<GitignoreEntryTag>
   // codexcli has no ignore processor; its `.codexignore` is a ghost entry.
   { target: "codexcli", feature: "ignore", entry: "**/.codexignore" },
 
-  // Codex CLI's `.codex/rules/` holds the `rulesync.rules` bash-permission file
-  // produced by `createCodexcliBashRulesFile` in codexcli-permissions.ts. That
-  // file is written outside `getSettablePaths`, so the directory is not derived
-  // automatically and needs a hand-maintained entry.
-  { target: "codexcli", feature: "permissions", entry: `**/${CODEXCLI_DIR}/rules/` },
+  // Codex CLI's `rulesync.rules` bash-permission file is produced by
+  // `createCodexcliBashRulesFile` in codexcli-permissions.ts. That file is
+  // written outside `getSettablePaths`, so it is not derived automatically and
+  // needs a hand-maintained entry. Only the single rulesync-owned file is
+  // ignored: `.codex/rules/` is a general Codex rules location where users can
+  // hand-author their own `*.rules` files that should stay version-controlled.
+  {
+    target: "codexcli",
+    feature: "permissions",
+    entry: `**/${CODEXCLI_DIR}/rules/${CODEXCLI_BASH_RULES_FILE_NAME}`,
+  },
 ];
 
 export const GITIGNORE_ENTRY_REGISTRY: ReadonlyArray<GitignoreEntryTag> = [


### PR DESCRIPTION
## Summary

The hand-maintained gitignore entry for Codex CLI's permissions feature ignored the entire `.codex/rules/` directory. Since `.codex/rules/` is a general Codex rules location where users can hand-author their own `*.rules` files, the directory-level entry silently excluded those user-authored files from version control, even though rulesync only generates the single `rulesync.rules` file there (via `createCodexcliBashRulesFile` in `codexcli-permissions.ts`).

## Changes

- Narrowed the entry in `HAND_MAINTAINED_GITIGNORE_ENTRIES` (`src/cli/commands/gitignore-entries.ts`) from `**/.codex/rules/` to `**/.codex/rules/rulesync.rules`, reusing `CODEXCLI_BASH_RULES_FILE_NAME` instead of hardcoding the file name, and updated the code comment.
- Updated the justified-exception snapshot in `gitignore-entries.test.ts` accordingly.
- Regenerated the project `.gitignore` with `pnpm dev gitignore`.

Closes #2263

🤖 Generated with [Claude Code](https://claude.com/claude-code)