### PR TITLE
docs: update feature support checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,10 @@ To add support for a new Tool/Feature (e.g., rules), follow these steps:
 
 1. `src/features/{feature}/{tool}-{feature}.ts` - create implementation.
 2. `src/features/{feature}/{tool}-{feature}.test.ts` - create tests.
-3. `src/types/tool-target-tuples.ts` - add the target to the feature-specific tuple. `ALL_TOOL_TARGETS` is derived from these tuples.
-4. `src/types/tool-targets.test.ts` and the feature processor tests - update the expected targets.
+3. `src/types/tool-target-tuples.ts` - add the target to the feature-specific tuple. `ALL_TOOL_TARGETS` is derived from these tuples. For a brand-new non-legacy target, also register its display metadata in `src/types/tool-display.ts`.
+4. Update the feature processor tests. Update the expected targets in `src/types/tool-targets.test.ts` only when adding a brand-new target.
 5. `src/features/{feature}/{feature}-processor.ts` - register the implementation in the factory.
-6. Define the implementation's project and global output paths through `getSettablePaths`. Ordinary gitignore entries are derived from these paths. Only add exceptional third-party by-products, shared trees, or global-only paths to `HAND_MAINTAINED_GITIGNORE_ENTRIES` in `src/cli/commands/gitignore-entries.ts`.
+6. Define each scope the tool supports through `getSettablePaths`, based on the tool's official documentation. Ordinary project-scope gitignore entries are derived from the paths returned for `global: false`. Only add exceptional third-party by-products, shared trees, or global-only paths to `HAND_MAINTAINED_GITIGNORE_ENTRIES` in `src/cli/commands/gitignore-entries.ts`.
 7. Add or preserve end-to-end happy-path coverage for the Tool × Feature combination.
 8. Run `pnpm dev gitignore` to update the project `.gitignore`.
 9. Run `pnpm run generate:tables` to update the generated supported-tools tables in `README.md` and `docs/reference/supported-tools.md`; do not edit those tables manually.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,17 +30,18 @@ pnpm dev generate
 
 ## How to Add Support for a New Tool/Feature
 
-To add support for a new Tool/Feature (e.g., rules), modify these files:
+To add support for a new Tool/Feature (e.g., rules), follow these steps:
 
 1. `src/features/{feature}/{tool}-{feature}.ts` - create implementation.
 2. `src/features/{feature}/{tool}-{feature}.test.ts` - create tests.
-3. `src/types/tool-targets.ts` - add to `ALL_TOOL_TARGETS`.
-4. `src/types/tool-targets.test.ts` - add to expected targets.
-5. `src/features/{feature}/{feature}-processor.ts` - register in factory.
-6. `src/cli/commands/gitignore.ts` - add output file pattern.
-7. `src/cli/commands/gitignore.test.ts` - update test.
-8. `README.md` - add to Supported Tools table.
-9. Run `pnpm dev gitignore` to update project `.gitignore`.
+3. `src/types/tool-target-tuples.ts` - add the target to the feature-specific tuple. `ALL_TOOL_TARGETS` is derived from these tuples.
+4. `src/types/tool-targets.test.ts` and the feature processor tests - update the expected targets.
+5. `src/features/{feature}/{feature}-processor.ts` - register the implementation in the factory.
+6. Define the implementation's project and global output paths through `getSettablePaths`. Ordinary gitignore entries are derived from these paths. Only add exceptional third-party by-products, shared trees, or global-only paths to `HAND_MAINTAINED_GITIGNORE_ENTRIES` in `src/cli/commands/gitignore-entries.ts`.
+7. Add or preserve end-to-end happy-path coverage for the Tool × Feature combination.
+8. Run `pnpm dev gitignore` to update the project `.gitignore`.
+9. Run `pnpm run generate:tables` to update the generated supported-tools tables in `README.md` and `docs/reference/supported-tools.md`; do not edit those tables manually.
+10. Keep the hand-written file-format documentation synchronized with the implementation, then run `pnpm cicheck`.
 
 See [.rulesync/rules/feature-change-guidelines.md](.rulesync/rules/feature-change-guidelines.md) for additional guidance.
 


### PR DESCRIPTION
## Summary

- point contributors to the feature-specific target tuples that feed `ALL_TOOL_TARGETS`
- explain when gitignore entries are derived and when hand-maintained entries are appropriate
- replace manual supported-tools table edits with the table-generation command
- preserve Tool × Feature E2E and hand-written file-format documentation requirements

## Validation

- confirmed target derivation in `src/types/tool-targets.ts` and `src/types/tool-target-tuples.ts`
- confirmed gitignore derivation in `src/cli/commands/gitignore-derive.ts` and exceptional entries in `src/cli/commands/gitignore-entries.ts`
- confirmed `generate:tables` in `package.json`
- `pnpm cicheck`

Closes #2382
