### PR TITLE
fix: honor flattenedCommandNaming on the convert path and polish follow-ups

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -54,8 +54,14 @@ Example:
   // command support (e.g. Cursor): "basename" (default) keeps only the
   // filename, so `pj/test.md` and `ops/test.md` collide and the last one
   // wins; "path" joins the directory segments into the filename
-  // (`pj/test.md` -> `pj-test.md`), keeping flattened names unique.
+  // (`pj/test.md` -> `pj-test.md`), which reduces collisions but cannot
+  // rule them out (a literal `pj-test.md` also maps to `pj-test.md`); the
+  // collision warning still applies.
   // Tools that support subdirectories (e.g. Claude Code) are unaffected.
+  // Note: switching from "basename" to "path" renames the generated files
+  // (e.g. `test.md` -> `pj-test.md`); run `rulesync generate` with
+  // `delete: true` (or `--delete`) once after switching, otherwise the
+  // stale old flat-named files remain alongside the new ones.
   "flattenedCommandNaming": "basename",
 
   // When true (default), `rulesync gitignore` only emits entries for the

--- a/skills/rulesync/configuration.md
+++ b/skills/rulesync/configuration.md
@@ -54,8 +54,14 @@ Example:
   // command support (e.g. Cursor): "basename" (default) keeps only the
   // filename, so `pj/test.md` and `ops/test.md` collide and the last one
   // wins; "path" joins the directory segments into the filename
-  // (`pj/test.md` -> `pj-test.md`), keeping flattened names unique.
+  // (`pj/test.md` -> `pj-test.md`), which reduces collisions but cannot
+  // rule them out (a literal `pj-test.md` also maps to `pj-test.md`); the
+  // collision warning still applies.
   // Tools that support subdirectories (e.g. Claude Code) are unaffected.
+  // Note: switching from "basename" to "path" renames the generated files
+  // (e.g. `test.md` -> `pj-test.md`); run `rulesync generate` with
+  // `delete: true` (or `--delete`) once after switching, otherwise the
+  // stale old flat-named files remain alongside the new ones.
   "flattenedCommandNaming": "basename",
 
   // When true (default), `rulesync gitignore` only emits entries for the

--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -391,7 +391,7 @@ describe("config-resolver", () => {
         ConfigResolver.resolve({
           configPath: join(testDir, "rulesync.jsonc"),
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/flattenedCommandNaming/);
     });
   });
 

--- a/src/config/config-resolver.test.ts
+++ b/src/config/config-resolver.test.ts
@@ -330,6 +330,71 @@ describe("config-resolver", () => {
     });
   });
 
