### PR TITLE
chore: update Homebrew formula to v14.2.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "14.1.0"
+  version "14.2.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "7895941f0a0a55e002de6d05f53d0fcdcc679c70f2c8b06f2934d31d826cf797"
+      sha256 "fa511e66b6831cd2289c89012ce40d16a0ac62f547c2c64f6fb5d39f0bc3529b"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "03dd7d94ffb9204f77b088fbe6932a3a4cb417eab8f75fbd2f892c5750e867f2"
+      sha256 "cfd785a78469cd3e712863742f83eafb1434e8396f66c896684fedc8c4d4998a"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "80ba2ee320376f9f152c53387c45a7b0c67f1bd27d84b8e2ef22db80c24c82ce"
+      sha256 "9850341f410b3c41301f932690106f2c3cfcd7beadbf692954cd26cf53d95a39"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "3914c8bc727e75e6f149f8dab0c86eb5a8fb91a3f2a1b3a1549c58daee3b2903"
+      sha256 "d76782fa8d6df05fb34d59f2ae4cdb9c50769f94ba898bee16041000f5248523"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v14.2.0 release.

Related release PR: #2355.
