### PR TITLE
Change default init targets

### DIFF
--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -50,6 +50,11 @@ describe("E2E: init", () => {
       expect(exists, `Expected ${path} to exist`).toBe(true);
     }
 
+    const config = parseJsonc(
+      await readFileContent(join(testDir, RULESYNC_CONFIG_RELATIVE_FILE_PATH)),
+    ) as Record<string, unknown>;
+    expect(config.targets).toEqual(["codexcli", "claudecode", "opencode"]);
+
     const permissions = parseJsonc(
       await readFileContent(join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH)),
     ) as Record<string, unknown>;

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -172,14 +172,17 @@ describe("init", () => {
 
       await init();
 
-      expect(writeFileContent).toHaveBeenCalledWith(
-        RULESYNC_CONFIG_RELATIVE_FILE_PATH,
-        expect.stringContaining('"targets"'),
-      );
-      expect(writeFileContent).toHaveBeenCalledWith(
-        RULESYNC_CONFIG_RELATIVE_FILE_PATH,
-        expect.stringContaining('"features"'),
-      );
+      const configWriteCall = vi
+        .mocked(writeFileContent)
+        .mock.calls.find((call) => call[0] === RULESYNC_CONFIG_RELATIVE_FILE_PATH);
+      expect(configWriteCall).toBeDefined();
+
+      const config = JSON.parse(configWriteCall?.[1] ?? "{}") as {
+        features?: string[];
+        targets?: string[];
+      };
+      expect(config.targets).toEqual(["codexcli", "claudecode", "opencode"]);
+      expect(config.features).toBeDefined();
     });
 
     it("should not create config file if it already exists", async () => {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -44,7 +44,7 @@ async function createConfigFile(): Promise<InitFileResult> {
     JSON.stringify(
       {
         $schema: RULESYNC_CONFIG_SCHEMA_URL,
-        targets: ["copilot", "cursor", "claudecode", "codexcli"],
+        targets: ["codexcli", "claudecode", "opencode"],
         features: [
           "rules",
           "ignore",


### PR DESCRIPTION
## Summary

- change newly initialized target defaults to Codex CLI, Claude Code, and OpenCode
- assert the exact default target order in unit and end-to-end tests
- preserve existing configuration files during initialization

## Verification

- `pnpm cicheck`
- `pnpm vitest run --config vitest.e2e.config.ts src/e2e/e2e-init.spec.ts --silent=false`

Closes #2369