### PR TITLE
chore: update Homebrew formula to v15.0.1

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "15.0.0"
+  version "15.0.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "41f897004b4b7d7afdb114376af3bfa1fe544eaca8c04b1ec238e19b4eafd37b"
+      sha256 "bb1eedab590f4ef3075315dec1df27cebeb49debe545bd084f7746d7d330e4fc"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "f8e4a8ee25bbb192633732ba2a36f050a04268fde319a41498202cad6eec91c9"
+      sha256 "917e100447621cfaea390cfc3e26f5f1cf84151554685c90644b9e3845d0cae1"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "7760915701322ea86ec840d343fdcb9d754be4d58933f82b3822aeda070615a9"
+      sha256 "1f61978418e4704c9243fca929fc07986b6238d1c1888d9e9c3ab267049fc51d"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "fd8b7cd601876f093ee01fcd7d899506a4997d956650de22aca1b1ae1dfc45c5"
+      sha256 "78663aee6d4892b63f5c56e46cd2e8f175901bb6cea2d7825172290d583e6701"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v15.0.1 release.

Release: https://github.com/dyoshikawa/rulesync/releases/tag/v15.0.1