### PR TITLE
fix(subagents): make copilot agent/runSubagent opt-in

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -349,7 +349,11 @@ claudecode: # for claudecode-specific parameters
   hooks: {} # (optional) hook config (passed through verbatim)
 copilot: # for GitHub Copilot specific parameters
   tools:
-    - web/fetch # agent/runSubagent is always included automatically
+    # Listed tools are emitted verbatim; omit `tools` entirely to grant the agent
+    # all tools. `agent/runSubagent` is opt-in — add it explicitly only when this
+    # subagent needs to orchestrate other subagents.
+    - web/fetch
+    - agent/runSubagent
 opencode: # for OpenCode-specific parameters
   mode: subagent # (optional, defaults to "subagent") OpenCode agent mode
   model: anthropic/claude-sonnet-4-20250514

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -349,7 +349,11 @@ claudecode: # for claudecode-specific parameters
   hooks: {} # (optional) hook config (passed through verbatim)
 copilot: # for GitHub Copilot specific parameters
   tools:
-    - web/fetch # agent/runSubagent is always included automatically
+    # Listed tools are emitted verbatim; omit `tools` entirely to grant the agent
+    # all tools. `agent/runSubagent` is opt-in — add it explicitly only when this
+    # subagent needs to orchestrate other subagents.
+    - web/fetch
+    - agent/runSubagent
 opencode: # for OpenCode-specific parameters
   mode: subagent # (optional, defaults to "subagent") OpenCode agent mode
   model: anthropic/claude-sonnet-4-20250514

--- a/src/features/subagents/copilot-subagent.test.ts
+++ b/src/features/subagents/copilot-subagent.test.ts
@@ -50,7 +50,7 @@ Plan tasks`;
   });
 
   describe("fromRulesyncSubagent", () => {
-    it("merges user tools with required agent/runSubagent", () => {
+    it("emits the user-specified tools verbatim without injecting agent/runSubagent (#1181)", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -60,7 +60,7 @@ Plan tasks`;
           name: "planner",
           description: "Plan things",
           copilot: {
-            tools: ["web/fetch", "agent/runSubagent"],
+            tools: ["web/fetch"],
             permissions: "workspace",
           },
         },
@@ -75,13 +75,40 @@ Plan tasks`;
         validate: true,
       }) as CopilotSubagent;
 
-      expect(subagent.getFrontmatter().tools).toEqual(["agent/runSubagent", "web/fetch"]);
+      expect(subagent.getFrontmatter().tools).toEqual(["web/fetch"]);
       expect(subagent.getFrontmatter()).toMatchObject({ permissions: "workspace" });
       expect(subagent.getRelativeDirPath()).toBe(".github/agents");
       expect(subagent.getRelativeFilePath()).toBe("planner.agent.md");
     });
 
-    it("adds required tool when user tools are missing", () => {
+    it("keeps agent/runSubagent when the user explicitly opts in (#1181)", () => {
+      const rulesyncSubagent = new RulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        relativeFilePath: "planner.agent.md",
+        frontmatter: {
+          targets: ["copilot"],
+          name: "planner",
+          description: "Plan things",
+          copilot: {
+            tools: ["agent/runSubagent", "web/fetch"],
+          },
+        },
+        body: "Plan tasks",
+        validate: true,
+      });
+
+      const subagent = CopilotSubagent.fromRulesyncSubagent({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+        rulesyncSubagent,
+        validate: true,
+      }) as CopilotSubagent;
+
+      expect(subagent.getFrontmatter().tools).toEqual(["agent/runSubagent", "web/fetch"]);
+    });
+
+    it("omits the tools field entirely when the user specifies no tools (#1181)", () => {
       const rulesyncSubagent = new RulesyncSubagent({
         outputRoot: testDir,
         relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -103,7 +130,7 @@ Plan tasks`;
         validate: true,
       }) as CopilotSubagent;
 
-      expect(subagent.getFrontmatter().tools).toEqual(["agent/runSubagent"]);
+      expect(subagent.getFrontmatter().tools).toBeUndefined();
       expect(subagent.getRelativeFilePath()).toBe("planner.agent.md");
     });
 

