### PR TITLE
feat(hooks): propagate Claude Code hook `if` conditions

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -146,6 +146,7 @@ Example:
 - `url` / `headers` / `allowedEnvVars` (optional, `http` hooks): the POST target URL, request headers (values support `$VAR` interpolation), and the env-var allowlist for that interpolation. Forwarded to Claude Code and Qwen Code http hooks.
 - `server` / `tool` / `input` (optional, `mcp_tool` hooks): the configured MCP server name, the tool to call on it, and the (arbitrary JSON) arguments, whose string values support `${path}` substitution from the hook input. Forwarded to Claude Code mcp_tool hooks.
 - `model` (optional, `prompt` / `agent` hooks): the model used for evaluation (defaults to a fast model). Forwarded to Claude Code prompt/agent hooks.
+- `if` (optional): a single permission rule (same syntax as `settings.json` permission rules, e.g. `"Bash(rm *)"`) that filters a hook by tool arguments in addition to the tool name. Forwarded to Claude Code, where it is evaluated only on tool events (`preToolUse`, `postToolUse`, `postToolUseFailure`, `permissionRequest`, `permissionDenied`); it round-trips as an opaque string.
 
 Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -146,6 +146,7 @@ Example:
 - `url` / `headers` / `allowedEnvVars` (optional, `http` hooks): the POST target URL, request headers (values support `$VAR` interpolation), and the env-var allowlist for that interpolation. Forwarded to Claude Code and Qwen Code http hooks.
 - `server` / `tool` / `input` (optional, `mcp_tool` hooks): the configured MCP server name, the tool to call on it, and the (arbitrary JSON) arguments, whose string values support `${path}` substitution from the hook input. Forwarded to Claude Code mcp_tool hooks.
 - `model` (optional, `prompt` / `agent` hooks): the model used for evaluation (defaults to a fast model). Forwarded to Claude Code prompt/agent hooks.
+- `if` (optional): a single permission rule (same syntax as `settings.json` permission rules, e.g. `"Bash(rm *)"`) that filters a hook by tool arguments in addition to the tool name. Forwarded to Claude Code, where it is evaluated only on tool events (`preToolUse`, `postToolUse`, `postToolUseFailure`, `permissionRequest`, `permissionDenied`); it round-trips as an opaque string.
 
 Top-level `hooks` keys must be canonical event names; unknown event names are rejected at parse time. Tool-specific override blocks (e.g. `kiro-ide.hooks`) additionally accept tool-native event keys, which pass through verbatim.
 

--- a/src/features/hooks/claudecode-hooks.test.ts
+++ b/src/features/hooks/claudecode-hooks.test.ts
@@ -137,6 +137,43 @@ describe("ClaudecodeHooks", () => {
       });
     });
 
