### PR TITLE
fix(security-scan): use high reasoning effort

### DIFF
--- a/scripts/security-scan-lib.test.ts
+++ b/scripts/security-scan-lib.test.ts
@@ -358,6 +358,11 @@ describe("generateOverallSummary", () => {
 
     expect(summary).toBe("重大な脆弱性が見つかりました。");
     expect(mockClient.chat.send).toHaveBeenCalledOnce();
+    expect(vi.mocked(mockClient.chat.send).mock.calls[0]?.[0]).toMatchObject({
+      chatRequest: {
+        reasoning: { effort: "high" },
+      },
+    });
   });
 
   it("should throw when no content returned", async () => {
@@ -467,6 +472,7 @@ describe("runSecurityScan", () => {
       chatRequest: {
         model: "test-model",
         messages: [{ role: "user", content: "analyze this\n\nsome code" }],
+        reasoning: { effort: "high" },
         stream: false,
       },
       appTitle: "rulesync security-scan",

--- a/scripts/security-scan-lib.ts
+++ b/scripts/security-scan-lib.ts
@@ -121,6 +121,7 @@ const sendChatOnce = async ({
       chatRequest: {
         model,
         messages: [{ role: "user", content: `${prompt}\n\n${scanContent}` }],
+        reasoning: { effort: "high" },
         responseFormat: {
           type: "json_schema" as const,
           jsonSchema: {
@@ -231,6 +232,7 @@ export const generateOverallSummary = async ({
       chatRequest: {
         model,
         messages: [{ role: "user", content: `${OVERALL_SUMMARY_PROMPT}\n\n${input}` }],
+        reasoning: { effort: "high" },
         stream: false as const,
       },
       httpReferer: "https://github.com/dyoshikawa/rulesync",


### PR DESCRIPTION
## Summary

- request high reasoning effort for per-file security analysis
- request high reasoning effort for the executive summary
- assert both OpenRouter request payloads in colocated tests

## Test plan

- `pnpm exec vitest run scripts/security-scan-lib.test.ts`
- `pnpm cicheck`

Closes #2338