### PR TITLE
chore: update Homebrew formula to v14.0.1

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "14.0.0"
+  version "14.0.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "a21a29a883925bdc2299c8f944eacd83ccd0f6416a6eb7abd1462d0b9aef5a37"
+      sha256 "8b1c7fb10b98d32bdb1c2f4a6a2b72f063c95d2cd0c93755697d2fe0f01e92e2"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "4fa524afe4c572e3346f953178bbf368c1ed0c62ff6ad6d1bdcb0b012f76a619"
+      sha256 "47774a477172f6c1ffda2cdbfba8b9d13a353e8dad96bca520262a61d1b493cf"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "82008b1ec6b77471c989b05f29dc856ddeed4da81e8d9a5117ffff9aef7b715a"
+      sha256 "e2030e47cc6bc5939d3b7fd21a80b16da4e7b2b19a3d37b6fb6354ef58d90581"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "a1011b0e158e07aa09faa2749ca9c24478f2183b868c6b467d0874b0b186a290"
+      sha256 "c4c4c3685b337fe82ea373ea2c4015c0d9ae1020af4b319b5456af17745c5e47"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v14.0.1 release.