### PR TITLE
Remove commands from the default init scaffold

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -15,7 +15,6 @@ import {
   RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
-import { RulesyncCommand } from "../../features/commands/rulesync-command.js";
 import { RulesyncHooks } from "../../features/hooks/rulesync-hooks.js";
 import { RulesyncMcp } from "../../features/mcp/rulesync-mcp.js";
 import { RulesyncRule } from "../../features/rules/rulesync-rule.js";
@@ -27,7 +26,6 @@ import { initCommand } from "./init.js";
 
 // Mock dependencies
 vi.mock("../../utils/file.js");
-vi.mock("../../features/commands/rulesync-command.js");
 vi.mock("../../features/hooks/rulesync-hooks.js");
 vi.mock("../../features/mcp/rulesync-mcp.js");
 vi.mock("../../features/rules/rulesync-rule.js");
@@ -64,9 +62,6 @@ describe("initCommand", () => {
           relativeFilePath: ".mcp.json",
         },
       ],
-    } as any);
-    vi.mocked(RulesyncCommand.getSettablePaths).mockReturnValue({
-      relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
     } as any);
     vi.mocked(RulesyncSubagent.getSettablePaths).mockReturnValue({
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -113,13 +108,13 @@ describe("initCommand", () => {
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
+      expect(ensureDir).not.toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
       );
-      expect(ensureDir).toHaveBeenCalledTimes(8);
+      expect(ensureDir).toHaveBeenCalledTimes(7);
     });
 
     it("should call createSampleFiles", async () => {
@@ -258,16 +253,6 @@ describe("initCommand", () => {
       expect(writeFileContent).toHaveBeenCalled();
       expect(mockLogger.success).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
     });
-
-    it("should handle RulesyncCommand.getSettablePaths errors", async () => {
-      vi.mocked(RulesyncCommand.getSettablePaths).mockImplementation(() => {
-        throw new Error("Command configuration error");
-      });
-
-      await expect(initCommand(mockLogger)).rejects.toThrow("Command configuration error");
-
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
-    });
   });
 
   describe("integration scenarios", () => {
@@ -280,7 +265,7 @@ describe("initCommand", () => {
 
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RULES_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
+      expect(ensureDir).not.toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
@@ -310,7 +295,6 @@ describe("initCommand", () => {
         RULESYNC_RELATIVE_DIR_PATH,
         RULESYNC_RULES_RELATIVE_DIR_PATH,
         RULESYNC_RELATIVE_DIR_PATH,
-        RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
         RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
         RULESYNC_RELATIVE_DIR_PATH,

--- a/src/e2e/e2e-init.spec.ts
+++ b/src/e2e/e2e-init.spec.ts
@@ -40,7 +40,6 @@ describe("E2E: init", () => {
       RULESYNC_HOOKS_RELATIVE_FILE_PATH,
       RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
       join(RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
-      join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md"),
       join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
     ];
 
@@ -54,8 +53,13 @@ describe("E2E: init", () => {
     ) as Record<string, unknown>;
     expect(config.targets).toEqual(["codexcli", "claudecode", "opencode"]);
     expect(config.features).not.toContain("ignore");
+    expect(config.features).not.toContain("commands");
     expect(config.features).toContain("permissions");
+    expect(config.features).toContain("skills");
     expect(await fileExists(join(testDir, RULESYNC_AIIGNORE_RELATIVE_FILE_PATH))).toBe(false);
+    expect(
+      await fileExists(join(testDir, RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md")),
+    ).toBe(false);
 
     const permissions = parseJsonc(
       await readFileContent(join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH)),

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -19,7 +19,6 @@ import {
   RULESYNC_SKILLS_RELATIVE_DIR_PATH,
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../constants/rulesync-paths.js";
-import { RulesyncCommand } from "../features/commands/rulesync-command.js";
 import { RulesyncHooks } from "../features/hooks/rulesync-hooks.js";
 import { RulesyncMcp } from "../features/mcp/rulesync-mcp.js";
 import { RulesyncRule } from "../features/rules/rulesync-rule.js";
@@ -29,7 +28,6 @@ import { ensureDir, fileExists, writeFileContent } from "../utils/file.js";
 import { init } from "./init.js";
 
 vi.mock("../utils/file.js");
-vi.mock("../features/commands/rulesync-command.js");
 vi.mock("../features/hooks/rulesync-hooks.js");
 vi.mock("../features/mcp/rulesync-mcp.js");
 vi.mock("../features/rules/rulesync-rule.js");
@@ -60,9 +58,6 @@ describe("init", () => {
           relativeFilePath: ".mcp.json",
         },
       ],
-    } as never);
-    vi.mocked(RulesyncCommand.getSettablePaths).mockReturnValue({
-      relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
     } as never);
     vi.mocked(RulesyncSubagent.getSettablePaths).mockReturnValue({
       relativeDirPath: RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
@@ -125,7 +120,6 @@ describe("init", () => {
       const expectedPaths = [
         join(RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
         RULESYNC_MCP_RELATIVE_FILE_PATH,
-        join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md"),
         join(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context", SKILL_FILE_NAME),
         RULESYNC_HOOKS_RELATIVE_FILE_PATH,
@@ -145,7 +139,7 @@ describe("init", () => {
 
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RULES_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_RELATIVE_DIR_PATH);
-      expect(ensureDir).toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
+      expect(ensureDir).not.toHaveBeenCalledWith(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH);
       expect(ensureDir).toHaveBeenCalledWith(
         join(RULESYNC_SKILLS_RELATIVE_DIR_PATH, "project-context"),
@@ -172,7 +166,6 @@ describe("init", () => {
       expect(config.features).toEqual([
         "rules",
         "mcp",
-        "commands",
         "subagents",
         "skills",
         "hooks",
@@ -220,7 +213,7 @@ describe("init", () => {
       expect(content).toContain('"mcpServers"');
     });
 
-    it("should create command sample file", async () => {
+    it("should not create a command sample file", async () => {
       await init();
 
       const commandFilePath = join(RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md");
@@ -228,9 +221,7 @@ describe("init", () => {
         .mocked(writeFileContent)
         .mock.calls.find((c) => c[0] === commandFilePath);
 
-      expect(writeCall).toBeDefined();
-      const content = writeCall?.[1] ?? "";
-      expect(content).toContain("description: 'Review a pull request'");
+      expect(writeCall).toBeUndefined();
     });
 
     it("should create subagent sample file", async () => {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -45,7 +45,7 @@ async function createConfigFile(): Promise<InitFileResult> {
       {
         $schema: RULESYNC_CONFIG_SCHEMA_URL,
         targets: ["codexcli", "claudecode", "opencode"],
-        features: ["rules", "mcp", "commands", "subagents", "skills", "hooks", "permissions"],
+        features: ["rules", "mcp", "subagents", "skills", "hooks", "permissions"],
         outputRoots: ["."],
         delete: true,
         verbose: false,
@@ -68,7 +68,6 @@ async function createSampleFiles(): Promise<InitFileResult[]> {
   const samples = [
     createFeatureScaffold({ feature: "rule", name: "overview" }),
     createFeatureScaffold({ feature: "mcp" }),
-    createFeatureScaffold({ feature: "command", name: "review-pr" }),
     createFeatureScaffold({ feature: "subagent", name: "planner" }),
     createFeatureScaffold({ feature: "skill", name: "project-context" }),
     createFeatureScaffold({ feature: "hooks" }),


### PR DESCRIPTION
Closes #2376

## Summary

- stop creating the sample review-pr command during rulesync init
- remove commands from the generated default feature list while keeping skills enabled
- update unit, CLI, and E2E coverage and retain the explicit Commands E2E matrix

## Validation

- pnpm cicheck
- pnpm exec vitest run --config vitest.e2e.config.ts src/e2e/e2e-init.spec.ts src/e2e/e2e-commands.spec.ts