### PR TITLE
feat: fall back to a stable hash name for non-representable Codex MCP server names

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -696,6 +696,8 @@ You can control which individual tools from an MCP server are enabled or disable
 
 > **Qwen Code note:** MCP servers are written to the `mcpServers` key of `.qwen/settings.json` (project) / `~/.qwen/settings.json` (global, via `--global`). Qwen supports stdio (`command`/`args`), SSE (`url`), and HTTP (`httpUrl`) transports. Rulesync maps the canonical per-server `enabledTools` ⇄ Qwen's `includeTools` (allowlist) and `disabledTools` ⇄ Qwen's `excludeTools` (denylist). Other top-level keys in `settings.json` are preserved on round-trip.
 
+> **Codex CLI server-name note:** Codex requires MCP server names matching `[a-zA-Z0-9_-]+`, so Rulesync auto-normalizes non-conforming names on generate (lowercase, runs of other characters become `_`, leading/trailing `_` trimmed) — e.g. `Postgres MCP - Production - Read Only` becomes `postgres_mcp_production_read_only`. If two names normalize to the same Codex name, the last processed server overwrites the earlier one (with a warning). A name with no representable characters at all (e.g. a fully Japanese name) falls back to a stable hash-derived name like `mcp_1a2b3c4d` instead of being dropped; rename the server in `.rulesync/mcp.json` to pick a readable Codex name. This normalization is one-way: importing back from the generated `config.toml` yields the normalized name, not the original.
+
 ### Codex-specific: pass shell env vars to MCP servers (`envVars`)
 
 Codex CLI supports a per-server array of shell env var names to inherit when launching the MCP server process. The source schema uses `envVars` (camelCase, matching the project convention used by sibling fields like `enabledTools`/`disabledTools`); the codex generator renames it to `env_vars` (snake_case) for codex's native `config.toml` format.

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -696,6 +696,8 @@ You can control which individual tools from an MCP server are enabled or disable
 
 > **Qwen Code note:** MCP servers are written to the `mcpServers` key of `.qwen/settings.json` (project) / `~/.qwen/settings.json` (global, via `--global`). Qwen supports stdio (`command`/`args`), SSE (`url`), and HTTP (`httpUrl`) transports. Rulesync maps the canonical per-server `enabledTools` ⇄ Qwen's `includeTools` (allowlist) and `disabledTools` ⇄ Qwen's `excludeTools` (denylist). Other top-level keys in `settings.json` are preserved on round-trip.
 
+> **Codex CLI server-name note:** Codex requires MCP server names matching `[a-zA-Z0-9_-]+`, so Rulesync auto-normalizes non-conforming names on generate (lowercase, runs of other characters become `_`, leading/trailing `_` trimmed) — e.g. `Postgres MCP - Production - Read Only` becomes `postgres_mcp_production_read_only`. If two names normalize to the same Codex name, the last processed server overwrites the earlier one (with a warning). A name with no representable characters at all (e.g. a fully Japanese name) falls back to a stable hash-derived name like `mcp_1a2b3c4d` instead of being dropped; rename the server in `.rulesync/mcp.json` to pick a readable Codex name. This normalization is one-way: importing back from the generated `config.toml` yields the normalized name, not the original.
+
 ### Codex-specific: pass shell env vars to MCP servers (`envVars`)
 
 Codex CLI supports a per-server array of shell env var names to inherit when launching the MCP server process. The source schema uses `envVars` (camelCase, matching the project convention used by sibling fields like `enabledTools`/`disabledTools`); the codex generator renames it to `env_vars` (snake_case) for codex's native `config.toml` format.

--- a/src/features/mcp/codexcli-mcp.test.ts
+++ b/src/features/mcp/codexcli-mcp.test.ts
@@ -350,7 +350,6 @@ args = ["server.js"]
             "Postgres MCP - Production - Read Only": { command: "node" },
             "My Server": { command: "first" },
             my_server: { command: "second" },
-            "constructor!": { command: "safe" },
             "already-valid": { command: "unchanged" },
           },
         }),
@@ -367,10 +366,39 @@ args = ["server.js"]
         "already-valid": { command: "unchanged" },
       });
       expect(warnSpy).toHaveBeenCalledWith(
-        'MCP server "constructor!" could not be normalized to a valid Codex MCP server name and was skipped.',
+        'Codex MCP server name collision: "My Server" and "my_server" both normalize to "my_server"; "my_server" (processed last) overwrites "My Server".',
       );
