### PR TITLE
chore: release v13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "12.0.0";
+const getVersion = () => "13.0.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v13.0.0.

See the draft release notes for the full changelog: https://github.com/dyoshikawa/rulesync/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)