### PR TITLE
ci: align stale mise-action version comments with the pinned tag

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v2
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
 
@@ -104,7 +104,7 @@ jobs:
           echo "BINARY_PATH=dist-bun/rulesync-windows-x64.exe" >> "$GITHUB_ENV"
 
       - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v2
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
 

--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/git-config
 
       - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v2
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           ref: main
 
       - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v2
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           experimental: true
 


### PR DESCRIPTION
## Summary

Aligns the stale `# v2` version comments on `jdx/mise-action` SHA pins with the tag the SHA actually points to.

Verified against upstream before editing: `e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d` is the commit for `jdx/mise-action` tag `v4.2.0` (the `v2` ref points elsewhere), so the correct comment on current `main` is `# v4.2.0`. Note the issue text cites `v4.2.1`/`dad1bfd3…` — that reflects the still-open Dependabot PR #2297 branch, not `main`; once #2297 merges, Dependabot will bump these now-parseable comments along with the SHA.

Changed (4 occurrences, comment-only):

- `.github/workflows/e2e-binaries.yml` (2 places): `# v2` → `# v4.2.0`
- `.github/workflows/publish.yml`: `# v2` → `# v4.2.0`
- `.github/workflows/publish-assets.yml`: `# v2` → `# v4.2.0`

Also performed the issue's optional sweep: every other SHA-pinned action comment across `.github/workflows/*.yml` was verified against its upstream tag (dereferencing annotated tags for `actions/github-script`, `flatt-security/setup-takumi-guard-npm`, `softprops/action-gh-release`) — all already accurate, no further drift.

No behavioral change; `pnpm cicheck` passes.

> [!NOTE]
> Left unmerged intentionally: workflow-file changes are excluded from autonomous merging. Please review and merge manually.

Closes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