+    });
+
+    it("should keep non-representable server names via a stable hash fallback instead of dropping them", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({
+          mcpServers: {
+            // Fully non-ASCII: normalizes to an empty string.
+            日本語サーバー: { command: "node", args: ["jp.js"] },
+            // Pure symbols: normalizes to an empty string.
+            "!!!": { command: "node", args: ["bang.js"] },
+            // Normalizes to the prototype-pollution key "constructor".
+            "constructor!": { command: "safe" },
+          },
+        }),
+      });
+
+      const codexcliMcp = await CodexcliMcp.fromRulesyncMcp({
+        outputRoot: testDir,
+        rulesyncMcp,
+      });
+
+      expect(codexcliMcp.getToml().mcp_servers).toEqual({
+        mcp_e212d0c9: { command: "node", args: ["jp.js"] },
+        mcp_e84c538e: { command: "node", args: ["bang.js"] },
+        mcp_f3634b38: { command: "safe" },
+      });
       expect(warnSpy).toHaveBeenCalledWith(
-        'Codex MCP server name collision: "My Server" and "my_server" both normalize to "my_server". Only the last processed server will be used.',
+        'MCP server "日本語サーバー" cannot be represented as a Codex MCP server name (ASCII [a-zA-Z0-9_-] only), so the stable fallback name "mcp_e212d0c9" was used. Rename the server in .rulesync/mcp.json to choose a readable Codex name.',
       );
     });
 

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -141,6 +141,7 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   const originalNames = new Map<string, string>();
 
   for (const [name, config] of Object.entries(mcpServers)) {
+    if (!isRecord(config)) continue;
     const { codexName, usedFallback } = normalizeCodexMcpServerName(name);
     if (usedFallback) {
       warnWithFallback(
@@ -148,7 +149,6 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
         `MCP server "${name}" cannot be represented as a Codex MCP server name (ASCII [a-zA-Z0-9_-] only), so the stable fallback name "${codexName}" was used. Rename the server in .rulesync/mcp.json to choose a readable Codex name.`,
       );
     }
-    if (!isRecord(config)) continue;
     const converted: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config)) {
       if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;

--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import * as smolToml from "smol-toml";
@@ -78,16 +79,26 @@ function mapOauthFromCodex(oauth: Record<string, unknown>): Record<string, unkno
 
 const CODEX_MCP_SERVER_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
-function normalizeCodexMcpServerName(name: string): string | null {
-  if (PROTOTYPE_POLLUTION_KEYS.has(name)) return null;
-  if (CODEX_MCP_SERVER_NAME_PATTERN.test(name)) return name;
+function normalizeCodexMcpServerName(name: string): { codexName: string; usedFallback: boolean } {
+  if (!PROTOTYPE_POLLUTION_KEYS.has(name) && CODEX_MCP_SERVER_NAME_PATTERN.test(name)) {
+    return { codexName: name, usedFallback: false };
+  }
 
   const normalizedName = name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
 
-  return normalizedName && !PROTOTYPE_POLLUTION_KEYS.has(normalizedName) ? normalizedName : null;
+  if (normalizedName && !PROTOTYPE_POLLUTION_KEYS.has(normalizedName)) {
+    return { codexName: normalizedName, usedFallback: false };
+  }
+
+  // Names with no ASCII-representable characters at all (e.g. a fully
+  // Japanese name like 日本語サーバー) or that normalize to a
+  // prototype-pollution key fall back to a stable hash-derived name instead
+  // of being dropped, so the server still reaches the Codex config.
+  const hash = createHash("sha256").update(name).digest("hex").slice(0, 8);
+  return { codexName: `mcp_${hash}`, usedFallback: true };
 }
 
 function convertFromCodexFormat(codexMcp: Record<string, unknown>): McpServers {
@@ -130,13 +141,12 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
   const originalNames = new Map<string, string>();
 
   for (const [name, config] of Object.entries(mcpServers)) {
-    const codexName = normalizeCodexMcpServerName(name);
-    if (codexName === null) {
+    const { codexName, usedFallback } = normalizeCodexMcpServerName(name);
+    if (usedFallback) {
       warnWithFallback(
         undefined,
-        `MCP server "${name}" could not be normalized to a valid Codex MCP server name and was skipped.`,
+        `MCP server "${name}" cannot be represented as a Codex MCP server name (ASCII [a-zA-Z0-9_-] only), so the stable fallback name "${codexName}" was used. Rename the server in .rulesync/mcp.json to choose a readable Codex name.`,
       );
-      continue;
     }
     if (!isRecord(config)) continue;
     const converted: Record<string, unknown> = {};
@@ -167,9 +177,12 @@ function convertToCodexFormat(mcpServers: McpServers): Record<string, unknown> {
 
     const previousName = originalNames.get(codexName);
     if (previousName !== undefined) {
+      // Worded as an overwrite (not "will be used") because the surviving
+      // entry can still be dropped later by removeEmptyEntries when its
+      // config is empty — in that case its own dropped-entry warning fires.
       warnWithFallback(
         undefined,
-        `Codex MCP server name collision: "${previousName}" and "${name}" both normalize to "${codexName}". Only the last processed server will be used.`,
+        `Codex MCP server name collision: "${previousName}" and "${name}" both normalize to "${codexName}"; "${name}" (processed last) overwrites "${previousName}".`,
       );
     }
     originalNames.set(codexName, name);


### PR DESCRIPTION
## Summary

Follow-ups from PR #2217's Codex MCP server-name normalization, resolving all findings recorded in the issue.

## Changes

- **F1 (fallback strategy — the design decision the issue was held open for):** a server name with no ASCII-representable characters at all (e.g. a fully Japanese name like `日本語サーバー`) or that normalizes to a prototype-pollution key now falls back to a **stable sha256-derived name** (`mcp_<hash8>`) instead of the whole server being silently dropped. The issue itself identified the hash-suffix fallback as the most user-friendly option, and it matters for this project's primary Japanese audience. The warning tells the user which fallback name was used and to rename the source server for a readable Codex name.
- **F3:** the collision warning is reworded from "Only the last processed server will be used" to an overwrite statement (`"Y" (processed last) overwrites "X"`), which stays accurate even when `removeEmptyEntries` later drops the surviving entry — that path fires its own dropped-entry warning.
- **F4:** tests now cover the empty-normalization paths directly (fully non-ASCII name, pure-symbol `!!!`) plus the pollution-key path (`constructor!`), asserting the stable fallback names and the warning.
- **F2 + F5:** `docs/reference/file-formats.md` gains a Codex CLI server-name note documenting the auto-normalization rules, collision last-wins behavior, hash fallback, and the one-way (non-reversible) round-trip (synced to `skills/rulesync/`).

Closes #2219

🤖 Generated with [Claude Code](https://claude.com/claude-code)