### PR TITLE
feat(cli): add declarative source command

### DIFF
--- a/docs/guide/declarative-sources.md
+++ b/docs/guide/declarative-sources.md
@@ -2,6 +2,12 @@
 
 Rulesync can fetch skills from external repositories using the `install` command. Instead of manually running `fetch` for each skill source, declare them in your `rulesync.jsonc` and run `rulesync install` to resolve and fetch them. Then `rulesync generate` picks them up as local curated skills. Typical workflow: `rulesync install && rulesync generate`.
 
+To add one source without editing JSONC by hand, run `rulesync add <source>`. It preserves existing comments, appends the source entry, installs it, and updates the appropriate lockfile:
+
+```bash
+rulesync add anthropics/skills --skills skill-creator
+```
+
 ## Configuration
 
 Add a `sources` array to your `rulesync.jsonc`:

--- a/docs/guide/declarative-sources.md
+++ b/docs/guide/declarative-sources.md
@@ -8,6 +8,8 @@ To add one source without editing JSONC by hand, run `rulesync add <source>`. It
 rulesync add anthropics/skills --skills skill-creator
 ```
 
+The command fetches only the source being added. Existing sources must already be locked and installed; run `rulesync install` first when they are not. If the new source fails, Rulesync restores the manifest, source lockfiles, and curated skills to their previous state.
+
 ## Configuration
 
 Add a `sources` array to your `rulesync.jsonc`:

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -43,6 +43,9 @@ rulesync generate --input-root ~/.aiglobal --targets "*" --features rules
 # Install skills from declarative sources in rulesync.jsonc
 rulesync install
 
+# Add a source to rulesync.jsonc, update the lockfile, and install it
+rulesync add anthropics/skills --skills skill-creator
+
 # Force re-resolve all source refs (ignore lockfile)
 rulesync install --update
 
@@ -147,6 +150,34 @@ rulesync gitignore --targets copilot --features rules,commands
 - **Common entries** (e.g., `.rulesync/skills/.curated/`, `rulesync.local.jsonc`) are always included regardless of filters.
 - **General entries** (e.g., memories, settings) are always included when their target is selected.
 - When re-running, all previously generated rulesync entries are removed before writing the new filtered set.
+
+## Add Command
+
+The `add` command appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs the selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
+
+```bash
+# GitHub source (default transport)
+rulesync add anthropics/skills --skills skill-creator
+
+# Any Git remote through the git CLI
+rulesync add https://example.com/team/skills.git --transport git --ref main --path skills
+
+# npm-compatible registry
+rulesync add @acme/skill-package --transport npm --registry https://registry.npmjs.org
+```
+
+The selected configuration file must already exist. Run `rulesync init` first, or pass `--config <path>`. Adding a source whose normalized source identity is already present fails instead of silently creating duplicate lockfile entries; edit the existing entry when changing its options.
+
+| Option               | Description                                            |
+| -------------------- | ------------------------------------------------------ |
+| `--skills <skills>`  | Comma-separated skill names; omit to install all       |
+| `--transport <type>` | `github` (default), `git`, or experimental `npm`       |
+| `--ref <ref>`        | Git ref, npm version, or npm dist-tag                  |
+| `--path <path>`      | Skills path within the source                          |
+| `--registry <url>`   | npm-compatible registry URL                            |
+| `--token-env <name>` | Environment variable containing the npm registry token |
+| `--token <token>`    | GitHub token for private repositories                  |
+| `--config <path>`    | Configuration file to edit (default: `rulesync.jsonc`) |
 
 ## Fetch Command
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -168,6 +168,8 @@ rulesync add @acme/skill-package --transport npm --registry https://registry.npm
 
 The selected configuration file must already exist. Run `rulesync init` first, or pass `--config <path>`. Adding a source whose normalized source identity is already present fails instead of silently creating duplicate lockfile entries; edit the existing entry when changing its options.
 
+The operation fetches only the source being added; existing declarations are not re-fetched. Existing sources must already be locked and installed, otherwise run `rulesync install` first. The operation is transactional: if the new source fails to install, Rulesync restores the manifest, source lockfiles, and curated skills to their pre-command state.
+
 | Option               | Description                                            |
 | -------------------- | ------------------------------------------------------ |
 | `--skills <skills>`  | Comma-separated skill names; omit to install all       |

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -43,6 +43,9 @@ rulesync generate --input-root ~/.aiglobal --targets "*" --features rules
 # Install skills from declarative sources in rulesync.jsonc
 rulesync install
 
+# Add a source to rulesync.jsonc, update the lockfile, and install it
+rulesync add anthropics/skills --skills skill-creator
+
 # Force re-resolve all source refs (ignore lockfile)
 rulesync install --update
 
@@ -147,6 +150,34 @@ rulesync gitignore --targets copilot --features rules,commands
 - **Common entries** (e.g., `.rulesync/skills/.curated/`, `rulesync.local.jsonc`) are always included regardless of filters.
 - **General entries** (e.g., memories, settings) are always included when their target is selected.
 - When re-running, all previously generated rulesync entries are removed before writing the new filtered set.
+
+## Add Command
+
+The `add` command appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs the selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
+
+```bash
+# GitHub source (default transport)
+rulesync add anthropics/skills --skills skill-creator
+
+# Any Git remote through the git CLI
+rulesync add https://example.com/team/skills.git --transport git --ref main --path skills
+
+# npm-compatible registry
+rulesync add @acme/skill-package --transport npm --registry https://registry.npmjs.org
+```
+
+The selected configuration file must already exist. Run `rulesync init` first, or pass `--config <path>`. Adding a source whose normalized source identity is already present fails instead of silently creating duplicate lockfile entries; edit the existing entry when changing its options.
+
+| Option               | Description                                            |
+| -------------------- | ------------------------------------------------------ |
+| `--skills <skills>`  | Comma-separated skill names; omit to install all       |
+| `--transport <type>` | `github` (default), `git`, or experimental `npm`       |
+| `--ref <ref>`        | Git ref, npm version, or npm dist-tag                  |
+| `--path <path>`      | Skills path within the source                          |
+| `--registry <url>`   | npm-compatible registry URL                            |
+| `--token-env <name>` | Environment variable containing the npm registry token |
+| `--token <token>`    | GitHub token for private repositories                  |
+| `--config <path>`    | Configuration file to edit (default: `rulesync.jsonc`) |
 
 ## Fetch Command
 

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -168,6 +168,8 @@ rulesync add @acme/skill-package --transport npm --registry https://registry.npm
 
 The selected configuration file must already exist. Run `rulesync init` first, or pass `--config <path>`. Adding a source whose normalized source identity is already present fails instead of silently creating duplicate lockfile entries; edit the existing entry when changing its options.
 
+The operation fetches only the source being added; existing declarations are not re-fetched. Existing sources must already be locked and installed, otherwise run `rulesync install` first. The operation is transactional: if the new source fails to install, Rulesync restores the manifest, source lockfiles, and curated skills to their pre-command state.
+
 | Option               | Description                                            |
 | -------------------- | ------------------------------------------------------ |
 | `--skills <skills>`  | Comma-separated skill names; omit to install all       |

--- a/skills/rulesync/declarative-sources.md
+++ b/skills/rulesync/declarative-sources.md
@@ -2,6 +2,12 @@
 
 Rulesync can fetch skills from external repositories using the `install` command. Instead of manually running `fetch` for each skill source, declare them in your `rulesync.jsonc` and run `rulesync install` to resolve and fetch them. Then `rulesync generate` picks them up as local curated skills. Typical workflow: `rulesync install && rulesync generate`.
 
+To add one source without editing JSONC by hand, run `rulesync add <source>`. It preserves existing comments, appends the source entry, installs it, and updates the appropriate lockfile:
+
+```bash
+rulesync add anthropics/skills --skills skill-creator
+```
+
 ## Configuration
 
 Add a `sources` array to your `rulesync.jsonc`:

--- a/skills/rulesync/declarative-sources.md
+++ b/skills/rulesync/declarative-sources.md
@@ -8,6 +8,8 @@ To add one source without editing JSONC by hand, run `rulesync add <source>`. It
 rulesync add anthropics/skills --skills skill-creator
 ```
 
+The command fetches only the source being added. Existing sources must already be locked and installed; run `rulesync install` first when they are not. If the new source fails, Rulesync restores the manifest, source lockfiles, and curated skills to their previous state.
+
 ## Configuration
 
 Add a `sources` array to your `rulesync.jsonc`:

--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -1,13 +1,19 @@
+import { symlink } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parse as parseJsonc } from "jsonc-parser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SourceEntry } from "../../config/config.js";
-import { resolveAndFetchSources } from "../../lib/sources.js";
+import {
+  RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
+  RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH,
+  RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH,
+} from "../../constants/rulesync-paths.js";
+import { getInstalledSourceSkillNames, resolveAndFetchSources } from "../../lib/sources.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { ensureDir, fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
 import { addCommand } from "./add.js";
 
 vi.mock("../../lib/sources.js");