--- a/src/features/subagents/copilot-subagent.ts
+++ b/src/features/subagents/copilot-subagent.ts
@@ -20,8 +20,6 @@ import {
   ToolSubagentSettablePaths,
 } from "./tool-subagent.js";
 
-const REQUIRED_TOOL = "agent/runSubagent";
-
 const CopilotSubagentFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.optional(z.string()),
@@ -41,11 +39,6 @@ const normalizeTools = (tools: string | string[] | undefined): string[] => {
   }
 
   return Array.isArray(tools) ? tools : [tools];
-};
-
-const ensureRequiredTool = (tools: string[]): string[] => {
-  const mergedTools = new Set([REQUIRED_TOOL, ...tools]);
-  return Array.from(mergedTools);
 };
 
 const toCopilotAgentFilePath = (relativeFilePath: string): string => {
@@ -145,17 +138,24 @@ export class CopilotSubagent extends ToolSubagent {
     const rulesyncFrontmatter = rulesyncSubagent.getFrontmatter();
     const copilotSection = rulesyncFrontmatter.copilot ?? {};
 
+    // Copilot custom-agent `tools` semantics: omitting the field grants the
+    // agent access to all available tools (including `agent/runSubagent`),
+    // while specifying it restricts the agent to only the listed tools. So we
+    // emit `tools` verbatim only when the user actually listed tools, and never
+    // force-inject `agent/runSubagent` — that orchestration capability is
+    // opt-in, added explicitly by users who need cross-subagent delegation.
+    // https://docs.github.com/en/copilot/reference/github-copilot-cli/custom-agents-configuration
+    const { tools: _rawTools, ...copilotRest } = copilotSection;
     const toolsField = copilotSection.tools;
     const userTools = normalizeTools(
       Array.isArray(toolsField) || typeof toolsField === "string" ? toolsField : undefined,
     );
-    const mergedTools = ensureRequiredTool(userTools);
 
     const copilotFrontmatter: CopilotSubagentFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
-      ...copilotSection,
-      ...(mergedTools.length > 0 && { tools: mergedTools }),
+      ...copilotRest,
+      ...(userTools.length > 0 && { tools: userTools }),
     };
 
     const body = rulesyncSubagent.getBody();


### PR DESCRIPTION
## Summary

GitHub Copilot custom-agent `tools` frontmatter semantics: **omitting** `tools` grants the agent access to **all** available tools (including `agent/runSubagent`), while **specifying** it **restricts** the agent to only the listed tools ([configuration reference](https://docs.github.com/en/copilot/reference/github-copilot-cli/custom-agents-configuration)).

Rulesync previously force-injected `agent/runSubagent` into every generated Copilot subagent. Under the documented semantics this actively harmed simple subagents: a subagent that would otherwise have no `tools` key was emitted with `tools: ["agent/runSubagent"]`, **restricting it to that single tool** and losing the implicit `read`/`edit`/`search` access it would get from omitting `tools`.

## Changes (Option A — maintainer-endorsed)

Per the maintainer's 2026-07-10 comment endorsing **Option A** ("no default; explicit opt-in"):

- Remove the `REQUIRED_TOOL = "agent/runSubagent"` auto-injection (`ensureRequiredTool`) from `CopilotSubagent.fromRulesyncSubagent`.
- Emit `tools` verbatim only when the user actually specified tools; omit the `tools` key entirely when none are specified (so omission maps to upstream's "all tools" default).
- `agent/runSubagent` is now opt-in: users add it explicitly to the `copilot.tools` list only when the subagent needs to orchestrate other subagents.
- Update unit tests and the `docs/reference/file-formats.md` example (synced to `skills/rulesync/`).

## Behavior

| `copilot.tools` in source | Generated `tools` |
| --- | --- |
| not specified / empty | omitted (agent gets all tools) |
| `[web/fetch]` | `[web/fetch]` (verbatim) |
| `[agent/runSubagent, web/fetch]` | `[agent/runSubagent, web/fetch]` (verbatim) |

Import (`toRulesyncSubagent`) already passes `tools` through verbatim, so existing generated files round-trip unchanged.

Closes #1181
