### PR TITLE
Generate research-tool-updates skill for all targets

### DIFF
--- a/.rulesync/skills/research-tool-updates/SKILL.md
+++ b/.rulesync/skills/research-tool-updates/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   capabilities rulesync has not yet followed, and file one GitHub issue per tool
   for the gaps.
 targets:
-  - claudecode
+  - "*"
 ---
 
 # Research Tool Updates


### PR DESCRIPTION
## Summary

- generate the `research-tool-updates` skill for every configured target
- make the skill available to Codex CLI under `.agents/skills/`

## Test plan

- `pnpm cicheck`
- pre-commit `pnpm dev generate`

Closes #2360
