### PR TITLE
chore: release v14.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "14.1.0",
+  "version": "14.2.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,7 +20,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "14.1.0";
+const getVersion = () => "14.2.0";
 
 function wrapCommand(
   name: string,


### PR DESCRIPTION
## Summary

- bump the CLI version to 14.2.0
- bump the npm package version to 14.2.0
- prepare the v14.2.0 release

## Test plan

- `pnpm cicheck`

## Related issues

#1598, #1938, #2092, #2334, #2336, #2337, #2338, #2342, #2346, #2348, and #2350
