### PR TITLE
Add provenance attestations for release binaries

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -13,6 +13,9 @@ on:
         type: string
 
 permissions:
+  artifact-metadata: write # Required for recording attested artifacts
+  attestations: write # Required for publishing build provenance
+  id-token: write # Required for signing build provenance with Sigstore
   contents: write # Required for uploading release assets
 
 jobs:
@@ -66,6 +69,11 @@ jobs:
           cd dist-bun
           sha256sum rulesync-* > SHA256SUMS
           cat SHA256SUMS
+
+      - name: Attest binary build provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-checksums: dist-bun/SHA256SUMS
 
       - name: Generate JSON Schemas
         run: pnpm generate:schema


### PR DESCRIPTION
## Summary

- grant the release workflow the permissions required to publish Sigstore-backed artifact attestations
- attest all five release binaries using their existing SHA256SUMS entries
- pin actions/attest v4.2.0 by commit SHA

## Validation

- pnpm cicheck
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/publish-assets.yml

Closes #2346