+    it("should emit the tool-event `if` condition on generate (#2225)", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            {
+              type: "command",
+              command: "block-rm.sh",
+              matcher: "Bash",
+              if: "Bash(rm *)",
+            },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const claudecodeHooks = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(claudecodeHooks.getFileContent());
+      const hook = parsed.hooks.PreToolUse[0].hooks[0];
+      expect(hook.if).toBe("Bash(rm *)");
+      expect(hook.command).toBe("block-rm.sh");
+    });
+
     it("should not leak type-specific fields onto other hook types", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
@@ -494,6 +531,67 @@ describe("ClaudecodeHooks", () => {
       expect(json.hooks.sessionStart).toHaveLength(1);
       expect(json.hooks.sessionStart?.[0]?.command).toContain("echo.sh");
       expect(json.hooks.stop).toHaveLength(1);
+    });
+
+    it("should read the tool-event `if` condition back on import (#2225)", () => {
+      const claudecodeHooks = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "Bash",
+                hooks: [{ type: "command", command: "block-rm.sh", if: "Bash(rm *)" }],
+              },
+            ],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = claudecodeHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.preToolUse?.[0]?.if).toBe("Bash(rm *)");
+      expect(json.hooks.preToolUse?.[0]?.matcher).toBe("Bash");
+    });
+
+    it("should round-trip the tool-event `if` condition through generate then import (#2225)", async () => {
+      await ensureDir(join(testDir, ".claude"));
+      await writeFileContent(join(testDir, ".claude", "settings.json"), JSON.stringify({}));
+
+      const config = {
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", command: "block-rm.sh", matcher: "Bash", if: "Bash(rm *)" },
+          ],
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const generated = await ClaudecodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const reimported = new ClaudecodeHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".claude",
+        relativeFilePath: "settings.json",
+        fileContent: generated.getFileContent(),
+        validate: false,
+      });
+
+      const json = reimported.toRulesyncHooks().getJson();
+      expect(json.hooks.preToolUse?.[0]?.if).toBe("Bash(rm *)");
     });
 
     it("should strip the quoted $CLAUDE_PROJECT_DIR prefix back to a ./-relative command", () => {

--- a/src/features/hooks/claudecode-hooks.ts
+++ b/src/features/hooks/claudecode-hooks.ts
@@ -57,6 +57,10 @@ const CLAUDE_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   supportedHookTypes: new Set(["command", "prompt", "http", "mcp_tool", "agent"]),
   // Claude Code documents a per-hook `model` selector on prompt/agent hooks.
   emitsPromptModel: true,
+  // Claude Code's tool-event `if` condition (a single permission rule) is
+  // Claude-Code-specific and round-trips as an opaque string.
+  // https://code.claude.com/docs/en/hooks
+  stringPassthroughFields: [{ canonical: "if", tool: "if" }],
 };
 
 export class ClaudecodeHooks extends ToolHooks {

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -256,10 +256,11 @@ function buildToolHooks({
     }
     const command = applyCommandPrefix({ def, converterConfig });
     hooks.push({
-      // Spread the boolean passthrough fields first so the explicitly-handled
-      // core fields below always win: a misconfigured `tool` name (e.g. mapping
-      // onto "type"/"command") can never silently shadow them.
+      // Spread the boolean and string passthrough fields first so the
+      // explicitly-handled core fields below always win: a misconfigured `tool`
+      // name (e.g. mapping onto "type"/"command") can never silently shadow them.
       ...emitBooleanPassthroughFields({ def, converterConfig }),
+      ...emitStringPassthroughFields({ def, converterConfig }),
       type: hookType,
       ...(command !== undefined && command !== null && { command }),
       ...(def.timeout !== undefined && def.timeout !== null && { timeout: def.timeout }),
@@ -274,8 +275,6 @@ function buildToolHooks({
       ...(converterConfig.passthroughFields?.includes("description") &&
         def.description !== undefined &&
         def.description !== null && { description: def.description }),
-      // Tool-specific opaque string fields (e.g. Claude Code's `if` condition).
-      ...emitStringPassthroughFields({ def, converterConfig }),
     });
   }
   return hooks;

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -39,6 +39,17 @@ export type ToolHooksConverterConfig = {
     readonly tool: string;
   }>;
   /**
+   * Per-hook string fields to carry through the round-trip, each mapping a
+   * canonical {@link HookDefinitionSchema} string field to its tool-side field
+   * name. Only non-empty string values are emitted on export and imported back;
+   * any other value is ignored so a malformed field can't leak through. Used
+   * for tool-specific opaque strings such as Claude Code's `if` condition.
+   */
+  stringPassthroughFields?: ReadonlyArray<{
+    readonly canonical: "if";
+    readonly tool: string;
+  }>;
+  /**
    * When true, only dot-relative commands (e.g. ./script.sh, ../script.sh, .rulesync/hooks/x.sh)
    * are prefixed with projectDirVar. Bare executable commands like `npx prettier ...` are left intact.
    */
@@ -163,6 +174,44 @@ function importBooleanPassthroughFields({
 }
 
 /**
+ * Emit the configured string passthrough fields on the tool side, mapping each
+ * canonical field name to its (possibly renamed) tool field name. Only non-empty
+ * string values are carried through.
+ */
+function emitStringPassthroughFields({
+  def,
+  converterConfig,
+}: {
+  def: HooksConfig["hooks"][string][number];
+  converterConfig: ToolHooksConverterConfig;
+}): Record<string, string> {
+  return Object.fromEntries(
+    (converterConfig.stringPassthroughFields ?? [])
+      .filter(({ canonical }) => typeof def[canonical] === "string" && def[canonical] !== "")
+      .map(({ canonical, tool }) => [tool, def[canonical] as string]),
+  );
+}
+
+/**
+ * Import the configured string passthrough fields back into canonical fields,
+ * reversing {@link emitStringPassthroughFields}. Only non-empty string values
+ * are read.
+ */
+function importStringPassthroughFields({
+  h,
+  converterConfig,
+}: {
+  h: Record<string, unknown>;
+  converterConfig: ToolHooksConverterConfig;
+}): Record<string, string> {
+  return Object.fromEntries(
+    (converterConfig.stringPassthroughFields ?? [])
+      .filter(({ tool }) => typeof h[tool] === "string" && h[tool] !== "")
+      .map(({ canonical, tool }) => [canonical, h[tool] as string]),
+  );
+}
+
+/**
  * Emit the payload fields specific to a hook type — `url`/`headers`/
  * `allowedEnvVars` for http, `server`/`tool`/`input` for mcp_tool, `model`
  * for prompt/agent. https://code.claude.com/docs/en/hooks
@@ -225,6 +274,8 @@ function buildToolHooks({
       ...(converterConfig.passthroughFields?.includes("description") &&
         def.description !== undefined &&
         def.description !== null && { description: def.description }),
+      // Tool-specific opaque string fields (e.g. Claude Code's `if` condition).
+      ...emitStringPassthroughFields({ def, converterConfig }),
     });
   }
   return hooks;
@@ -396,6 +447,7 @@ function toolHookToCanonical({
     ...(converterConfig.passthroughFields?.includes("description") &&
       typeof h.description === "string" && { description: h.description }),
     ...importBooleanPassthroughFields({ h, converterConfig }),
+    ...importStringPassthroughFields({ h, converterConfig }),
     ...(rawEntry.matcher !== undefined &&
       rawEntry.matcher !== null &&
       rawEntry.matcher !== "" && { matcher: rawEntry.matcher }),

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -92,6 +92,13 @@ export const HookDefinitionSchema = z.looseObject({
   // (defaults to a fast model when omitted). Qwen Code documents the same
   // field on prompt hooks, but the qwencode adapter does not forward it yet.
   model: z.optional(safeString),
+  // Claude Code tool events (PreToolUse/PostToolUse/PostToolUseFailure/
+  // PermissionRequest/PermissionDenied): `if` filters a hook by tool arguments,
+  // holding a single permission rule with the same syntax as settings.json
+  // permission rules (e.g. `"Bash(rm *)"`). Claude Code has no combining
+  // (`&&`/`||`/list) syntax, so it round-trips as an opaque string.
+  // https://code.claude.com/docs/en/hooks
+  if: z.optional(safeString),
 });
 
 export type HookDefinition = z.infer<typeof HookDefinitionSchema>;


### PR DESCRIPTION
## Summary

Claude Code hooks support an optional `if` field that filters a hook by tool *arguments* (not just the tool name), holding a single permission rule with the same syntax as `settings.json` permission rules (e.g. `"Bash(rm *)"`). Rulesync previously dropped this field: it was not part of the canonical hook schema, and the Claude Code generator emits hook entries from a fixed field list, so any `if` never reached the generated `.claude/settings.json`.

This PR makes `if` round-trip end to end, scoped to Claude Code only.

## Changes

- Add an optional `if` (string) field to `HookDefinitionSchema` (`src/types/hooks.ts`), documented as a Claude-Code tool-event condition.
- Add a generic `stringPassthroughFields` mechanism to the shared converter (`src/features/hooks/tool-hooks-converter.ts`), mirroring the existing `booleanPassthroughFields` (emit on generate, import back). Only non-empty strings are carried through.
- Register `stringPassthroughFields: [{ canonical: "if", tool: "if" }]` in the Claude Code converter config only, so other tools continue to omit `if`.
- Unit tests for generate, import, and a generate→import round-trip.
- Document `if` in `docs/reference/file-formats.md` (synced to `skills/rulesync/`).

## Notes

- `if` holds exactly one permission rule; Claude Code has no `&&`/`||`/list syntax, so it is treated as an opaque string with no combining logic.
- Kept Claude-Code-scoped by design — no cross-tool mappings invented.

Closes #2225