+  describe("flattenedCommandNaming", () => {
+    it("should load flattenedCommandNaming from config file", async () => {
+      const configContent = JSON.stringify({
+        outputRoots: ["./"],
+        targets: ["cursor"],
+        flattenedCommandNaming: "path",
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      expect(config.getFlattenedCommandNaming()).toBe("path");
+    });
+
+    it("should default flattenedCommandNaming to basename when not specified", async () => {
+      const configContent = JSON.stringify({
+        outputRoots: ["./"],
+        targets: ["cursor"],
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      expect(config.getFlattenedCommandNaming()).toBe("basename");
+    });
+
+    it("should allow rulesync.local.jsonc to override flattenedCommandNaming", async () => {
+      const baseConfigContent = JSON.stringify({
+        outputRoots: ["./"],
+        targets: ["cursor"],
+        flattenedCommandNaming: "basename",
+      });
+      const localConfigContent = JSON.stringify({
+        flattenedCommandNaming: "path",
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), baseConfigContent);
+      await writeFileContent(join(testDir, "rulesync.local.jsonc"), localConfigContent);
+
+      const config = await ConfigResolver.resolve({
+        configPath: join(testDir, "rulesync.jsonc"),
+      });
+
+      expect(config.getFlattenedCommandNaming()).toBe("path");
+    });
+
+    it("should reject an invalid flattenedCommandNaming value", async () => {
+      const configContent = JSON.stringify({
+        outputRoots: ["./"],
+        targets: ["cursor"],
+        flattenedCommandNaming: "foo",
+      });
+      await writeFileContent(join(testDir, "rulesync.jsonc"), configContent);
+
+      await expect(
+        ConfigResolver.resolve({
+          configPath: join(testDir, "rulesync.jsonc"),
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
   describe("local configuration (rulesync.local.jsonc)", () => {
     it("should use rulesync.local.jsonc to override rulesync.jsonc", async () => {
       const baseConfigContent = JSON.stringify({

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -10,7 +10,7 @@ import { ToolFile } from "../../types/tool-file.js";
 import { commandsProcessorToolTargetTuple } from "../../types/tool-target-tuples.js";
 import type { ToolTarget } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
-import { checkPathTraversal, findFilesByGlobs } from "../../utils/file.js";
+import { checkPathTraversal, findFilesByGlobs, toPosixPath } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { AgentsmdCommand } from "./agentsmd-command.js";
 import { AntigravityCliCommand } from "./antigravity-cli-command.js";
@@ -628,7 +628,7 @@ export class CommandsProcessor extends FeatureProcessor {
     const relativeFilePath = rulesyncCommand.getRelativeFilePath();
     const flatPath =
       this.flattenedCommandNaming === "path"
-        ? relativeFilePath.split(/[\\/]/).join("-")
+        ? toPosixPath(relativeFilePath).split("/").join("-")
         : basename(relativeFilePath);
     if (flatPath === relativeFilePath) return rulesyncCommand;
     return rulesyncCommand.withRelativeFilePath(flatPath);

--- a/src/lib/convert.test.ts
+++ b/src/lib/convert.test.ts
@@ -48,6 +48,7 @@ describe("convertFromTool", () => {
     getGlobal: ReturnType<typeof vi.fn>;
     getDryRun: ReturnType<typeof vi.fn>;
     isPreviewMode: ReturnType<typeof vi.fn>;
+    getFlattenedCommandNaming: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -60,6 +61,7 @@ describe("convertFromTool", () => {
       getGlobal: vi.fn().mockReturnValue(false),
       getDryRun: vi.fn().mockReturnValue(false),
       isPreviewMode: vi.fn().mockReturnValue(false),
+      getFlattenedCommandNaming: vi.fn().mockReturnValue("basename"),
     };
 
     vi.mocked(RulesProcessor.getToolTargets).mockReturnValue(["cursor", "claudecode", "copilot"]);
@@ -265,6 +267,22 @@ describe("convertFromTool", () => {
         global: false,
         includeSimulated: false,
       });
+    });
+
+    it("should pass the configured flattenedCommandNaming to CommandsProcessor", async () => {
+      mockConfig.getFeatures.mockReturnValue(["commands"]);
+      mockConfig.getFlattenedCommandNaming.mockReturnValue("path");
+
+      await convertFromTool({
+        logger,
+        config: mockConfig as never,
+        fromTool: "cursor",
+        toTools: ["claudecode"],
+      });
+
+      expect(CommandsProcessor).toHaveBeenCalledWith(
+        expect.objectContaining({ flattenedCommandNaming: "path" }),
+      );
     });
   });
 

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -256,7 +256,14 @@ function buildCommandsStrategy(ctx: ConvertContext) {
     itemLabel: "command file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new CommandsProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
+      new CommandsProcessor({
+        outputRoot,
+        toolTarget,
+        global,
+        dryRun,
+        logger,
+        flattenedCommandNaming: config.getFlattenedCommandNaming(),
+      }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -30,7 +30,9 @@ export type GitignoreDestination = z.infer<typeof GitignoreDestinationSchema>;
 // Naming strategy for command files flattened for tools without subdirectory
 // support: "basename" keeps only the filename (`pj/test.md` -> `test.md`,
 // colliding paths overwrite each other), "path" joins the directory segments
-// into the filename (`pj/test.md` -> `pj-test.md`), keeping names unique.
+// into the filename (`pj/test.md` -> `pj-test.md`), which reduces collisions
+// but cannot rule them out (a literal `pj-test.md` also maps to `pj-test.md`,
+// last write wins); the collision warning still applies.
 export const FlattenedCommandNamingSchema = z.enum(["basename", "path"]);
 export type FlattenedCommandNaming = z.infer<typeof FlattenedCommandNamingSchema>;
 


### PR DESCRIPTION
## Summary

Resolves the concrete follow-ups from the PR #2314 review recorded in #2323:

1. **(mid) Convert path now honors `flattenedCommandNaming`.** `buildCommandsStrategy` in `src/lib/convert.ts` passes `config.getFlattenedCommandNaming()` into `CommandsProcessor`, with a regression test asserting the propagation. Previously a user with `"path"` configured got collision-free names from `rulesync generate` but colliding `"basename"` names from `rulesync convert`.
2. **(low) Wording softened.** `src/types/features.ts` and `docs/guide/configuration.md` (mirrored to `skills/rulesync/`) no longer claim `"path"` keeps names unique — it reduces collisions but cannot rule them out (`pj/test.md` vs a literal `pj-test.md`); the collision warning still applies.
3. **(low) Config-resolution tests added** for `flattenedCommandNaming`: file value reaches `Config`, default is `"basename"`, `rulesync.local.jsonc` overrides the base value, and an invalid value is rejected.
4. **(low) Path flattening uses `toPosixPath()`** from `src/utils/file.ts` instead of a hand-rolled `split(/[\\/]/)`, per the coding guidelines.
5. **(low) Migration note added** to the configuration docs: switching `"basename"` → `"path"` renames generated files, so run a generate with `delete: true` once, otherwise stale flat-named files remain.

Item 6 of the issue (whether `flattenedCommandNaming` should move under `featureOptions` before the shape ossifies) is a design decision and is deliberately **not** resolved here — split out to #2325.

## Test plan

- `pnpm cicheck` (green; 7,314 tests)
- New tests: convert-path propagation regression test, 4 config-resolution tests

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
