### PR TITLE
feat(hooks): add native Gemini CLI target

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 | Goose                  |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |        |
 | Hermes Agent           |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |        |
 | Grok CLI               |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |     ✅      |        |
+| Gemini CLI             |       |        |     |          |           |        |  ✅   |             |        |
 | Cursor                 |  ✅   |   ✅   | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |        |
 | deepagents-cli         |  ✅   |        | ✅  |          |    ✅     |   ✅   |  ✅   |             |        |
 | Factory Droid          |  ✅   |        | ✅  |    ✅    |    ✅     |   ✅   |  ✅   |     ✅      |        |

--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -16,6 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Goose                  | goose           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   |   ✅   | ✅ 🌏 |     🌏      |        |
 | Hermes Agent           | hermesagent     |  ✅   |        |    🌏    |    🌏    |   ✅ 🌏   |   🌏   |  🌏   |     🌏      |        |
 | Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |
+| Gemini CLI             | geminicli       |       |        |          |          |           |        | ✅ 🌏 |             |        |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |        |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -16,6 +16,7 @@ Rulesync supports both **generation** and **import** for All of the major AI cod
 | Goose                  | goose           | ✅ 🌏 |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   |   ✅   | ✅ 🌏 |     🌏      |        |
 | Hermes Agent           | hermesagent     |  ✅   |        |    🌏    |    🌏    |   ✅ 🌏   |   🌏   |  🌏   |     🌏      |        |
 | Grok CLI               | grokcli         | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |
+| Gemini CLI             | geminicli       |       |        |          |          |           |        | ✅ 🌏 |             |        |
 | Cursor                 | cursor          |  ✅   |   ✅   |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |
 | deepagents-cli         | deepagents      | ✅ 🌏 |        |  ✅ 🌏   |          |   ✅ 🌏   | ✅ 🌏  |  🌏   |             |        |
 | Factory Droid          | factorydroid    | ✅ 🌏 |        |  ✅ 🌏   |  ✅ 🌏   |   ✅ 🌏   | ✅ 🌏  | ✅ 🌏 |    ✅ 🌏    |        |

--- a/src/constants/geminicli-paths.ts
+++ b/src/constants/geminicli-paths.ts
@@ -1,0 +1,2 @@
+export const GEMINICLI_DIR = ".gemini";
+export const GEMINICLI_SETTINGS_FILE_NAME = "settings.json";

