### PR TITLE
feat: add Rulesync feature scaffolding

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -156,7 +156,36 @@ rulesync gitignore --targets copilot --features rules,commands
 
 ## Add Command
 
-The `add` command appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs selected rules into `.rulesync/rules/.curated/`, installs selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
+The `add` command can scaffold one Rulesync feature file or append one declarative source to `rulesync.jsonc`.
+
+### Feature scaffolding
+
+Use a feature keyword to create a valid, editable starter file:
+
+```bash
+# Named Markdown features
+rulesync add rule --name overview
+rulesync add command --name review-pr.md
+rulesync add subagent --name planner
+rulesync add skill --name project-context
+rulesync add check --name security
+
+# Singleton features
+rulesync add mcp
+rulesync add hooks
+rulesync add ignore
+rulesync add permissions
+```
+
+Named features accept a name with or without the `.md` suffix. Skills use the directory layout `.rulesync/skills/<name>/SKILL.md`; the other named features create `<name>.md` in their canonical Rulesync directory. Names cannot contain path separators.
+
+When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. Non-interactive execution fails safely; pass `--force` to overwrite explicitly.
+
+Feature keywords are reserved when no source-specific option is present. To add a source whose identifier is also a feature keyword, provide a source option that makes the intent explicit, such as `rulesync add skill --transport npm`.
+
+### Declarative sources
+
+For any other source identifier, `add` appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs selected rules into `.rulesync/rules/.curated/`, installs selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
 
 ```bash
 # GitHub source (default transport)
@@ -181,6 +210,8 @@ The operation fetches only the source being added; existing declarations are not
 
 | Option                | Description                                                                                       |
 | --------------------- | ------------------------------------------------------------------------------------------------- |
+| `--name <name>`       | Name for a rule, command, subagent, skill, or check scaffold                                      |
+| `--force`             | Replace an existing scaffold file without prompting                                               |
 | `--skills <skills>`   | Comma-separated skill names. `*` selects all skills.                                              |
 | `--rules <rules>`     | Comma-separated rule names. Names may omit `.md`; `*` selects direct `.md` files under rulesPath. |
 | `--transport <type>`  | `github` (default), `git`, or experimental `npm`                                                  |

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -179,7 +179,7 @@ rulesync add permissions
 
 Named features accept a name with or without the `.md` suffix. Skills use the directory layout `.rulesync/skills/<name>/SKILL.md`; the other named features create `<name>.md` in their canonical Rulesync directory. Names cannot contain path separators.
 
-When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. Non-interactive execution fails safely; pass `--force` to overwrite explicitly.
+When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. JSON, silent, and non-interactive execution fail safely; pass `--force` to overwrite explicitly. Singleton scaffolds recognize supported JSONC and legacy variants and replace the effective existing file instead of creating a shadowed canonical file.
 
 Feature keywords are reserved when no source-specific option is present. To add a source whose identifier is also a feature keyword, provide a source option that makes the intent explicit, such as `rulesync add skill --transport npm`.
 

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -156,7 +156,36 @@ rulesync gitignore --targets copilot --features rules,commands
 
 ## Add Command
 
-The `add` command appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs selected rules into `.rulesync/rules/.curated/`, installs selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
+The `add` command can scaffold one Rulesync feature file or append one declarative source to `rulesync.jsonc`.
+
+### Feature scaffolding
+
+Use a feature keyword to create a valid, editable starter file:
+
+```bash
+# Named Markdown features
+rulesync add rule --name overview
+rulesync add command --name review-pr.md
+rulesync add subagent --name planner
+rulesync add skill --name project-context
+rulesync add check --name security
+
+# Singleton features
+rulesync add mcp
+rulesync add hooks
+rulesync add ignore
+rulesync add permissions
+```
+
+Named features accept a name with or without the `.md` suffix. Skills use the directory layout `.rulesync/skills/<name>/SKILL.md`; the other named features create `<name>.md` in their canonical Rulesync directory. Names cannot contain path separators.
+
+When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. Non-interactive execution fails safely; pass `--force` to overwrite explicitly.
+
+Feature keywords are reserved when no source-specific option is present. To add a source whose identifier is also a feature keyword, provide a source option that makes the intent explicit, such as `rulesync add skill --transport npm`.
+
+### Declarative sources
+
+For any other source identifier, `add` appends one source to `rulesync.jsonc` and immediately runs the declarative source resolver. It preserves JSONC comments, installs selected rules into `.rulesync/rules/.curated/`, installs selected skills into `.rulesync/skills/.curated/`, and updates `rulesync.lock` or `rulesync-npm.lock.json`.
 
 ```bash
 # GitHub source (default transport)
@@ -181,6 +210,8 @@ The operation fetches only the source being added; existing declarations are not
 
 | Option                | Description                                                                                       |
 | --------------------- | ------------------------------------------------------------------------------------------------- |
+| `--name <name>`       | Name for a rule, command, subagent, skill, or check scaffold                                      |
+| `--force`             | Replace an existing scaffold file without prompting                                               |
 | `--skills <skills>`   | Comma-separated skill names. `*` selects all skills.                                              |
 | `--rules <rules>`     | Comma-separated rule names. Names may omit `.md`; `*` selects direct `.md` files under rulesPath. |
 | `--transport <type>`  | `github` (default), `git`, or experimental `npm`                                                  |

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -179,7 +179,7 @@ rulesync add permissions
 
 Named features accept a name with or without the `.md` suffix. Skills use the directory layout `.rulesync/skills/<name>/SKILL.md`; the other named features create `<name>.md` in their canonical Rulesync directory. Names cannot contain path separators.
 
-When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. Non-interactive execution fails safely; pass `--force` to overwrite explicitly.
+When the target file exists, interactive execution asks before replacing it. Declining leaves the file unchanged. JSON, silent, and non-interactive execution fail safely; pass `--force` to overwrite explicitly. Singleton scaffolds recognize supported JSONC and legacy variants and replace the effective existing file instead of creating a shadowed canonical file.
 
 Feature keywords are reserved when no source-specific option is present. To add a source whose identifier is also a feature keyword, provide a source option that makes the intent explicit, such as `rulesync add skill --transport npm`.
 

