### PR TITLE
chore: update Homebrew formula to v15.0.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "14.2.0"
+  version "15.0.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "fa511e66b6831cd2289c89012ce40d16a0ac62f547c2c64f6fb5d39f0bc3529b"
+      sha256 "41f897004b4b7d7afdb114376af3bfa1fe544eaca8c04b1ec238e19b4eafd37b"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "cfd785a78469cd3e712863742f83eafb1434e8396f66c896684fedc8c4d4998a"
+      sha256 "f8e4a8ee25bbb192633732ba2a36f050a04268fde319a41498202cad6eec91c9"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "9850341f410b3c41301f932690106f2c3cfcd7beadbf692954cd26cf53d95a39"
+      sha256 "7760915701322ea86ec840d343fdcb9d754be4d58933f82b3822aeda070615a9"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "d76782fa8d6df05fb34d59f2ae4cdb9c50769f94ba898bee16041000f5248523"
+      sha256 "fd8b7cd601876f093ee01fcd7d899506a4997d956650de22aca1b1ae1dfc45c5"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v15.0.0 release: https://github.com/dyoshikawa/rulesync/releases/tag/v15.0.0