### PR TITLE
docs: correct stale Hermes Agent rule comment for progressive subdirectory discovery

### DIFF
--- a/src/features/rules/hermesagent-rule.ts
+++ b/src/features/rules/hermesagent-rule.ts
@@ -19,16 +19,24 @@ export type HermesagentRuleParams = AiFileParams & {
 /**
  * Rule generator for Hermes Agent.
  *
- * Hermes Agent auto-injects the project-root `.hermes.md` file into its system
- * prompt. It reads only this single root instruction file; there is no project
- * subdirectory of rule files and no documented user-level rules file (the global
- * `~/.hermes/SOUL.md` is an agent-identity slot, not user instructions). Rules
- * are therefore project-scope only.
+ * Hermes Agent auto-injects the project-root context file into its system
+ * prompt (root priority: `.hermes.md` → `HERMES.md` → `AGENTS.md` →
+ * `CLAUDE.md` → `.cursorrules`). Since the progressive subdirectory hint
+ * discovery feature (hermes-agent #5291), it also reads nested
+ * `AGENTS.md`/`CLAUDE.md`/`.cursorrules` files as it navigates directories
+ * (`.hermes.md` stays root-only). There is no documented user-level rules
+ * file (the global `~/.hermes/SOUL.md` is an agent-identity slot, not user
+ * instructions), so rules are project-scope only.
+ * @see https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/context-files.md
  *
- * rulesync's topic-based non-root rules have no project subdirectory to map onto,
- * so their bodies are folded into the single root `.hermes.md` by the
- * RulesProcessor; there is no separate non-root output location (`nonRoot` is
- * `undefined`). This mirrors the grokcli / warp / deepagents targets.
+ * rulesync deliberately does NOT emit nested per-directory files for that
+ * discovery: rulesync's non-root rules are topic-based (globs/description)
+ * and carry no target-directory placement, so mapping them onto nested
+ * `AGENTS.md` files would require inventing placement semantics no other
+ * adapter has. Their bodies are instead folded into the single root
+ * `.hermes.md` by the RulesProcessor; there is no separate non-root output
+ * location (`nonRoot` is `undefined`). This mirrors the grokcli / warp /
+ * deepagents targets (decision recorded in issue #2214).
  */
 export type HermesagentRuleSettablePaths = Pick<ToolRuleSettablePaths, "root"> & {
   root: {


### PR DESCRIPTION
## Summary

Hermes Agent added progressive subdirectory context-file discovery (hermes-agent #5291): it now reads nested `AGENTS.md`/`CLAUDE.md`/`.cursorrules` files as it navigates directories (`.hermes.md` stays root-only), per the [context-files docs](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/context-files.md). The doc comment in `src/features/rules/hermesagent-rule.ts` claimed "there is no project subdirectory of rule files", which is no longer accurate.

## Changes

- Correct the comment to describe the current upstream surface (root priority chain + nested discovery).
- Record the scoping decision the issue was held open for: rulesync **deliberately keeps folding non-root rules into the single root `.hermes.md`** rather than emitting nested per-directory `AGENTS.md` files. rulesync's non-root rules are topic-based (globs/description) and carry no target-directory placement semantics, so nested emission would require inventing a placement model that no adapter in the AGENTS.md family (grokcli / warp / deepagents) has. If a directory-placement model is ever added for the whole family, Hermes can join it.

Comment-only change; no behavior difference.

Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)