--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -1,4 +1,4 @@
-import { symlink } from "node:fs/promises";
+import { rm, symlink } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parse as parseJsonc } from "jsonc-parser";
@@ -12,14 +12,20 @@ import {
   RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
   RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_HOOKS_RELATIVE_FILE_PATH,
+  RULESYNC_HOOKS_JSONC_RELATIVE_FILE_PATH,
+  RULESYNC_IGNORE_RELATIVE_FILE_PATH,
   RULESYNC_MCP_RELATIVE_FILE_PATH,
+  RULESYNC_MCP_JSONC_RELATIVE_FILE_PATH,
   RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH,
   RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
+  RULESYNC_PERMISSIONS_JSONC_RELATIVE_FILE_PATH,
   RULESYNC_RULES_RELATIVE_DIR_PATH,
   RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
+import { RulesyncSkill } from "../../features/skills/rulesync-skill.js";
+import { RulesyncSubagent } from "../../features/subagents/rulesync-subagent.js";
 import {
   getInstalledSourceRuleNames,
   getInstalledSourceSkillNames,
@@ -77,13 +83,13 @@ describe("addCommand", () => {
         source: "subagent",
         name: "reviewer",
         relativeFilePath: join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "reviewer.md"),
-        expectedContent: "name: reviewer",
+        expectedContent: 'name: "reviewer"',
       },
       {
         source: "skill",
         name: "security.md",
         relativeFilePath: join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "security", SKILL_FILE_NAME),
-        expectedContent: "name: security",
+        expectedContent: 'name: "security"',
       },
       {
         source: "check",
@@ -134,6 +140,72 @@ describe("addCommand", () => {
       },
     );
 
+    it.each([
+      {
+        source: "mcp",
+        relativeFilePath: RULESYNC_MCP_JSONC_RELATIVE_FILE_PATH,
+        expectedContent: '"mcpServers"',
+      },
+      {
+        source: "mcp",
+        relativeFilePath: join(".rulesync", ".mcp.json"),
+        expectedContent: '"mcpServers"',
+      },
+      {
+        source: "hooks",
+        relativeFilePath: RULESYNC_HOOKS_JSONC_RELATIVE_FILE_PATH,
+        expectedContent: '"hooks"',
+      },
+      {
+        source: "ignore",
+        relativeFilePath: RULESYNC_IGNORE_RELATIVE_FILE_PATH,
+        expectedContent: "credentials/",
+      },
+      {
+        source: "permissions",
+        relativeFilePath: RULESYNC_PERMISSIONS_JSONC_RELATIVE_FILE_PATH,
+        expectedContent: '"permission"',
+      },
+    ])(
+      "should overwrite the effective $source variant at $relativeFilePath",
+      async ({ source, relativeFilePath, expectedContent }) => {
+        const targetPath = join(testDir, relativeFilePath);
+        await writeFileContent(targetPath, "replace me\n");
+
+        await addCommand(logger, { source, force: true });
+
+        expect(await readFileContent(targetPath)).toContain(expectedContent);
+      },
+    );
+
+    it.each([
+      { source: "subagent", name: "null" },
+      { source: "subagent", name: "true" },
+      { source: "subagent", name: "123" },
+      { source: "subagent", name: "2026-07-22" },
+      { source: "skill", name: "null" },
+      { source: "skill", name: "true" },
+      { source: "skill", name: "123" },
+      { source: "skill", name: "2026-07-22" },
+    ])(
+      "should preserve the $source name $name as a frontmatter string",
+      async ({ source, name }) => {
+        await addCommand(logger, { source, name });
+
+        const feature =
+          source === "subagent"
+            ? await RulesyncSubagent.fromFile({
+                outputRoot: testDir,
+                relativeFilePath: `${name}.md`,
+              })
+            : await RulesyncSkill.fromDir({
+                outputRoot: testDir,
+                dirName: name,
+              });
+        expect(feature.getFrontmatter().name).toBe(name);
+      },
+    );
+
     it("should preserve an existing scaffold when overwrite confirmation is declined", async () => {
       const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
       const targetPath = join(testDir, relativeFilePath);
@@ -163,6 +235,57 @@ describe("addCommand", () => {
       });
 
       expect(await readFileContent(targetPath)).toContain("# Existing");
+    });
+
+    it.each([
+      { mode: "JSON", jsonMode: true, silent: false },
+      { mode: "silent", jsonMode: false, silent: true },
+    ])(
+      "should fail without prompting before overwrite in $mode mode",
+      async ({ jsonMode, silent }) => {
+        const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
+        const targetPath = join(testDir, relativeFilePath);
+        await writeFileContent(targetPath, "keep me\n");
+        const confirmOverwrite = vi.fn();
+        logger = { ...createMockLogger(), jsonMode, silent };
+
+        await expect(
+          addCommand(logger, {
+            source: "rule",
+            name: "existing",
+            confirmOverwrite,
+          }),
+        ).rejects.toThrow(/JSON or silent mode.*--force/);
+
+        expect(confirmOverwrite).not.toHaveBeenCalled();
+        expect(await readFileContent(targetPath)).toBe("keep me\n");
+      },
+    );
+
+    it("should reject a nested scaffold path replaced with a symlink during overwrite confirmation", async () => {
+      const projectRoot = join(testDir, "project");
+      const relativeFilePath = join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "existing", SKILL_FILE_NAME);
+      const targetPath = join(projectRoot, relativeFilePath);
+      const targetDir = join(projectRoot, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      const outsideDir = join(testDir, "outside-skills");
+      const outsideSkillDir = join(outsideDir, "existing");
+      await writeFileContent(targetPath, "replace me\n");
+      await ensureDir(outsideDir);
+      vi.mocked(process.cwd).mockReturnValue(projectRoot);
+
+      await expect(
+        addCommand(logger, {
+          source: "skill",
+          name: "existing",
+          confirmOverwrite: async () => {
+            await rm(targetDir, { recursive: true });
+            await symlink(outsideDir, targetDir, "dir");
+            return true;
+          },
+        }),
+      ).rejects.toThrow(/Refusing to write through a symbolic link|must resolve inside the root/);
+
+      expect(await fileExists(outsideSkillDir)).toBe(false);
     });
 
     it("should fail safely instead of overwriting in non-interactive mode", async () => {

--- a/src/cli/commands/add.test.ts
+++ b/src/cli/commands/add.test.ts
@@ -5,10 +5,20 @@ import { parse as parseJsonc } from "jsonc-parser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SourceEntry } from "../../config/config.js";
+import { SKILL_FILE_NAME } from "../../constants/general.js";
 import {
+  RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+  RULESYNC_CHECKS_RELATIVE_DIR_PATH,
+  RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
   RULESYNC_CURATED_SKILLS_RELATIVE_DIR_PATH,
+  RULESYNC_HOOKS_RELATIVE_FILE_PATH,
+  RULESYNC_MCP_RELATIVE_FILE_PATH,
   RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH,
+  RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
+  RULESYNC_RULES_RELATIVE_DIR_PATH,
+  RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH,
+  RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
 import {
   getInstalledSourceRuleNames,
@@ -47,6 +57,188 @@ describe("addCommand", () => {
     await cleanup();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+  });
+
+  describe("feature scaffolding", () => {
+    it.each([
+      {
+        source: "rule",
+        name: "overview.md",
+        relativeFilePath: join(RULESYNC_RULES_RELATIVE_DIR_PATH, "overview.md"),
+        expectedContent: "# Project Overview",
+      },
+      {
+        source: "command",
+        name: "deploy.md",
+        relativeFilePath: join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "deploy.md"),
+        expectedContent: "Run the Deploy workflow",
+      },
+      {
+        source: "subagent",
+        name: "reviewer",
+        relativeFilePath: join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "reviewer.md"),
+        expectedContent: "name: reviewer",
+      },
+      {
+        source: "skill",
+        name: "security.md",
+        relativeFilePath: join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "security", SKILL_FILE_NAME),
+        expectedContent: "name: security",
+      },
+      {
+        source: "check",
+        name: "security",
+        relativeFilePath: join(RULESYNC_CHECKS_RELATIVE_DIR_PATH, "security.md"),
+        expectedContent: "severity: medium",
+      },
+    ])(
+      "should scaffold the named $source feature",
+      async ({ source, name, relativeFilePath, expectedContent }) => {
+        await addCommand(logger, { source, name });
+
+        expect(await readFileContent(join(testDir, relativeFilePath))).toContain(expectedContent);
+        expect(logger.success).toHaveBeenCalledWith(`Created ${relativeFilePath}`);
+        expect(resolveAndFetchSources).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      {
+        source: "mcp",
+        relativeFilePath: RULESYNC_MCP_RELATIVE_FILE_PATH,
+        expectedContent: '"mcpServers"',
+      },
+      {
+        source: "hooks",
+        relativeFilePath: RULESYNC_HOOKS_RELATIVE_FILE_PATH,
+        expectedContent: '"hooks"',
+      },
+      {
+        source: "ignore",
+        relativeFilePath: RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
+        expectedContent: "credentials/",
+      },
+      {
+        source: "permissions",
+        relativeFilePath: RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
+        expectedContent: '"permission"',
+      },
+    ])(
+      "should scaffold the singleton $source feature",
+      async ({ source, relativeFilePath, expectedContent }) => {
+        await addCommand(logger, { source });
+
+        expect(await readFileContent(join(testDir, relativeFilePath))).toContain(expectedContent);
+        expect(logger.success).toHaveBeenCalledWith(`Created ${relativeFilePath}`);
+        expect(resolveAndFetchSources).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should preserve an existing scaffold when overwrite confirmation is declined", async () => {
+      const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
+      const targetPath = join(testDir, relativeFilePath);
+      await writeFileContent(targetPath, "keep me\n");
+      const confirmOverwrite = vi.fn().mockResolvedValue(false);
+
+      await addCommand(logger, {
+        source: "rule",
+        name: "existing",
+        confirmOverwrite,
+      });
+
+      expect(confirmOverwrite).toHaveBeenCalledWith(relativeFilePath);
+      expect(await readFileContent(targetPath)).toBe("keep me\n");
+      expect(logger.info).toHaveBeenCalledWith(`Kept ${relativeFilePath} unchanged.`);
+    });
+
+    it("should replace an existing scaffold when overwrite confirmation is accepted", async () => {
+      const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
+      const targetPath = join(testDir, relativeFilePath);
+      await writeFileContent(targetPath, "replace me\n");
+
+      await addCommand(logger, {
+        source: "rule",
+        name: "existing",
+        confirmOverwrite: vi.fn().mockResolvedValue(true),
+      });
+
+      expect(await readFileContent(targetPath)).toContain("# Existing");
+    });
+
+    it("should fail safely instead of overwriting in non-interactive mode", async () => {
+      const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
+      const targetPath = join(testDir, relativeFilePath);
+      await writeFileContent(targetPath, "keep me\n");
+
+      await expect(
+        addCommand(logger, {
+          source: "rule",
+          name: "existing",
+        }),
+      ).rejects.toThrow(/non-interactive mode.*--force/);
+
+      expect(await readFileContent(targetPath)).toBe("keep me\n");
+    });
+
+    it("should overwrite without prompting when force is set", async () => {
+      const relativeFilePath = join(RULESYNC_RULES_RELATIVE_DIR_PATH, "existing.md");
+      const targetPath = join(testDir, relativeFilePath);
+      await writeFileContent(targetPath, "replace me\n");
+      const confirmOverwrite = vi.fn();
+
+      await addCommand(logger, {
+        source: "rule",
+        name: "existing",
+        force: true,
+        confirmOverwrite,
+      });
+
+      expect(confirmOverwrite).not.toHaveBeenCalled();
+      expect(await readFileContent(targetPath)).toContain("# Existing");
+    });
+
+    it.each(["../outside", "nested/name", String.raw`nested\name`, ".curated"])(
+      "should reject an unsafe feature name: %s",
+      async (name) => {
+        await expect(addCommand(logger, { source: "rule", name })).rejects.toThrow(
+          /Invalid rule name/,
+        );
+      },
+    );
+
+    it("should reject a name for a singleton feature", async () => {
+      await expect(addCommand(logger, { source: "mcp", name: "extra" })).rejects.toThrow(
+        /does not accept --name/,
+      );
+    });
+
+    it("should treat a feature keyword with source options as a declarative source", async () => {
+      const configPath = join(testDir, "rulesync.jsonc");
+      await writeFileContent(
+        configPath,
+        `{
+  "targets": ["claudecode"],
+  "features": ["skills"]
+}
+`,
+      );
+
+      await addCommand(logger, { source: "skill", transport: "npm" });
+
+      const parsed = parseJsonc(await readFileContent(configPath)) as { sources: SourceEntry[] };
+      expect(parsed.sources).toEqual([{ source: "skill", transport: "npm" }]);
+      expect(resolveAndFetchSources).toHaveBeenCalled();
+    });
+
+    it("should reject mixed scaffold and declarative source options", async () => {
+      await expect(
+        addCommand(logger, {
+          source: "rule",
+          name: "overview",
+          rules: ["remote-rule"],
+        }),
+      ).rejects.toThrow(/cannot be combined/);
+    });
   });
 
   it("should append a source, preserve comments, and install only the added source", async () => {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,5 +1,6 @@
 import { cp, mkdtemp, realpath, rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
+import { createInterface } from "node:readline/promises";
 
 import {
   applyEdits,
@@ -20,6 +21,7 @@ import {
   RULESYNC_NPM_SOURCES_LOCK_RELATIVE_FILE_PATH,
   RULESYNC_SOURCES_LOCK_RELATIVE_FILE_PATH,
 } from "../../constants/rulesync-paths.js";
+import { createFeatureScaffold, parseScaffoldFeatureKeyword } from "../../lib/feature-scaffold.js";
 import { normalizeNpmSourceKey } from "../../lib/npm-sources-lock.js";
 import { normalizeSourceKey } from "../../lib/sources-lock.js";
 import {
@@ -32,6 +34,7 @@ import {
   assertTreeContainsNoSymlinks,
   assertWritablePathInsideRoot,
   directoryExists,
+  ensureDir,
   fileExists,
   readFileContent,
   readFileContentOrNull,
@@ -52,8 +55,11 @@ export type AddCommandOptions = {
   tokenEnv?: string;
   token?: string;
   configPath?: string;
+  name?: string;
+  force?: boolean;
   verbose?: boolean;
   silent?: boolean;
+  confirmOverwrite?: (relativeFilePath: string) => Promise<boolean>;
 };
 
 const SOURCE_ENTRY_KEYS = [
@@ -242,6 +248,100 @@ function buildSourceEntry(options: AddCommandOptions): SourceEntry {
   });
 }
 
+function hasSourceOnlyOptions(options: AddCommandOptions): boolean {
+  return [
+    options.skills,
+    options.rules,
+    options.transport,
+    options.ref,
+    options.path,
+    options.rulesPath,
+    options.registry,
+    options.tokenEnv,
+    options.token,
+    options.configPath,
+  ].some((value) => value !== undefined);
+}
+
+async function promptForOverwrite(relativeFilePath: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      `Refusing to overwrite ${relativeFilePath} in non-interactive mode. Re-run with --force to replace it.`,
+    );
+  }
+
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await prompt.question(`Overwrite ${relativeFilePath}? [y/N] `);
+    return /^(?:y|yes)$/i.test(answer.trim());
+  } finally {
+    prompt.close();
+  }
+}
+
+async function addFeatureScaffold({
+  logger,
+  options,
+}: {
+  logger: Logger;
+  options: AddCommandOptions;
+}): Promise<void> {
+  const feature = parseScaffoldFeatureKeyword(options.source);
+  if (!feature) {
+    throw new Error("--name and --force are only valid when adding a Rulesync feature file.");
+  }
+
+  const scaffold = createFeatureScaffold({ feature, name: options.name });
+  const projectRoot = process.cwd();
+  const targetPath = join(projectRoot, scaffold.relativeFilePath);
+  await assertWritablePathInsideRoot({ rootPath: projectRoot, targetPath });
+
+  if ((await fileExists(targetPath)) && !options.force) {
+    const confirmed = await (options.confirmOverwrite ?? promptForOverwrite)(
+      scaffold.relativeFilePath,
+    );
+    if (!confirmed) {
+      logger.info(`Kept ${scaffold.relativeFilePath} unchanged.`);
+      if (logger.jsonMode) {
+        logger.captureData("created", []);
+        logger.captureData("skipped", [scaffold.relativeFilePath]);
+      }
+      return;
+    }
+  }
+
+  await ensureDir(dirname(targetPath));
+  await writeFileContent(targetPath, scaffold.content);
+  logger.success(`Created ${scaffold.relativeFilePath}`);
+  if (logger.jsonMode) {
+    logger.captureData("created", [scaffold.relativeFilePath]);
+    logger.captureData("skipped", []);
+  }
+}
+
+async function handleFeatureScaffoldRequest({
+  logger,
+  options,
+}: {
+  logger: Logger;
+  options: AddCommandOptions;
+}): Promise<boolean> {
+  const feature = parseScaffoldFeatureKeyword(options.source);
+  const sourceOnlyOptions = hasSourceOnlyOptions(options);
+  const scaffoldOnlyOptions = options.name !== undefined || options.force === true;
+
+  if (feature && scaffoldOnlyOptions && sourceOnlyOptions) {
+    throw new Error(
+      "Feature scaffold options (--name, --force) cannot be combined with declarative source options.",
+    );
+  }
+  if ((feature && !sourceOnlyOptions) || scaffoldOnlyOptions) {
+    await addFeatureScaffold({ logger, options });
+    return true;
+  }
+  return false;
+}
+
 function parseConfigContent(content: string, configPath: string) {
   const errors: ParseError[] = [];
   const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
@@ -255,6 +355,10 @@ function parseConfigContent(content: string, configPath: string) {
 }
 
 export async function addCommand(logger: Logger, options: AddCommandOptions): Promise<void> {
+  if (await handleFeatureScaffoldRequest({ logger, options })) {
+    return;
+  }
+
   const projectRoot = process.cwd();
   const relativeConfigPath = options.configPath ?? RULESYNC_CONFIG_RELATIVE_FILE_PATH;
   const configPath = resolvePath(relativeConfigPath, projectRoot);

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -293,28 +293,40 @@ async function addFeatureScaffold({
 
   const scaffold = createFeatureScaffold({ feature, name: options.name });
   const projectRoot = process.cwd();
-  const targetPath = join(projectRoot, scaffold.relativeFilePath);
+  let relativeFilePath = scaffold.relativeFilePath;
+  for (const candidateRelativeFilePath of scaffold.candidateRelativeFilePaths) {
+    if (await fileExists(join(projectRoot, candidateRelativeFilePath))) {
+      relativeFilePath = candidateRelativeFilePath;
+      break;
+    }
+  }
+  const targetPath = join(projectRoot, relativeFilePath);
   await assertWritablePathInsideRoot({ rootPath: projectRoot, targetPath });
 
   if ((await fileExists(targetPath)) && !options.force) {
-    const confirmed = await (options.confirmOverwrite ?? promptForOverwrite)(
-      scaffold.relativeFilePath,
-    );
+    if (logger.jsonMode || logger.silent) {
+      throw new Error(
+        `Refusing to prompt before overwriting ${relativeFilePath} in JSON or silent mode. Re-run with --force to replace it.`,
+      );
+    }
+    const confirmed = await (options.confirmOverwrite ?? promptForOverwrite)(relativeFilePath);
     if (!confirmed) {
-      logger.info(`Kept ${scaffold.relativeFilePath} unchanged.`);
+      logger.info(`Kept ${relativeFilePath} unchanged.`);
       if (logger.jsonMode) {
         logger.captureData("created", []);
-        logger.captureData("skipped", [scaffold.relativeFilePath]);
+        logger.captureData("skipped", [relativeFilePath]);
       }
       return;
     }
   }
 
+  await assertWritablePathInsideRoot({ rootPath: projectRoot, targetPath });
   await ensureDir(dirname(targetPath));
+  await assertWritablePathInsideRoot({ rootPath: projectRoot, targetPath });
   await writeFileContent(targetPath, scaffold.content);
-  logger.success(`Created ${scaffold.relativeFilePath}`);
+  logger.success(`Created ${relativeFilePath}`);
   if (logger.jsonMode) {
-    logger.captureData("created", [scaffold.relativeFilePath]);
+    logger.captureData("created", [relativeFilePath]);
     logger.captureData("skipped", []);
   }
 }

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -113,12 +113,11 @@ describe("initCommand", () => {
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SKILLS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
       );
-      expect(ensureDir).toHaveBeenCalledTimes(8);
+      expect(ensureDir).toHaveBeenCalledTimes(9);
     });
 
     it("should call createSampleFiles", async () => {
@@ -281,7 +280,6 @@ describe("initCommand", () => {
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SKILLS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
       );
@@ -312,9 +310,10 @@ describe("initCommand", () => {
         RULESYNC_RELATIVE_DIR_PATH,
         RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
-        RULESYNC_SKILLS_RELATIVE_DIR_PATH,
-        RULESYNC_RELATIVE_DIR_PATH,
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
+        RULESYNC_RELATIVE_DIR_PATH,
+        RULESYNC_RELATIVE_DIR_PATH,
+        RULESYNC_RELATIVE_DIR_PATH,
       ]);
     });
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -90,7 +90,9 @@ const main = async () => {
 
   program
     .command("add <source>")
-    .description("Add a declarative rule or skill source to rulesync.jsonc and install it")
+    .description("Add a Rulesync feature file or install a declarative rule or skill source")
+    .option("--name <name>", "Name for a rule, command, subagent, skill, or check scaffold")
+    .option("-f, --force", "Overwrite an existing scaffold file without prompting")
     .option("--skills <skills>", "Comma-separated skill names to install", parseCommaSeparatedList)
     .option("--rules <rules>", "Comma-separated rule names to install", parseCommaSeparatedList)
     .option("--transport <transport>", "Source transport: github, git, or npm")

--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { SKILL_FILE_NAME } from "../constants/general.js";
 import {
   RULESYNC_AIIGNORE_RELATIVE_FILE_PATH,
   RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
@@ -9,9 +10,10 @@ import {
   RULESYNC_MCP_RELATIVE_FILE_PATH,
   RULESYNC_OVERVIEW_FILE_NAME,
   RULESYNC_RULES_RELATIVE_DIR_PATH,
+  RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../constants/rulesync-paths.js";
-import { fileExists } from "../utils/file.js";
+import { fileExists, readFileContent } from "../utils/file.js";
 import { execFileAsync, rulesyncArgs, rulesyncCmd, useTestDirectory } from "./e2e-helper.js";
 
 describe("E2E: init", () => {
@@ -34,5 +36,25 @@ describe("E2E: init", () => {
       const exists = await fileExists(join(testDir, path));
       expect(exists, `Expected ${path} to exist`).toBe(true);
     }
+  });
+
+  it("should scaffold named and singleton feature files through the add command", async () => {
+    const testDir = getTestDir();
+    await execFileAsync(rulesyncCmd, [...rulesyncArgs, "add", "rule", "--name", "architecture.md"]);
+    await execFileAsync(rulesyncCmd, [...rulesyncArgs, "add", "skill", "--name", "project-audit"]);
+    await execFileAsync(rulesyncCmd, [...rulesyncArgs, "add", "mcp"]);
+
+    const rulePath = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "architecture.md");
+    const skillPath = join(
+      testDir,
+      RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+      "project-audit",
+      SKILL_FILE_NAME,
+    );
+    const mcpPath = join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH);
+
+    expect(await readFileContent(rulePath)).toContain("# Architecture");
+    expect(await readFileContent(skillPath)).toContain("name: project-audit");
+    expect(await readFileContent(mcpPath)).toContain('"mcpServers"');
   });
 });

--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -54,7 +54,7 @@ describe("E2E: init", () => {
     const mcpPath = join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH);
 
     expect(await readFileContent(rulePath)).toContain("# Architecture");
-    expect(await readFileContent(skillPath)).toContain("name: project-audit");
+    expect(await readFileContent(skillPath)).toContain('name: "project-audit"');
     expect(await readFileContent(mcpPath)).toContain('"mcpServers"');
   });
 });

--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -13,6 +13,7 @@ import {
   RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../constants/rulesync-paths.js";
+import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
 import { fileExists, readFileContent } from "../utils/file.js";
 import { execFileAsync, rulesyncArgs, rulesyncCmd, useTestDirectory } from "./e2e-helper.js";
 
@@ -54,7 +55,15 @@ describe("E2E: init", () => {
     const mcpPath = join(testDir, RULESYNC_MCP_RELATIVE_FILE_PATH);
 
     expect(await readFileContent(rulePath)).toContain("# Architecture");
-    expect(await readFileContent(skillPath)).toContain('name: "project-audit"');
+    expect(
+      (
+        await RulesyncSkill.fromDir({
+          outputRoot: testDir,
+          dirName: "project-audit",
+        })
+      ).getFrontmatter().name,
+    ).toBe("project-audit");
+    expect(await fileExists(skillPath)).toBe(true);
     expect(await readFileContent(mcpPath)).toContain('"mcpServers"');
   });
 });

--- a/src/lib/feature-scaffold.ts
+++ b/src/lib/feature-scaffold.ts
@@ -1,0 +1,409 @@
+import { join } from "node:path";
+
+import { SKILL_FILE_NAME } from "../constants/general.js";
+import {
+  RULESYNC_MCP_SCHEMA_URL,
+  RULESYNC_PERMISSIONS_SCHEMA_URL,
+} from "../constants/rulesync-paths.js";
+import { RulesyncCheck } from "../features/checks/rulesync-check.js";
+import { RulesyncCommand } from "../features/commands/rulesync-command.js";
+import { RulesyncHooks } from "../features/hooks/rulesync-hooks.js";
+import { RulesyncIgnore } from "../features/ignore/rulesync-ignore.js";
+import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
+import { RulesyncPermissions } from "../features/permissions/rulesync-permissions.js";
+import { RulesyncRule } from "../features/rules/rulesync-rule.js";
+import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
+import { RulesyncSubagent } from "../features/subagents/rulesync-subagent.js";
+
+export type ScaffoldFeature =
+  | "rule"
+  | "command"
+  | "subagent"
+  | "skill"
+  | "check"
+  | "mcp"
+  | "hooks"
+  | "ignore"
+  | "permissions";
+
+export type FeatureScaffold = {
+  feature: ScaffoldFeature;
+  relativeFilePath: string;
+  content: string;
+};
+
+const FEATURE_KEYWORDS = new Map<string, ScaffoldFeature>([
+  ["rule", "rule"],
+  ["rules", "rule"],
+  ["command", "command"],
+  ["commands", "command"],
+  ["subagent", "subagent"],
+  ["subagents", "subagent"],
+  ["skill", "skill"],
+  ["skills", "skill"],
+  ["check", "check"],
+  ["checks", "check"],
+  ["mcp", "mcp"],
+  ["hook", "hooks"],
+  ["hooks", "hooks"],
+  ["ignore", "ignore"],
+  ["permission", "permissions"],
+  ["permissions", "permissions"],
+]);
+
+const NAMED_FEATURES = new Set<ScaffoldFeature>(["rule", "command", "subagent", "skill", "check"]);
+
+export function parseScaffoldFeatureKeyword(value: string): ScaffoldFeature | undefined {
+  return FEATURE_KEYWORDS.get(value.toLowerCase());
+}
+
+export function isNamedScaffoldFeature(feature: ScaffoldFeature): boolean {
+  return NAMED_FEATURES.has(feature);
+}
+
+export function normalizeScaffoldName({
+  feature,
+  name,
+}: {
+  feature: ScaffoldFeature;
+  name: string | undefined;
+}): string | undefined {
+  if (!isNamedScaffoldFeature(feature)) {
+    if (name !== undefined) {
+      throw new Error(`Feature "${feature}" does not accept --name.`);
+    }
+    return undefined;
+  }
+
+  if (name === undefined || name.trim() === "") {
+    throw new Error(`Feature "${feature}" requires --name <name>.`);
+  }
+
+  const normalized = name.trim().replace(/\.md$/i, "");
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(normalized)) {
+    throw new Error(
+      `Invalid ${feature} name "${name}". Use letters, numbers, dots, underscores, or hyphens without path separators.`,
+    );
+  }
+  return normalized;
+}
+
+function titleFromName(name: string): string {
+  return name
+    .split(/[-_.]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function ruleTemplate(name: string): string {
+  if (name === "overview") {
+    return `---
+root: true
+targets: ["*"]
+description: "Project overview and general development guidelines"
+globs: ["**/*"]
+---
+
+# Project Overview
+
+## General Guidelines
+
+- Use TypeScript for all new code
+- Follow consistent naming conventions
+- Write self-documenting code with clear variable and function names
+- Prefer composition over inheritance
+- Use meaningful comments for complex business logic
+
+## Code Style
+
+- Use 2 spaces for indentation
+- Use semicolons
+- Use double quotes for strings
+- Use trailing commas in multi-line objects and arrays
+
+## Architecture Principles
+
+- Organize code by feature, not by file type
+- Keep related files close together
+- Use dependency injection for better testability
+- Implement proper error handling
+- Follow single responsibility principle
+`;
+  }
+
+  const title = titleFromName(name);
+  return `---
+root: false
+targets: ["*"]
+description: "${title} guidelines"
+globs: ["**/*"]
+---
+
+# ${title}
+
+Describe the project guidance that should apply when the configured globs match.
+`;
+}
+
+function commandTemplate(name: string): string {
+  if (name === "review-pr") {
+    return `---
+description: 'Review a pull request'
+targets: ["*"]
+---
+
+target_pr = $ARGUMENTS
+
+If target_pr is not provided, use the PR of the current branch.
+
+Execute the following in parallel:
+
+1. Check code quality and style consistency
+2. Review test coverage
+3. Verify documentation updates
+4. Check for potential bugs or security issues
+
+Then provide a summary of findings and suggestions for improvement.
+`;
+  }
+
+  const title = titleFromName(name);
+  return `---
+description: "Run the ${title} workflow"
+targets: ["*"]
+---
+
+# ${title}
+
+Use $ARGUMENTS as input and describe the steps this command should perform.
+`;
+}
+
+function subagentTemplate(name: string): string {
+  if (name === "planner") {
+    return `---
+name: planner
+targets: ["*"]
+description: >-
+  This is the general-purpose planner. The user asks the agent to plan to
+  suggest a specification, implement a new feature, refactor the codebase, or
+  fix a bug. This agent can be called by the user explicitly only.
+claudecode:
+  model: inherit
+---
+
+You are the planner for any tasks.
+
+Based on the user's instruction, create a plan while analyzing the related files. Then, report the plan in detail. You can output files to @tmp/ if needed.
+
+Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
+`;
+  }
+
+  const title = titleFromName(name);
+  return `---
+name: ${name}
+targets: ["*"]
+description: "${title} specialist"
+---
+
+You are the ${title} specialist. Describe the role, constraints, and expected output here.
+`;
+}
+
+function skillTemplate(name: string): string {
+  if (name === "project-context") {
+    return `---
+name: project-context
+description: "Summarize the project context and key constraints"
+targets: ["*"]
+---
+
+Summarize the project goals, core constraints, and relevant dependencies.
+Call out any architecture decisions, shared conventions, and validation steps.
+Keep the summary concise and ready to reuse in future tasks.`;
+  }
+
+  const title = titleFromName(name);
+  return `---
+name: ${name}
+description: "Use ${title} guidance for relevant tasks"
+targets: ["*"]
+---
+
+# ${title}
+
+Describe when to use this skill and the workflow it should follow.
+`;
+}
+
+function checkTemplate(name: string): string {
+  const title = titleFromName(name);
+  return `---
+targets: ["*"]
+description: "${title} review criteria"
+severity: medium
+---
+
+# ${title}
+
+Describe the conditions this check should detect and the evidence it should report.
+`;
+}
+
+function singletonTemplate(feature: ScaffoldFeature): string {
+  switch (feature) {
+    case "mcp":
+      return `{
+  "$schema": "${RULESYNC_MCP_SCHEMA_URL}",
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp",
+      "env": {}
+    },
+    "rulesync": {
+      "type": "stdio",
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "rulesync",
+        "mcp"
+      ],
+      "env": {}
+    }
+  }
+}
+`;
+    case "hooks":
+      return `{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "command": ".rulesync/hooks/format.sh"
+      }
+    ]
+  }
+}
+`;
+    case "ignore":
+      return `credentials/
+`;
+    case "permissions":
+      return `{
+  "$schema": "${RULESYNC_PERMISSIONS_SCHEMA_URL}",
+  "permission": {
+    "bash": {
+      "git status": "allow",
+      "git diff": "allow",
+      "ls *": "allow",
+      "rm -rf *": "deny",
+      "*": "ask"
+    },
+    "edit": {
+      "src/**": "allow"
+    },
+    "read": {
+      ".env": "deny"
+    }
+  }
+}
+`;
+    default:
+      throw new Error(`Feature "${feature}" requires a name.`);
+  }
+}
+
+export function createFeatureScaffold({
+  feature,
+  name,
+}: {
+  feature: ScaffoldFeature;
+  name?: string;
+}): FeatureScaffold {
+  const normalizedName = normalizeScaffoldName({ feature, name });
+
+  switch (feature) {
+    case "rule":
+      return {
+        feature,
+        relativeFilePath: join(
+          RulesyncRule.getSettablePaths().recommended.relativeDirPath,
+          `${normalizedName}.md`,
+        ),
+        content: ruleTemplate(normalizedName!),
+      };
+    case "command":
+      return {
+        feature,
+        relativeFilePath: join(
+          RulesyncCommand.getSettablePaths().relativeDirPath,
+          `${normalizedName}.md`,
+        ),
+        content: commandTemplate(normalizedName!),
+      };
+    case "subagent":
+      return {
+        feature,
+        relativeFilePath: join(
+          RulesyncSubagent.getSettablePaths().relativeDirPath,
+          `${normalizedName}.md`,
+        ),
+        content: subagentTemplate(normalizedName!),
+      };
+    case "skill":
+      return {
+        feature,
+        relativeFilePath: join(
+          RulesyncSkill.getSettablePaths().relativeDirPath,
+          normalizedName!,
+          SKILL_FILE_NAME,
+        ),
+        content: skillTemplate(normalizedName!),
+      };
+    case "check":
+      return {
+        feature,
+        relativeFilePath: join(
+          RulesyncCheck.getSettablePaths().relativeDirPath,
+          `${normalizedName}.md`,
+        ),
+        content: checkTemplate(normalizedName!),
+      };
+    case "mcp": {
+      const paths = RulesyncMcp.getSettablePaths().recommended;
+      return {
+        feature,
+        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        content: singletonTemplate(feature),
+      };
+    }
+    case "hooks": {
+      const paths = RulesyncHooks.getSettablePaths();
+      return {
+        feature,
+        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        content: singletonTemplate(feature),
+      };
+    }
+    case "ignore": {
+      const paths = RulesyncIgnore.getSettablePaths().recommended;
+      return {
+        feature,
+        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        content: singletonTemplate(feature),
+      };
+    }
+    case "permissions": {
+      const paths = RulesyncPermissions.getSettablePaths();
+      return {
+        feature,
+        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        content: singletonTemplate(feature),
+      };
+    }
+  }
+}

--- a/src/lib/feature-scaffold.ts
+++ b/src/lib/feature-scaffold.ts
@@ -29,6 +29,7 @@ export type ScaffoldFeature =
 export type FeatureScaffold = {
   feature: ScaffoldFeature;
   relativeFilePath: string;
+  candidateRelativeFilePaths: string[];
   content: string;
 };
 
@@ -94,6 +95,23 @@ function titleFromName(name: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function namedFeatureScaffold({
+  feature,
+  relativeFilePath,
+  content,
+}: {
+  feature: ScaffoldFeature;
+  relativeFilePath: string;
+  content: string;
+}): FeatureScaffold {
+  return {
+    feature,
+    relativeFilePath,
+    candidateRelativeFilePaths: [relativeFilePath],
+    content,
+  };
 }
 
 function ruleTemplate(name: string): string {
@@ -203,7 +221,7 @@ Attention, again, you are just the planner, so though you can read any files and
 
   const title = titleFromName(name);
   return `---
-name: ${name}
+name: ${JSON.stringify(name)}
 targets: ["*"]
 description: "${title} specialist"
 ---
@@ -227,7 +245,7 @@ Keep the summary concise and ready to reuse in future tasks.`;
 
   const title = titleFromName(name);
   return `---
-name: ${name}
+name: ${JSON.stringify(name)}
 description: "Use ${title} guidance for relevant tasks"
 targets: ["*"]
 ---
@@ -328,34 +346,34 @@ export function createFeatureScaffold({
 
   switch (feature) {
     case "rule":
-      return {
+      return namedFeatureScaffold({
         feature,
         relativeFilePath: join(
           RulesyncRule.getSettablePaths().recommended.relativeDirPath,
           `${normalizedName}.md`,
         ),
         content: ruleTemplate(normalizedName!),
-      };
+      });
     case "command":
-      return {
+      return namedFeatureScaffold({
         feature,
         relativeFilePath: join(
           RulesyncCommand.getSettablePaths().relativeDirPath,
           `${normalizedName}.md`,
         ),
         content: commandTemplate(normalizedName!),
-      };
+      });
     case "subagent":
-      return {
+      return namedFeatureScaffold({
         feature,
         relativeFilePath: join(
           RulesyncSubagent.getSettablePaths().relativeDirPath,
           `${normalizedName}.md`,
         ),
         content: subagentTemplate(normalizedName!),
-      };
+      });
     case "skill":
-      return {
+      return namedFeatureScaffold({
         feature,
         relativeFilePath: join(
           RulesyncSkill.getSettablePaths().relativeDirPath,
@@ -363,45 +381,76 @@ export function createFeatureScaffold({
           SKILL_FILE_NAME,
         ),
         content: skillTemplate(normalizedName!),
-      };
+      });
     case "check":
-      return {
+      return namedFeatureScaffold({
         feature,
         relativeFilePath: join(
           RulesyncCheck.getSettablePaths().relativeDirPath,
           `${normalizedName}.md`,
         ),
         content: checkTemplate(normalizedName!),
-      };
+      });
     case "mcp": {
-      const paths = RulesyncMcp.getSettablePaths().recommended;
+      const paths = RulesyncMcp.getSettablePaths();
+      const relativeFilePath = join(
+        paths.recommended.relativeDirPath,
+        paths.recommended.relativeFilePath,
+      );
       return {
         feature,
-        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        relativeFilePath,
+        candidateRelativeFilePaths: [
+          ...(paths.jsonc ? [join(paths.jsonc.relativeDirPath, paths.jsonc.relativeFilePath)] : []),
+          relativeFilePath,
+          ...(paths.legacy
+            ? [join(paths.legacy.relativeDirPath, paths.legacy.relativeFilePath)]
+            : []),
+        ],
         content: singletonTemplate(feature),
       };
     }
     case "hooks": {
       const paths = RulesyncHooks.getSettablePaths();
+      const relativeFilePath = join(paths.relativeDirPath, paths.relativeFilePath);
       return {
         feature,
-        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        relativeFilePath,
+        candidateRelativeFilePaths: [
+          ...(paths.jsonc ? [join(paths.jsonc.relativeDirPath, paths.jsonc.relativeFilePath)] : []),
+          relativeFilePath,
+        ],
         content: singletonTemplate(feature),
       };
     }
     case "ignore": {
-      const paths = RulesyncIgnore.getSettablePaths().recommended;
+      const paths = RulesyncIgnore.getSettablePaths();
+      const relativeFilePath = join(
+        paths.recommended.relativeDirPath,
+        paths.recommended.relativeFilePath,
+      );
       return {
         feature,
-        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        relativeFilePath,
+        candidateRelativeFilePaths: [
+          relativeFilePath,
+          ...(paths.legacy
+            ? [join(paths.legacy.relativeDirPath, paths.legacy.relativeFilePath)]
+            : []),
+        ],
         content: singletonTemplate(feature),
       };
     }
     case "permissions": {
       const paths = RulesyncPermissions.getSettablePaths();
+      const relativeFilePath = join(paths.relativeDirPath, paths.relativeFilePath);
       return {
         feature,
-        relativeFilePath: join(paths.relativeDirPath, paths.relativeFilePath),
+        relativeFilePath,
+        candidateRelativeFilePaths: [
+          ...(paths.jsonc ? [join(paths.jsonc.relativeDirPath, paths.jsonc.relativeFilePath)] : []),
+          relativeFilePath,
+        ],
         content: singletonTemplate(feature),
       };
     }

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -140,7 +140,6 @@ describe("init", () => {
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SKILLS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
       );

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,23 +1,12 @@
-import { join } from "node:path";
+import { dirname } from "node:path";
 
 import { ConfigFile } from "../config/config.js";
-import { SKILL_FILE_NAME } from "../constants/general.js";
 import {
   RULESYNC_CONFIG_RELATIVE_FILE_PATH,
   RULESYNC_CONFIG_SCHEMA_URL,
-  RULESYNC_MCP_SCHEMA_URL,
-  RULESYNC_OVERVIEW_FILE_NAME,
-  RULESYNC_PERMISSIONS_SCHEMA_URL,
 } from "../constants/rulesync-paths.js";
-import { RulesyncCommand } from "../features/commands/rulesync-command.js";
-import { RulesyncHooks } from "../features/hooks/rulesync-hooks.js";
-import { RulesyncIgnore } from "../features/ignore/rulesync-ignore.js";
-import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
-import { RulesyncPermissions } from "../features/permissions/rulesync-permissions.js";
-import { RulesyncRule } from "../features/rules/rulesync-rule.js";
-import { RulesyncSkill } from "../features/skills/rulesync-skill.js";
-import { RulesyncSubagent } from "../features/subagents/rulesync-subagent.js";
 import { ensureDir, fileExists, writeFileContent } from "../utils/file.js";
+import { createFeatureScaffold } from "./feature-scaffold.js";
 
 type InitFileResult = {
   created: boolean;
@@ -85,234 +74,22 @@ async function createConfigFile(): Promise<InitFileResult> {
 }
 
 async function createSampleFiles(): Promise<InitFileResult[]> {
+  const samples = [
+    createFeatureScaffold({ feature: "rule", name: "overview" }),
+    createFeatureScaffold({ feature: "mcp" }),
+    createFeatureScaffold({ feature: "command", name: "review-pr" }),
+    createFeatureScaffold({ feature: "subagent", name: "planner" }),
+    createFeatureScaffold({ feature: "skill", name: "project-context" }),
+    createFeatureScaffold({ feature: "ignore" }),
+    createFeatureScaffold({ feature: "hooks" }),
+    createFeatureScaffold({ feature: "permissions" }),
+  ];
+
   const results: InitFileResult[] = [];
-
-  // Sample file contents
-  const sampleRuleFile = {
-    filename: RULESYNC_OVERVIEW_FILE_NAME,
-    content: `---
-root: true
-targets: ["*"]
-description: "Project overview and general development guidelines"
-globs: ["**/*"]
----
-
-# Project Overview
-
-## General Guidelines
-
-- Use TypeScript for all new code
-- Follow consistent naming conventions
-- Write self-documenting code with clear variable and function names
-- Prefer composition over inheritance
-- Use meaningful comments for complex business logic
-
-## Code Style
-
-- Use 2 spaces for indentation
-- Use semicolons
-- Use double quotes for strings
-- Use trailing commas in multi-line objects and arrays
-
-## Architecture Principles
-
-- Organize code by feature, not by file type
-- Keep related files close together
-- Use dependency injection for better testability
-- Implement proper error handling
-- Follow single responsibility principle
-`,
-  };
-
-  const sampleMcpFile = {
-    filename: "mcp.json",
-    content: `{
-  "$schema": "${RULESYNC_MCP_SCHEMA_URL}",
-  "mcpServers": {
-    "deepwiki": {
-      "type": "http",
-      "url": "https://mcp.deepwiki.com/mcp",
-      "env": {}
-    },
-    "rulesync": {
-      "type": "stdio",
-      "command": "pnpm",
-      "args": [
-        "dlx",
-        "rulesync",
-        "mcp"
-      ],
-      "env": {}
-    }
+  for (const sample of samples) {
+    await ensureDir(dirname(sample.relativeFilePath));
+    results.push(await writeIfNotExists(sample.relativeFilePath, sample.content));
   }
-}
-`,
-  };
-
-  const sampleCommandFile = {
-    filename: "review-pr.md",
-    content: `---
-description: 'Review a pull request'
-targets: ["*"]
----
-
-target_pr = $ARGUMENTS
-
-If target_pr is not provided, use the PR of the current branch.
-
-Execute the following in parallel:
-
-1. Check code quality and style consistency
-2. Review test coverage
-3. Verify documentation updates
-4. Check for potential bugs or security issues
-
-Then provide a summary of findings and suggestions for improvement.
-`,
-  };
-
-  const sampleSubagentFile = {
-    filename: "planner.md",
-    content: `---
-name: planner
-targets: ["*"]
-description: >-
-  This is the general-purpose planner. The user asks the agent to plan to
-  suggest a specification, implement a new feature, refactor the codebase, or
-  fix a bug. This agent can be called by the user explicitly only.
-claudecode:
-  model: inherit
----
-
-You are the planner for any tasks.
-
-Based on the user's instruction, create a plan while analyzing the related files. Then, report the plan in detail. You can output files to @tmp/ if needed.
-
-Attention, again, you are just the planner, so though you can read any files and run any commands for analysis, please don't write any code.
-`,
-  };
-
-  const sampleSkillFile = {
-    dirName: "project-context",
-    content: `---
-name: project-context
-description: "Summarize the project context and key constraints"
-targets: ["*"]
----
-
-Summarize the project goals, core constraints, and relevant dependencies.
-Call out any architecture decisions, shared conventions, and validation steps.
-Keep the summary concise and ready to reuse in future tasks.`,
-  };
-
-  const sampleIgnoreFile = {
-    content: `credentials/
-`,
-  };
-
-  const sampleHooksFile = {
-    content: `{
-  "version": 1,
-  "hooks": {
-    "postToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "command": ".rulesync/hooks/format.sh"
-      }
-    ]
-  }
-}
-`,
-  };
-
-  // Keep the scaffolded defaults conservative: broad "allow" globs such as
-  // "git *" or "npm run *" are effectively arbitrary code execution (git can run
-  // commands via -c/aliases/hooks; npm run executes package.json scripts), so the
-  // sample allows only a few explicit read-only commands and leaves everything
-  // else to the "*": "ask" catch-all. Users can widen it as they see fit.
-  const samplePermissionsFile = {
-    content: `{
-  "$schema": "${RULESYNC_PERMISSIONS_SCHEMA_URL}",
-  "permission": {
-    "bash": {
-      "git status": "allow",
-      "git diff": "allow",
-      "ls *": "allow",
-      "rm -rf *": "deny",
-      "*": "ask"
-    },
-    "edit": {
-      "src/**": "allow"
-    },
-    "read": {
-      ".env": "deny"
-    }
-  }
-}
-`,
-  };
-
-  // Get paths from settable paths
-  const rulePaths = RulesyncRule.getSettablePaths();
-  const mcpPaths = RulesyncMcp.getSettablePaths();
-  const commandPaths = RulesyncCommand.getSettablePaths();
-  const subagentPaths = RulesyncSubagent.getSettablePaths();
-  const skillPaths = RulesyncSkill.getSettablePaths();
-  const ignorePaths = RulesyncIgnore.getSettablePaths();
-  const hooksPaths = RulesyncHooks.getSettablePaths();
-  const permissionsPaths = RulesyncPermissions.getSettablePaths();
-
-  // Ensure directories
-  await ensureDir(rulePaths.recommended.relativeDirPath);
-  await ensureDir(mcpPaths.recommended.relativeDirPath);
-  await ensureDir(commandPaths.relativeDirPath);
-  await ensureDir(subagentPaths.relativeDirPath);
-  await ensureDir(skillPaths.relativeDirPath);
-  await ensureDir(ignorePaths.recommended.relativeDirPath);
-
-  // Create rule sample file
-  const ruleFilepath = join(rulePaths.recommended.relativeDirPath, sampleRuleFile.filename);
-  results.push(await writeIfNotExists(ruleFilepath, sampleRuleFile.content));
-
-  // Create MCP sample file
-  const mcpFilepath = join(
-    mcpPaths.recommended.relativeDirPath,
-    mcpPaths.recommended.relativeFilePath,
-  );
-  results.push(await writeIfNotExists(mcpFilepath, sampleMcpFile.content));
-
-  // Create command sample file
-  const commandFilepath = join(commandPaths.relativeDirPath, sampleCommandFile.filename);
-  results.push(await writeIfNotExists(commandFilepath, sampleCommandFile.content));
-
-  // Create subagent sample file
-  const subagentFilepath = join(subagentPaths.relativeDirPath, sampleSubagentFile.filename);
-  results.push(await writeIfNotExists(subagentFilepath, sampleSubagentFile.content));
-
-  // Create skill sample file
-  const skillDirPath = join(skillPaths.relativeDirPath, sampleSkillFile.dirName);
-  await ensureDir(skillDirPath);
-  const skillFilepath = join(skillDirPath, SKILL_FILE_NAME);
-  results.push(await writeIfNotExists(skillFilepath, sampleSkillFile.content));
-
-  // Create ignore sample file
-  const ignoreFilepath = join(
-    ignorePaths.recommended.relativeDirPath,
-    ignorePaths.recommended.relativeFilePath,
-  );
-  results.push(await writeIfNotExists(ignoreFilepath, sampleIgnoreFile.content));
-
-  // Create hooks sample file
-  const hooksFilepath = join(hooksPaths.relativeDirPath, hooksPaths.relativeFilePath);
-  results.push(await writeIfNotExists(hooksFilepath, sampleHooksFile.content));
-
-  // Create permissions sample file
-  const permissionsFilepath = join(
-    permissionsPaths.relativeDirPath,
-    permissionsPaths.relativeFilePath,
-  );
-  results.push(await writeIfNotExists(permissionsFilepath, samplePermissionsFile.content));
-
   return results;
 }
 


### PR DESCRIPTION
## Summary

- extend `rulesync add` with named scaffolds for rules, commands, subagents, skills, and checks
- add singleton scaffolds for MCP, hooks, ignore, and permissions with safe overwrite prompting and `--force`
- share scaffold templates with `rulesync init` and document source-keyword disambiguation
- cover every feature path, collision behavior, unsafe names, source compatibility, and CLI execution

Closes #2348

## Test plan

- `pnpm cicheck` (329 test files, 7,440 tests)
- `pnpm exec vitest run --config vitest.e2e.config.ts src/e2e/e2e-init.spec.ts --silent=false`