--- a/src/features/hooks/geminicli-hooks.test.ts
+++ b/src/features/hooks/geminicli-hooks.test.ts
@@ -1,0 +1,192 @@
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RULESYNC_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { readFileContent, writeFileContent } from "../../utils/file.js";
+import { GeminicliHooks } from "./geminicli-hooks.js";
+import { RulesyncHooks } from "./rulesync-hooks.js";
+
+describe("GeminicliHooks", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const makeRulesyncHooks = (config: unknown): RulesyncHooks =>
+    new RulesyncHooks({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+      relativeFilePath: "hooks.json",
+      fileContent: JSON.stringify(config),
+      validate: false,
+    });
+
+  it("uses Gemini settings.json in project and global mode", () => {
+    expect(GeminicliHooks.getSettablePaths()).toEqual({
+      relativeDirPath: ".gemini",
+      relativeFilePath: "settings.json",
+    });
+    expect(GeminicliHooks.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: ".gemini",
+      relativeFilePath: "settings.json",
+    });
+  });
+
+  it("maps canonical events to Gemini CLI native event names", async () => {
+    const source = makeRulesyncHooks({
+      version: 1,
+      hooks: {
+        sessionStart: [{ command: "echo start", matcher: "startup" }],
+        beforeSubmitPrompt: [{ command: "echo before-agent" }],
+        stop: [{ command: "echo after-agent" }],
+        preModelInvocation: [{ command: "echo before-model" }],
+        postModelInvocation: [{ command: "echo after-model" }],
+        beforeToolSelection: [{ command: "echo select" }],
+        preToolUse: [{ command: "echo before-tool", matcher: "write_file" }],
+        postToolUse: [{ command: "echo after-tool", timeout: 5 }],
+        preCompact: [{ command: "echo compress" }],
+        notification: [{ command: "echo notify" }],
+        sessionEnd: [{ command: "echo end" }],
+      },
+    });
+
+    const generated = await GeminicliHooks.fromRulesyncHooks({
+      rulesyncHooks: source,
+      outputRoot: testDir,
+    });
+    const parsed = JSON.parse(generated.getFileContent());
+
+    expect(Object.keys(parsed.hooks)).toEqual([
+      "SessionStart",
+      "BeforeAgent",
+      "AfterAgent",
+      "BeforeModel",
+      "AfterModel",
+      "BeforeToolSelection",
+      "BeforeTool",
+      "AfterTool",
+      "PreCompress",
+      "Notification",
+      "SessionEnd",
+    ]);
+    expect(parsed.hooks.BeforeTool).toEqual([
+      { matcher: "write_file", hooks: [{ type: "command", command: "echo before-tool" }] },
+    ]);
+    expect(parsed.hooks.AfterTool[0].hooks[0]).toEqual({
+      type: "command",
+      command: "echo after-tool",
+      timeout: 5,
+    });
+  });
+
+  it("preserves unrelated settings while replacing only hooks in project and global mode", async () => {
+    for (const global of [false, true]) {
+      const root = global ? join(testDir, "home") : join(testDir, "project");
+      const settingsPath = join(root, ".gemini", "settings.json");
+      await writeFileContent(
+        settingsPath,
+        JSON.stringify({ theme: "Dracula", security: { auth: "oauth" }, hooks: { Old: [] } }),
+      );
+      const generated = await GeminicliHooks.fromRulesyncHooks({
+        rulesyncHooks: makeRulesyncHooks({ hooks: { preToolUse: [{ command: "echo safe" }] } }),
+        outputRoot: root,
+        global,
+      });
+      await writeFileContent(settingsPath, generated.getFileContent());
+      expect(JSON.parse(await readFileContent(settingsPath))).toEqual({
+        theme: "Dracula",
+        security: { auth: "oauth" },
+        hooks: { BeforeTool: [{ hooks: [{ type: "command", command: "echo safe" }] }] },
+      });
+    }
+  });
+
+  it("imports and regenerates Gemini native hooks without losing native fields", async () => {
+    const native = {
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "shell",
+            sequential: true,
+            hooks: [
+              {
+                type: "command",
+                command: "./check.sh",
+                name: "check",
+                description: "Checks input",
+                timeout: 30,
+              },
+            ],
+          },
+        ],
+        BeforeAgent: [{ hooks: [{ type: "command", command: "echo prompt" }] }],
+      },
+    };
+    const settingsPath = join(testDir, ".gemini", "settings.json");
+    await writeFileContent(settingsPath, JSON.stringify({ theme: "Default", ...native }));
+
+    const imported = await GeminicliHooks.fromFile({ outputRoot: testDir });
+    expect(JSON.parse(imported.toRulesyncHooks().getFileContent())).toEqual({
+      version: 1,
+      hooks: {
+        preToolUse: [
+          {
+            type: "command",
+            command: "./check.sh",
+            matcher: "shell",
+            timeout: 30,
+            name: "check",
+            description: "Checks input",
+            sequential: true,
+          },
+        ],
+        beforeSubmitPrompt: [{ type: "command", command: "echo prompt" }],
+      },
+    });
+
+    const regenerated = await GeminicliHooks.fromRulesyncHooks({
+      rulesyncHooks: imported.toRulesyncHooks(),
+      outputRoot: testDir,
+    });
+    const regeneratedHooks = JSON.parse(regenerated.getFileContent()).hooks;
+    expect(regeneratedHooks).toEqual({
+      ...native.hooks,
+      BeforeTool: [
+        {
+          ...native.hooks.BeforeTool[0],
+          hooks: [
+            {
+              type: "command",
+              command: '"$GEMINI_PROJECT_DIR"/check.sh',
+              name: "check",
+              description: "Checks input",
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid settings JSON instead of overwriting it", async () => {
+    const settingsPath = join(testDir, ".gemini", "settings.json");
+    await writeFileContent(settingsPath, "{ invalid");
+    await expect(
+      GeminicliHooks.fromRulesyncHooks({
+        rulesyncHooks: makeRulesyncHooks({ hooks: { preToolUse: [{ command: "echo no" }] } }),
+        outputRoot: testDir,
+      }),
+    ).rejects.toThrow();
+    expect(await readFileContent(settingsPath)).toBe("{ invalid");
+  });
+});

--- a/src/features/hooks/geminicli-hooks.ts
+++ b/src/features/hooks/geminicli-hooks.ts
@@ -1,0 +1,188 @@
+import { join } from "node:path";
+
+import { GEMINICLI_DIR, GEMINICLI_SETTINGS_FILE_NAME } from "../../constants/geminicli-paths.js";
+import type { AiFileParams } from "../../types/ai-file.js";
+import type { ValidationResult } from "../../types/ai-file.js";
+import {
+  GEMINICLI_HOOK_EVENTS,
+  GEMINICLI_TO_CANONICAL_EVENT_NAMES,
+  CANONICAL_TO_GEMINICLI_EVENT_NAMES,
+} from "../../types/hooks.js";
+import { formatError } from "../../utils/error.js";
+import { readFileContentOrNull, readOrInitializeFileContent } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
+import {
+  applySharedConfigPatch,
+  GEMINICLI_SETTINGS_SHARED_FILE_KEY,
+} from "../shared/shared-config-gateway.js";
+import type { RulesyncHooks } from "./rulesync-hooks.js";
+import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
+import {
+  buildImportedHooksConfig,
+  canonicalToToolHooks,
+  toolHooksToCanonical,
+} from "./tool-hooks-converter.js";
+import {
+  ToolHooks,
+  type ToolHooksForDeletionParams,
+  type ToolHooksFromFileParams,
+  type ToolHooksFromRulesyncHooksParams,
+  type ToolHooksSettablePaths,
+} from "./tool-hooks.js";
+
+const GEMINICLI_NO_MATCHER_EVENTS: ReadonlySet<string> = new Set([]);
+
+const GEMINICLI_CONVERTER_CONFIG: ToolHooksConverterConfig = {
+  supportedEvents: GEMINICLI_HOOK_EVENTS,
+  canonicalToToolEventNames: CANONICAL_TO_GEMINICLI_EVENT_NAMES,
+  toolToCanonicalEventNames: GEMINICLI_TO_CANONICAL_EVENT_NAMES,
+  projectDirVar: "$GEMINI_PROJECT_DIR",
+  prefixDotRelativeCommandsOnly: true,
+  noMatcherEvents: GEMINICLI_NO_MATCHER_EVENTS,
+  supportedHookTypes: new Set(["command"]),
+  passthroughFields: ["name", "description"],
+};
+export class GeminicliHooks extends ToolHooks {
+  constructor(params: AiFileParams) {
+    super({
+      ...params,
+      fileContent: params.fileContent ?? "{}",
+    });
+  }
+
+  override isDeletable(): boolean {
+    return false;
+  }
+
+  static getSettablePaths(_options: { global?: boolean } = {}): ToolHooksSettablePaths {
+    // Currently, both global and project mode use the same paths.
+    // The parameter is kept for consistency with other ToolHooks implementations.
+    return { relativeDirPath: GEMINICLI_DIR, relativeFilePath: GEMINICLI_SETTINGS_FILE_NAME };
+  }
+
+  static async fromFile({
+    outputRoot = process.cwd(),
+    validate = true,
+    global = false,
+  }: ToolHooksFromFileParams): Promise<GeminicliHooks> {
+    const paths = GeminicliHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const fileContent = (await readFileContentOrNull(filePath)) ?? '{"hooks":{}}';
+    return new GeminicliHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  static async fromRulesyncHooks({
+    outputRoot = process.cwd(),
+    rulesyncHooks,
+    validate = true,
+    global = false,
+    logger,
+  }: ToolHooksFromRulesyncHooksParams & {
+    global?: boolean;
+    logger?: Logger;
+  }): Promise<GeminicliHooks> {
+    const paths = GeminicliHooks.getSettablePaths({ global });
+    const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
+    const existingContent = await readOrInitializeFileContent(
+      filePath,
+      JSON.stringify({}, null, 2),
+    );
+    const config = rulesyncHooks.getJson();
+    const geminiHooks = canonicalToToolHooks({
+      config,
+      toolOverrideHooks: (config.geminicli as { hooks?: typeof config.hooks } | undefined)?.hooks,
+      converterConfig: GEMINICLI_CONVERTER_CONFIG,
+      logger,
+    });
+    for (const [eventName, definitions] of Object.entries(config.hooks)) {
+      const nativeEvent = CANONICAL_TO_GEMINICLI_EVENT_NAMES[eventName] ?? eventName;
+      const entries = geminiHooks[nativeEvent] as Array<Record<string, unknown>> | undefined;
+      if (!entries) continue;
+      for (const entry of entries) {
+        const matcher = typeof entry.matcher === "string" ? entry.matcher : undefined;
+        if (definitions.some((def) => def.matcher === matcher && def.sequential === true)) {
+          entry.sequential = true;
+        }
+      }
+    }
+    const fileContent = applySharedConfigPatch({
+      fileKey: GEMINICLI_SETTINGS_SHARED_FILE_KEY,
+      feature: "hooks",
+      existingContent,
+      patch: { hooks: geminiHooks },
+      filePath,
+    });
+    return new GeminicliHooks({
+      outputRoot,
+      relativeDirPath: paths.relativeDirPath,
+      relativeFilePath: paths.relativeFilePath,
+      fileContent,
+      validate,
+    });
+  }
+
+  toRulesyncHooks(): RulesyncHooks {
+    let settings: { hooks?: unknown };
+    try {
+      settings = JSON.parse(this.getFileContent());
+    } catch (error) {
+      throw new Error(
+        `Failed to parse Gemini CLI hooks content in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}: ${formatError(error)}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    const hooks = toolHooksToCanonical({
+      hooks: settings.hooks,
+      converterConfig: GEMINICLI_CONVERTER_CONFIG,
+    });
+    if (settings.hooks && typeof settings.hooks === "object" && !Array.isArray(settings.hooks)) {
+      for (const [nativeEvent, rawEntries] of Object.entries(settings.hooks)) {
+        const eventName = GEMINICLI_TO_CANONICAL_EVENT_NAMES[nativeEvent] ?? nativeEvent;
+        const definitions = hooks[eventName];
+        if (!definitions || !Array.isArray(rawEntries)) continue;
+        for (const rawEntry of rawEntries) {
+          if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) continue;
+          const entry = rawEntry as Record<string, unknown>;
+          if (entry.sequential !== true) continue;
+          const matcher = typeof entry.matcher === "string" ? entry.matcher : undefined;
+          for (const def of definitions.filter((candidate) => candidate.matcher === matcher)) {
+            def.sequential = true;
+          }
+        }
+      }
+    }
+    return this.toRulesyncHooksDefault({
+      fileContent: JSON.stringify(
+        buildImportedHooksConfig({ hooks, overrideKey: "geminicli" }),
+        null,
+        2,
+      ),
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  static forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+  }: ToolHooksForDeletionParams): GeminicliHooks {
+    return new GeminicliHooks({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: JSON.stringify({ hooks: {} }, null, 2),
+      validate: false,
+    });
+  }
+}

--- a/src/features/hooks/hooks-processor.test.ts
+++ b/src/features/hooks/hooks-processor.test.ts
@@ -541,6 +541,7 @@ describe("HooksProcessor", () => {
         "vibe",
         "qwencode",
         "reasonix",
+        "geminicli",
         "grokcli",
       ]);
     });
@@ -567,6 +568,7 @@ describe("HooksProcessor", () => {
         "vibe",
         "qwencode",
         "reasonix",
+        "geminicli",
         "grokcli",
       ]);
     });
@@ -591,6 +593,7 @@ describe("HooksProcessor", () => {
         "vibe",
         "qwencode",
         "reasonix",
+        "geminicli",
         "grokcli",
       ]);
     });
@@ -615,6 +618,7 @@ describe("HooksProcessor", () => {
         "vibe",
         "qwencode",
         "reasonix",
+        "geminicli",
         "grokcli",
       ]);
     });

--- a/src/features/hooks/hooks-processor.ts
+++ b/src/features/hooks/hooks-processor.ts
@@ -15,6 +15,7 @@ import {
   FACTORYDROID_HOOK_EVENTS,
   GOOSE_HOOK_EVENTS,
   GROKCLI_HOOK_EVENTS,
+  GEMINICLI_HOOK_EVENTS,
   HERMESAGENT_HOOK_EVENTS,
   JUNIE_HOOK_EVENTS,
   KILO_HOOK_EVENTS,
@@ -43,6 +44,7 @@ import { CursorHooks } from "./cursor-hooks.js";
 import { DeepagentsHooks } from "./deepagents-hooks.js";
 import { DevinHooks } from "./devin-hooks.js";
 import { FactorydroidHooks } from "./factorydroid-hooks.js";
+import { GeminicliHooks } from "./geminicli-hooks.js";
 import { GooseHooks } from "./goose-hooks.js";
 import { GrokcliHooks } from "./grokcli-hooks.js";
 import { HermesagentHooks } from "./hermesagent-hooks.js";
@@ -477,6 +479,16 @@ export const toolHooksFactories = new Map<HooksProcessorToolTarget, ToolHooksFac
       supportedHookTypes: ["command"],
       // Only PreToolUse/PostToolUse honor `match`; the adapter itself drops it
       // (with a warning) on UserPromptSubmit/Stop.
+      supportsMatcher: true,
+    },
+  ],
+  [
+    "geminicli",
+    {
+      class: GeminicliHooks,
+      meta: { supportsProject: true, supportsGlobal: true, supportsImport: true },
+      supportedEvents: GEMINICLI_HOOK_EVENTS,
+      supportedHookTypes: ["command"],
       supportsMatcher: true,
     },
   ],

--- a/src/features/shared/shared-config-gateway.ts
+++ b/src/features/shared/shared-config-gateway.ts
@@ -251,6 +251,7 @@ export type SharedConfigFileDeclaration = {
 // `dir/file` tokens matching `deriveSharedFileWriters()` — always POSIX
 // separators, independent of the platform-specific path constants.
 export const CLAUDE_SETTINGS_SHARED_FILE_KEY = ".claude/settings.json";
+export const GEMINICLI_SETTINGS_SHARED_FILE_KEY = ".gemini/settings.json";
 export const HERMES_CONFIG_SHARED_FILE_KEY = ".hermes/config.yaml";
 export const TAKT_CONFIG_SHARED_FILE_KEY = ".takt/config.yaml";
 export const CODEXCLI_CONFIG_SHARED_FILE_KEY = ".codex/config.toml";
@@ -288,6 +289,11 @@ export const sharedConfigFileKey = ({
  * undeclared writer fails CI instead of merging by accident.
  */
 export const SHARED_CONFIG_OWNERSHIP: Readonly<Record<string, SharedConfigFileDeclaration>> = {
+  [GEMINICLI_SETTINGS_SHARED_FILE_KEY]: {
+    format: "json",
+    invalidRootPolicy: "error",
+    features: { hooks: { kind: "replace-owned-keys", ownedKeys: ["hooks"] } },
+  },
   [CLAUDE_SETTINGS_SHARED_FILE_KEY]: {
     format: "json",
     features: {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -471,6 +471,21 @@ export const AUGMENTCODE_HOOK_EVENTS: readonly HookEvent[] = [
   "notification",
 ];
 
+/** Hook events supported by Gemini CLI settings.json native hooks. */
+export const GEMINICLI_HOOK_EVENTS: readonly HookEvent[] = [
+  "sessionStart",
+  "sessionEnd",
+  "beforeSubmitPrompt",
+  "stop",
+  "preModelInvocation",
+  "postModelInvocation",
+  "beforeToolSelection",
+  "preToolUse",
+  "postToolUse",
+  "preCompact",
+  "notification",
+];
+
 /**
  * Hook events supported by Mistral Vibe (mistral-vibe).
  *
@@ -1210,4 +1225,22 @@ export const CANONICAL_TO_GROKCLI_EVENT_NAMES: Record<string, string> = {
  */
 export const GROKCLI_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
   Object.entries(CANONICAL_TO_GROKCLI_EVENT_NAMES).map(([k, v]) => [v, k]),
+);
+
+/** Gemini CLI native lifecycle event mappings. */
+export const CANONICAL_TO_GEMINICLI_EVENT_NAMES: Record<string, string> = {
+  sessionStart: "SessionStart",
+  sessionEnd: "SessionEnd",
+  beforeSubmitPrompt: "BeforeAgent",
+  stop: "AfterAgent",
+  preModelInvocation: "BeforeModel",
+  postModelInvocation: "AfterModel",
+  beforeToolSelection: "BeforeToolSelection",
+  preToolUse: "BeforeTool",
+  postToolUse: "AfterTool",
+  preCompact: "PreCompress",
+  notification: "Notification",
+};
+export const GEMINICLI_TO_CANONICAL_EVENT_NAMES: Record<string, string> = Object.fromEntries(
+  Object.entries(CANONICAL_TO_GEMINICLI_EVENT_NAMES).map(([key, value]) => [value, key]),
 );

--- a/src/types/tool-display.ts
+++ b/src/types/tool-display.ts
@@ -25,6 +25,7 @@ export const TOOL_DISPLAY: ReadonlyArray<ToolDisplayEntry> = [
   { key: "goose", label: "Goose", group: "ai" },
   { key: "hermesagent", label: "Hermes Agent", group: "ai" },
   { key: "grokcli", label: "Grok CLI", group: "ai" },
+  { key: "geminicli", label: "Gemini CLI", group: "ai" },
   { key: "cursor", label: "Cursor", group: "ai" },
   { key: "deepagents", label: "deepagents-cli", group: "ai" },
   { key: "factorydroid", label: "Factory Droid", group: "ai" },

--- a/src/types/tool-target-tuples.ts
+++ b/src/types/tool-target-tuples.ts
@@ -219,6 +219,7 @@ export const hooksProcessorToolTargetTuple = [
   "qwencode",
   "reasonix",
   "grokcli",
+  "geminicli",
 ] as const;
 
 export const permissionsProcessorToolTargetTuple = [

--- a/src/types/tool-targets.test.ts
+++ b/src/types/tool-targets.test.ts
@@ -53,6 +53,7 @@ describe("tool targets", () => {
         "devin",
         "zed",
         "agentsskills",
+        "geminicli",
       ];
 
       expect([...ALL_TOOL_TARGETS]).toEqual(expectedTargets);


### PR DESCRIPTION
## Summary

- add `geminicli` as a native hooks target for current Google Gemini CLI
- safely patch the `hooks` key in global/project `.gemini/settings.json` while preserving unrelated settings
- support import/generate round-trips, canonical event mappings, Gemini-specific overrides, command metadata, and docs
- add processor, path, target, schema, and adapter coverage

## Compatibility

This is intentionally separate from Antigravity targets. It manages only the native Gemini CLI hooks surface.

## Test plan

- `pnpm check`
- focused Gemini/processor/tool-target tests
- `pnpm test` — 324 files, 7,272 tests passed

Closes #2318.
