### PR TITLE
chore: release v14.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "14.0.0";
+const getVersion = () => "14.0.1";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
Release v14.0.1.

This is a maintenance release containing dependency updates only (Dependabot groups #2298 and #2297). See the draft release notes for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)