### PR TITLE
Fix AI Assistant MCP validation and docs

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -708,6 +708,8 @@ Servers under the shared `mcpServers` key are emitted to every targeted tool. To
 
 > **Deprecated: per-server `targets`.** The older per-server `"targets": ["tool", ...]` array is still honored as a filter (a missing value or `["*"]` means every tool), but it is deprecated and logs a warning at generate time. Migrate by moving the server into the matching `{toolname}.mcpServers` block(s).
 
+> **JetBrains AI Assistant note:** Rulesync writes the native `{ "mcpServers": { ... } }` configuration to `.ai/mcp/mcp.json` in project mode and `~/.ai/mcp/mcp.json` in global mode. Both scopes support STDIO and remote server entries using the shape documented in [JetBrains AI Assistant's MCP guide](https://www.jetbrains.com/help/ai-assistant/mcp.html).
+
 #### JSON Schema Support
 
 Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -708,6 +708,8 @@ Servers under the shared `mcpServers` key are emitted to every targeted tool. To
 
 > **Deprecated: per-server `targets`.** The older per-server `"targets": ["tool", ...]` array is still honored as a filter (a missing value or `["*"]` means every tool), but it is deprecated and logs a warning at generate time. Migrate by moving the server into the matching `{toolname}.mcpServers` block(s).
 
+> **JetBrains AI Assistant note:** Rulesync writes the native `{ "mcpServers": { ... } }` configuration to `.ai/mcp/mcp.json` in project mode and `~/.ai/mcp/mcp.json` in global mode. Both scopes support STDIO and remote server entries using the shape documented in [JetBrains AI Assistant's MCP guide](https://www.jetbrains.com/help/ai-assistant/mcp.html).
+
 #### JSON Schema Support
 
 Rulesync provides a JSON Schema for editor validation and autocompletion. Add the `$schema` property to your `.rulesync/mcp.json`:

--- a/src/features/mcp/aiassistant-mcp.test.ts
+++ b/src/features/mcp/aiassistant-mcp.test.ts
@@ -12,6 +12,7 @@ import { AiassistantMcp } from "./aiassistant-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 
 describe("AiassistantMcp", () => {
+  const relativeDirPath = join(".ai", "mcp");
   let testDir: string;
   let cleanup: () => Promise<void>;
 
@@ -34,13 +35,13 @@ describe("AiassistantMcp", () => {
       });
 
       const aiassistantMcp = new AiassistantMcp({
-        relativeDirPath: ".ai/mcp",
+        relativeDirPath,
         relativeFilePath: "mcp.json",
         fileContent: validJsonContent,
       });
 
       expect(aiassistantMcp).toBeInstanceOf(AiassistantMcp);
-      expect(aiassistantMcp.getRelativeDirPath()).toBe(".ai/mcp");
+      expect(aiassistantMcp.getRelativeDirPath()).toBe(relativeDirPath);
       expect(aiassistantMcp.getRelativeFilePath()).toBe("mcp.json");
       expect(aiassistantMcp.getJson()).toEqual(JSON.parse(validJsonContent));
     });
@@ -48,7 +49,7 @@ describe("AiassistantMcp", () => {
 
   describe("fromFile", () => {
     it("reads .ai/mcp/mcp.json from disk", async () => {
-      const dir = join(testDir, ".ai/mcp");
+      const dir = join(testDir, relativeDirPath);
       await ensureDir(dir);
       const filePath = join(dir, "mcp.json");
       const content = JSON.stringify({ mcpServers: { A: { command: "echo" } } }, null, 2);
@@ -93,7 +94,7 @@ describe("AiassistantMcp", () => {
         rulesyncMcp: rulesync,
       });
 
-      expect(aiassistant.getRelativeDirPath()).toBe(".ai/mcp");
+      expect(aiassistant.getRelativeDirPath()).toBe(relativeDirPath);
       expect(aiassistant.getRelativeFilePath()).toBe("mcp.json");
       expect(aiassistant.getFileContent()).toBe(rulesyncContent);
     });
@@ -104,7 +105,7 @@ describe("AiassistantMcp", () => {
       const content = JSON.stringify({ mcpServers: { X: { command: "echo" } } }, null, 2);
       const aiassistant = new AiassistantMcp({
         outputRoot: testDir,
-        relativeDirPath: ".ai/mcp",
+        relativeDirPath,
         relativeFilePath: "mcp.json",
         fileContent: content,
       });

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -379,6 +379,34 @@ describe("RulesyncMcp", () => {
       expect(result.success).toBe(true);
       expect(result.error).toBeNull();
     });
+
+    it("should validate an AI Assistant tool-scoped block", () => {
+      const rulesyncMcp = makeInstance({
+        mcpServers: { shared: { command: "node" } },
+        aiassistant: {
+          mcpServers: {
+            extra: { command: "uvx" },
+            shared: null,
+          },
+        },
+      });
+
+      expect(rulesyncMcp.validate()).toEqual({ success: true, error: null });
+    });
+
+    it("should reject a malformed AI Assistant tool-scoped block", () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: basename(RULESYNC_MCP_RELATIVE_FILE_PATH),
+        fileContent: JSON.stringify({
+          mcpServers: {},
+          aiassistant: { mcpServers: { malformed: "not-a-server" } },
+        }),
+        validate: false,
+      });
+
+      expect(rulesyncMcp.validate().success).toBe(false);
+    });
   });
 
   describe("getJson", () => {
@@ -842,6 +870,20 @@ describe("RulesyncMcp", () => {
 
       const forCursor = instance.forTarget({ toolTarget: "cursor" });
       expect(Object.keys(forCursor.getMcpServers())).toEqual(["shared"]);
+    });
+
+    it("should apply AI Assistant additions and null removals", () => {
+      const instance = makeInstance({
+        mcpServers: { shared: { command: "node" }, kept: { command: "deno" } },
+        aiassistant: {
+          mcpServers: { shared: null, extra: { command: "uvx" } },
+        },
+      });
+
+      expect(instance.forTarget({ toolTarget: "aiassistant" }).getMcpServers()).toEqual({
+        kept: { command: "deno" },
+        extra: { command: "uvx" },
+      });
     });
 
     it("should replace a same-named shared server wholesale", () => {

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -60,6 +60,7 @@ export const RulesyncMcpFileSchema = z.looseObject({
   amp: z.optional(toolScopedMcpSchema),
   "antigravity-cli": z.optional(toolScopedMcpSchema),
   "antigravity-ide": z.optional(toolScopedMcpSchema),
+  aiassistant: z.optional(toolScopedMcpSchema),
   augmentcode: z.optional(toolScopedMcpSchema),
   claudecode: z.optional(toolScopedMcpSchema),
   cline: z.optional(toolScopedMcpSchema),


### PR DESCRIPTION
## Summary

- validate AI Assistant tool-scoped MCP blocks like other MCP targets
- cover valid overlays, null removals, malformed blocks, and platform-safe paths
- document project and global JetBrains AI Assistant MCP output paths

## Verification

- pnpm cicheck

Closes #2337