### PR TITLE
docs: record why goose global rules do not emit ~/.agents/AGENTS.md

### DIFF
--- a/src/features/rules/goose-rule.ts
+++ b/src/features/rules/goose-rule.ts
@@ -43,6 +43,15 @@ export type GooseRuleSettablePathsGlobal = ToolRuleSettablePathsGlobal;
  * is `undefined`). This mirrors the grokcli, warp, and deepagents targets.
  *
  * Goose uses plain markdown files (.goosehints) without frontmatter.
+ *
+ * Global scope emits only `~/.config/goose/.goosehints`. Goose v1.41.0 (PR
+ * block/goose#9736) additionally loads the vendor-neutral
+ * `~/.agents/AGENTS.md` alongside the config-dir hints, but rulesync
+ * deliberately does not emit that shared path from the goose target: the
+ * config-dir hints remain fully loaded (no capability loss), and the
+ * cross-tool `~/.agents/AGENTS.md` is already written by targets that own it
+ * (e.g. cline in global mode) — a second writer would need cross-target
+ * shared-file coordination for zero gain (decision recorded in issue #2207).
  */
 export class GooseRule extends ToolRule {
   static getSettablePaths({


### PR DESCRIPTION
## Summary

Goose v1.41.0 ([block/goose#9736](https://github.com/block/goose/pull/9736)) additionally loads the vendor-neutral `~/.agents/AGENTS.md` global hints alongside the existing config-dir hints. Issue #2207 framed the follow-up as an explicit Option A (also emit the shared path from the goose target) / Option B (document that the surface is already covered) decision.

This resolves it as **Option B**, recorded as a comment in `goose-rule.ts`:

- Goose's own `~/.config/goose/.goosehints` remains fully loaded — there is no capability loss today (the issue itself confirms "nothing breaks").
- The cross-tool `~/.agents/AGENTS.md` is already written by the targets that own it (e.g. `cline` in global mode). Making `goose` a second writer of a shared global file would require cross-target shared-file coordination (the same class of problem the antigravity targets needed shared-file keys for) for zero capability gain.

Comment-only change; no behavior difference.

Closes #2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)