### PR TITLE
Normalize generated line endings across platforms

### DIFF
--- a/src/utils/content-equivalence.test.ts
+++ b/src/utils/content-equivalence.test.ts
@@ -152,4 +152,24 @@ Body
       fileContentsEquivalent({ filePath: "/x/foo.txt", expected: "a\n", existing: "b\n" }),
     ).toBe(false);
   });
+
+  it("treats CRLF and LF as equivalent for text files", () => {
+    expect(
+      fileContentsEquivalent({
+        filePath: "/x/foo.txt",
+        expected: "line1\nline2\n",
+        existing: "line1\r\nline2\r\n",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats standalone carriage returns and LF as equivalent for text files", () => {
+    expect(
+      fileContentsEquivalent({
+        filePath: "/x/foo.txt",
+        expected: "line1\nline2\n",
+        existing: "line1\rline2\r",
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -219,6 +219,16 @@ describe("file utilities", () => {
       expect(result).toBe("content\n");
     });
 
+    it("should normalize Windows line endings throughout the content", () => {
+      const result = addTrailingNewline("line1\r\nline2\r\nline3\r\n");
+      expect(result).toBe("line1\nline2\nline3\n");
+    });
+
+    it("should normalize standalone carriage returns", () => {
+      const result = addTrailingNewline("line1\rline2\r");
+      expect(result).toBe("line1\nline2\n");
+    });
+
     it("should handle multiple lines with trailing whitespace", () => {
       const result = addTrailingNewline("line1\nline2  \t");
       expect(result).toBe("line1\nline2\n");

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -264,7 +264,7 @@ export async function readFileBuffer(filepath: string): Promise<Buffer> {
 }
 
 /**
- * Adds exactly one trailing newline to content.
+ * Normalizes text to LF line endings and adds exactly one trailing newline.
  * Removes any existing trailing whitespace and appends a single newline.
  */
 export function addTrailingNewline(content: string): string {
@@ -272,7 +272,7 @@ export function addTrailingNewline(content: string): string {
     return "\n";
   }
 
-  return content.trimEnd() + "\n";
+  return content.replaceAll("\r\n", "\n").replaceAll("\r", "\n").trimEnd() + "\n";
 }
 
 export async function writeFileContent(filepath: string, content: string): Promise<void> {


### PR DESCRIPTION
Closes #1239

## Summary
- normalize CRLF and standalone CR line endings to LF at the shared text output boundary
- treat platform-specific line endings as equivalent in check and generation flows
- retain the existing POSIX path normalization regression coverage

## Validation
- pnpm cicheck