### PR TITLE
feat: enable Codex development configuration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,12 +1,13 @@
-default_permissions = ":danger-full-access"
+default_permissions = "rulesync"
 approval_policy = "on-request"
-approvals_reviewer = "auto_review"
+approvals_reviewer = "user"
 
-[mcp_servers.deepwiki]
-type = "http"
-url = "https://mcp.deepwiki.com/mcp"
+[permissions.rulesync]
+extends = ":workspace"
 
-[mcp_servers.rulesync]
-type = "stdio"
-command = "pnpm"
-args = ["dev", "mcp"]
+[permissions.rulesync.filesystem]
+":minimal" = "read"
+glob_scan_max_depth = 8
+
+[permissions.rulesync.filesystem.":workspace_roots"]
+".git/**" = "write"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,3 @@
-default_permissions = "rulesync"
+default_permissions = ":danger-full-access"
 approval_policy = "on-request"
-approvals_reviewer = "user"
-
-[permissions.rulesync]
-extends = ":workspace"
-
-[permissions.rulesync.filesystem]
-":minimal" = "read"
+approvals_reviewer = "auto_review"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,7 +7,3 @@ extends = ":workspace"
 
 [permissions.rulesync.filesystem]
 ":minimal" = "read"
-glob_scan_max_depth = 8
-
-[permissions.rulesync.filesystem.":workspace_roots"]
-".git/**" = "write"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+default_permissions = ":danger-full-access"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+
+[mcp_servers.deepwiki]
+type = "http"
+url = "https://mcp.deepwiki.com/mcp"
+
+[mcp_servers.rulesync]
+type = "stdio"
+command = "pnpm"
+args = ["dev", "mcp"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -131,7 +131,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # Install Codex CLI
 ARG CODEX_VERSION=0.145.0
 ARG CODEX_INSTALLER_SHA256=1154e9daf713aacd1534efca8042bfd6665ad24bc1d1dfd86b8f439fe60a7a5d
-RUN curl -fsSL https://chatgpt.com/codex/install.sh -o /tmp/codex-install.sh && \
+RUN curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/install.sh" -o /tmp/codex-install.sh && \
     echo "$CODEX_INSTALLER_SHA256  /tmp/codex-install.sh" | sha256sum --check - && \
     CODEX_RELEASE="$CODEX_VERSION" CODEX_NON_INTERACTIVE=1 sh /tmp/codex-install.sh && \
     rm /tmp/codex-install.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -121,13 +121,20 @@ RUN curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/
 ENV PNPM_HOME=/home/node/.pnpm
 ENV npm_config_registry=https://npm.flatt.tech/
 ENV PATH=$PNPM_HOME/bin:$PATH
-RUN mkdir -p "$PNPM_HOME"
+RUN mkdir -p "$PNPM_HOME" && \
+    mise exec -- pnpm add -g \
+    @google/gemini-cli
 
 # Install Claude Code
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install Codex CLI
-RUN curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh
+ARG CODEX_VERSION=0.145.0
+ARG CODEX_INSTALLER_SHA256=1154e9daf713aacd1534efca8042bfd6665ad24bc1d1dfd86b8f439fe60a7a5d
+RUN curl -fsSL https://chatgpt.com/codex/install.sh -o /tmp/codex-install.sh && \
+    echo "$CODEX_INSTALLER_SHA256  /tmp/codex-install.sh" | sha256sum --check - && \
+    CODEX_RELEASE="$CODEX_VERSION" CODEX_NON_INTERACTIVE=1 sh /tmp/codex-install.sh && \
+    rm /tmp/codex-install.sh
 
 # Install OpenCode
 RUN curl -fsSL https://opencode.ai/install | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -121,13 +121,13 @@ RUN curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/
 ENV PNPM_HOME=/home/node/.pnpm
 ENV npm_config_registry=https://npm.flatt.tech/
 ENV PATH=$PNPM_HOME/bin:$PATH
-RUN mkdir -p "$PNPM_HOME" && \
-    mise exec -- pnpm add -g \
-    @openai/codex \
-    @google/gemini-cli
+RUN mkdir -p "$PNPM_HOME"
 
 # Install Claude Code
 RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Install Codex CLI
+RUN curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 sh
 
 # Install OpenCode
 RUN curl -fsSL https://opencode.ai/install | bash

--- a/.rulesync/permissions.jsonc
+++ b/.rulesync/permissions.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/permissions-schema.json",
+  "permission": {},
+  "codexcli": {
+    "base_permission_profile": ":danger-full-access"
+  }
+}

--- a/.rulesync/permissions.jsonc
+++ b/.rulesync/permissions.jsonc
@@ -3,6 +3,7 @@
   "permission": {},
   "codexcli": {
     "base_permission_profile": ":workspace",
-    "approvals_reviewer": "user"
+    "approvals_reviewer": "user",
+    "git_write_rules": false
   }
 }

--- a/.rulesync/permissions.jsonc
+++ b/.rulesync/permissions.jsonc
@@ -2,8 +2,9 @@
   "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/permissions-schema.json",
   "permission": {},
   "codexcli": {
-    "base_permission_profile": ":workspace",
-    "approvals_reviewer": "user",
+    "base_permission_profile": ":danger-full-access",
+    "approvals_reviewer": "auto_review",
+    "approval_policy": "on-request",
     "git_write_rules": false
   }
 }

--- a/.rulesync/permissions.jsonc
+++ b/.rulesync/permissions.jsonc
@@ -2,6 +2,7 @@
   "$schema": "https://github.com/dyoshikawa/rulesync/releases/latest/download/permissions-schema.json",
   "permission": {},
   "codexcli": {
-    "base_permission_profile": ":danger-full-access"
+    "base_permission_profile": ":workspace",
+    "approvals_reviewer": "user"
   }
 }

--- a/.rulesync/permissions.jsonc
+++ b/.rulesync/permissions.jsonc
@@ -4,7 +4,6 @@
   "codexcli": {
     "base_permission_profile": ":danger-full-access",
     "approvals_reviewer": "auto_review",
-    "approval_policy": "on-request",
-    "git_write_rules": false
+    "approval_policy": "on-request"
   }
 }

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -31,6 +31,15 @@
       "skills": true,
       "hooks": true
     },
+    "codexcli": {
+      "rules": true,
+      "commands": true,
+      "mcp": true,
+      "subagents": true,
+      "skills": true,
+      "hooks": true,
+      "permissions": true
+    },
     "takt": {
       "rules": true,
       "commands": true,

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -33,11 +33,11 @@
     },
     "codexcli": {
       "rules": true,
-      "commands": true,
-      "mcp": true,
+      "commands": false,
+      "mcp": false,
       "subagents": true,
       "skills": true,
-      "hooks": true,
+      "hooks": false,
       "permissions": true
     },
     "takt": {


### PR DESCRIPTION
## Summary

- install a pinned Codex CLI release through its checksum-verified GitHub Release asset
- preserve the existing Gemini CLI installation
- enable Codex rules, subagents, skills, and permission generation
- configure danger-full-access with automatic review and on-request approvals
- leave project Codex commands, hooks, and MCP servers disabled
- add the generated project `.codex/config.toml`

## Test plan

- `pnpm dev generate`
- `pnpm cicheck`

## Reference

- https://learn.chatgpt.com/docs/config-file/environment-variables#installer-variables

Closes #2334
