### PR TITLE
docs: update goal-release references to skills

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,6 @@ jobs:
           gh release edit "$TAG" --draft=false --latest
 
   # The Homebrew tap formula (Formula/rulesync.rb) is no longer updated by a
-  # dedicated CI job here. The /goal-release command regenerates it from the
+  # dedicated CI job here. The `goal-release` skill regenerates it from the
   # release's SHA256SUMS after the release PR merges and the Publish Assets
   # workflow uploads the binaries (scripts/generate-homebrew-formula.ts).

--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -1,7 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
-# This file is regenerated on each release by the /goal-release command
+# This file is regenerated on each release by the `goal-release` skill
 # (scripts/generate-homebrew-formula.ts) after the release assets are built.
 # Do not edit it by hand; changes are overwritten on the next release.
 class Rulesync < Formula

--- a/scripts/generate-homebrew-formula.ts
+++ b/scripts/generate-homebrew-formula.ts
@@ -70,7 +70,7 @@ export function generateHomebrewFormula(version: string, shas: FormulaShas): str
   return `# typed: false
 # frozen_string_literal: true
 
-# This file is regenerated on each release by the /goal-release command
+# This file is regenerated on each release by the \`goal-release\` skill
 # (scripts/generate-homebrew-formula.ts) after the release assets are built.
 # Do not edit it by hand; changes are overwritten on the next release.
 class Rulesync < Formula


### PR DESCRIPTION
## Summary

- replace the remaining `/goal-release command` wording with `goal-release` skill terminology
- keep the generated Homebrew formula comment synchronized with its generator
- update the release workflow comment without changing workflow behavior

## Test plan

- `pnpm cicheck`

Closes #2331