### PR TITLE
chore: update Homebrew formula to v14.0.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "13.0.0"
+  version "14.0.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "53982d3dd4915b476a4f897bfd9f0debfa7357eb5c0aa0c718d9fd61a4370d8a"
+      sha256 "a21a29a883925bdc2299c8f944eacd83ccd0f6416a6eb7abd1462d0b9aef5a37"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "491994b14dcca9afb84cd92136ebd7fd530b488744ad7504669a9024b004d361"
+      sha256 "4fa524afe4c572e3346f953178bbf368c1ed0c62ff6ad6d1bdcb0b012f76a619"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "428a0446f39e1e1edef942e4c9db96473d23dcc380b55871167cd7e02f8701cd"
+      sha256 "82008b1ec6b77471c989b05f29dc856ddeed4da81e8d9a5117ffff9aef7b715a"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "5b1bec35d207c8b4247159fdff660964271799c6abb9f93067149762ed809739"
+      sha256 "a1011b0e158e07aa09faa2749ca9c24478f2183b868c6b467d0874b0b186a290"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v14.0.0 release.