### PR TITLE
Preserve Factory Droid absolute and bare hook commands

### DIFF
--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -7,6 +7,7 @@ import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { FactorydroidHooks } from "./factorydroid-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
+import { canonicalToToolHooks, type ToolHooksConverterConfig } from "./tool-hooks-converter.js";
 
 describe("FactorydroidHooks", () => {
   let testDir: string;
@@ -129,6 +130,63 @@ describe("FactorydroidHooks", () => {
       expect(
         parsed.hooks.SessionStart[0].hooks.map((hook: { command: string }) => hook.command),
       ).toEqual(commands);
+    });
+
+    it("should preserve absolute commands when the converter prefixes other command forms", () => {
+      const commands = [
+        "/usr/local/bin/notify --verbose",
+        String.raw`C:\tools\notify.exe --verbose`,
+        String.raw`\\server\share\notify.exe --verbose`,
+        "~/.factory/hooks/notify.sh --verbose",
+      ];
+      const converterConfig: ToolHooksConverterConfig = {
+        supportedEvents: ["sessionStart"],
+        canonicalToToolEventNames: { sessionStart: "SessionStart" },
+        toolToCanonicalEventNames: { SessionStart: "sessionStart" },
+        projectDirVar: "$PROJECT_DIR",
+        prefixDotRelativeCommandsOnly: false,
+      };
+
+      const converted = canonicalToToolHooks({
+        config: {
+          hooks: { sessionStart: commands.map((command) => ({ type: "command", command })) },
+        },
+        toolOverrideHooks: undefined,
+        converterConfig,
+      });
+      const sessionStart = converted.SessionStart?.[0] as {
+        hooks: Array<{ command: string }>;
+      };
+
+      expect(sessionStart.hooks.map(({ command }) => command)).toEqual(commands);
+    });
+
+    it("should prefix quoted dot-relative command paths", async () => {
+      const commands = [`"./scripts/my hook.sh" --fix`, `'./scripts/my hook.sh' --fix`];
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: commands.map((command) => ({ type: "command", command })) },
+        }),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+      const parsed = JSON.parse(factorydroidHooks.getFileContent());
+
+      expect(
+        parsed.hooks.SessionStart[0].hooks.map((hook: { command: string }) => hook.command),
+      ).toEqual([
+        `"$FACTORY_PROJECT_DIR"/"scripts/my hook.sh" --fix`,
+        `"$FACTORY_PROJECT_DIR"/'scripts/my hook.sh' --fix`,
+      ]);
     });
 
     it("should preserve bare executable commands", async () => {

--- a/src/features/hooks/factorydroid-hooks.test.ts
+++ b/src/features/hooks/factorydroid-hooks.test.ts
@@ -68,7 +68,7 @@ describe("FactorydroidHooks", () => {
       expect(parsed.hooks.afterFileEdit).toBeUndefined();
     });
 
-    it("should prefix non-absolute commands with $FACTORY_PROJECT_DIR", async () => {
+    it("should prefix project-relative commands with $FACTORY_PROJECT_DIR", async () => {
       await ensureDir(join(testDir, ".factory"));
       await writeFileContent(join(testDir, ".factory", "settings.json"), JSON.stringify({}));
 
@@ -99,6 +99,59 @@ describe("FactorydroidHooks", () => {
       expect(sessionStartEntry.matcher).toBeUndefined();
       expect(sessionStartEntry.hooks[0].command).toContain("$FACTORY_PROJECT_DIR");
       expect(sessionStartEntry.hooks[0].command).toContain(".rulesync/hooks/session-start.sh");
+    });
+
+    it("should preserve absolute command paths across platforms", async () => {
+      const commands = [
+        "/usr/local/bin/notify --verbose",
+        String.raw`C:\tools\notify.exe --verbose`,
+        String.raw`\\server\share\notify.exe --verbose`,
+        "~/.factory/hooks/notify.sh --verbose",
+      ];
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: commands.map((command) => ({ type: "command", command })) },
+        }),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+      const parsed = JSON.parse(factorydroidHooks.getFileContent());
+
+      expect(
+        parsed.hooks.SessionStart[0].hooks.map((hook: { command: string }) => hook.command),
+      ).toEqual(commands);
+    });
+
+    it("should preserve bare executable commands", async () => {
+      const command = "npx prettier --write .";
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: [{ type: "command", command }] },
+        }),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+      const parsed = JSON.parse(factorydroidHooks.getFileContent());
+
+      expect(parsed.hooks.SessionStart[0].hooks[0].command).toBe(command);
     });
 
     it("should quote only the $FACTORY_PROJECT_DIR variable, keeping trailing arguments outside the quotes", async () => {
@@ -674,6 +727,40 @@ describe("FactorydroidHooks", () => {
   });
 
   describe("round-trip", () => {
+    it("should keep absolute and bare commands unchanged on disk and after import", async () => {
+      const commands = ["/tmp/notify.sh", "npx prettier --write ."];
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: { sessionStart: commands.map((command) => ({ type: "command", command })) },
+        }),
+        validate: false,
+      });
+
+      const factorydroidHooks = await FactorydroidHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+      const generatedCommands = JSON.parse(
+        factorydroidHooks.getFileContent(),
+      ).hooks.SessionStart[0].hooks.map((hook: { command: string }) => hook.command);
+      expect(generatedCommands).toEqual(commands);
+
+      await ensureDir(join(testDir, ".factory"));
+      await writeFileContent(factorydroidHooks.getFilePath(), factorydroidHooks.getFileContent());
+      const loaded = await FactorydroidHooks.fromFile({ outputRoot: testDir, validate: false });
+      const importedCommands = loaded
+        .toRulesyncHooks()
+        .getJson()
+        .hooks.sessionStart?.map((hook) => hook.command);
+
+      expect(importedCommands).toEqual(commands);
+    });
+
     it("should preserve hooks through fromRulesyncHooks -> write -> fromFile -> toRulesyncHooks", async () => {
       const config = {
         version: 1,

--- a/src/features/hooks/factorydroid-hooks.ts
+++ b/src/features/hooks/factorydroid-hooks.ts
@@ -35,6 +35,7 @@ const FACTORYDROID_CONVERTER_CONFIG: ToolHooksConverterConfig = {
   canonicalToToolEventNames: CANONICAL_TO_FACTORYDROID_EVENT_NAMES,
   toolToCanonicalEventNames: FACTORYDROID_TO_CANONICAL_EVENT_NAMES,
   projectDirVar: "$FACTORY_PROJECT_DIR",
+  prefixDotRelativeCommandsOnly: true,
   supportedHookTypes: new Set(["command", "prompt"]),
 };
 

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -1,3 +1,5 @@
+import { posix, win32 } from "node:path";
+
 import { type HookEvent, type HookType, type HooksConfig, isHookEvent } from "../../types/hooks.js";
 import type { Logger } from "../../utils/logger.js";
 import { compact } from "../../utils/object.js";
@@ -122,10 +124,17 @@ function applyCommandPrefix({
 }): unknown {
   const commandText = def.command;
   const trimmedCommand = typeof commandText === "string" ? commandText.trimStart() : undefined;
+  const unquotedCommand = trimmedCommand?.replace(/^["']/, "");
+  const isAbsoluteCommand =
+    typeof unquotedCommand === "string" &&
+    (posix.isAbsolute(unquotedCommand) ||
+      win32.isAbsolute(unquotedCommand) ||
+      unquotedCommand.startsWith("~/"));
   const shouldPrefix =
     converterConfig.projectDirVar !== "" &&
     typeof trimmedCommand === "string" &&
     !trimmedCommand.startsWith("$") &&
+    !isAbsoluteCommand &&
     (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
 
   // Only the variable itself is quoted (not the whole command) so a project path

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -125,6 +125,7 @@ function applyCommandPrefix({
   const commandText = def.command;
   const trimmedCommand = typeof commandText === "string" ? commandText.trimStart() : undefined;
   const unquotedCommand = trimmedCommand?.replace(/^["']/, "");
+  const isDotRelativeCommand = unquotedCommand?.startsWith(".") ?? false;
   const isAbsoluteCommand =
     typeof unquotedCommand === "string" &&
     (posix.isAbsolute(unquotedCommand) ||
@@ -135,14 +136,20 @@ function applyCommandPrefix({
     typeof trimmedCommand === "string" &&
     !trimmedCommand.startsWith("$") &&
     !isAbsoluteCommand &&
-    (!converterConfig.prefixDotRelativeCommandsOnly || trimmedCommand.startsWith("."));
+    (!converterConfig.prefixDotRelativeCommandsOnly || isDotRelativeCommand);
 
   // Only the variable itself is quoted (not the whole command) so a project path
   // containing a space can't be word-split by the shell, while any trailing
   // arguments after the script path stay outside the quotes and still split normally.
-  return shouldPrefix && typeof trimmedCommand === "string"
-    ? `"${converterConfig.projectDirVar}"/${trimmedCommand.replace(/^\.\//, "")}`
-    : def.command;
+  if (!shouldPrefix || typeof trimmedCommand !== "string") {
+    return def.command;
+  }
+
+  // Keep a leading quote around paths containing spaces, but remove `./`
+  // inside it so the quoted project root and quoted relative path concatenate
+  // into one shell word: "$PROJECT_DIR"/"scripts/my hook.sh".
+  const relativeCommand = trimmedCommand.replace(/^(["'])\.\//, "$1").replace(/^\.\//, "");
+  return `"${converterConfig.projectDirVar}"/${relativeCommand}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- never prefix absolute hook commands across POSIX and Windows path forms
- limit Factory Droid project-directory prefixing to dot-relative commands
- add on-disk and import round-trip coverage for absolute and bare commands

## Verification

- pnpm cicheck

Closes #2327