@@ -22,9 +28,10 @@ describe("addCommand", () => {
     ({ testDir, cleanup } = await setupTestDirectory());
     vi.spyOn(process, "cwd").mockReturnValue(testDir);
     logger = createMockLogger();
+    vi.mocked(getInstalledSourceSkillNames).mockResolvedValue([]);
     vi.mocked(resolveAndFetchSources).mockResolvedValue({
       fetchedSkillCount: 2,
-      sourcesProcessed: 2,
+      sourcesProcessed: 1,
       failedSourceCount: 0,
     });
   });
@@ -35,7 +42,7 @@ describe("addCommand", () => {
     vi.clearAllMocks();
   });
 
-  it("should append a source, preserve comments, and install all declared sources", async () => {
+  it("should append a source, preserve comments, and install only the added source", async () => {
     const configPath = join(testDir, "rulesync.jsonc");
     await writeFileContent(
       configPath,
@@ -64,10 +71,21 @@ describe("addCommand", () => {
       { source: "owner/existing" },
       { source: "anthropics/skills", skills: ["skill-creator"] },
     ]);
-    expect(resolveAndFetchSources).toHaveBeenCalledWith({
-      sources: parsed.sources,
+    expect(getInstalledSourceSkillNames).toHaveBeenCalledWith({
+      sources: [{ source: "owner/existing" }],
       projectRoot: testDir,
-      options: { token: undefined },
+      logger,
+    });
+    expect(resolveAndFetchSources).toHaveBeenCalledWith({
+      sources: [{ source: "anthropics/skills", skills: ["skill-creator"] }],
+      projectRoot: testDir,
+      options: {
+        token: undefined,
+        updateSources: true,
+        preserveUnlistedLockEntries: true,
+        requireResolvedSkills: true,
+        reservedSkillNames: [],
+      },
       logger,
     });
     expect(logger.success).toHaveBeenCalledWith(
@@ -179,8 +197,102 @@ describe("addCommand", () => {
     expect(resolveAndFetchSources).not.toHaveBeenCalled();
   });
 
-  it("should retain the manifest entry and report a failed install", async () => {
+  it("should reject a source already declared by the local config without editing the base", async () => {
     const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+    await writeFileContent(
+      join(testDir, "rulesync.local.jsonc"),
+      `{
+  "sources": [{ "source": "owner/local" }]
+}
+`,
+    );
+
+    await expect(addCommand(logger, { source: "owner/local" })).rejects.toThrow(
+      /already declared in the effective configuration/,
+    );
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a config symlink that resolves outside the project root", async () => {
+    const projectRoot = join(testDir, "project");
+    const outsideConfigPath = join(testDir, "outside.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`;
+    await ensureDir(projectRoot);
+    await writeFileContent(outsideConfigPath, originalContent);
+    await symlink(outsideConfigPath, join(projectRoot, "rulesync.jsonc"));
+    vi.mocked(process.cwd).mockReturnValue(projectRoot);
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /must resolve inside the project root/,
+    );
+
+    expect(await readFileContent(outsideConfigPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a lockfile symlink without modifying its target", async () => {
+    const projectRoot = join(testDir, "project");
+    const outsideLockPath = join(testDir, "outside.lock");
+    await ensureDir(projectRoot);
+    await writeFileContent(
+      join(projectRoot, "rulesync.jsonc"),
+      `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`,
+    );
+    await writeFileContent(outsideLockPath, "outside lock\n");
+    await symlink(outsideLockPath, join(projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH));
+    vi.mocked(process.cwd).mockReturnValue(projectRoot);
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /Refusing to write through a symbolic link/,
+    );
+
+    expect(await readFileContent(outsideLockPath)).toBe("outside lock\n");
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a curated tree containing a symbolic link", async () => {
+    const projectRoot = join(testDir, "project");
+    const outsideSkillDir = join(testDir, "outside-skill");
+    const curatedPath = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+    await ensureDir(outsideSkillDir);
+    await writeFileContent(
+      join(projectRoot, "rulesync.jsonc"),
+      `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`,
+    );
+    await ensureDir(curatedPath);
+    await symlink(outsideSkillDir, join(curatedPath, "escaped"));
+    vi.mocked(process.cwd).mockReturnValue(projectRoot);
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /tree containing a symbolic link/,
+    );
+
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a curated path that is not a directory", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const curatedPath = join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
     await writeFileContent(
       configPath,
       `{
@@ -189,18 +301,98 @@ describe("addCommand", () => {
 }
 `,
     );
-    vi.mocked(resolveAndFetchSources).mockResolvedValue({
-      fetchedSkillCount: 0,
-      sourcesProcessed: 1,
-      failedSourceCount: 1,
+    await writeFileContent(curatedPath, "not a directory\n");
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /Expected a directory at writable path/,
+    );
+
+    expect(await readFileContent(curatedPath)).toBe("not a directory\n");
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject source URLs containing credentials", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+    const credentials = ["user", "secret"].join(":");
+
+    await expect(
+      addCommand(logger, {
+        source: `https://${credentials}@example.com/owner/repo.git`,
+        transport: "git",
+      }),
+    ).rejects.toThrow(/must not contain credentials/);
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should restore the manifest and report a failed install", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const sourcesLockPath = join(testDir, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH);
+    const npmSourcesLockPath = join(testDir, RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH);
+    const existingSkillPath = join(
+      testDir,
+      RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
+      "existing",
+      "SKILL.md",
+    );
+    const addedSkillPath = join(
+      testDir,
+      RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
+      "added",
+      "SKILL.md",
+    );
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+    await writeFileContent(sourcesLockPath, "original lock\n");
+    await writeFileContent(existingSkillPath, "original skill\n");
+    vi.mocked(resolveAndFetchSources).mockImplementation(async () => {
+      await writeFileContent(sourcesLockPath, "updated lock\n");
+      await writeFileContent(npmSourcesLockPath, "new npm lock\n");
+      await writeFileContent(existingSkillPath, "modified skill\n");
+      await writeFileContent(addedSkillPath, "added skill\n");
+      return {
+        fetchedSkillCount: 1,
+        sourcesProcessed: 1,
+        failedSourceCount: 1,
+      };
     });
 
     await expect(addCommand(logger, { source: "owner/unavailable" })).rejects.toThrow(
-      /Added the source.*failed to install/,
+      /Failed to install.*restored rulesync\.jsonc/,
     );
 
-    expect(await fileExists(configPath)).toBe(true);
-    const parsed = parseJsonc(await readFileContent(configPath)) as { sources: SourceEntry[] };
-    expect(parsed.sources).toEqual([{ source: "owner/unavailable" }]);
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(await readFileContent(sourcesLockPath)).toBe("original lock\n");
+    expect(await fileExists(npmSourcesLockPath)).toBe(false);
+    expect(await readFileContent(existingSkillPath)).toBe("original skill\n");
+    expect(await fileExists(addedSkillPath)).toBe(false);
+  });
+
+  it("should restore the manifest when source resolution rejects", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+    vi.mocked(resolveAndFetchSources).mockRejectedValue(new Error("Lockfile write failed"));
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      "Lockfile write failed",
+    );
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
   });
 });

--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -1,0 +1,206 @@
+import { join } from "node:path";
+
+import { parse as parseJsonc } from "jsonc-parser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SourceEntry } from "../../config/config.js";
+import { resolveAndFetchSources } from "../../lib/sources.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { fileExists, readFileContent, writeFileContent } from "../../utils/file.js";
+import { addCommand } from "./add.js";
+
+vi.mock("../../lib/sources.js");
+
+describe("addCommand", () => {
+  let testDir: string;
+  let cleanup: () => Promise<void>;
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ testDir, cleanup } = await setupTestDirectory());
+    vi.spyOn(process, "cwd").mockReturnValue(testDir);
+    logger = createMockLogger();
+    vi.mocked(resolveAndFetchSources).mockResolvedValue({
+      fetchedSkillCount: 2,
+      sourcesProcessed: 2,
+      failedSourceCount: 0,
+    });
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("should append a source, preserve comments, and install all declared sources", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    await writeFileContent(
+      configPath,
+      `{
+  // Keep this project comment.
+  "targets": ["claudecode"],
+  "features": ["skills"],
+  "sources": [
+    // Keep this source comment.
+    { "source": "owner/existing" },
+  ],
+}
+`,
+    );
+
+    await addCommand(logger, {
+      source: "anthropics/skills",
+      skills: ["skill-creator"],
+    });
+
+    const updatedContent = await readFileContent(configPath);
+    expect(updatedContent).toContain("// Keep this project comment.");
+    expect(updatedContent).toContain("// Keep this source comment.");
+    const parsed = parseJsonc(updatedContent) as { sources: SourceEntry[] };
+    expect(parsed.sources).toEqual([
+      { source: "owner/existing" },
+      { source: "anthropics/skills", skills: ["skill-creator"] },
+    ]);
+    expect(resolveAndFetchSources).toHaveBeenCalledWith({
+      sources: parsed.sources,
+      projectRoot: testDir,
+      options: { token: undefined },
+      logger,
+    });
+    expect(logger.success).toHaveBeenCalledWith(
+      'Added "anthropics/skills" to rulesync.jsonc and installed 2 skill(s).',
+    );
+  });
+
+  it("should create the sources property when it is absent", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    await writeFileContent(
+      configPath,
+      `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`,
+    );
+
+    await addCommand(logger, { source: "owner/new" });
+
+    const parsed = parseJsonc(await readFileContent(configPath)) as { sources: SourceEntry[] };
+    expect(parsed.sources).toEqual([{ source: "owner/new" }]);
+  });
+
+  it("should reject a duplicate normalized source without modifying the config", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"],
+  "sources": [{ "source": "https://github.com/Owner/Repo.git" }]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(/already declared/);
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a duplicate shared by the GitHub and git transports", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"],
+  "sources": [{ "source": "owner/repo", "transport": "github" }]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+
+    await expect(
+      addCommand(logger, {
+        source: "https://github.com/owner/repo.git",
+        transport: "git",
+      }),
+    ).rejects.toThrow(/already declared/);
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject a missing configuration file", async () => {
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /Run 'rulesync init' first/,
+    );
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should reject invalid JSONC without modifying the config", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"],
+  "sources": [
+}
+`;
+    await writeFileContent(configPath, originalContent);
+
+    await expect(addCommand(logger, { source: "owner/repo" })).rejects.toThrow(
+      /Failed to parse rulesync\.jsonc/,
+    );
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should roll back the edit when rulesync.local.jsonc overrides sources", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    const originalContent = `{
+  "targets": ["claudecode"],
+  "features": ["skills"],
+  "sources": [{ "source": "owner/base" }]
+}
+`;
+    await writeFileContent(configPath, originalContent);
+    await writeFileContent(
+      join(testDir, "rulesync.local.jsonc"),
+      `{
+  "sources": [{ "source": "owner/local" }]
+}
+`,
+    );
+
+    await expect(addCommand(logger, { source: "owner/new" })).rejects.toThrow(
+      /rulesync\.local\.jsonc.*overrides sources/,
+    );
+
+    expect(await readFileContent(configPath)).toBe(originalContent);
+    expect(resolveAndFetchSources).not.toHaveBeenCalled();
+  });
+
+  it("should retain the manifest entry and report a failed install", async () => {
+    const configPath = join(testDir, "rulesync.jsonc");
+    await writeFileContent(
+      configPath,
+      `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`,
+    );
+    vi.mocked(resolveAndFetchSources).mockResolvedValue({
+      fetchedSkillCount: 0,
+      sourcesProcessed: 1,
+      failedSourceCount: 1,
+    });
+
+    await expect(addCommand(logger, { source: "owner/unavailable" })).rejects.toThrow(
+      /Added the source.*failed to install/,
+    );
+
+    expect(await fileExists(configPath)).toBe(true);
+    const parsed = parseJsonc(await readFileContent(configPath)) as { sources: SourceEntry[] };
+    expect(parsed.sources).toEqual([{ source: "owner/unavailable" }]);
+  });
+});

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from "node:path";
+import { cp, lstat, mkdtemp, readdir, realpath, rm } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 
 import {
   applyEdits,
@@ -12,13 +13,23 @@ import {
 import { ConfigResolver } from "../../config/config-resolver.js";
 import { ConfigFileSchema, type SourceEntry, SourceEntrySchema } from "../../config/config.js";
 import {
+  RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_CONFIG_RELATIVE_FILE_PATH,
   RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH,
+  RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH,
 } from "../../constants/rulesync-paths.js";
 import { normalizeNpmSourceKey } from "../../lib/npm-sources-lock.js";
 import { normalizeSourceKey } from "../../lib/sources-lock.js";
-import { resolveAndFetchSources } from "../../lib/sources.js";
-import { fileExists, readFileContent, resolvePath, writeFileContent } from "../../utils/file.js";
+import { getInstalledSourceSkillNames, resolveAndFetchSources } from "../../lib/sources.js";
+import {
+  directoryExists,
+  fileExists,
+  readFileContent,
+  readFileContentOrNull,
+  resolvePath,
+  writeFileContent,
+} from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 
 export type AddCommandOptions = {
@@ -46,6 +57,172 @@ const SOURCE_ENTRY_KEYS = [
   "agent",
   "scope",
 ] as const satisfies ReadonlyArray<keyof SourceEntry>;
+
+type InstallSnapshot = {
+  backupRoot: string;
+  curatedExisted: boolean;
+  sourcesLockContent: string | null;
+  npmSourcesLockContent: string | null;
+};
+
+function pathEscapesRoot(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+}
+
+async function assertWritablePathInsideProject({
+  projectRoot,
+  targetPath,
+}: {
+  projectRoot: string;
+  targetPath: string;
+}): Promise<void> {
+  let existingPath = targetPath;
+  while (true) {
+    try {
+      const stats = await lstat(existingPath);
+      if (existingPath === targetPath && stats.isSymbolicLink()) {
+        throw new Error(`Refusing to write through a symbolic link: ${targetPath}.`);
+      }
+      const relativeRealPath = relative(await realpath(projectRoot), await realpath(existingPath));
+      if (pathEscapesRoot(relativeRealPath)) {
+        throw new Error(`Writable path must resolve inside the project root: ${targetPath}.`);
+      }
+      return;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+      const parentPath = dirname(existingPath);
+      if (parentPath === existingPath) {
+        throw error;
+      }
+      existingPath = parentPath;
+    }
+  }
+}
+
+async function assertTreeContainsNoSymlinks(dirPath: string): Promise<void> {
+  for (const entry of await readdir(dirPath, { withFileTypes: true })) {
+    const entryPath = join(dirPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to write into a tree containing a symbolic link: ${entryPath}.`);
+    }
+    if (entry.isDirectory()) {
+      await assertTreeContainsNoSymlinks(entryPath);
+    }
+  }
+}
+
+async function assertDirectoryIfExists(dirPath: string): Promise<void> {
+  try {
+    if (!(await lstat(dirPath)).isDirectory()) {
+      throw new Error(`Expected a directory at writable path: ${dirPath}.`);
+    }
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
+function assertSourceHasNoEmbeddedCredentials(source: string): void {
+  if (!/^[a-z][a-z\d+.-]*:\/\//i.test(source)) {
+    return;
+  }
+  const url = new URL(source);
+  if (url.username !== "" || url.password !== "") {
+    throw new Error(
+      "Source URLs must not contain credentials. Use an environment variable, credential helper, or SSH authentication instead.",
+    );
+  }
+}
+
+async function createInstallSnapshot({
+  projectRoot,
+  manifestContent,
+}: {
+  projectRoot: string;
+  manifestContent: string;
+}): Promise<InstallSnapshot> {
+  const backupRoot = await mkdtemp(join(projectRoot, ".rulesync-add-backup-"));
+  const curatedPath = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const curatedExisted = await directoryExists(curatedPath);
+  if (curatedExisted) {
+    await cp(curatedPath, join(backupRoot, "curated"), { recursive: true });
+  }
+  const sourcesLockContent = await readFileContentOrNull(
+    join(projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH),
+  );
+  const npmSourcesLockContent = await readFileContentOrNull(
+    join(projectRoot, RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH),
+  );
+  await writeFileContent(join(backupRoot, "manifest.jsonc"), manifestContent);
+  if (sourcesLockContent !== null) {
+    await writeFileContent(
+      join(backupRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH),
+      sourcesLockContent,
+    );
+  }
+  if (npmSourcesLockContent !== null) {
+    await writeFileContent(
+      join(backupRoot, RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH),
+      npmSourcesLockContent,
+    );
+  }
+  return {
+    backupRoot,
+    curatedExisted,
+    sourcesLockContent,
+    npmSourcesLockContent,
+  };
+}
+
+async function restoreFile({ path, content }: { path: string; content: string | null }) {
+  if (content === null) {
+    await rm(path, { force: true });
+    return;
+  }
+  await writeFileContent(path, content);
+}
+
+async function restoreInstallSnapshot({
+  projectRoot,
+  snapshot,
+}: {
+  projectRoot: string;
+  snapshot: InstallSnapshot;
+}): Promise<void> {
+  const curatedPath = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  await rm(curatedPath, { recursive: true, force: true });
+  if (snapshot.curatedExisted) {
+    await cp(join(snapshot.backupRoot, "curated"), curatedPath, { recursive: true });
+  }
+  await restoreFile({
+    path: join(projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH),
+    content: snapshot.sourcesLockContent,
+  });
+  await restoreFile({
+    path: join(projectRoot, RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH),
+    content: snapshot.npmSourcesLockContent,
+  });
+}
+
+async function rollbackAdd({
+  configPath,
+  originalContent,
+  projectRoot,
+  snapshot,
+}: {
+  configPath: string;
+  originalContent: string;
+  projectRoot: string;
+  snapshot: InstallSnapshot;
+}): Promise<void> {
+  await Promise.all([
+    writeFileContent(configPath, originalContent),
+    restoreInstallSnapshot({ projectRoot, snapshot }),
+  ]);
+}
 
 function sourceIdentity(entry: SourceEntry): string {
   const transport = entry.transport ?? "github";
@@ -81,6 +258,7 @@ function detectFormattingOptions(content: string): FormattingOptions {
 }
 
 function buildSourceEntry(options: AddCommandOptions): SourceEntry {
+  assertSourceHasNoEmbeddedCredentials(options.source);
   return SourceEntrySchema.parse({
     source: options.source,
     skills: options.skills,
@@ -115,7 +293,32 @@ export async function addCommand(logger: Logger, options: AddCommandOptions): Pr
     );
   }
 
+  const realProjectRoot = await realpath(projectRoot);
+  const realConfigPath = await realpath(configPath);
+  const relativeRealConfigPath = relative(realProjectRoot, realConfigPath);
+  if (pathEscapesRoot(relativeRealConfigPath)) {
+    throw new Error(
+      `Configuration file must resolve inside the project root: ${relativeConfigPath}.`,
+    );
+  }
+
   const sourceEntry = buildSourceEntry(options);
+  const curatedPath = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  await Promise.all([
+    assertWritablePathInsideProject({ projectRoot, targetPath: curatedPath }),
+    assertWritablePathInsideProject({
+      projectRoot,
+      targetPath: join(projectRoot, RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH),
+    }),
+    assertWritablePathInsideProject({
+      projectRoot,
+      targetPath: join(projectRoot, RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH),
+    }),
+  ]);
+  await assertDirectoryIfExists(curatedPath);
+  if (await directoryExists(curatedPath)) {
+    await assertTreeContainsNoSymlinks(curatedPath);
+  }
   const originalContent = await readFileContent(configPath);
   const parsedConfig = parseConfigContent(originalContent, relativeConfigPath);
   const existingSources = parsedConfig.sources ?? [];
@@ -127,23 +330,41 @@ export async function addCommand(logger: Logger, options: AddCommandOptions): Pr
     );
   }
 
+  const configBeforeEdit = await ConfigResolver.resolve(
+    {
+      configPath,
+      verbose: options.verbose,
+      silent: options.silent,
+    },
+    { logger },
+  );
+  if (configBeforeEdit.getSources().some((entry) => sourceIdentity(entry) === identity)) {
+    throw new Error(
+      `Source "${sourceEntry.source}" is already declared in the effective configuration. Edit the existing entry to change its options.`,
+    );
+  }
+  const reservedSkillNames = await getInstalledSourceSkillNames({
+    sources: configBeforeEdit.getSources(),
+    projectRoot,
+    logger,
+  });
+
   const editPath =
     parsedConfig.sources === undefined ? ["sources"] : ["sources", existingSources.length];
   const editValue = parsedConfig.sources === undefined ? [sourceEntry] : sourceEntry;
-  const edits = modify(originalContent, editPath, editValue, {
-    formattingOptions: detectFormattingOptions(originalContent),
-  });
+  const formattingOptions = detectFormattingOptions(originalContent);
+  const edits = modify(originalContent, editPath, editValue, { formattingOptions });
   let updatedContent = applyEdits(originalContent, edits);
   if (!updatedContent.endsWith("\n")) {
-    updatedContent += "\n";
+    updatedContent += formattingOptions.eol;
   }
 
   // Validate the complete edited document before replacing the user's file.
   parseConfigContent(updatedContent, relativeConfigPath);
-  await writeFileContent(configPath, updatedContent);
-
-  let sources: SourceEntry[];
+  const snapshot = await createInstallSnapshot({ projectRoot, manifestContent: originalContent });
+  let cleanupSnapshot = true;
   try {
+    await writeFileContent(configPath, updatedContent);
     const config = await ConfigResolver.resolve(
       {
         configPath,
@@ -152,39 +373,59 @@ export async function addCommand(logger: Logger, options: AddCommandOptions): Pr
       },
       { logger },
     );
-    sources = config.getSources();
+    const sources = config.getSources();
     if (!sources.some((entry) => sourceEntriesEqual(entry, sourceEntry))) {
       throw new Error(
         `${join(dirname(configPath), RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH)} overrides sources from ${relativeConfigPath}. Add the source to the overriding config or remove its sources key.`,
       );
     }
-  } catch (error) {
-    await writeFileContent(configPath, originalContent);
-    throw error;
-  }
 
-  const result = await resolveAndFetchSources({
-    sources,
-    projectRoot,
-    options: { token: options.token },
-    logger,
-  });
+    const result = await resolveAndFetchSources({
+      sources: [sourceEntry],
+      projectRoot,
+      options: {
+        token: options.token,
+        updateSources: true,
+        preserveUnlistedLockEntries: true,
+        requireResolvedSkills: true,
+        reservedSkillNames,
+      },
+      logger,
+    });
 
-  if (logger.jsonMode) {
-    logger.captureData("source", sourceEntry.source);
-    logger.captureData("configPath", relativeConfigPath);
-    logger.captureData("sourcesProcessed", result.sourcesProcessed);
-    logger.captureData("skillsFetched", result.fetchedSkillCount);
-    logger.captureData("failedSourceCount", result.failedSourceCount);
-  }
+    if (logger.jsonMode) {
+      logger.captureData("source", sourceEntry.source);
+      logger.captureData("configPath", relativeConfigPath);
+      logger.captureData("sourcesProcessed", result.sourcesProcessed);
+      logger.captureData("skillsFetched", result.fetchedSkillCount);
+      logger.captureData("failedSourceCount", result.failedSourceCount);
+    }
 
-  if (result.failedSourceCount > 0) {
-    throw new Error(
-      `Added the source to ${relativeConfigPath}, but ${result.failedSourceCount} of ${result.sourcesProcessed} source(s) failed to install. See the log above for details.`,
+    if (result.failedSourceCount > 0) {
+      throw new Error(
+        `Failed to install ${result.failedSourceCount} of ${result.sourcesProcessed} source(s); restored ${relativeConfigPath}. See the log above for details.`,
+      );
+    }
+
+    logger.success(
+      `Added "${sourceEntry.source}" to ${relativeConfigPath} and installed ${result.fetchedSkillCount} skill(s).`,
     );
+  } catch (error) {
+    try {
+      await rollbackAdd({ configPath, originalContent, projectRoot, snapshot });
+    } catch (rollbackError) {
+      cleanupSnapshot = false;
+      // oxlint-disable-next-line preserve-caught-error -- AggregateError retains both the operation and rollback failures.
+      throw new AggregateError(
+        [error, rollbackError],
+        `Failed to roll back the add operation. Recovery snapshot retained at ${snapshot.backupRoot}.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    if (cleanupSnapshot) {
+      await rm(snapshot.backupRoot, { recursive: true, force: true });
+    }
   }
-
-  logger.success(
-    `Added "${sourceEntry.source}" to ${relativeConfigPath} and installed ${result.fetchedSkillCount} skill(s).`,
-  );
 }

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,0 +1,190 @@
+import { dirname, join } from "node:path";
+
+import {
+  applyEdits,
+  modify,
+  parse as parseJsonc,
+  type FormattingOptions,
+  type ParseError,
+  printParseErrorCode,
+} from "jsonc-parser";
+
+import { ConfigResolver } from "../../config/config-resolver.js";
+import { ConfigFileSchema, type SourceEntry, SourceEntrySchema } from "../../config/config.js";
+import {
+  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+} from "../../constants/rulesync-paths.js";
+import { normalizeNpmSourceKey } from "../../lib/npm-sources-lock.js";
+import { normalizeSourceKey } from "../../lib/sources-lock.js";
+import { resolveAndFetchSources } from "../../lib/sources.js";
+import { fileExists, readFileContent, resolvePath, writeFileContent } from "../../utils/file.js";
+import type { Logger } from "../../utils/logger.js";
+
+export type AddCommandOptions = {
+  source: string;
+  skills?: string[];
+  transport?: SourceEntry["transport"];
+  ref?: string;
+  path?: string;
+  registry?: string;
+  tokenEnv?: string;
+  token?: string;
+  configPath?: string;
+  verbose?: boolean;
+  silent?: boolean;
+};
+
+const SOURCE_ENTRY_KEYS = [
+  "source",
+  "skills",
+  "transport",
+  "ref",
+  "path",
+  "registry",
+  "tokenEnv",
+  "agent",
+  "scope",
+] as const satisfies ReadonlyArray<keyof SourceEntry>;
+
+function sourceIdentity(entry: SourceEntry): string {
+  const transport = entry.transport ?? "github";
+  const normalizedSource =
+    transport === "npm" ? normalizeNpmSourceKey(entry.source) : normalizeSourceKey(entry.source);
+  const lockfileKind = transport === "npm" ? "npm" : "git";
+  return `${lockfileKind}:${normalizedSource}`;
+}
+
+function sourceEntriesEqual(left: SourceEntry, right: SourceEntry): boolean {
+  return SOURCE_ENTRY_KEYS.every((key) => {
+    const leftValue = left[key];
+    const rightValue = right[key];
+    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+      return (
+        leftValue.length === rightValue.length &&
+        leftValue.every((value, index) => value === rightValue[index])
+      );
+    }
+    return leftValue === rightValue;
+  });
+}
+
+function detectFormattingOptions(content: string): FormattingOptions {
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const indentedLine = content.match(/^(\s+)["}]/m)?.[1] ?? "  ";
+  const insertSpaces = !indentedLine.includes("\t");
+  return {
+    eol,
+    insertSpaces,
+    tabSize: insertSpaces ? indentedLine.length : 1,
+  };
+}
+
+function buildSourceEntry(options: AddCommandOptions): SourceEntry {
+  return SourceEntrySchema.parse({
+    source: options.source,
+    skills: options.skills,
+    transport: options.transport,
+    ref: options.ref,
+    path: options.path,
+    registry: options.registry,
+    tokenEnv: options.tokenEnv,
+  });
+}
+
+function parseConfigContent(content: string, configPath: string) {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
+  const firstError = errors[0];
+  if (firstError) {
+    throw new Error(
+      `Failed to parse ${configPath}: ${printParseErrorCode(firstError.error)} at offset ${firstError.offset}.`,
+    );
+  }
+  return ConfigFileSchema.parse(parsed);
+}
+
+export async function addCommand(logger: Logger, options: AddCommandOptions): Promise<void> {
+  const projectRoot = process.cwd();
+  const relativeConfigPath = options.configPath ?? RULESYNC_CONFIG_RELATIVE_FILE_PATH;
+  const configPath = resolvePath(relativeConfigPath, projectRoot);
+
+  if (!(await fileExists(configPath))) {
+    throw new Error(
+      `Configuration file not found: ${relativeConfigPath}. Run 'rulesync init' first or pass --config.`,
+    );
+  }
+
+  const sourceEntry = buildSourceEntry(options);
+  const originalContent = await readFileContent(configPath);
+  const parsedConfig = parseConfigContent(originalContent, relativeConfigPath);
+  const existingSources = parsedConfig.sources ?? [];
+  const identity = sourceIdentity(sourceEntry);
+
+  if (existingSources.some((entry) => sourceIdentity(entry) === identity)) {
+    throw new Error(
+      `Source "${sourceEntry.source}" is already declared in ${relativeConfigPath}. Edit the existing entry to change its options.`,
+    );
+  }
+
+  const editPath =
+    parsedConfig.sources === undefined ? ["sources"] : ["sources", existingSources.length];
+  const editValue = parsedConfig.sources === undefined ? [sourceEntry] : sourceEntry;
+  const edits = modify(originalContent, editPath, editValue, {
+    formattingOptions: detectFormattingOptions(originalContent),
+  });
+  let updatedContent = applyEdits(originalContent, edits);
+  if (!updatedContent.endsWith("\n")) {
+    updatedContent += "\n";
+  }
+
+  // Validate the complete edited document before replacing the user's file.
+  parseConfigContent(updatedContent, relativeConfigPath);
+  await writeFileContent(configPath, updatedContent);
+
+  let sources: SourceEntry[];
+  try {
+    const config = await ConfigResolver.resolve(
+      {
+        configPath,
+        verbose: options.verbose,
+        silent: options.silent,
+      },
+      { logger },
+    );
+    sources = config.getSources();
+    if (!sources.some((entry) => sourceEntriesEqual(entry, sourceEntry))) {
+      throw new Error(
+        `${join(dirname(configPath), RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH)} overrides sources from ${relativeConfigPath}. Add the source to the overriding config or remove its sources key.`,
+      );
+    }
+  } catch (error) {
+    await writeFileContent(configPath, originalContent);
+    throw error;
+  }
+
+  const result = await resolveAndFetchSources({
+    sources,
+    projectRoot,
+    options: { token: options.token },
+    logger,
+  });
+
+  if (logger.jsonMode) {
+    logger.captureData("source", sourceEntry.source);
+    logger.captureData("configPath", relativeConfigPath);
+    logger.captureData("sourcesProcessed", result.sourcesProcessed);
+    logger.captureData("skillsFetched", result.fetchedSkillCount);
+    logger.captureData("failedSourceCount", result.failedSourceCount);
+  }
+
+  if (result.failedSourceCount > 0) {
+    throw new Error(
+      `Added the source to ${relativeConfigPath}, but ${result.failedSourceCount} of ${result.sourcesProcessed} source(s) failed to install. See the log above for details.`,
+    );
+  }
+
+  logger.success(
+    `Added "${sourceEntry.source}" to ${relativeConfigPath} and installed ${result.fetchedSkillCount} skill(s).`,
+  );
+}

--- a/src/cli/commands/install-npm.integration.test.ts
+++ b/src/cli/commands/install-npm.integration.test.ts
@@ -273,7 +273,9 @@ describe("installCommand with npm-transport sources (happy path)", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await installCommand(logger, {});
+    await expect(installCommand(logger, {})).rejects.toThrow(
+      /Failed to install 1 of 1 rulesync source/,
+    );
 
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("Integrity verification failed"),
@@ -299,7 +301,9 @@ describe("installCommand with npm-transport sources (happy path)", () => {
     );
     fetchMock.mockResolvedValue(new Response("unauthorized", { status: 401 }));
 
-    await installCommand(logger, {});
+    await expect(installCommand(logger, {})).rejects.toThrow(
+      /Failed to install 1 of 1 rulesync source/,
+    );
 
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("HTTP 401"));
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("NPM_TOKEN"));

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -42,6 +42,7 @@ describe("installCommand", () => {
       vi.mocked(resolveAndFetchSources).mockResolvedValue({
         fetchedSkillCount: 3,
         sourcesProcessed: 1,
+        failedSourceCount: 0,
       });
 
       await installCommand(mockLogger, {});
@@ -66,6 +67,7 @@ describe("installCommand", () => {
       vi.mocked(resolveAndFetchSources).mockResolvedValue({
         fetchedSkillCount: 0,
         sourcesProcessed: 1,
+        failedSourceCount: 0,
       });
 
       await installCommand(mockLogger, {});
@@ -115,6 +117,7 @@ describe("installCommand", () => {
       vi.mocked(resolveAndFetchSources).mockResolvedValue({
         fetchedSkillCount: 0,
         sourcesProcessed: 1,
+        failedSourceCount: 0,
       });
 
       await installCommand(mockLogger, { update: true });
@@ -132,6 +135,7 @@ describe("installCommand", () => {
       vi.mocked(resolveAndFetchSources).mockResolvedValue({
         fetchedSkillCount: 0,
         sourcesProcessed: 1,
+        failedSourceCount: 0,
       });
 
       await installCommand(mockLogger, { frozen: true });
@@ -149,6 +153,7 @@ describe("installCommand", () => {
       vi.mocked(resolveAndFetchSources).mockResolvedValue({
         fetchedSkillCount: 0,
         sourcesProcessed: 1,
+        failedSourceCount: 0,
       });
 
       await installCommand(mockLogger, { token: "my-token" });

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -108,6 +108,21 @@ describe("installCommand", () => {
         /Both apm.yml and rulesync.jsonc/,
       );
     });
+
+    it("should throw when one or more rulesync sources fail", async () => {
+      const sources: SourceEntry[] = [{ source: "owner/repo" }];
+      vi.mocked(ConfigResolver.resolve).mockResolvedValue(createMockConfig(sources));
+      vi.mocked(resolveAndFetchSources).mockResolvedValue({
+        fetchedSkillCount: 0,
+        sourcesProcessed: 1,
+        failedSourceCount: 1,
+      });
+
+      await expect(installCommand(mockLogger, {})).rejects.toThrow(
+        /Failed to install 1 of 1 rulesync source/,
+      );
+      expect(mockLogger.success).not.toHaveBeenCalled();
+    });
   });
 
   describe("option forwarding (rulesync mode)", () => {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -87,6 +87,13 @@ async function runRulesyncInstall(logger: Logger, options: InstallCommandOptions
   if (logger.jsonMode) {
     logger.captureData("sourcesProcessed", result.sourcesProcessed);
     logger.captureData("skillsFetched", result.fetchedSkillCount);
+    logger.captureData("failedSourceCount", result.failedSourceCount);
+  }
+
+  if (result.failedSourceCount > 0) {
+    throw new Error(
+      `Failed to install ${result.failedSourceCount} of ${result.sourcesProcessed} rulesync source(s). See the log above for details.`,
+    );
   }
 
   if (result.fetchedSkillCount > 0) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { FetchOptions } from "../types/fetch.js";
 import { formatError } from "../utils/error.js";
 import type { Logger } from "../utils/logger.js";
 import { parseCommaSeparatedList } from "../utils/parse-comma-separated-list.js";
+import { addCommand, type AddCommandOptions } from "./commands/add.js";
 import { convertCommand, ConvertOptions } from "./commands/convert.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { generateCommand, GenerateOptions } from "./commands/generate.js";
@@ -83,6 +84,33 @@ const main = async () => {
           features: cliFeatures,
           verbose: (options as { verbose?: boolean }).verbose,
           silent: (options as { silent?: boolean }).silent,
+        });
+      }),
+    );
+
+  program
+    .command("add <source>")
+    .description("Add a declarative skill source to rulesync.jsonc and install it")
+    .option("--skills <skills>", "Comma-separated skill names to install", parseCommaSeparatedList)
+    .option("--transport <transport>", "Source transport: github, git, or npm")
+    .option("-r, --ref <ref>", "Git ref, npm version, or npm dist-tag")
+    .option("-p, --path <path>", "Skills path within the source")
+    .option("--registry <url>", "npm-compatible registry URL")
+    .option("--token-env <name>", "Environment variable containing the npm registry token")
+    .option("--token <token>", "GitHub token for private repositories")
+    .option("-c, --config <path>", "Path to configuration file")
+    .option("-V, --verbose", "Verbose output")
+    .option("-s, --silent", "Suppress all output")
+    .action(
+      wrapCommand("add", "ADD_FAILED", async (logger, options, _globalOpts, positionalArgs) => {
+        const source = positionalArgs[0] as string;
+        const addOptions = options as Omit<AddCommandOptions, "source" | "configPath"> & {
+          config?: string;
+        };
+        await addCommand(logger, {
+          ...addOptions,
+          source,
+          configPath: addOptions.config,
         });
       }),
     );

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -34,7 +34,7 @@ const GITIGNORE_DESTINATION_KEY = "gitignoreDestination";
  * Schema for a single source entry in the sources array.
  * Declares an external repository from which skills can be fetched.
  */
-const SourceEntrySchema = z
+export const SourceEntrySchema = z
   .object({
     source: z.string().check(minLength(1, "source must be a non-empty string")),
     skills: optional(z.array(z.string())),

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -111,7 +111,11 @@ describe("resolveAndFetchSources", () => {
   it("should return zero counts with empty sources", async () => {
     const result = await resolveAndFetchSources({ logger, sources: [], projectRoot: testDir });
 
-    expect(result).toEqual({ fetchedSkillCount: 0, sourcesProcessed: 0 });
+    expect(result).toEqual({
+      fetchedSkillCount: 0,
+      sourcesProcessed: 0,
+      failedSourceCount: 0,
+    });
   });
 
   it("should skip fetching when skipSources is true", async () => {
@@ -122,7 +126,11 @@ describe("resolveAndFetchSources", () => {
       options: { skipSources: true },
     });
 
-    expect(result).toEqual({ fetchedSkillCount: 0, sourcesProcessed: 0 });
+    expect(result).toEqual({
+      fetchedSkillCount: 0,
+      sourcesProcessed: 0,
+      failedSourceCount: 0,
+    });
     expect(mockClientInstance.getDefaultBranch).not.toHaveBeenCalled();
   });
 
@@ -417,6 +425,7 @@ describe("resolveAndFetchSources", () => {
     // Second source should succeed despite first failing
     expect(result.fetchedSkillCount).toBe(1);
     expect(result.sourcesProcessed).toBe(2);
+    expect(result.failedSourceCount).toBe(1);
   });
 
   it("should handle GitLab source gracefully", async () => {
@@ -429,6 +438,7 @@ describe("resolveAndFetchSources", () => {
     // Should not throw, but log error and skip
     expect(result.fetchedSkillCount).toBe(0);
     expect(result.sourcesProcessed).toBe(1);
+    expect(result.failedSourceCount).toBe(0);
   });
 
   it("should prune stale lockfile entries and preserve current sources", async () => {
@@ -621,7 +631,11 @@ describe("resolveAndFetchSources", () => {
       options: { frozen: true },
     });
 
-    expect(result).toEqual({ fetchedSkillCount: 1, sourcesProcessed: 1 });
+    expect(result).toEqual({
+      fetchedSkillCount: 1,
+      sourcesProcessed: 1,
+      failedSourceCount: 0,
+    });
     expect(mockClientInstance.getDefaultBranch).not.toHaveBeenCalled();
     expect(mockClientInstance.resolveRefToSha).not.toHaveBeenCalled();
     expect(writeLockFile).not.toHaveBeenCalled();

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -11,7 +11,7 @@ import {
   removeDirectory,
   writeFileContent,
 } from "../utils/file.js";
-import { resolveAndFetchSources } from "./sources.js";
+import { getInstalledSourceSkillNames, resolveAndFetchSources } from "./sources.js";
 
 let mockClientInstance: any;
 
@@ -134,7 +134,42 @@ describe("resolveAndFetchSources", () => {
     expect(mockClientInstance.getDefaultBranch).not.toHaveBeenCalled();
   });
 
-  it("should clean per-source locked skill directories before re-fetching", async () => {
+  it("should reserve skill names from fully installed existing sources", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "org/existing": {
+          resolvedRef: "existing-sha",
+          skills: { "existing-skill": { integrity: "sha256-existing" } },
+        },
+      },
+    });
+    vi.mocked(directoryExists).mockResolvedValue(true);
+
+    const result = await getInstalledSourceSkillNames({
+      sources: [{ source: "org/existing" }],
+      projectRoot: testDir,
+      logger,
+    });
+
+    expect(result).toEqual(["existing-skill"]);
+  });
+
+  it("should reject an existing source that is not locked and installed", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    vi.mocked(readLockFile).mockResolvedValue({ lockfileVersion: 1, sources: {} });
+
+    await expect(
+      getInstalledSourceSkillNames({
+        sources: [{ source: "org/missing" }],
+        projectRoot: testDir,
+        logger,
+      }),
+    ).rejects.toThrow(/Run 'rulesync install' before adding another source/);
+  });
+
+  it("should preserve locked skill directories when no remote skills match", async () => {
     const { readLockFile } = await import("./sources-lock.js");
     const curatedDir = join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
 
@@ -152,9 +187,7 @@ describe("resolveAndFetchSources", () => {
       },
     });
 
-    // old-skill-a exists on disk, old-skill-b does not.
-    // Because old-skill-b is missing, the SHA-match skip check fails,
-    // and per-source cleanup runs for old-skill-a (which exists).
+    // old-skill-a exists on disk, old-skill-b does not, so the resolver checks the remote.
     vi.mocked(directoryExists).mockImplementation(async (path: string) => {
       if (path === join(curatedDir, "old-skill-a")) return true;
       return false;
@@ -169,9 +202,8 @@ describe("resolveAndFetchSources", () => {
       projectRoot: testDir,
     });
 
-    // Only old-skill-a should be removed (it existed on disk)
-    expect(removeDirectory).toHaveBeenCalledWith(join(curatedDir, "old-skill-a"));
-    // Should NOT do a blanket removal of the curated dir
+    // A source with no matching remote skills fails before mutating the previous install.
+    expect(removeDirectory).not.toHaveBeenCalledWith(join(curatedDir, "old-skill-a"));
     expect(removeDirectory).not.toHaveBeenCalledWith(curatedDir);
   });
 
@@ -242,6 +274,55 @@ describe("resolveAndFetchSources", () => {
       "SKILL.md",
     );
     expect(writeFileContent).toHaveBeenCalledWith(expectedFilePath, "# My Skill\nContent here.");
+  });
+
+  it("should honor ref and path fields for a GitHub source", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    vi.mocked(readLockFile).mockResolvedValue({ lockfileVersion: 1, sources: {} });
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === "exports/skills") {
+          return [{ name: "my-skill", path: "exports/skills/my-skill", type: "dir" }];
+        }
+        if (path === "exports/skills/my-skill") {
+          return [
+            {
+              name: "SKILL.md",
+              path: "exports/skills/my-skill/SKILL.md",
+              type: "file",
+              size: 100,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+
+    const result = await resolveAndFetchSources({
+      logger,
+      sources: [
+        {
+          source: "https://github.com/org/repo",
+          ref: "trusted-release",
+          path: "exports/skills",
+        },
+      ],
+      projectRoot: testDir,
+    });
+
+    expect(result.fetchedSkillCount).toBe(1);
+    expect(mockClientInstance.getDefaultBranch).not.toHaveBeenCalled();
+    expect(mockClientInstance.resolveRefToSha).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "trusted-release",
+    );
+    expect(mockClientInstance.listDirectory).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "exports/skills",
+      "abc123def456",
+    );
   });
 
   it("should skip skills that exist locally", async () => {
@@ -346,6 +427,7 @@ describe("resolveAndFetchSources", () => {
     // Should not throw, just skip the source
     expect(result.fetchedSkillCount).toBe(0);
     expect(result.sourcesProcessed).toBe(1);
+    expect(result.failedSourceCount).toBe(1);
   });
 
   it("should re-resolve refs when updateSources is true", async () => {
@@ -438,7 +520,7 @@ describe("resolveAndFetchSources", () => {
     // Should not throw, but log error and skip
     expect(result.fetchedSkillCount).toBe(0);
     expect(result.sourcesProcessed).toBe(1);
-    expect(result.failedSourceCount).toBe(0);
+    expect(result.failedSourceCount).toBe(1);
   });
 
   it("should prune stale lockfile entries and preserve current sources", async () => {
@@ -478,6 +560,54 @@ describe("resolveAndFetchSources", () => {
     expect(writtenLock.sources["org/old-removed-repo"]).toBeUndefined();
     // The current source should be preserved (normalized key)
     expect(writtenLock.sources["org/new-repo"]).toBeDefined();
+  });
+
+  it("should preserve unlisted lock entries when resolving only a newly added source", async () => {
+    const { readLockFile, writeLockFile } = await import("./sources-lock.js");
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "org/existing-repo": {
+          resolvedRef: "existing-sha",
+          skills: { "existing-skill": { integrity: "sha256-existing" } },
+        },
+        "org/new-repo": {
+          resolvedRef: "stale-sha",
+          skills: { "stale-skill": { integrity: "sha256-stale" } },
+        },
+      },
+    });
+    vi.mocked(directoryExists).mockResolvedValue(true);
+    mockClientInstance.listDirectory.mockImplementation(
+      async (_owner: string, _repo: string, path: string) => {
+        if (path === "skills") {
+          return [{ name: "new-skill", path: "skills/new-skill", type: "dir" }];
+        }
+        if (path === "skills/new-skill") {
+          return [{ name: "SKILL.md", path: "skills/new-skill/SKILL.md", type: "file", size: 50 }];
+        }
+        return [];
+      },
+    );
+
+    const result = await resolveAndFetchSources({
+      logger,
+      sources: [{ source: "https://github.com/org/new-repo" }],
+      projectRoot: testDir,
+      options: {
+        updateSources: true,
+        preserveUnlistedLockEntries: true,
+        requireResolvedSkills: true,
+      },
+    });
+
+    expect(result.failedSourceCount).toBe(0);
+    const writeCalls = vi.mocked(writeLockFile).mock.calls;
+    const writtenLock = writeCalls.at(-1)![0].lock;
+    expect(writtenLock.sources["org/existing-repo"]).toBeDefined();
+    expect(writtenLock.sources["org/new-repo"]).toBeDefined();
+    expect(writtenLock.sources["org/new-repo"]?.skills["stale-skill"]).toBeUndefined();
+    expect(removeDirectory).not.toHaveBeenCalled();
   });
 
   it("should not prune current sources even when config uses different URL format than lock key", async () => {
@@ -1258,6 +1388,52 @@ describe("resolveAndFetchSources", () => {
     expect(writeFileContent).toHaveBeenCalledWith(
       join(testDir, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH, "humanizer", "SKILL.md"),
       "# Humanizer",
+    );
+  });
+
+  it("should clean a locked root fallback before writing its replacement", async () => {
+    const { readLockFile } = await import("./sources-lock.js");
+    vi.mocked(readLockFile).mockResolvedValue({
+      lockfileVersion: 1,
+      sources: {
+        "org/humanizer:.": {
+          resolvedRef: "locked-sha",
+          skills: { humanizer: { integrity: "sha256-old" } },
+        },
+      },
+    });
+    let skillDirectoryCheckCount = 0;
+    vi.mocked(directoryExists).mockImplementation(async (path: string) => {
+      if (path.endsWith(join("humanizer"))) {
+        skillDirectoryCheckCount += 1;
+        return skillDirectoryCheckCount > 1;
+      }
+      return false;
+    });
+    mockClientInstance.listDirectory.mockResolvedValue([
+      { name: "SKILL.md", path: "SKILL.md", type: "file", size: 50 },
+    ]);
+    mockClientInstance.getFileContent.mockResolvedValue("# Replacement");
+
+    const result = await resolveAndFetchSources({
+      logger,
+      sources: [{ source: "org/humanizer:.", skills: ["humanizer"] }],
+      projectRoot: testDir,
+    });
+
+    expect(result.failedSourceCount).toBe(0);
+    const skillPath = join(
+      testDir,
+      RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
+      "humanizer",
+      "SKILL.md",
+    );
+    const writeIndex = vi
+      .mocked(writeFileContent)
+      .mock.calls.findIndex(([path]) => path === skillPath);
+    expect(writeIndex).toBeGreaterThanOrEqual(0);
+    expect(vi.mocked(removeDirectory).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(writeFileContent).mock.invocationCallOrder[writeIndex]!,
     );
   });
 

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -78,6 +78,12 @@ export type ResolveAndFetchSourcesOptions = {
   frozen?: boolean;
   /** GitHub token for private repositories. */
   token?: string;
+  /** Keep lock entries for sources omitted from this invocation. */
+  preserveUnlistedLockEntries?: boolean;
+  /** Treat a source resolving to no installed or locked skills as a failure. */
+  requireResolvedSkills?: boolean;
+  /** Skill names owned by earlier sources and unavailable to this invocation. */
+  reservedSkillNames?: string[];
 };
 
 export type ResolveAndFetchSourcesResult = {
@@ -115,12 +121,17 @@ export async function resolveAndFetchSources(params: {
   // Read existing lockfiles. npm-transport sources are pinned in a separate
   // lockfile (`rulesync-npm.lock.json`) because they lock a package version +
   // tarball integrity instead of a git commit SHA.
-  let lock: SourcesLock = options.updateSources
-    ? createEmptyLock()
-    : await readLockFile({ projectRoot, logger });
-  let npmLock: NpmSourcesLock = options.updateSources
-    ? createEmptyNpmLock()
-    : await readNpmLockFile({ projectRoot, logger });
+  let lock: SourcesLock =
+    options.updateSources && !options.preserveUnlistedLockEntries
+      ? createEmptyLock()
+      : await readLockFile({ projectRoot, logger });
+  let npmLock: NpmSourcesLock =
+    options.updateSources && !options.preserveUnlistedLockEntries
+      ? createEmptyNpmLock()
+      : await readNpmLockFile({ projectRoot, logger });
+  if (options.updateSources && options.preserveUnlistedLockEntries) {
+    ({ lock, npmLock } = removeInvokedLockEntries({ lock, npmLock, sources }));
+  }
 
   // Frozen mode: validate lockfiles cover all declared sources.
   // Missing curated skills are fetched using locked refs.
@@ -140,7 +151,7 @@ export async function resolveAndFetchSources(params: {
 
   let totalSkillCount = 0;
   let failedSourceCount = 0;
-  const allFetchedSkillNames = new Set<string>();
+  const allFetchedSkillNames = new Set(options.reservedSkillNames ?? []);
 
   for (const sourceEntry of sources) {
     try {
@@ -159,6 +170,10 @@ export async function resolveAndFetchSources(params: {
 
       lock = result.lock;
       npmLock = result.npmLock;
+      failedSourceCount += resolvedSkillFailureCount({
+        required: options.requireResolvedSkills ?? false,
+        resolvedSkillNames: result.fetchedSkillNames,
+      });
       totalSkillCount += result.skillCount;
       for (const name of result.fetchedSkillNames) {
         allFetchedSkillNames.add(name);
@@ -169,8 +184,10 @@ export async function resolveAndFetchSources(params: {
     }
   }
 
-  lock = pruneStaleLockEntries({ lock, sources, logger });
-  npmLock = pruneStaleNpmLockEntries({ npmLock, sources, logger });
+  if (!options.preserveUnlistedLockEntries) {
+    lock = pruneStaleLockEntries({ lock, sources, logger });
+    npmLock = pruneStaleNpmLockEntries({ npmLock, sources, logger });
+  }
 
   await writeLockFilesIfChanged({
     projectRoot,
@@ -187,6 +204,49 @@ export async function resolveAndFetchSources(params: {
     sourcesProcessed: sources.length,
     failedSourceCount,
   };
+}
+
+function resolvedSkillFailureCount({
+  required,
+  resolvedSkillNames,
+}: {
+  required: boolean;
+  resolvedSkillNames: string[];
+}): number {
+  return required && resolvedSkillNames.length === 0 ? 1 : 0;
+}
+
+export async function getInstalledSourceSkillNames({
+  sources,
+  projectRoot,
+  logger,
+}: {
+  sources: SourceEntry[];
+  projectRoot: string;
+  logger: Logger;
+}): Promise<string[]> {
+  const lock = await readLockFile({ projectRoot, logger });
+  const npmLock = await readNpmLockFile({ projectRoot, logger });
+  const curatedDir = join(projectRoot, RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH);
+  const skillNames = new Set<string>();
+  for (const source of sources) {
+    const npmTransport = (source.transport ?? "github") === "npm";
+    const entry = npmTransport
+      ? getNpmLockedSource(npmLock, source.source)
+      : getLockedSource(lock, source.source);
+    const lockedSkillNames = entry
+      ? npmTransport
+        ? getNpmLockedSkillNames(entry as NpmLockedSource)
+        : getLockedSkillNames(entry as LockedSource)
+      : [];
+    if (entry === undefined || !(await checkLockedSkillsExist(curatedDir, lockedSkillNames))) {
+      throw new Error(
+        `Existing source "${source.source}" is not fully installed. Run 'rulesync install' before adding another source.`,
+      );
+    }
+    lockedSkillNames.forEach((skillName) => skillNames.add(skillName));
+  }
+  return [...skillNames];
 }
 
 /**
@@ -407,6 +467,45 @@ function pruneStaleLockEntries(params: {
   return { lockfileVersion: lock.lockfileVersion, sources: prunedSources };
 }
 
+function removeInvokedLockEntries({
+  lock,
+  npmLock,
+  sources,
+}: {
+  lock: SourcesLock;
+  npmLock: NpmSourcesLock;
+  sources: SourceEntry[];
+}): { lock: SourcesLock; npmLock: NpmSourcesLock } {
+  const invokedGitSources = new Set(
+    sources
+      .filter((source) => (source.transport ?? "github") !== "npm")
+      .map((source) => normalizeSourceKey(source.source)),
+  );
+  const invokedNpmSources = new Set(
+    sources
+      .filter((source) => (source.transport ?? "github") === "npm")
+      .map((source) => normalizeNpmSourceKey(source.source)),
+  );
+  return {
+    lock: {
+      lockfileVersion: lock.lockfileVersion,
+      sources: Object.fromEntries(
+        Object.entries(lock.sources).filter(
+          ([source]) => !invokedGitSources.has(normalizeSourceKey(source)),
+        ),
+      ),
+    },
+    npmLock: {
+      lockfileVersion: npmLock.lockfileVersion,
+      sources: Object.fromEntries(
+        Object.entries(npmLock.sources).filter(
+          ([source]) => !invokedNpmSources.has(normalizeNpmSourceKey(source)),
+        ),
+      ),
+    },
+  };
+}
+
 /**
  * Prune stale npm lockfile entries whose keys are not in the current
  * npm-transport sources (immutable — returns a fresh lock object).
@@ -570,6 +669,18 @@ function mergeFetchedWithLockedSkills(params: {
     }
   }
   return mergedSkills;
+}
+
+function assertMatchingSkillsFound({
+  skillNames,
+  source,
+}: {
+  skillNames: string[];
+  source: string;
+}): void {
+  if (skillNames.length === 0) {
+    throw new Error(`No matching skills found in ${source}.`);
+  }
 }
 
 /**
@@ -958,6 +1069,13 @@ async function discoverGithubSkillDirs(params: {
     if (
       shouldUseRootFallback({ skillFilter, isWildcard, hasRootSkillFile, hasRequestedSkillDir })
     ) {
+      if (locked) {
+        await cleanPreviousCuratedSkills({
+          curatedDir,
+          lockedSkillNames: Object.keys(locked.skills),
+          logger,
+        });
+      }
       const fallback = await fetchRootLevelFallbackSkill({
         entries,
         parsed,
@@ -1022,11 +1140,15 @@ async function fetchSource(params: {
   } = params;
   const { lock } = params;
 
-  const parsed = parseSource(sourceEntry.source);
+  const parsedFromSource = parseSource(sourceEntry.source);
+  const parsed: ParsedSource = {
+    ...parsedFromSource,
+    ref: sourceEntry.ref ?? parsedFromSource.ref,
+    path: sourceEntry.path ?? parsedFromSource.path,
+  };
 
   if (parsed.provider === "gitlab") {
-    logger.warn(`GitLab sources are not yet supported. Skipping "${sourceEntry.source}".`);
-    return { skillCount: 0, fetchedSkillNames: [], updatedLock: lock };
+    throw new Error(`GitLab sources are not yet supported: "${sourceEntry.source}".`);
   }
 
   const sourceKey = sourceEntry.source;
@@ -1084,8 +1206,7 @@ async function fetchSource(params: {
     logger,
   });
   if (discovery.status === "notFound") {
-    logger.warn(`No skills/ directory found in ${sourceKey}. Skipping.`);
-    return { skillCount: 0, fetchedSkillNames: [], updatedLock: lock };
+    throw new Error(`No skills/ directory found in ${sourceKey}.`);
   }
   const { remoteSkillDirs, fallbackHandled, remoteSkillNames: fallbackSkillNames } = discovery;
 
@@ -1094,8 +1215,9 @@ async function fetchSource(params: {
     ? remoteSkillDirs
     : remoteSkillDirs.filter((d) => skillFilter.includes(d.name));
   const remoteSkillNames = fallbackHandled ? fallbackSkillNames : filteredDirs.map((d) => d.name);
+  assertMatchingSkillsFound({ skillNames: remoteSkillNames, source: sourceKey });
 
-  if (locked) {
+  if (locked && !fallbackHandled) {
     await cleanPreviousCuratedSkills({ curatedDir, lockedSkillNames, logger });
   }
 
@@ -1221,6 +1343,7 @@ async function fetchSourceViaGit(params: {
 
   const allNames = [...skillFileMap.keys()];
   const filteredNames = isWildcard ? allNames : allNames.filter((n) => skillFilter.includes(n));
+  assertMatchingSkillsFound({ skillNames: filteredNames, source: url });
 
   if (locked) {
     await cleanPreviousCuratedSkills({ curatedDir, lockedSkillNames, logger });
@@ -1520,6 +1643,7 @@ async function fetchSourceViaNpm(params: {
   const skillFileMap = groupRemoteFilesBySkillRoot({ remoteFiles, skillFilter, isWildcard });
   const allNames = [...skillFileMap.keys()];
   const filteredNames = isWildcard ? allNames : allNames.filter((n) => skillFilter.includes(n));
+  assertMatchingSkillsFound({ skillNames: filteredNames, source: packageName });
 
   if (locked) {
     await cleanPreviousCuratedSkills({ curatedDir, lockedSkillNames, logger });

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -83,6 +83,7 @@ export type ResolveAndFetchSourcesOptions = {
 export type ResolveAndFetchSourcesResult = {
   fetchedSkillCount: number;
   sourcesProcessed: number;
+  failedSourceCount: number;
 };
 
 type RemoteSkillFile = {
@@ -103,12 +104,12 @@ export async function resolveAndFetchSources(params: {
   const { sources, projectRoot, options = {}, logger } = params;
 
   if (sources.length === 0) {
-    return { fetchedSkillCount: 0, sourcesProcessed: 0 };
+    return { fetchedSkillCount: 0, sourcesProcessed: 0, failedSourceCount: 0 };
   }
 
   if (options.skipSources) {
     logger.info("Skipping source fetching.");
-    return { fetchedSkillCount: 0, sourcesProcessed: 0 };
+    return { fetchedSkillCount: 0, sourcesProcessed: 0, failedSourceCount: 0 };
   }
 
   // Read existing lockfiles. npm-transport sources are pinned in a separate
@@ -138,6 +139,7 @@ export async function resolveAndFetchSources(params: {
   const localSkillNames = await getLocalSkillDirNames(projectRoot);
 
   let totalSkillCount = 0;
+  let failedSourceCount = 0;
   const allFetchedSkillNames = new Set<string>();
 
   for (const sourceEntry of sources) {
@@ -162,6 +164,7 @@ export async function resolveAndFetchSources(params: {
         allFetchedSkillNames.add(name);
       }
     } catch (error) {
+      failedSourceCount += 1;
       logSourceFetchFailure({ sourceEntry, error, logger });
     }
   }
@@ -179,7 +182,11 @@ export async function resolveAndFetchSources(params: {
     logger,
   });
 
-  return { fetchedSkillCount: totalSkillCount, sourcesProcessed: sources.length };
+  return {
+    fetchedSkillCount: totalSkillCount,
+    sourcesProcessed: sources.length,
+    failedSourceCount,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a rulesync add command that appends declarative skill sources while preserving JSONC comments
- install all effective sources immediately and update the existing source lockfiles
- reject normalized duplicates and roll back edits hidden by a local config override
- document the new workflow and add coverage for mutation, validation, rollback, and failure handling

## Testing

- pnpm cicheck

Closes #2092