### PR TITLE
feat: round-trip Claude Code http/mcp_tool/agent hooks faithfully

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -130,6 +130,9 @@ Example:
 - `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
 - `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
 - `shell` (optional): Either `"bash"` or `"powershell"` — the only two interpreter values any tool accepts. Forwarded to Qwen Code command hooks.
+- `url` / `headers` / `allowedEnvVars` (optional, `http` hooks): the POST target URL, request headers (values support `$VAR` interpolation), and the env-var allowlist for that interpolation. Forwarded to Claude Code and Qwen Code http hooks.
+- `server` / `tool` / `input` (optional, `mcp_tool` hooks): the configured MCP server name, the tool to call on it, and the (arbitrary JSON) arguments, whose string values support `${path}` substitution from the hook input. Forwarded to Claude Code mcp_tool hooks.
+- `model` (optional, `prompt` / `agent` hooks): the model used for evaluation (defaults to a fast model). Forwarded to Claude Code prompt/agent hooks.
 
 Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -130,6 +130,9 @@ Example:
 - `failClosed` (optional): Boolean. When `true`, a hook failure (crash, timeout, invalid JSON) blocks the action instead of allowing it through. Passed through to Cursor's `.cursor/hooks.json` and to JetBrains Junie's `~/.junie/config.json` (as Junie's equivalently-named `blockOnError` flag).
 - `async` (optional): Boolean. When `true`, the hook command runs in the background without blocking. Forwarded to Qwen Code (`.qwen/settings.json`) and JetBrains Junie (`~/.junie/config.json`, same field name).
 - `shell` (optional): Either `"bash"` or `"powershell"` — the only two interpreter values any tool accepts. Forwarded to Qwen Code command hooks.
+- `url` / `headers` / `allowedEnvVars` (optional, `http` hooks): the POST target URL, request headers (values support `$VAR` interpolation), and the env-var allowlist for that interpolation. Forwarded to Claude Code and Qwen Code http hooks.
+- `server` / `tool` / `input` (optional, `mcp_tool` hooks): the configured MCP server name, the tool to call on it, and the (arbitrary JSON) arguments, whose string values support `${path}` substitution from the hook input. Forwarded to Claude Code mcp_tool hooks.
+- `model` (optional, `prompt` / `agent` hooks): the model used for evaluation (defaults to a fast model). Forwarded to Claude Code prompt/agent hooks.
 
 Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -73,6 +73,102 @@ describe("ClaudecodeHooks", () => {
       expect(parsed.hooks.afterFileEdit).toBeUndefined();
     });
 
+    it("should emit http/mcp_tool/agent hooks with their type-specific payload fields", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          postToolUse: [
+            {
+              type: "http",
+              url: "http://localhost:8080/hooks/post-use",
+              headers: { Authorization: "Bearer $MY_TOKEN" },
+              allowedEnvVars: ["MY_TOKEN"],
+              timeout: 10,
+              matcher: "Write|Edit",
+            },
+            {
+              type: "mcp_tool",
+              server: "my_server",
+              tool: "security_scan",
+              input: { file_path: "${tool_input.file_path}" },
+              matcher: "Write|Edit",
+            },
+            { type: "agent", prompt: "Review this change: $ARGUMENTS", model: "haiku" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      const groups = parsed.hooks.PostToolUse;
+      const allHooks = groups.flatMap((g: { hooks: Record<string, unknown>[] }) => g.hooks);
+      const httpHook = allHooks.find((h: { type?: string }) => h.type === "http");
+      expect(httpHook).toMatchObject({
+        url: "http://localhost:8080/hooks/post-use",
+        headers: { Authorization: "Bearer $MY_TOKEN" },
+        allowedEnvVars: ["MY_TOKEN"],
+        timeout: 10,
+      });
+      const mcpHook = allHooks.find((h: { type?: string }) => h.type === "mcp_tool");
+      expect(mcpHook).toMatchObject({
+        server: "my_server",
+        tool: "security_scan",
+        input: { file_path: "${tool_input.file_path}" },
+      });
+      const agentHook = allHooks.find((h: { type?: string }) => h.type === "agent");
+      expect(agentHook).toMatchObject({
+        prompt: "Review this change: $ARGUMENTS",
+        model: "haiku",
+      });
+    });
+
+    it("should not leak type-specific fields onto other hook types", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          // A command hook wrongly authored with http/mcp_tool payloads.
+          stop: [{ type: "command", command: "audit.sh", url: "https://example.com", server: "s" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      const hook = parsed.hooks.Stop[0].hooks[0];
+      expect(hook.command).toBe("audit.sh");
+      expect(hook.url).toBeUndefined();
+      expect(hook.server).toBeUndefined();
+    });
+
     it("should support the current documented Claude Code hook events (#1628)", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
@@ -445,6 +541,77 @@ describe("ClaudecodeHooks", () => {
       const rulesyncHooks = claudecodeHooks.toRulesyncHooks();
       const json = rulesyncHooks.getJson();
       expect(json.hooks.sessionStart?.[0]?.command).toBe("./scripts/format.sh --fix --quiet");
+    });
+
+    it("should preserve http/mcp_tool/agent hooks with their payload fields on import", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: "Write|Edit",
+                hooks: [
+                  {
+                    type: "http",
+                    url: "http://localhost:8080/hooks/post-use",
+                    headers: { Authorization: "Bearer $MY_TOKEN" },
+                    allowedEnvVars: ["MY_TOKEN"],
+                  },
+                  {
+                    type: "mcp_tool",
+                    server: "my_server",
+                    tool: "security_scan",
+                    input: { file_path: "${tool_input.file_path}" },
+                  },
+                  { type: "agent", prompt: "Review: $ARGUMENTS", model: "haiku" },
+                ],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = claudecodeHooks.toRulesyncHooks().getJson();
+      const defs = json.hooks.postToolUse ?? [];
+      expect(defs[0]).toMatchObject({
+        type: "http",
+        url: "http://localhost:8080/hooks/post-use",
+        headers: { Authorization: "Bearer $MY_TOKEN" },
+        allowedEnvVars: ["MY_TOKEN"],
+        matcher: "Write|Edit",
+      });
+      expect(defs[1]).toMatchObject({
+        type: "mcp_tool",
+        server: "my_server",
+        tool: "security_scan",
+        input: { file_path: "${tool_input.file_path}" },
+      });
+      expect(defs[2]).toMatchObject({
+        type: "agent",
+        prompt: "Review: $ARGUMENTS",
+        model: "haiku",
+      });
+    });
+
+    it("should coerce unknown hook types to command on import", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            Stop: [{ hooks: [{ type: "webhook", command: "audit.sh" }] }],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = claudecodeHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.stop?.[0]).toMatchObject({ type: "command", command: "audit.sh" });
     });
 
     it("should route unmapped native event names into the claudecode override block", () => {

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -50,10 +50,11 @@ const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   projectDirVar: "$CLAUDE_PROJECT_DIR",
   prefixDotRelativeCommandsOnly: true,
   noMatcherEvents: CLAUDE_NO_MATCHER_EVENTS,
-  // Claude Code also documents `http`/`mcp_tool`/`agent` hook handlers, but the
-  // shared converter only carries the command/prompt payload fields, so only
-  // those two round-trip faithfully today (tracked in issue #2231).
-  supportedHookTypes: new Set(["command", "prompt"]),
+  // All five documented Claude Code handler types round-trip faithfully:
+  // the shared converter carries each type's payload fields (`url`/`headers`/
+  // `allowedEnvVars` for http, `server`/`tool`/`input` for mcp_tool, `model`
+  // for prompt/agent). https://code.claude.com/docs/en/hooks
+  supportedHookTypes: new Set(["command", "prompt", "http", "mcp_tool", "agent"]),
 };
 
 export class ClaudecodeHooks extends ToolHooks {

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -55,6 +55,8 @@ const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   // `allowedEnvVars` for http, `server`/`tool`/`input` for mcp_tool, `model`
   // for prompt/agent). https://code.claude.com/docs/en/hooks
   supportedHookTypes: new Set(["command", "prompt", "http", "mcp_tool", "agent"]),
+  // Claude Code documents a per-hook `model` selector on prompt/agent hooks.
+  emitsPromptModel: true,
 };
 
 export class ClaudecodeHooks extends ToolHooks {

--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -383,6 +383,36 @@ describe("FactorydroidHooks", () => {
       expect(hookDef.prompt).toBe("Check this tool call");
       expect(hookDef.timeout).toBe(30000);
     });
+
+    it("should not emit the canonical model field (undocumented for Factory Droid)", async () => {
+      await ensureDir(join(testDir, ".factory"));
+      await writeFileContent(join(testDir, ".factory", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [{ type: "prompt", prompt: "Check this tool call", model: "haiku" }],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(factorydroidHooks.getFileContent());
+      const hookDef = parsed.hooks.PreToolUse[0].hooks[0];
+      expect(hookDef.prompt).toBe("Check this tool call");
+      expect(hookDef.model).toBeUndefined();
+    });
   });
 
   describe("toRulesyncHooks", () => {

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -174,7 +174,9 @@ export const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFac
         supportsImport: true,
       },
       supportedEvents: CLAUDE_HOOK_EVENTS,
-      supportedHookTypes: ["command", "prompt"],
+      // All five documented handler types are emitted faithfully with their
+      // type-specific payload fields. https://code.claude.com/docs/en/hooks
+      supportedHookTypes: ["command", "prompt", "http", "mcp_tool", "agent"],
       supportsMatcher: true,
     },
   ],

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -44,6 +44,13 @@ export type ToolHooksConverterConfig = {
    */
   prefixDotRelativeCommandsOnly?: boolean;
   /**
+   * When true, prompt/agent hooks emit the canonical `model` field. Only tools
+   * that document a per-hook model selector (Claude Code) should opt in —
+   * other prompt-capable tools (Factory Droid, Devin) do not document the
+   * field, so it must not leak into their generated configs.
+   */
+  emitsPromptModel?: boolean;
+  /**
    * Events that do not support the `matcher` field. Any matcher defined on these events
    * will be silently dropped with a warning during export.
    */
@@ -163,9 +170,11 @@ function importBooleanPassthroughFields({
 function emitTypePayloadFields({
   def,
   hookType,
+  converterConfig,
 }: {
   def: HooksConfig["hooks"][string][number];
   hookType: HookType;
+  converterConfig: ToolHooksConverterConfig;
 }): Record<string, unknown> {
   if (hookType === "http") {
     return compact({ url: def.url, headers: def.headers, allowedEnvVars: def.allowedEnvVars });
@@ -173,7 +182,7 @@ function emitTypePayloadFields({
   if (hookType === "mcp_tool") {
     return compact({ server: def.server, tool: def.tool, input: def.input });
   }
-  if (hookType === "prompt" || hookType === "agent") {
+  if ((hookType === "prompt" || hookType === "agent") && converterConfig.emitsPromptModel) {
     return compact({ model: def.model });
   }
   return {};
@@ -209,7 +218,7 @@ function buildToolHooks({
       // Type-specific payload fields (https://code.claude.com/docs/en/hooks).
       // Gated per type so e.g. an `url` authored on a command hook never
       // leaks into the generated config.
-      ...emitTypePayloadFields({ def, hookType }),
+      ...emitTypePayloadFields({ def, hookType, converterConfig }),
       ...(converterConfig.passthroughFields?.includes("name") &&
         def.name !== undefined &&
         def.name !== null && { name: def.name }),
@@ -305,9 +314,6 @@ function stripCommandPrefix({
 }
 
 /**
- * Convert a single tool hook record into a canonical hook definition.
- */
-/**
  * Hook types preserved verbatim on import — Claude Code's five documented
  * handler types. Anything else is coerced to `command` as before.
  * https://code.claude.com/docs/en/hooks
@@ -360,6 +366,9 @@ function importTypePayloadFields({
   return {};
 }
 
+/**
+ * Convert a single tool hook record into a canonical hook definition.
+ */
 function toolHookToCanonical({
   h,
   rawEntry,

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -1,5 +1,6 @@
 import { type HookEvent, type HookType, type HooksConfig, isHookEvent } from "../../types/hooks.js";
 import type { Logger } from "../../utils/logger.js";
+import { compact } from "../../utils/object.js";
 
 type ToolMatcherEntry = {
   matcher?: string;
@@ -155,6 +156,30 @@ function importBooleanPassthroughFields({
 }
 
 /**
+ * Emit the payload fields specific to a hook type — `url`/`headers`/
+ * `allowedEnvVars` for http, `server`/`tool`/`input` for mcp_tool, `model`
+ * for prompt/agent. https://code.claude.com/docs/en/hooks
+ */
+function emitTypePayloadFields({
+  def,
+  hookType,
+}: {
+  def: HooksConfig["hooks"][string][number];
+  hookType: HookType;
+}): Record<string, unknown> {
+  if (hookType === "http") {
+    return compact({ url: def.url, headers: def.headers, allowedEnvVars: def.allowedEnvVars });
+  }
+  if (hookType === "mcp_tool") {
+    return compact({ server: def.server, tool: def.tool, input: def.input });
+  }
+  if (hookType === "prompt" || hookType === "agent") {
+    return compact({ model: def.model });
+  }
+  return {};
+}
+
+/**
  * Convert the definitions of a single matcher group into tool hook entries,
  * honoring supported hook types and passthrough fields.
  */
@@ -181,6 +206,10 @@ function buildToolHooks({
       ...(command !== undefined && command !== null && { command }),
       ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
       ...(def.prompt !== undefined && def.prompt !== null && { prompt: def.prompt }),
+      // Type-specific payload fields (https://code.claude.com/docs/en/hooks).
+      // Gated per type so e.g. an `url` authored on a command hook never
+      // leaks into the generated config.
+      ...emitTypePayloadFields({ def, hookType }),
       ...(converterConfig.passthroughFields?.includes("name") &&
         def.name !== undefined &&
         def.name !== null && { name: def.name }),
@@ -278,6 +307,59 @@ function stripCommandPrefix({
 /**
  * Convert a single tool hook record into a canonical hook definition.
  */
+/**
+ * Hook types preserved verbatim on import — Claude Code's five documented
+ * handler types. Anything else is coerced to `command` as before.
+ * https://code.claude.com/docs/en/hooks
+ */
+const IMPORTED_HOOK_TYPES = new Set<HookType>(["command", "prompt", "http", "mcp_tool", "agent"]);
+
+function isImportedHookType(value: unknown): value is HookType {
+  return typeof value === "string" && IMPORTED_HOOK_TYPES.has(value as HookType);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every((v) => typeof v === "string");
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Import the payload fields specific to a hook type, type-checking each raw
+ * value before it enters the canonical definition.
+ */
+function importTypePayloadFields({
+  h,
+  hookType,
+}: {
+  h: Record<string, unknown>;
+  hookType: HookType;
+}): Partial<HooksConfig["hooks"][string][number]> {
+  if (hookType === "http") {
+    return {
+      ...(typeof h.url === "string" && { url: h.url }),
+      ...(isStringRecord(h.headers) && { headers: h.headers }),
+      ...(isStringArray(h.allowedEnvVars) && { allowedEnvVars: h.allowedEnvVars }),
+    };
+  }
+  if (hookType === "mcp_tool") {
+    return {
+      ...(typeof h.server === "string" && { server: h.server }),
+      ...(typeof h.tool === "string" && { tool: h.tool }),
+      ...(h.input !== null &&
+        typeof h.input === "object" &&
+        !Array.isArray(h.input) && { input: h.input as Record<string, unknown> }),
+    };
+  }
+  if (hookType === "prompt" || hookType === "agent") {
+    return typeof h.model === "string" ? { model: h.model } : {};
+  }
+  return {};
+}
+
 function toolHookToCanonical({
   h,
   rawEntry,
@@ -288,7 +370,7 @@ function toolHookToCanonical({
   converterConfig: ToolHooksConverterConfig;
 }): HooksConfig["hooks"][string][number] {
   const command = stripCommandPrefix({ command: h.command, converterConfig });
-  const hookType = h.type === "command" || h.type === "prompt" ? h.type : "command";
+  const hookType = isImportedHookType(h.type) ? h.type : "command";
   const timeout = typeof h.timeout === "number" ? h.timeout : undefined;
   const prompt = typeof h.prompt === "string" ? h.prompt : undefined;
   return {
@@ -296,6 +378,10 @@ function toolHookToCanonical({
     ...(command !== undefined && command !== null && { command }),
     ...(timeout !== undefined && timeout !== null && { timeout }),
     ...(prompt !== undefined && prompt !== null && { prompt }),
+    // Type-specific payload fields, preserved so http/mcp_tool/agent hooks
+    // found in an existing settings file round-trip instead of silently
+    // degrading to broken command hooks.
+    ...importTypePayloadFields({ h, hookType }),
     ...(converterConfig.passthroughFields?.includes("name") &&
       typeof h.name === "string" && { name: h.name }),
     ...(converterConfig.passthroughFields?.includes("description") &&

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -88,8 +88,9 @@ export const HookDefinitionSchema = z.looseObject({
   server: z.optional(safeString),
   tool: z.optional(safeString),
   input: z.optional(z.looseObject({})),
-  // Claude Code / Qwen Code `prompt` and `agent` hooks: the model used for
-  // evaluation (defaults to a fast model when omitted).
+  // Claude Code `prompt` and `agent` hooks: the model used for evaluation
+  // (defaults to a fast model when omitted). Qwen Code documents the same
+  // field on prompt hooks, but the qwencode adapter does not forward it yet.
   model: z.optional(safeString),
 });
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -81,6 +81,16 @@ export const HookDefinitionSchema = z.looseObject({
   headers: z.optional(z.record(z.string(), safeString)),
   allowedEnvVars: z.optional(z.array(z.string())),
   once: z.optional(z.boolean()),
+  // Claude Code `mcp_tool` hooks: `server` names a configured MCP server,
+  // `tool` the tool to call on it, and `input` the (arbitrary JSON) arguments
+  // passed to the tool, whose string values support `${path}` substitution.
+  // https://code.claude.com/docs/en/hooks
+  server: z.optional(safeString),
+  tool: z.optional(safeString),
+  input: z.optional(z.looseObject({})),
+  // Claude Code / Qwen Code `prompt` and `agent` hooks: the model used for
+  // evaluation (defaults to a fast model when omitted).
+  model: z.optional(safeString),
 });
 
 export type HookDefinition = z.infer<typeof HookDefinitionSchema>;


### PR DESCRIPTION
## Summary

Claude Code documents five hook handler types — `command`, `http`, `mcp_tool`, `prompt`, `agent` ([hooks reference](https://code.claude.com/docs/en/hooks)) — but rulesync only round-tripped `command` and `prompt` faithfully. Authoring an `http` hook for `claudecode` dropped its `url`/`headers`, and importing an existing `.claude/settings.json` silently rewrote `http`/`mcp_tool`/`agent` hooks to broken `command` hooks (data loss).

The canonical `type` enum was already widened to include `agent`/`mcp_tool` in #2278, which resolved the design blocker recorded in the issue comments; this PR wires the per-type payload fields through the Claude converter.

## Changes

- **Canonical schema** (`src/types/hooks.ts`): added `server` / `tool` / `input` (mcp_tool hooks) and `model` (prompt/agent hooks), verified verbatim against the Claude Code hooks reference. The http fields (`url`, `headers`, `allowedEnvVars`) were already canonical from the Qwen Code work.
- **Shared converter** (`tool-hooks-converter.ts`):
  - `buildToolHooks` emits each type's payload fields via a new `emitTypePayloadFields` helper, gated per type so a field authored on the wrong hook type never leaks into generated configs.
  - `toolHookToCanonical` preserves all five documented types on import (unknown types still coerce to `command`) and imports the payload fields with per-field type checks (`importTypePayloadFields`).
- **Claude Code target**: `supportedHookTypes` is now `command | prompt | http | mcp_tool | agent` in both the converter config and the processor entry, so these hooks are emitted instead of being filtered with a warning.
- **Docs**: the hook entry keys reference in `docs/reference/file-formats.md` documents the new fields (synced to `skills/rulesync/`).
- **Tests**: generation asserts http/mcp_tool/agent hooks carry their payloads and that fields never leak across types; import asserts the three types round-trip with payloads intact and unknown types still coerce to `command`.

Other shared-converter tools are unaffected: their `supportedHookTypes` filters still exclude these types before emission.

Closes #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code)