### PR TITLE
feat: tighten hooks.json string fields to enums (type, shell, event keys)

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -124,11 +124,14 @@ Example:
 **Hook entry keys:**
 
 - `command` (required): Shell command to execute when the event fires.
-- `type` (optional): Either `"command"` (default) or `"prompt"`. Not all tools support `prompt`; see notes below.
+- `type` (optional): One of `"command"` (default), `"prompt"`, `"http"`, `"agent"`, `"mcp_tool"`, or `"function"` — the union of the hook types accepted across supported tools. Each tool supports a subset (most support only `command`); hooks with a type a tool does not support are skipped for that tool with a warning. See notes below.
 - `matcher` (optional): Regex used by tools that scope hooks to specific tool names (e.g. `preToolUse`, `postToolUse`, `notification`). Ignored by events that do not take a matcher (e.g. `sessionStart`, `worktreeCreate`, `worktreeRemove`).
 - `timeout` (optional): Per-hook timeout in seconds, forwarded to tools that support it.
 - `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
 - `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
+- `shell` (optional): Either `"bash"` or `"powershell"` — the only two interpreter values any tool accepts. Forwarded to Qwen Code command hooks.
+
+Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 
 Events present in the shared `hooks` block but unsupported by a given tool are skipped for that tool (a warning is logged at generate time). The canonical `notification` event maps to deepagents-cli's `input.required` (human-in-the-loop interrupt).
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -124,11 +124,14 @@ Example:
 **Hook entry keys:**
 
 - `command` (required): Shell command to execute when the event fires.
-- `type` (optional): Either `"command"` (default) or `"prompt"`. Not all tools support `prompt`; see notes below.
+- `type` (optional): One of `"command"` (default), `"prompt"`, `"http"`, `"agent"`, `"mcp_tool"`, or `"function"` — the union of the hook types accepted across supported tools. Each tool supports a subset (most support only `command`); hooks with a type a tool does not support are skipped for that tool with a warning. See notes below.
 - `matcher` (optional): Regex used by tools that scope hooks to specific tool names (e.g. `preToolUse`, `postToolUse`, `notification`). Ignored by events that do not take a matcher (e.g. `sessionStart`, `worktreeCreate`, `worktreeRemove`).
 - `timeout` (optional): Per-hook timeout in seconds, forwarded to tools that support it.
 - `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
 - `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
+- `shell` (optional): Either `"bash"` or `"powershell"` — the only two interpreter values any tool accepts. Forwarded to Qwen Code command hooks.
+
+Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 
 Events present in the shared `hooks` block but unsupported by a given tool are skipped for that tool (a warning is logged at generate time). The canonical `notification` event maps to deepagents-cli's `input.required` (human-in-the-loop interrupt).
 

--- a/src/features/hooks/antigravity-hooks.ts
+++ b/src/features/hooks/antigravity-hooks.ts
@@ -17,7 +17,11 @@ import type { Logger } from "../../utils/logger.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -39,6 +43,7 @@ const ANTIGRAVITY_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   toolToCanonicalEventNames: ANTIGRAVITY_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "",
   noMatcherEvents: new Set(["preModelInvocation", "postModelInvocation", "stop"]),
