### PR TITLE
ci: resolve Takumi Guard workflow follow-ups

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -34,10 +34,9 @@ jobs:
         with:
           experimental: true
 
-      - name: Setup Takumi Guard npm registry
-        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1
-
       - name: Install dependencies
+        # Bun is not supported by the setup action. The tracked .npmrc still
+        # routes this installation through Takumi Guard.
         run: bun install
 
       - name: Build binaries

--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -49,10 +49,9 @@ jobs:
         with:
           experimental: true
 
-      - name: Setup Takumi Guard npm registry
-        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1
-
       - name: Install dependencies
+        # Bun is not supported by the setup action. The tracked .npmrc still
+        # routes this installation through Takumi Guard.
         run: bun install
 
       - name: Build binaries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,8 @@ jobs:
         # Keep the environment override and CLI flag together so publishing
         # cannot fall back to the installation proxy if either is refactored.
         env:
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-        run: pnpm publish --registry="$NPM_CONFIG_REGISTRY"
+          PNPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: pnpm publish --registry="$PNPM_CONFIG_REGISTRY"
 
       - name: Publish target draft release
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,11 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Publish to npm
-        run: pnpm publish --registry=https://registry.npmjs.org/
+        # Keep the environment override and CLI flag together so publishing
+        # cannot fall back to the installation proxy if either is refactored.
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: pnpm publish --registry="$NPM_CONFIG_REGISTRY"
 
       - name: Publish target draft release
         env:


### PR DESCRIPTION
Closes #2090

## Summary
- remove the unsupported Takumi Guard setup action from Bun-only jobs while retaining proxy routing through the tracked `.npmrc`
- pin npm publishing to the public npm registry through both `NPM_CONFIG_REGISTRY` and the explicit `--registry` option
- document the intended Bun and publishing behavior inline

## Validation
- `pnpm cicheck`