### PR TITLE
Release v15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "14.2.0",
+  "version": "15.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -17,7 +17,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "14.2.0";
+const getVersion = () => "15.0.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## Summary

- bump the CLI version to 15.0.0
- bump the npm package version to 15.0.0
- prepare the v15.0.0 release

## Test plan

- `pnpm cicheck`

## Related issues

#382, #1239, #2034, #2090, #2358, #2359, #2360, #2364, #2365, #2366, #2369, and #2376
