### PR TITLE
fix(rules): preserve global non-root rules for folded targets

### DIFF
--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -902,6 +902,94 @@ globs: ["src/**/*"]
     expect(generatedContent).not.toContain("Non-Root Rule Content");
   });
 
+  it.each([
+    { target: "codexcli", outputPath: join(".codex", "AGENTS.md") },
+    { target: "pi", outputPath: join(".pi", "agent", "AGENTS.md") },
+  ] as const)(
+    "should fold $target non-root rules into its global root file",
+    async ({ target, outputPath }) => {
+      const projectDir = getProjectDir();
+      const homeDir = getHomeDir();
+
+      await writeFileContent(
+        join(projectDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+        `---
+root: true
+targets: ["${target}"]
+description: "Root rule"
+---
+
+# Global Root Rule
+`,
+      );
+      await writeFileContent(
+        join(projectDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "detail.md"),
+        `---
+targets: ["${target}"]
+description: "Detail rule"
+globs: ["src/**/*"]
+---
+
+# Global Detail Rule
+`,
+      );
+
+      await runGenerate({
+        target,
+        features: "rules",
+        global: true,
+        env: { HOME_DIR: homeDir },
+      });
+
+      const generatedContent = await readFileContent(join(homeDir, outputPath));
+      expect(generatedContent).toContain("Global Root Rule");
+      expect(generatedContent).toContain("Global Detail Rule");
+    },
+  );
+
+  it("should route pi.systemPrompt:append rules to global APPEND_SYSTEM.md", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+
+    await writeFileContent(
+      join(projectDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+      `---
+root: true
+targets: ["pi"]
+description: "Root rule"
+---
+
+# Global Pi Root Rule
+`,
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "append.md"),
+      `---
+targets: ["pi"]
+description: "System prompt addition"
+pi:
+  systemPrompt: append
+---
+
+# Global Pi System Prompt
+`,
+    );
+
+    await runGenerate({
+      target: "pi",
+      features: "rules",
+      global: true,
+      env: { HOME_DIR: homeDir },
+    });
+
+    const rootContent = await readFileContent(join(homeDir, ".pi", "agent", "AGENTS.md"));
+    expect(rootContent).toContain("Global Pi Root Rule");
+    expect(rootContent).not.toContain("Global Pi System Prompt");
+
+    const appendContent = await readFileContent(join(homeDir, ".pi", "agent", "APPEND_SYSTEM.md"));
+    expect(appendContent).toContain("Global Pi System Prompt");
+  });
+
   it("should generate qwencode non-root rules into ~/.qwen/rules in global mode", async () => {
     const projectDir = getProjectDir();
     const homeDir = getHomeDir();

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -904,6 +904,7 @@ globs: ["src/**/*"]
 
   it.each([
     { target: "codexcli", outputPath: join(".codex", "AGENTS.md") },
+    { target: "junie", outputPath: join(".junie", "AGENTS.md") },
     { target: "pi", outputPath: join(".pi", "agent", "AGENTS.md") },
   ] as const)(
     "should fold $target non-root rules into its global root file",

--- a/src/features/rules/junie-rule.test.ts
+++ b/src/features/rules/junie-rule.test.ts
@@ -703,7 +703,7 @@ describe("JunieRule", () => {
       expect(junieRule.getFileContent()).toContain("# Global Junie Guidelines");
     });
 
-    it("should reject non-root rules in global mode", () => {
+    it("should create a global fold candidate from a non-root RulesyncRule", () => {
       const rulesyncRule = new RulesyncRule({
         relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
         relativeFilePath: "detail.md",
@@ -716,13 +716,16 @@ describe("JunieRule", () => {
         body: "# Detail",
       });
 
-      expect(() =>
-        JunieRule.fromRulesyncRule({
-          outputRoot: testDir,
-          rulesyncRule,
-          global: true,
-        }),
-      ).toThrow(/non-root rules in global mode/);
+      const junieRule = JunieRule.fromRulesyncRule({
+        outputRoot: testDir,
+        rulesyncRule,
+        global: true,
+      });
+
+      expect(junieRule.getRelativeDirPath()).toBe(".junie");
+      expect(junieRule.getRelativeFilePath()).toBe("AGENTS.md");
+      expect(junieRule.getFileContent()).toBe("# Detail");
+      expect(junieRule.isRoot()).toBe(false);
     });
 
     it("should read the global root guideline file", async () => {

--- a/src/features/rules/junie-rule.ts
+++ b/src/features/rules/junie-rule.ts
@@ -149,19 +149,17 @@ export class JunieRule extends ToolRule {
       if (!("root" in paths) || !paths.root) {
         throw new Error("JunieRule global settable paths must include a root path");
       }
-      if (!rulesyncRule.getFrontmatter().root) {
-        throw new Error(
-          `JunieRule does not support non-root rules in global mode; expected a root rule but got '${rulesyncRule.getRelativeFilePath()}'`,
-        );
-      }
-      return new JunieRule(
-        this.buildToolRuleParamsDefault({
-          outputRoot,
-          rulesyncRule,
-          validate,
-          rootPath: paths.root,
-        }),
-      );
+      const frontmatter = rulesyncRule.getFrontmatter();
+      return new JunieRule({
+        outputRoot,
+        relativeDirPath: paths.root.relativeDirPath,
+        relativeFilePath: paths.root.relativeFilePath,
+        fileContent: rulesyncRule.getBody(),
+        validate,
+        root: frontmatter.root ?? false,
+        description: frontmatter.description,
+        globs: frontmatter.globs,
+      });
     }
 
     // Both root and non-root rules target the single root `.junie/AGENTS.md`;

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -25,6 +25,10 @@ import { WarpRule } from "./warp-rule.js";
 
 const logger = createMockLogger();
 
+const globalFoldTargets = RulesProcessor.getToolTargets({ global: true }).filter(
+  (target) => RulesProcessor.getFactory(target)?.meta.foldsNonRootIntoRoot === true,
+);
+
 describe("RulesProcessor", () => {
   let testDir: string;
   let cleanup: () => Promise<void>;
@@ -2320,12 +2324,22 @@ targets: ["claudecode"]
       );
     });
 
-    it.each([
-      ["codexcli", ".codex"],
-      ["pi", join(".pi", "agent")],
-    ] as const)(
+    it("should expose every global-capable folded target to the regression matrix", () => {
+      expect(globalFoldTargets).toEqual([
+        "codexcli",
+        "deepagents",
+        "goose",
+        "grokcli",
+        "junie",
+        "kimi-code",
+        "pi",
+        "reasonix",
+      ]);
+    });
+
+    it.each(globalFoldTargets)(
       "should retain and fold global non-root rules for %s",
-      async (toolTarget, expectedRelativeDirPath) => {
+      async (toolTarget) => {
         await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
         await writeFileContent(
           join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
@@ -2355,9 +2369,13 @@ targets: ["${toolTarget}"]
         expect(rulesyncFiles).toHaveLength(2);
 
         const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
+        const globalRootPath = RulesProcessor.getFactory(toolTarget)?.class.getSettablePaths({
+          global: true,
+        }).root;
         expect(toolFiles).toHaveLength(1);
-        expect(toolFiles[0]?.getRelativeDirPath()).toBe(expectedRelativeDirPath);
-        expect(toolFiles[0]?.getRelativeFilePath()).toBe("AGENTS.md");
+        expect(globalRootPath).toBeDefined();
+        expect(toolFiles[0]?.getRelativeDirPath()).toBe(globalRootPath?.relativeDirPath);
+        expect(toolFiles[0]?.getRelativeFilePath()).toBe(globalRootPath?.relativeFilePath);
         expect(toolFiles[0]?.getFileContent()).toContain("# Global root");
         expect(toolFiles[0]?.getFileContent()).toContain("# Global detail");
         expect(warnSpy).not.toHaveBeenCalledWith(
@@ -2365,6 +2383,40 @@ targets: ["${toolTarget}"]
         );
       },
     );
+
+    it("should keep ignoring global non-root rules for root-only targets", async () => {
+      await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
+      await writeFileContent(
+        join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
+        `---
+root: true
+targets: ["cline"]
+---
+# Global root`,
+      );
+      await writeFileContent(
+        join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "detail.md"),
+        `---
+targets: ["cline"]
+---
+# Global detail`,
+      );
+
+      const warnSpy = vi.spyOn(logger, "warn");
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "cline",
+        global: true,
+      });
+
+      const rulesyncFiles = await processor.loadRulesyncFiles();
+      expect(rulesyncFiles).toHaveLength(1);
+      expect((rulesyncFiles[0] as RulesyncRule).getFrontmatter().root).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("non-root rulesync rules found, but it's in global mode"),
+      );
+    });
 
     it("should filter non-root rules by target in global mode", async () => {
       await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -2320,6 +2320,52 @@ targets: ["claudecode"]
       );
     });
 
+    it.each([
+      ["codexcli", ".codex"],
+      ["pi", join(".pi", "agent")],
+    ] as const)(
+      "should retain and fold global non-root rules for %s",
+      async (toolTarget, expectedRelativeDirPath) => {
+        await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
+        await writeFileContent(
+          join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "root.md"),
+          `---
+root: true
+targets: ["${toolTarget}"]
+---
+# Global root`,
+        );
+        await writeFileContent(
+          join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, "detail.md"),
+          `---
+targets: ["${toolTarget}"]
+---
+# Global detail`,
+        );
+
+        const warnSpy = vi.spyOn(logger, "warn");
+        const processor = new RulesProcessor({
+          logger,
+          outputRoot: testDir,
+          toolTarget,
+          global: true,
+        });
+
+        const rulesyncFiles = await processor.loadRulesyncFiles();
+        expect(rulesyncFiles).toHaveLength(2);
+
+        const toolFiles = await processor.convertRulesyncFilesToToolFiles(rulesyncFiles);
+        expect(toolFiles).toHaveLength(1);
+        expect(toolFiles[0]?.getRelativeDirPath()).toBe(expectedRelativeDirPath);
+        expect(toolFiles[0]?.getRelativeFilePath()).toBe("AGENTS.md");
+        expect(toolFiles[0]?.getFileContent()).toContain("# Global root");
+        expect(toolFiles[0]?.getFileContent()).toContain("# Global detail");
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining("non-root rulesync rules found, but it's in global mode"),
+        );
+      },
+    );
+
     it("should filter non-root rules by target in global mode", async () => {
       await ensureDir(join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH));
       await writeFileContent(

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1399,10 +1399,12 @@ As this project's AI coding tool, you must follow the additional conventions bel
       );
     }
 
-    // In global mode, return root rule + non-root rules if the target supports global nonRoot
+    // In global mode, retain non-root rules when the target can emit or fold them globally
     if (this.global) {
       const globalPaths = factory.class.getSettablePaths({ global: true });
-      const supportsGlobalNonRoot = "nonRoot" in globalPaths && globalPaths.nonRoot !== null;
+      const supportsGlobalNonRoot =
+        ("nonRoot" in globalPaths && globalPaths.nonRoot !== null) ||
+        factory.meta.foldsNonRootIntoRoot === true;
 
       const nonRootRules = rulesyncRules.filter(
         (rule) =>

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1404,7 +1404,7 @@ As this project's AI coding tool, you must follow the additional conventions bel
       const globalPaths = factory.class.getSettablePaths({ global: true });
       const supportsGlobalNonRoot =
         ("nonRoot" in globalPaths && globalPaths.nonRoot !== null) ||
-        factory.meta.foldsNonRootIntoRoot === true;
+        (factory.meta.supportsGlobal && factory.meta.foldsNonRootIntoRoot === true);
 
       const nonRootRules = rulesyncRules.filter(
         (rule) =>


### PR DESCRIPTION
## Summary

Preserve global non-root rules for targets that fold them into their root rule file.

## Problem

In global mode, non-root rules are retained only when a target exposes a physical
`nonRoot` output path. Folded targets such as Codex and Pi intentionally expose no
such path, so their non-root rules are discarded before `foldsNonRootIntoRoot` is
evaluated.

This also prevents Pi rules using `systemPrompt: append` from reaching
`APPEND_SYSTEM.md`.

## Reproduction

Generate a root and non-root rule for Codex or Pi in global mode. Only the root body
is emitted; the non-root rule is reported as ignored. The same inputs are folded
correctly in project mode.

## Fix

Retain global non-root rules when the target either exposes a global `nonRoot` path
or supports global scope and declares `foldsNonRootIntoRoot`. Junie global conversion
now maps both root and non-root inputs to `.junie/AGENTS.md` so the processor can fold
them consistently.

## Tests

- Added a derived processor regression matrix covering all seven global-capable
  folded targets.
- Added direct Junie global non-root conversion coverage.
- Added E2E coverage for global Codex, Junie, and Pi folding.
- Added E2E coverage for global Pi `APPEND_SYSTEM.md` routing.
- `pnpm run cicheck`

Closes #2358
