### PR TITLE
Release v14.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "14.0.1",
+  "version": "14.1.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "14.0.1";
+const getVersion = () => "14.1.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Release v14.1.0

This PR bumps the version to **v14.1.0** in preparation for release.

### Highlights

- **feat(pi)**: Pi hooks support via a generated TypeScript extension (#2324)
- **feat(commands)**: `flattenedCommandNaming` option for collision-free flattened command names (#2314)
- **fix**: honor config-file `silent`/`verbose` in the logger (#2316) and rewrite relative doc links for the flat `skills/rulesync/` mirror (#2315)

Full release notes are attached to the draft GitHub release `v14.1.0`.

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v14.0.1...v14.1.0