+  supportedHookTypes: new Set(["command"]),
 };
 
 /**
@@ -197,8 +202,9 @@ class AntigravityHooks extends ToolHooks {
       hooks: flattenAntigravityHooks(parsed),
       converterConfig: ANTIGRAVITY_CONVERTER_CONFIG,
     });
+    const overrideKey = (this.constructor as typeof AntigravityHooks).getOverrideKey();
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(buildImportedHooksConfig({ hooks, overrideKey }), null, 2),
     });
   }
 

--- a/src/features/hooks/augmentcode-hooks.ts
+++ b/src/features/hooks/augmentcode-hooks.ts
@@ -18,7 +18,11 @@ import type { Logger } from "../../utils/logger.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -46,6 +50,7 @@ const AUGMENTCODE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   toolToCanonicalEventNames: AUGMENTCODE_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "",
   noMatcherEvents: AUGMENTCODE_NO_MATCHER_EVENTS,
+  supportedHookTypes: new Set(["command"]),
 };
 
 /**
@@ -161,7 +166,11 @@ export class AugmentcodeHooks extends ToolHooks {
       converterConfig: AUGMENTCODE_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "augmentcode" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { HooksConfigSchema } from "../../types/hooks.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { ClaudecodeHooks } from "./claudecode-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
@@ -444,6 +445,35 @@ describe("ClaudecodeHooks", () => {
       const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
       const json = rulesyncHooks.getJson();
       expect(json.hooks.sessionStart?.[0]?.command).toBe("./scripts/format.sh --fix --quiet");
+    });
+
+    it("should route unmapped native event names into the claudecode override block", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [{ hooks: [{ type: "command", command: "echo start" }] }],
+            // A hypothetical event Claude Code ships before rulesync maps it.
+            BrandNewEvent: [{ hooks: [{ type: "command", command: "echo new" }] }],
+          },
+        }),
+        validate: false,
+      });
+
+      const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
+      const json = rulesyncHooks.getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      // The unmapped key must not land in the top-level hooks record (whose
+      // keys are restricted to canonical event names)...
+      expect(json.hooks.BrandNewEvent).toBeUndefined();
+      // ...but under the claudecode override block, so the imported file still
+      // passes canonical validation on the next generate run.
+      const overrideHooks = (json as { claudecode?: { hooks?: Record<string, unknown[]> } })
+        .claudecode?.hooks;
+      expect(overrideHooks?.BrandNewEvent).toHaveLength(1);
+      expect(HooksConfigSchema.safeParse(json).success).toBe(true);
     });
   });
 

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -17,7 +17,11 @@ import {
 } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -46,6 +50,10 @@ const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   projectDirVar: "$CLAUDE_PROJECT_DIR",
   prefixDotRelativeCommandsOnly: true,
   noMatcherEvents: CLAUDE_NO_MATCHER_EVENTS,
+  // Claude Code also documents `http`/`mcp_tool`/`agent` hook handlers, but the
+  // shared converter only carries the command/prompt payload fields, so only
+  // those two round-trip faithfully today (tracked in issue #2231).
+  supportedHookTypes: new Set(["command", "prompt"]),
 };
 
 export class ClaudecodeHooks extends ToolHooks {
@@ -139,7 +147,11 @@ export class ClaudecodeHooks extends ToolHooks {
       converterConfig: CLAUDE_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "claudecode" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/codexcli-hooks.ts
+++ b/src/features/hooks/codexcli-hooks.ts
@@ -20,7 +20,11 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -182,7 +186,11 @@ export class CodexcliHooks extends ToolHooks {
       converterConfig: CODEXCLI_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "codexcli" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/copilot-hooks.ts
+++ b/src/features/hooks/copilot-hooks.ts
@@ -16,6 +16,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -221,7 +222,11 @@ export class CopilotHooks extends ToolHooks {
     }
     const hooks = copilotHooksToCanonical(parsed.hooks, options?.logger);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "copilot" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/copilotcli-hooks.ts
+++ b/src/features/hooks/copilotcli-hooks.ts
@@ -21,6 +21,7 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { compact } from "../../utils/object.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -210,7 +211,7 @@ function buildCopilotCliEntriesForEvent({
         ...timeoutPart,
         ...rest,
       });
-    } else {
+    } else if (hookType === "command") {
       // `env` is a canonical field Copilot CLI supports natively on command hooks.
       entries.push({
         type: "command",
@@ -220,6 +221,8 @@ function buildCopilotCliEntriesForEvent({
         ...rest,
       });
     }
+    // Other canonical types (`agent`, `mcp_tool`, `function`) have no Copilot
+    // CLI equivalent and are skipped (the HooksProcessor warns about them).
   }
   return entries;
 }
@@ -405,7 +408,11 @@ export class CopilotcliHooks extends ToolHooks {
     }
     const hooks = copilotCliHooksToCanonical(parsed.hooks, options?.logger);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "copilotcli" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/cursor-hooks.ts
+++ b/src/features/hooks/cursor-hooks.ts
@@ -11,6 +11,7 @@ import {
 } from "../../types/hooks.js";
 import { readFileContent } from "../../utils/file.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -85,20 +86,28 @@ export class CursorHooks extends ToolHooks {
     // architectural consistency with other tool converters (Claude, Factory Droid) and
     // becomes essential if Cursor's event naming diverges from canonical in the future.
     const mappedHooks: HooksConfig["hooks"] = {};
+    // Cursor only documents `command` and `prompt` hooks; other canonical
+    // types are skipped (the HooksProcessor warns about them).
+    const cursorSupportedTypes = new Set(["command", "prompt"]);
     for (const [eventName, defs] of Object.entries(mergedHooks)) {
       const cursorEventName = CANONICAL_TO_CURSOR_EVENT_NAMES[eventName] ?? eventName;
-      mappedHooks[cursorEventName] = defs.map((def) => ({
-        ...(def.type !== undefined && def.type !== null && { type: def.type }),
-        ...(def.command !== undefined && def.command !== null && { command: def.command }),
-        ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
-        ...(def.loop_limit !== undefined && { loop_limit: def.loop_limit }),
-        ...(def.matcher !== undefined && def.matcher !== null && { matcher: def.matcher }),
-        ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
-        ...(def.failClosed !== undefined &&
-          def.failClosed !== null && {
-            failClosed: def.failClosed,
-          }),
-      }));
+      const mappedDefs = defs
+        .filter((def) => cursorSupportedTypes.has(def.type ?? "command"))
+        .map((def) => ({
+          ...(def.type !== undefined && def.type !== null && { type: def.type }),
+          ...(def.command !== undefined && def.command !== null && { command: def.command }),
+          ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
+          ...(def.loop_limit !== undefined && { loop_limit: def.loop_limit }),
+          ...(def.matcher !== undefined && def.matcher !== null && { matcher: def.matcher }),
+          ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
+          ...(def.failClosed !== undefined &&
+            def.failClosed !== null && {
+              failClosed: def.failClosed,
+            }),
+        }));
+      if (mappedDefs.length > 0) {
+        mappedHooks[cursorEventName] = mappedDefs;
+      }
     }
     const cursorConfig = {
       version: config.version ?? 1,
@@ -130,7 +139,11 @@ export class CursorHooks extends ToolHooks {
     }
     const version = parsed.version ?? 1;
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version, hooks: canonicalHooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks: canonicalHooks, overrideKey: "cursor", version }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/deepagents-hooks.ts
+++ b/src/features/hooks/deepagents-hooks.ts
@@ -11,6 +11,7 @@ import {
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -62,7 +63,7 @@ function canonicalToDeepagentsHooks(config: HooksConfig): DeepagentsHookEntry[] 
     if (!deepagentsEvent) continue;
 
     for (const def of definitions) {
-      if (def.type === "prompt") continue;
+      if ((def.type ?? "command") !== "command") continue;
       if (!def.command) continue;
       if (def.matcher) continue;
 
@@ -184,7 +185,11 @@ export class DeepagentsHooks extends ToolHooks {
     const hooks = deepagentsToCanonicalHooks(hooksEntries);
 
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "deepagents" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/devin-hooks.ts
+++ b/src/features/hooks/devin-hooks.ts
@@ -19,7 +19,11 @@ import { isRecord } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -197,7 +201,11 @@ export class DevinHooks extends ToolHooks {
       converterConfig: DEVIN_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "devin" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -17,7 +17,11 @@ import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/
 import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -31,6 +35,7 @@ const FACTORYDROID_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   canonicalToToolEventNames: CANONICAL_TO_FACTORYDROID_EVENT_NAMES,
   toolToCanonicalEventNames: FACTORYDROID_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "$FACTORY_PROJECT_DIR",
+  supportedHookTypes: new Set(["command", "prompt"]),
 };
 
 export class FactorydroidHooks extends ToolHooks {
@@ -138,7 +143,11 @@ export class FactorydroidHooks extends ToolHooks {
       converterConfig: FACTORYDROID_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "factorydroid" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/goose-hooks.ts
+++ b/src/features/hooks/goose-hooks.ts
@@ -11,7 +11,11 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -127,7 +131,11 @@ export class GooseHooks extends ToolHooks {
       converterConfig: GOOSE_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "goose" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/grokcli-hooks.ts
+++ b/src/features/hooks/grokcli-hooks.ts
@@ -13,7 +13,11 @@ import type { Logger } from "../../utils/logger.js";
 import { isRecord } from "../../utils/type-guards.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -159,7 +163,11 @@ export class GrokcliHooks extends ToolHooks {
       converterConfig: GROKCLI_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "grokcli" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/hermesagent-hooks.ts
+++ b/src/features/hooks/hermesagent-hooks.ts
@@ -19,6 +19,7 @@ import {
   stringifySharedConfig,
 } from "../shared/shared-config-gateway.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import { ToolHooks, type ToolHooksFromRulesyncHooksParams } from "./tool-hooks.js";
 
 type HermesagentHooksParams = Omit<AiFileParams, "relativeDirPath" | "relativeFilePath">;
@@ -229,7 +230,11 @@ export class HermesagentHooks extends ToolHooks {
     const config = parseSharedConfig({ format: "yaml", fileContent: this.getFileContent() });
     const hooks = hermesHooksToCanonical(config.hooks);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "hermesagent" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -450,7 +450,9 @@ export const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFac
         supportsImport: true,
       },
       supportedEvents: QWENCODE_HOOK_EVENTS,
-      supportedHookTypes: ["command"],
+      // Qwen Code documents four hook executor types, and the adapter emits
+      // all of them faithfully (including per-type fields like `url`).
+      supportedHookTypes: ["command", "prompt", "http", "function"],
       supportsMatcher: true,
     },
   ],

--- a/src/features/hooks/junie-hooks.ts
+++ b/src/features/hooks/junie-hooks.ts
@@ -13,7 +13,11 @@ import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/
 import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
-import { canonicalToToolHooks, toolHooksToCanonical } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -145,7 +149,11 @@ export class JunieHooks extends ToolHooks {
       converterConfig: JUNIE_CONVERTER_CONFIG,
     });
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "junie" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/kiro-hooks.test.ts
+++ b/src/features/hooks/kiro-hooks.test.ts
@@ -342,7 +342,7 @@ describe("KiroHooks", () => {
       expect(parsed.hooks.stop).toBeUndefined();
     });
 
-    it("should handle unknown event names gracefully", () => {
+    it("should route unknown event names into the kiro override block", () => {
       const kiroHooks = new KiroHooks(
         createMockAiFileParams({
           fileContent: JSON.stringify({
@@ -356,8 +356,13 @@ describe("KiroHooks", () => {
       const rulesyncHooks = kiroHooks.toRulesyncHooks();
       const parsed = rulesyncHooks.getJson();
 
-      expect(parsed.hooks.someUnknownEvent).toBeDefined();
-      expect(parsed.hooks.someUnknownEvent?.[0]?.command).toBe("echo unknown");
+      // Unknown native keys must not land in the top-level hooks record (whose
+      // keys are restricted to canonical event names) but under the kiro
+      // override block, so the imported file passes canonical validation.
+      expect(parsed.hooks.someUnknownEvent).toBeUndefined();
+      const overrideHooks = (parsed as { kiro?: { hooks?: Record<string, unknown[]> } }).kiro
+        ?.hooks;
+      expect(overrideHooks?.someUnknownEvent?.[0]).toMatchObject({ command: "echo unknown" });
     });
   });
 

--- a/src/features/hooks/kiro-hooks.ts
+++ b/src/features/hooks/kiro-hooks.ts
@@ -16,6 +16,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -218,8 +219,9 @@ export class KiroHooks extends ToolHooks {
       );
     }
     const hooks = kiroHooksToCanonical(agentConfig.hooks);
+    const overrideKey = (this.constructor as typeof KiroHooks).getOverrideKey();
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(buildImportedHooksConfig({ hooks, overrideKey }), null, 2),
     });
   }
 

--- a/src/features/hooks/kiro-ide-hooks.test.ts
+++ b/src/features/hooks/kiro-ide-hooks.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { HooksConfigSchema } from "../../types/hooks.js";
 import { KiroIdeHooks } from "./kiro-ide-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
 
@@ -144,5 +145,42 @@ describe("KiroIdeHooks", () => {
     expect(canonical.hooks.preToolUse[0].timeout).toBe(30);
     expect(canonical.hooks.stop[0].type).toBe("prompt");
     expect(canonical.hooks.stop[0].prompt).toBe("Summarize");
+  });
+
+  it("routes IDE-only triggers into the kiro-ide override block on import", async () => {
+    const hooks = new KiroIdeHooks({
+      outputRoot: testDir,
+      relativeDirPath: join(".kiro", "hooks"),
+      relativeFilePath: "rulesync.json",
+      fileContent: JSON.stringify({
+        version: "v1",
+        hooks: [
+          {
+            name: "format-on-save",
+            trigger: "PostFileSave",
+            action: { type: "command", command: "pnpm fmt" },
+            enabled: true,
+          },
+          {
+            name: "lint",
+            trigger: "PreToolUse",
+            action: { type: "command", command: "echo lint" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    const rulesyncHooks = hooks.toRulesyncHooks();
+    const canonical = JSON.parse(rulesyncHooks.getFileContent());
+    // The IDE-only trigger must not land in the top-level hooks record (whose
+    // keys are restricted to canonical event names) but under the kiro-ide
+    // override block, which passes tool-native keys through verbatim.
+    expect(canonical.hooks.PostFileSave).toBeUndefined();
+    expect(canonical.hooks.preToolUse[0].command).toBe("echo lint");
+    expect(canonical["kiro-ide"].hooks.PostFileSave[0].command).toBe("pnpm fmt");
+    // The imported content must survive canonical re-validation, so the next
+    // generate run does not fail on it.
+    expect(HooksConfigSchema.safeParse(canonical).success).toBe(true);
   });
 });

--- a/src/features/hooks/kiro-ide-hooks.ts
+++ b/src/features/hooks/kiro-ide-hooks.ts
@@ -15,6 +15,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -237,7 +238,11 @@ export class KiroIdeHooks extends ToolHooks {
     }
     const hooks = kiroIdeHooksToCanonical(parsed.hooks ?? []);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "kiro-ide" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/opencode-style-generator.ts
+++ b/src/features/hooks/opencode-style-generator.ts
@@ -46,7 +46,7 @@ function collectOpencodeStyleHandlers({
 
     const handlers: Handler[] = [];
     for (const def of definitions) {
-      if (def.type === "prompt") continue;
+      if ((def.type ?? "command") !== "command") continue;
       if (!def.command) continue;
       handlers.push({
         command: def.command,

--- a/src/features/hooks/qwencode-hooks.test.ts
+++ b/src/features/hooks/qwencode-hooks.test.ts
@@ -509,6 +509,42 @@ describe("QwencodeHooks", () => {
       });
     });
 
+    it("should preserve the function hook type on import instead of collapsing to command", () => {
+      const qwencodeHooks = new QwencodeHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              PreToolUse: [{ hooks: [{ type: "function", name: "skillHook" }] }],
+            },
+          }),
+        }),
+      );
+
+      const parsed = qwencodeHooks.toRulesyncHooks().getJson();
+      expect(parsed.hooks.preToolUse?.[0]).toEqual({
+        type: "function",
+        name: "skillHook",
+      });
+    });
+
+    it("should drop an unsupported shell value on import instead of failing", () => {
+      const qwencodeHooks = new QwencodeHooks(
+        createMockAiFileParams({
+          fileContent: JSON.stringify({
+            hooks: {
+              PreToolUse: [{ hooks: [{ type: "command", command: "ls", shell: "zsh" }] }],
+            },
+          }),
+        }),
+      );
+
+      const parsed = qwencodeHooks.toRulesyncHooks().getJson();
+      expect(parsed.hooks.preToolUse?.[0]).toEqual({
+        type: "command",
+        command: "ls",
+      });
+    });
+
     it("should import command-only per-hook fields (async/env/shell/statusMessage)", () => {
       const qwencodeHooks = new QwencodeHooks(
         createMockAiFileParams({

--- a/src/features/hooks/qwencode-hooks.ts
+++ b/src/features/hooks/qwencode-hooks.ts
@@ -160,12 +160,17 @@ function qwencodeMatcherEntryToCanonical(
       ? entry.matcher
       : undefined;
   for (const h of hooks) {
-    // Preserve the `http` transport (and its target URL) instead of
-    // collapsing every non-prompt hook to `command`.
+    // Preserve every documented Qwen Code hook type (`command`, `prompt`,
+    // `http`, `function`) instead of collapsing unknown types to `command`.
     const hookType =
-      h.type === "command" || h.type === "prompt" || h.type === "http" ? h.type : "command";
+      h.type === "command" || h.type === "prompt" || h.type === "http" || h.type === "function"
+        ? h.type
+        : "command";
     const isHttp = hookType === "http";
     const isCommand = hookType === "command";
+    // The canonical schema restricts `shell` to the two values Qwen accepts;
+    // drop anything else rather than failing the whole import.
+    const shell = h.shell === "bash" || h.shell === "powershell" ? h.shell : undefined;
     defs.push({
       type: hookType,
       ...compact({
@@ -179,7 +184,7 @@ function qwencodeMatcherEntryToCanonical(
         // Command-only per-hook fields (Qwen Code PR #2827) — command type only.
         async: isCommand ? h.async : undefined,
         env: isCommand ? h.env : undefined,
-        shell: isCommand ? h.shell : undefined,
+        shell: isCommand ? shell : undefined,
         // Http-only per-hook fields (Qwen Code PR #2827).
         headers: isHttp ? h.headers : undefined,
         allowedEnvVars: isHttp ? h.allowedEnvVars : undefined,

--- a/src/features/hooks/qwencode-hooks.ts
+++ b/src/features/hooks/qwencode-hooks.ts
@@ -16,6 +16,7 @@ import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/
 import { compact } from "../../utils/object.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -79,11 +80,16 @@ function canonicalToQwencodeHooks(config: HooksConfig): Record<string, unknown[]
     ...sharedHooks,
     ...config.qwencode?.hooks,
   };
+  // Qwen Code documents exactly four hook executor types; other canonical
+  // types (`agent`, `mcp_tool`) have no Qwen equivalent and are skipped (the
+  // HooksProcessor warns about them).
+  const qwencodeSupportedTypes = new Set(["command", "prompt", "http", "function"]);
   const qwencode: Record<string, unknown[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
     const qwencodeEventName = CANONICAL_TO_QWENCODE_EVENT_NAMES[eventName] ?? eventName;
     const byMatcher = new Map<string, HooksConfig["hooks"][string]>();
     for (const def of definitions) {
+      if (!qwencodeSupportedTypes.has(def.type ?? "command")) continue;
       const key = def.matcher ?? "";
       const list = byMatcher.get(key);
       if (list) list.push(def);
@@ -303,10 +309,13 @@ export class QwencodeHooks extends ToolHooks {
     }
     const hooks = qwencodeHooksToCanonical(settings.hooks);
     // Preserve the top-level `disableAllHooks` switch under the qwencode namespace.
-    const canonical: HooksConfig =
-      typeof settings.disableAllHooks === "boolean"
-        ? { version: 1, hooks, qwencode: { disableAllHooks: settings.disableAllHooks } }
-        : { version: 1, hooks };
+    const canonical: HooksConfig = buildImportedHooksConfig({
+      hooks,
+      overrideKey: "qwencode",
+      ...(typeof settings.disableAllHooks === "boolean" && {
+        extraOverride: { disableAllHooks: settings.disableAllHooks },
+      }),
+    });
     return this.toRulesyncHooksDefault({
       fileContent: JSON.stringify(canonical, null, 2),
     });

--- a/src/features/hooks/reasonix-hooks.ts
+++ b/src/features/hooks/reasonix-hooks.ts
@@ -13,6 +13,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -253,7 +254,11 @@ export class ReasonixHooks extends ToolHooks {
     }
     const hooks = reasonixHooksToCanonical(settings.hooks);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "reasonix" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -1,4 +1,4 @@
-import type { HookEvent, HookType, HooksConfig } from "../../types/hooks.js";
+import { type HookEvent, type HookType, type HooksConfig, isHookEvent } from "../../types/hooks.js";
 import type { Logger } from "../../utils/logger.js";
 
 type ToolMatcherEntry = {
@@ -319,6 +319,49 @@ function toolMatcherEntryToCanonical({
 }): HooksConfig["hooks"][string] {
   const hookDefs = rawEntry.hooks ?? [];
   return hookDefs.map((h) => toolHookToCanonical({ h, rawEntry, converterConfig }));
+}
+
+/**
+ * Assemble the canonical hooks config a tool importer writes to
+ * `.rulesync/hooks.json`.
+ *
+ * The top-level `hooks` record only accepts canonical event names, so any
+ * imported native event key without a canonical mapping is moved under the
+ * importing tool's own override block (`<overrideKey>.hooks`), whose keys stay
+ * lenient. This mirrors the generate direction — override blocks pass
+ * tool-native keys through verbatim — so documented native triggers (e.g.
+ * kiro-ide's `PostFileSave`) survive an import → generate round-trip instead
+ * of failing canonical validation.
+ */
+export function buildImportedHooksConfig({
+  hooks,
+  overrideKey,
+  version = 1,
+  extraOverride,
+}: {
+  hooks: HooksConfig["hooks"];
+  overrideKey: string;
+  version?: number;
+  extraOverride?: Record<string, unknown>;
+}): HooksConfig {
+  const canonical: HooksConfig["hooks"] = {};
+  const native: HooksConfig["hooks"] = {};
+  for (const [event, defs] of Object.entries(hooks)) {
+    if (isHookEvent(event)) {
+      canonical[event] = defs;
+    } else {
+      native[event] = defs;
+    }
+  }
+  const override: Record<string, unknown> = { ...extraOverride };
+  if (Object.keys(native).length > 0) {
+    override.hooks = native;
+  }
+  const config: HooksConfig = { version, hooks: canonical };
+  if (Object.keys(override).length > 0) {
+    (config as Record<string, unknown>)[overrideKey] = override;
+  }
+  return config;
 }
 
 export function toolHooksToCanonical({

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -1,4 +1,4 @@
-import type { HookEvent, HooksConfig } from "../../types/hooks.js";
+import type { HookEvent, HookType, HooksConfig } from "../../types/hooks.js";
 import type { Logger } from "../../utils/logger.js";
 
 type ToolMatcherEntry = {
@@ -24,7 +24,7 @@ export type ToolHooksConverterConfig = {
   canonicalToToolEventNames: Record<string, string>;
   toolToCanonicalEventNames: Record<string, string>;
   projectDirVar: string;
-  supportedHookTypes?: ReadonlySet<"command" | "prompt" | "http">;
+  supportedHookTypes?: ReadonlySet<HookType>;
   passthroughFields?: ReadonlyArray<"name" | "description">;
   /**
    * Per-hook boolean fields to carry through the round-trip, each mapping a

--- a/src/features/hooks/vibe-hooks.ts
+++ b/src/features/hooks/vibe-hooks.ts
@@ -16,6 +16,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
+import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
   ToolHooks,
   type ToolHooksForDeletionParams,
@@ -320,7 +321,11 @@ export class VibeHooks extends ToolHooks {
     }
     const hooks = vibeHooksToCanonical(parsed);
     return this.toRulesyncHooksDefault({
-      fileContent: JSON.stringify({ version: 1, hooks }, null, 2),
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "vibe" }),
+        null,
+        2,
+      ),
     });
   }
 

--- a/src/types/hooks.test.ts
+++ b/src/types/hooks.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  HOOK_TYPES,
+  HookDefinitionSchema,
+  HooksConfigSchema,
   CANONICAL_TO_CLAUDE_EVENT_NAMES,
   CANONICAL_TO_CODEXCLI_EVENT_NAMES,
   CANONICAL_TO_CURSOR_EVENT_NAMES,
@@ -156,5 +159,60 @@ describe("Factory Droid event naming", () => {
     expect(CANONICAL_TO_FACTORYDROID_EVENT_NAMES.subagentStop).toBe("SubagentStop");
     expect(CANONICAL_TO_FACTORYDROID_EVENT_NAMES.preCompact).toBe("PreCompact");
     expect(CANONICAL_TO_FACTORYDROID_EVENT_NAMES.notification).toBe("Notification");
+  });
+});
+
+describe("HookDefinitionSchema", () => {
+  it("should accept every canonical hook type", () => {
+    for (const type of HOOK_TYPES) {
+      const result = HookDefinitionSchema.safeParse({ type });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject an unknown hook type", () => {
+    const result = HookDefinitionSchema.safeParse({ type: "webhook" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept bash and powershell shells", () => {
+    for (const shell of ["bash", "powershell"]) {
+      const result = HookDefinitionSchema.safeParse({ type: "command", command: "ls", shell });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject an unsupported shell", () => {
+    const result = HookDefinitionSchema.safeParse({
+      type: "command",
+      command: "ls",
+      shell: "zsh",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("HooksConfigSchema", () => {
+  it("should accept canonical event names as top-level hooks keys", () => {
+    const result = HooksConfigSchema.safeParse({
+      hooks: { preToolUse: [{ type: "command", command: "ls" }] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject an unknown top-level event name", () => {
+    const result = HooksConfigSchema.safeParse({
+      hooks: { preToolUsee: [{ type: "command", command: "ls" }] },
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain("preToolUsee");
+  });
+
+  it("should keep tool-override hook keys lenient for native passthrough triggers", () => {
+    const result = HooksConfigSchema.safeParse({
+      hooks: {},
+      "kiro-ide": { hooks: { PostFileSave: [{ type: "command", command: "ls" }] } },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -20,12 +20,27 @@ export const safeString = z.pipe(
 );
 
 /**
+ * All canonical hook types — the union of the `type` values accepted by every
+ * supported tool:
+ * - `command` — universal (Claude Code, Codex CLI, Qwen Code, Cursor, …)
+ * - `prompt` — Claude Code, Codex CLI, Qwen Code, Copilot CLI, Cursor, Devin
+ * - `http` — Claude Code, Qwen Code, Copilot CLI, Grok CLI
+ * - `agent` — Claude Code, Codex CLI
+ * - `mcp_tool` — Claude Code
+ * - `function` — Qwen Code (internal Skill-system executor)
+ */
+export const HOOK_TYPES = ["command", "prompt", "http", "agent", "mcp_tool", "function"] as const;
+
+/** All canonical hook types. */
+export type HookType = (typeof HOOK_TYPES)[number];
+
+/**
  * Canonical hook definition.
  * Used in .rulesync/hooks.json and mapped to tool-specific formats.
  */
 export const HookDefinitionSchema = z.looseObject({
   command: z.optional(safeString),
-  type: z.optional(z.enum(["command", "prompt", "http"])),
+  type: z.optional(z.enum(HOOK_TYPES)),
   // Qwen Code: target URL for `http` hooks (the hook POSTs JSON to this URL).
   // https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/hooks.md
   url: z.optional(safeString),
@@ -52,7 +67,10 @@ export const HookDefinitionSchema = z.looseObject({
   // can't ride into a generated shell env var or HTTP header (header-splitting
   // shape), consistent with how `command`/`url` are guarded.
   env: z.optional(z.record(z.string(), safeString)),
-  shell: z.optional(safeString),
+  // Only Claude Code and Qwen Code expose an interpreter selector, and both
+  // restrict it to the same two values, so the field is a closed enum.
+  // https://code.claude.com/docs/en/hooks
+  shell: z.optional(z.enum(["bash", "powershell"])),
   // `statusMessage` is the progress text shown while the hook runs; Qwen Code
   // accepts it on both command and http hooks.
   statusMessage: z.optional(safeString),
@@ -67,63 +85,64 @@ export const HookDefinitionSchema = z.looseObject({
 
 export type HookDefinition = z.infer<typeof HookDefinitionSchema>;
 
-/** All canonical hook types. */
-export type HookType = "command" | "prompt" | "http";
-
 /**
  * All canonical hook event names.
  * Each tool supports a subset of these events.
  */
-export type HookEvent =
-  | "sessionStart"
-  | "sessionEnd"
-  | "preToolUse"
-  | "postToolUse"
-  | "preModelInvocation"
-  | "postModelInvocation"
-  | "beforeSubmitPrompt"
-  | "stop"
-  | "subagentStop"
-  | "preCompact"
-  | "postCompact"
-  | "contextOffload"
-  | "postToolUseFailure"
-  | "subagentStart"
-  | "beforeShellExecution"
-  | "afterShellExecution"
-  | "beforeMCPExecution"
-  | "afterMCPExecution"
-  | "beforeReadFile"
-  | "afterFileEdit"
-  | "beforeAgentResponse"
-  | "afterAgentResponse"
-  | "afterAgentThought"
-  | "beforeTabFileRead"
-  | "afterTabFileEdit"
-  | "permissionRequest"
-  | "notification"
-  | "setup"
-  | "afterError"
-  | "beforeToolSelection"
-  | "worktreeCreate"
-  | "worktreeRemove"
-  | "workspaceOpen"
-  | "messageDisplay"
-  | "todoCreated"
-  | "todoCompleted"
-  | "stopFailure"
-  | "instructionsLoaded"
-  | "userPromptExpansion"
-  | "postToolBatch"
-  | "permissionDenied"
-  | "taskCreated"
-  | "taskCompleted"
-  | "teammateIdle"
-  | "configChange"
-  | "cwdChanged"
-  | "fileChanged"
-  | "elicitation"
-  | "elicitationResult";
+export const HOOK_EVENTS = [
+  "sessionStart",
+  "sessionEnd",
+  "preToolUse",
+  "postToolUse",
+  "preModelInvocation",
+  "postModelInvocation",
+  "beforeSubmitPrompt",
+  "stop",
+  "subagentStop",
+  "preCompact",
+  "postCompact",
+  "contextOffload",
+  "postToolUseFailure",
+  "subagentStart",
+  "beforeShellExecution",
+  "afterShellExecution",
+  "beforeMCPExecution",
+  "afterMCPExecution",
+  "beforeReadFile",
+  "afterFileEdit",
+  "beforeAgentResponse",
+  "afterAgentResponse",
+  "afterAgentThought",
+  "beforeTabFileRead",
+  "afterTabFileEdit",
+  "permissionRequest",
+  "notification",
+  "setup",
+  "afterError",
+  "beforeToolSelection",
+  "worktreeCreate",
+  "worktreeRemove",
+  "workspaceOpen",
+  "messageDisplay",
+  "todoCreated",
+  "todoCompleted",
+  "stopFailure",
+  "instructionsLoaded",
+  "userPromptExpansion",
+  "postToolBatch",
+  "permissionDenied",
+  "taskCreated",
+  "taskCompleted",
+  "teammateIdle",
+  "configChange",
+  "cwdChanged",
+  "fileChanged",
+  "elicitation",
+  "elicitationResult",
+] as const;
+
+/** All canonical hook event names. */
+export type HookEvent = (typeof HOOK_EVENTS)[number];
 
 /** Hook events supported by Cursor. */
 export const CURSOR_HOOK_EVENTS: readonly HookEvent[] = [
@@ -622,12 +641,34 @@ export const HERMESAGENT_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Obje
 
 const hooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema));
 
+const HOOK_EVENT_SET: ReadonlySet<string> = new Set(HOOK_EVENTS);
+
+/**
+ * Top-level `hooks` record whose keys must be canonical event names, so typos
+ * are rejected at parse time. Keys are validated with a refinement (instead of
+ * an enum key schema) to keep the inferred type a plain string record.
+ *
+ * The per-tool override blocks below deliberately keep the lenient
+ * `hooksRecordSchema`: some are documented to pass tool-native event keys
+ * through verbatim (e.g. kiro-ide's IDE-only `PostFileSave`/`PreTaskExec`
+ * triggers), which the canonical enum would reject.
+ */
+const canonicalHooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema)).check(
+  z.refine((record) => Object.keys(record).every((key) => HOOK_EVENT_SET.has(key)), {
+    error: (issue) => {
+      const keys = Object.keys((issue.input as Record<string, unknown>) ?? {});
+      const unknown = keys.filter((key) => !HOOK_EVENT_SET.has(key));
+      return `unknown hook event name(s): ${unknown.join(", ")}`;
+    },
+  }),
+);
+
 /**
  * Canonical hooks config (canonical event names in camelCase).
  */
 export const HooksConfigSchema = z.looseObject({
   version: z.optional(z.number()),
-  hooks: hooksRecordSchema,
+  hooks: canonicalHooksRecordSchema,
   cursor: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   claudecode: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),
   copilot: z.optional(z.looseObject({ hooks: z.optional(hooksRecordSchema) })),

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -643,6 +643,9 @@ const hooksRecordSchema = z.record(z.string(), z.array(HookDefinitionSchema));
 
 const HOOK_EVENT_SET: ReadonlySet<string> = new Set(HOOK_EVENTS);
 
+/** Whether `value` is a canonical hook event name. */
+export const isHookEvent = (value: string): value is HookEvent => HOOK_EVENT_SET.has(value);
+
 /**
  * Top-level `hooks` record whose keys must be canonical event names, so typos
  * are rejected at parse time. Keys are validated with a refinement (instead of


### PR DESCRIPTION
## Summary

The canonical `.rulesync/hooks.json` schema typed several closed-set fields as loose strings, so typos passed validation silently — and the `type` enum was narrower than the real cross-tool value space, rejecting values that are valid upstream.

## Changes

- **`type` enum expanded** to the verified union `command | prompt | http | agent | mcp_tool | function` (`HOOK_TYPES` in `src/types/hooks.ts`), with a comment mapping each value to the tool(s) that contribute it. This fixes the latent rejection of Claude Code's `agent`/`mcp_tool` and Qwen Code's `function` hook types. Verified against the Claude Code hooks docs (five types: command/http/mcp_tool/prompt/agent) and the Qwen Code hooks docs (four types: command/http/function/prompt).
- **`shell` converted** from `safeString` to `z.enum(["bash", "powershell"])` — Claude Code and Qwen Code are the only tools with an interpreter selector, and both accept exactly these two values.
- **Top-level `hooks` event keys validated** against a new runtime `HOOK_EVENTS` array (the `HookEvent` type is now derived from it), so unknown/typo'd canonical event names are rejected at parse time with a message listing the offending keys. Per-tool override blocks keep the lenient string-keyed record so documented tool-native passthrough triggers (e.g. kiro-ide's `PostFileSave`/`PreTaskExec`) still work.
- **Qwen Code import** now preserves the `function` hook type faithfully instead of collapsing it to `command`, and drops unsupported `shell` values rather than failing the import.
- `ToolHooksConverterConfig.supportedHookTypes` now reuses the widened `HookType` union.
- `z.looseObject` / `z.optional` are preserved everywhere for forward compatibility.
- Docs: updated the hook entry key reference in `docs/reference/file-formats.md` (synced to `skills/rulesync/`).
- Tests: every union `type` value accepted; `shell: zsh` rejected while `bash`/`powershell` accepted; unknown top-level event key rejected while override-block native keys stay accepted; Qwen `function` round-trip and invalid-shell drop covered.

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)