### PR TITLE
fix(hermesagent): honor HERMES_HOME globally

### DIFF
--- a/docs/reference/supported-tools.md
+++ b/docs/reference/supported-tools.md
@@ -61,12 +61,18 @@ subagents, and checks, plus global MCP servers, commands, subagents, skills,
 hooks, and permissions. Generation, `--check`, and import round-trips are
 covered for both advertised scopes.
 
-Rulesync honors Hermes profiles through `HERMES_HOME`. Project plugins are
-registered by adding their names to `$HERMES_HOME/config.yaml`, but Rulesync
-does not persist Hermes's global project-plugin trust gate. Run Hermes from a
-trusted project root with `HERMES_ENABLE_PROJECT_PLUGINS=true` for an explicit,
-session-scoped opt-in. A future Hermes release that changes its loaders,
-schemas, or plugin API requires a new compatibility validation.
+Rulesync honors Hermes profiles through `HERMES_HOME`. When it is set, its value
+is the profile root itself: global configuration is read and written directly
+under `$HERMES_HOME` (`config.yaml`, `skills/`, `plugins/`, and `rulesync/`),
+without appending `.hermes`. When it is unset, the default remains
+`~/.hermes`. Project-scoped paths remain rooted in the project.
+
+Project plugins are registered by adding their names to
+`$HERMES_HOME/config.yaml`, but Rulesync does not persist Hermes's global
+project-plugin trust gate. Run Hermes from a trusted project root with
+`HERMES_ENABLE_PROJECT_PLUGINS=true` for an explicit, session-scoped opt-in. A
+future Hermes release that changes its loaders, schemas, or plugin API requires
+a new compatibility validation.
 
 ## Deprecation notes
 

--- a/skills/rulesync/supported-tools.md
+++ b/skills/rulesync/supported-tools.md
@@ -61,12 +61,18 @@ subagents, and checks, plus global MCP servers, commands, subagents, skills,
 hooks, and permissions. Generation, `--check`, and import round-trips are
 covered for both advertised scopes.
 
-Rulesync honors Hermes profiles through `HERMES_HOME`. Project plugins are
-registered by adding their names to `$HERMES_HOME/config.yaml`, but Rulesync
-does not persist Hermes's global project-plugin trust gate. Run Hermes from a
-trusted project root with `HERMES_ENABLE_PROJECT_PLUGINS=true` for an explicit,
-session-scoped opt-in. A future Hermes release that changes its loaders,
-schemas, or plugin API requires a new compatibility validation.
+Rulesync honors Hermes profiles through `HERMES_HOME`. When it is set, its value
+is the profile root itself: global configuration is read and written directly
+under `$HERMES_HOME` (`config.yaml`, `skills/`, `plugins/`, and `rulesync/`),
+without appending `.hermes`. When it is unset, the default remains
+`~/.hermes`. Project-scoped paths remain rooted in the project.
+
+Project plugins are registered by adding their names to
+`$HERMES_HOME/config.yaml`, but Rulesync does not persist Hermes's global
+project-plugin trust gate. Run Hermes from a trusted project root with
+`HERMES_ENABLE_PROJECT_PLUGINS=true` for an explicit, session-scoped opt-in. A
+future Hermes release that changes its loaders, schemas, or plugin API requires
+a new compatibility validation.
 
 ## Deprecation notes
 

--- a/src/e2e/e2e-convert.spec.ts
+++ b/src/e2e/e2e-convert.spec.ts
@@ -328,6 +328,7 @@ This rule is converted to multiple tools.
       to: "claudecode",
       features: "rules",
       dryRun: true,
+      env: { NODE_ENV: "e2e" },
     });
 
     // Dry-run summary must advertise itself; no destination file should be written.

--- a/src/e2e/e2e-hermesagent-home.spec.ts
+++ b/src/e2e/e2e-hermesagent-home.spec.ts
@@ -1,0 +1,228 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+  RULESYNC_HOOKS_RELATIVE_FILE_PATH,
+  RULESYNC_MCP_RELATIVE_FILE_PATH,
+  RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH,
+  RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+  RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+import { fileExists, readFileContent, removeFile, writeFileContent } from "../utils/file.js";
+import { runGenerate, runImport, useGlobalTestDirectories } from "./e2e-helper.js";
+
+describe("E2E: HERMES_HOME", () => {
+  const { getProjectDir, getHomeDir } = useGlobalTestDirectories();
+
+  it("uses the custom Hermes profile root for every global feature", async () => {
+    const projectDir = getProjectDir();
+    const homeDir = getHomeDir();
+    const hermesHome = join(homeDir, "custom-hermes");
+    const env = { HOME_DIR: homeDir, HERMES_HOME: hermesHome };
+    const commandSourcePath = join(projectDir, RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "review-pr.md");
+
+    await writeFileContent(
+      commandSourcePath,
+      [
+        "---",
+        'description: "Review a pull request"',
+        'targets: ["hermesagent"]',
+        "---",
+        "Review it.",
+      ].join("\n"),
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "planner.md"),
+      [
+        "---",
+        "name: Planner",
+        'description: "Plans implementation work"',
+        'targets: ["hermesagent"]',
+        "---",
+        "Break the work into steps.",
+      ].join("\n"),
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "release", "SKILL.md"),
+      [
+        "---",
+        "name: release",
+        'description: "Prepare a release"',
+        'targets: ["hermesagent"]',
+        "---",
+        "Prepare the release.",
+      ].join("\n"),
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_MCP_RELATIVE_FILE_PATH),
+      JSON.stringify({
+        mcpServers: {
+          generated: { command: "node", args: ["server.js"] },
+        },
+      }),
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_HOOKS_RELATIVE_FILE_PATH),
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "generated-session-start" }],
+        },
+      }),
+    );
+    await writeFileContent(
+      join(projectDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+      JSON.stringify({
+        permission: {
+          bash: { "git status *": "allow", "rm -rf *": "deny" },
+        },
+      }),
+    );
+    await writeFileContent(join(hermesHome, "config.yaml"), "model: hermes-large\n");
+
+    await runGenerate({
+      target: "hermesagent",
+      features: "mcp,commands,subagents,skills,hooks,permissions",
+      global: true,
+      env,
+    });
+
+    expect(
+      await readFileContent(join(hermesHome, "rulesync", "commands", "review-pr.json")),
+    ).toContain("Review it.");
+    expect(
+      await readFileContent(join(hermesHome, "rulesync", "subagents", "planner.json")),
+    ).toContain("Break the work into steps.");
+    expect(await readFileContent(join(hermesHome, "skills", "release", "SKILL.md"))).toContain(
+      "Prepare the release.",
+    );
+
+    const config = await readFileContent(join(hermesHome, "config.yaml"));
+    expect(config).toContain("model: hermes-large");
+    expect(config).toContain("generated:");
+    expect(config).toContain("on_session_start:");
+    expect(config).toContain("generated-session-start");
+    expect(config).toContain("rm -rf *");
+    expect(config).toContain("rulesync-commands");
+    expect(config).toContain("rulesync-subagents");
+    expect(await fileExists(join(homeDir, ".hermes", "config.yaml"))).toBe(false);
+
+    await runGenerate({
+      target: "hermesagent",
+      features: "mcp,commands,subagents,skills,hooks,permissions",
+      global: true,
+      check: true,
+      env,
+    });
+
+    await removeFile(commandSourcePath);
+    await runGenerate({
+      target: "hermesagent",
+      features: "commands",
+      global: true,
+      deleteFiles: true,
+      env,
+    });
+    expect(await fileExists(join(hermesHome, "rulesync", "commands", "review-pr.json"))).toBe(
+      false,
+    );
+    expect(await fileExists(join(hermesHome, "plugins", "rulesync-commands", "__init__.py"))).toBe(
+      false,
+    );
+    const configAfterDelete = await readFileContent(join(hermesHome, "config.yaml"));
+    expect(configAfterDelete).not.toContain("rulesync-commands");
+    expect(configAfterDelete).toContain("rulesync-subagents");
+    expect(configAfterDelete).toContain("generated-session-start");
+  });
+
+  it("imports every global feature from the custom profile into the global RuleSync root", async () => {
+    const homeDir = getHomeDir();
+    const hermesHome = join(homeDir, "custom-hermes");
+    const env = { HOME_DIR: homeDir, HERMES_HOME: hermesHome };
+
+    await writeFileContent(
+      join(hermesHome, "config.yaml"),
+      [
+        "mcp_servers:",
+        "  imported:",
+        "    command: node",
+        "    args: [imported.js]",
+        "hooks:",
+        "  on_session_start:",
+        "    - command: imported-session-start",
+        'command_allowlist: ["git status *"]',
+        "approvals:",
+        '  deny: ["rm -rf *"]',
+      ].join("\n"),
+    );
+    await writeFileContent(
+      join(homeDir, ".hermes", "config.yaml"),
+      ["mcp_servers:", "  wrong-profile:", "    command: false"].join("\n"),
+    );
+    await writeFileContent(
+      join(hermesHome, "rulesync", "commands", "imported-command.json"),
+      JSON.stringify({
+        slug: "imported-command",
+        description: "Imported command",
+        prompt: "Run the imported command.",
+      }),
+    );
+    await writeFileContent(
+      join(hermesHome, "rulesync", "subagents", "imported-agent.json"),
+      JSON.stringify({
+        slug: "imported-agent",
+        name: "Imported agent",
+        description: "Imported subagent",
+        prompt: "Run the imported subagent.",
+      }),
+    );
+    await writeFileContent(
+      join(hermesHome, "skills", "imported-skill", "SKILL.md"),
+      [
+        "---",
+        "name: imported-skill",
+        'description: "Imported skill"',
+        "---",
+        "Run the imported skill.",
+      ].join("\n"),
+    );
+
+    await runImport({
+      target: "hermesagent",
+      features: "mcp,commands,subagents,skills,hooks,permissions",
+      global: true,
+      env,
+    });
+
+    expect(
+      await readFileContent(
+        join(homeDir, RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "imported-command.md"),
+      ),
+    ).toContain("Run the imported command.");
+    expect(
+      await readFileContent(
+        join(homeDir, RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH, "imported-agent.md"),
+      ),
+    ).toContain("Run the imported subagent.");
+    expect(
+      await readFileContent(
+        join(homeDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "imported-skill", "SKILL.md"),
+      ),
+    ).toContain("Run the imported skill.");
+
+    const importedMcp = await readFileContent(join(homeDir, RULESYNC_MCP_RELATIVE_FILE_PATH));
+    expect(importedMcp).toContain("imported.js");
+    expect(importedMcp).not.toContain("wrong-profile");
+    expect(await readFileContent(join(homeDir, RULESYNC_HOOKS_RELATIVE_FILE_PATH))).toContain(
+      "imported-session-start",
+    );
+    const importedPermissions = await readFileContent(
+      join(homeDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+    );
+    expect(importedPermissions).toContain("git status *");
+    expect(importedPermissions).toContain("rm -rf *");
+    expect(await fileExists(join(hermesHome, ".rulesync"))).toBe(false);
+  });
+});

--- a/src/e2e/e2e-hermesagent-home.spec.ts
+++ b/src/e2e/e2e-hermesagent-home.spec.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { CLAUDECODE_COMMANDS_DIR_PATH } from "../constants/claudecode-paths.js";
 import {
   RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
   RULESYNC_HOOKS_RELATIVE_FILE_PATH,
@@ -11,7 +12,36 @@ import {
   RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH,
 } from "../constants/rulesync-paths.js";
 import { fileExists, readFileContent, removeFile, writeFileContent } from "../utils/file.js";
-import { runGenerate, runImport, useGlobalTestDirectories } from "./e2e-helper.js";
+import {
+  execFileAsync,
+  rulesyncArgs,
+  rulesyncCmd,
+  runGenerate,
+  runImport,
+  useGlobalTestDirectories,
+} from "./e2e-helper.js";
+
+async function runGlobalHermesCommandConvert({
+  env,
+}: {
+  env: Record<string, string>;
+}): Promise<void> {
+  await execFileAsync(
+    rulesyncCmd,
+    [
+      ...rulesyncArgs,
+      "convert",
+      "--from",
+      "claudecode",
+      "--to",
+      "hermesagent",
+      "--features",
+      "commands",
+      "--global",
+    ],
+    { env: { ...process.env, ...env } },
+  );
+}
 
 describe("E2E: HERMES_HOME", () => {
   const { getProjectDir, getHomeDir } = useGlobalTestDirectories();
@@ -135,6 +165,47 @@ describe("E2E: HERMES_HOME", () => {
     expect(configAfterDelete).not.toContain("rulesync-commands");
     expect(configAfterDelete).toContain("rulesync-subagents");
     expect(configAfterDelete).toContain("generated-session-start");
+  });
+
+  it("converts global commands into the custom profile without touching HOME config", async () => {
+    const homeDir = getHomeDir();
+    const hermesHome = join(homeDir, "custom-hermes");
+    const env = { HOME_DIR: homeDir, HERMES_HOME: hermesHome };
+    const homeConfigContent = [
+      "# Preserve this comment and formatting.",
+      "unrelated:",
+      "  formatting: preserved",
+      "",
+    ].join("\n");
+
+    await writeFileContent(
+      join(homeDir, CLAUDECODE_COMMANDS_DIR_PATH, "review-pr.md"),
+      "Review the pull request.",
+    );
+    await writeFileContent(join(homeDir, "config.yaml"), homeConfigContent);
+
+    await runGlobalHermesCommandConvert({ env });
+
+    expect(
+      await readFileContent(join(hermesHome, "rulesync", "commands", "review-pr.json")),
+    ).toContain("Review the pull request.");
+    expect(await fileExists(join(hermesHome, "plugins", "rulesync-commands", "plugin.yaml"))).toBe(
+      true,
+    );
+    expect(await fileExists(join(hermesHome, "plugins", "rulesync-commands", "__init__.py"))).toBe(
+      true,
+    );
+    expect(
+      await fileExists(join(hermesHome, "plugins", "rulesync-commands", ".rulesync-owned")),
+    ).toBe(true);
+    expect(await readFileContent(join(hermesHome, "config.yaml"))).toContain("rulesync-commands");
+
+    expect(await readFileContent(join(homeDir, "config.yaml"))).toBe(homeConfigContent);
+    expect(await fileExists(join(homeDir, "rulesync", "commands", "review-pr.json"))).toBe(false);
+    expect(await fileExists(join(homeDir, "plugins", "rulesync-commands", "plugin.yaml"))).toBe(
+      false,
+    );
+    expect(await fileExists(join(homeDir, ".hermes", "config.yaml"))).toBe(false);
   });
 
   it("imports every global feature from the custom profile into the global RuleSync root", async () => {

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -22,6 +22,7 @@ import {
   toPosixPath,
   writeFileContent,
 } from "../../utils/file.js";
+import { getHermesagentRelativeFilePath } from "../../utils/hermesagent.js";
 import type { Logger } from "../../utils/logger.js";
 import { AgentsmdCommand } from "./agentsmd-command.js";
 import { AntigravityCliCommand } from "./antigravity-cli-command.js";
@@ -93,7 +94,10 @@ type ToolCommandFactory = {
       global?: boolean;
       forDeletion?: boolean;
     }): Promise<ToolFile[]> | ToolFile[];
-    canDeleteAuxiliaryFiles?(params: { outputRoot: string }): Promise<boolean> | boolean;
+    canDeleteAuxiliaryFiles?(params: {
+      outputRoot: string;
+      global?: boolean;
+    }): Promise<boolean> | boolean;
     validateRulesyncCommands?(params: {
       inputRoot: string;
       rulesyncCommands: RulesyncCommand[];
@@ -738,7 +742,10 @@ export class CommandsProcessor extends FeatureProcessor {
       const hasOwnershipGuard = factory.class.canDeleteAuxiliaryFiles !== undefined;
       const canDelete =
         !hasOwnershipGuard ||
-        (await factory.class.canDeleteAuxiliaryFiles?.({ outputRoot: this.outputRoot })) === true;
+        (await factory.class.canDeleteAuxiliaryFiles?.({
+          outputRoot: this.outputRoot,
+          global: this.global,
+        })) === true;
       if (!canDelete) return [];
       const auxiliaryFiles = await factory.class.getAuxiliaryFiles?.({
         toolCommands,
@@ -798,7 +805,10 @@ export class CommandsProcessor extends FeatureProcessor {
   ): Promise<number> {
     const ownershipPath = join(
       this.outputRoot,
-      HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH,
+      getHermesagentRelativeFilePath({
+        global: this.global,
+        relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH,
+      }),
     );
     const shouldDisableHermesCommandsPlugin =
       this.toolTarget === "hermesagent" &&
@@ -807,7 +817,13 @@ export class CommandsProcessor extends FeatureProcessor {
     let changedCount = await super.removeOrphanAiFiles(existingFiles, generatedFiles);
 
     if (!shouldDisableHermesCommandsPlugin) return changedCount;
-    const configPath = join(this.outputRoot, HERMESAGENT_CONFIG_FILE_PATH);
+    const configPath = join(
+      this.outputRoot,
+      getHermesagentRelativeFilePath({
+        global: this.global,
+        relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
+      }),
+    );
     const currentContent = await readFileContentOrNull(configPath);
     if (currentContent === null) return changedCount;
     const nextContent = getDisabledHermesCommandsPluginConfigContent(currentContent);

--- a/src/features/commands/hermesagent-command.ts
+++ b/src/features/commands/hermesagent-command.ts
@@ -20,6 +20,11 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { ToolFile } from "../../types/tool-file.js";
 import { findFilesByGlobs, readFileContentOrNull, toPosixPath } from "../../utils/file.js";
 import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRelativeFilePath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
+import {
   applySharedConfigPatch,
   HERMES_CONFIG_SHARED_FILE_KEY,
   parseSharedConfig,
@@ -171,11 +176,27 @@ class HermesagentCommandAuxiliaryFile extends ToolFile {
   }
 
   shouldMergeExistingFileContent(): boolean {
-    return this.getRelativePathFromCwd() === toPosixPath(HERMESAGENT_CONFIG_FILE_PATH);
+    return (
+      this.getRelativePathFromCwd() ===
+      toPosixPath(
+        getHermesagentRelativeFilePath({
+          global: this.global,
+          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
+        }),
+      )
+    );
   }
 
   setFileContent(newFileContent: string): void {
-    if (this.getRelativePathFromCwd() === toPosixPath(HERMESAGENT_CONFIG_FILE_PATH)) {
+    if (
+      this.getRelativePathFromCwd() ===
+      toPosixPath(
+        getHermesagentRelativeFilePath({
+          global: this.global,
+          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
+        }),
+      )
+    ) {
       super.setFileContent(getEnabledPluginConfigContent(newFileContent));
       return;
     }
@@ -185,16 +206,35 @@ class HermesagentCommandAuxiliaryFile extends ToolFile {
   getFileContent(): string {
     if (
       this.getRelativePathFromCwd() ===
-      toPosixPath(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH)
+      toPosixPath(
+        getHermesagentRelativeFilePath({
+          global: this.global,
+          relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH,
+        }),
+      )
     ) {
       return getPluginManifestContent();
     }
     if (
-      this.getRelativePathFromCwd() === toPosixPath(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH)
+      this.getRelativePathFromCwd() ===
+      toPosixPath(
+        getHermesagentRelativeFilePath({
+          global: this.global,
+          relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH,
+        }),
+      )
     ) {
       return getPluginInitContent();
     }
-    if (this.getRelativePathFromCwd() === toPosixPath(HERMESAGENT_CONFIG_FILE_PATH)) {
+    if (
+      this.getRelativePathFromCwd() ===
+      toPosixPath(
+        getHermesagentRelativeFilePath({
+          global: this.global,
+          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
+        }),
+      )
+    ) {
       return getEnabledPluginConfigContent(super.getFileContent());
     }
     return super.getFileContent();
@@ -206,14 +246,27 @@ export class HermesagentCommand extends ToolCommand {
     return this.isTargetedByRulesyncCommandDefault({ rulesyncCommand, toolTarget: "hermesagent" });
   }
 
-  static getSettablePaths(): { relativeDirPath: string } {
-    return { relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_DIR_PATH };
+  static getSettablePaths({ global = false }: { global?: boolean } = {}): {
+    relativeDirPath: string;
+  } {
+    return {
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_DIR_PATH,
+      }),
+    };
   }
 
-  static getExtraSharedWritePaths(): { relativeDirPath: string; relativeFilePath: string }[] {
+  static getExtraSharedWritePaths({ global = false }: { global?: boolean } = {}): {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  }[] {
     return [
       {
-        relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+        }),
         relativeFilePath: basename(HERMESAGENT_CONFIG_FILE_PATH),
       },
     ];
@@ -270,6 +323,7 @@ export class HermesagentCommand extends ToolCommand {
   static async getAuxiliaryFiles({
     toolCommands,
     outputRoot,
+    global = false,
     forDeletion = false,
   }: {
     toolCommands: ToolCommand[];
@@ -281,21 +335,33 @@ export class HermesagentCommand extends ToolCommand {
     const pluginFiles: ToolFile[] = [
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        }),
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH),
         fileContent: "",
+        global,
       }),
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        }),
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH),
         fileContent: "Generated and owned by RuleSync.\n",
+        global,
       }),
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+        }),
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH),
         fileContent: "",
+        global,
       }),
     ];
     if (forDeletion) return pluginFiles;
@@ -303,16 +369,32 @@ export class HermesagentCommand extends ToolCommand {
       ...pluginFiles,
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+        }),
         relativeFilePath: basename(HERMESAGENT_CONFIG_FILE_PATH),
         fileContent: "",
+        global,
       }),
     ];
   }
 
-  static async canDeleteAuxiliaryFiles({ outputRoot }: { outputRoot: string }): Promise<boolean> {
+  static async canDeleteAuxiliaryFiles({
+    outputRoot,
+    global = false,
+  }: {
+    outputRoot: string;
+    global?: boolean;
+  }): Promise<boolean> {
     const marker = await readFileContentOrNull(
-      join(outputRoot, HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH),
+      join(
+        outputRoot,
+        getHermesagentRelativeFilePath({
+          global,
+          relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH,
+        }),
+      ),
     );
     return marker === "Generated and owned by RuleSync.\n";
   }
@@ -323,7 +405,7 @@ export class HermesagentCommand extends ToolCommand {
     relativeFilePath,
     validate = true,
   }: ToolCommandFromFileParams): Promise<HermesagentCommand> {
-    const relativeDirPath = HERMESAGENT_RULESYNC_COMMANDS_DIR_PATH;
+    const relativeDirPath = this.getSettablePaths({ global }).relativeDirPath;
     return new HermesagentCommand({
       fileContent: await readFile(join(outputRoot, relativeDirPath, relativeFilePath), "utf8"),
       global,
@@ -353,6 +435,7 @@ export class HermesagentCommand extends ToolCommand {
   static override fromRulesyncCommand({
     outputRoot,
     rulesyncCommand,
+    global = false,
   }: ToolCommandFromRulesyncCommandParams): HermesagentCommand {
     const slug = hermesSlashName(basename(rulesyncCommand.getRelativeFilePath(), ".md"));
     const spec: HermesCommandSpec = {
@@ -362,9 +445,10 @@ export class HermesagentCommand extends ToolCommand {
     };
     return new HermesagentCommand({
       outputRoot,
-      relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_DIR_PATH,
+      relativeDirPath: this.getSettablePaths({ global }).relativeDirPath,
       relativeFilePath: `${slug}.json`,
       fileContent: `${JSON.stringify(spec, null, 2)}\n`,
+      global,
     });
   }
 
@@ -386,7 +470,10 @@ export class HermesagentCommand extends ToolCommand {
       frontmatter: { description: spec.description },
       body: spec.prompt,
       fileContent: "",
-      outputRoot: this.outputRoot,
+      outputRoot: getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: this.outputRoot,
+        global: this.global,
+      }),
     });
   }
 }

--- a/src/features/hooks/hermesagent-hooks.ts
+++ b/src/features/hooks/hermesagent-hooks.ts
@@ -14,6 +14,10 @@ import {
   type HooksConfig,
 } from "../../types/hooks.js";
 import { readFileContent } from "../../utils/file.js";
+import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
 import type { Logger } from "../../utils/logger.js";
 import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
 import {
@@ -253,9 +257,12 @@ function hermesHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
  * @see https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/hooks.md
  */
 export class HermesagentHooks extends ToolHooks {
-  static getSettablePaths() {
+  static getSettablePaths({ global = false }: { global?: boolean } = {}) {
     return {
-      relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      }),
       relativeFilePath: HERMESAGENT_CONFIG_FILE_NAME,
     };
   }
@@ -263,7 +270,7 @@ export class HermesagentHooks extends ToolHooks {
   constructor(params: HermesagentHooksParams) {
     super({
       ...params,
-      ...HermesagentHooks.getSettablePaths(),
+      ...HermesagentHooks.getSettablePaths({ global: params.global }),
     });
   }
 
@@ -281,19 +288,24 @@ export class HermesagentHooks extends ToolHooks {
   static async fromFile({
     outputRoot = process.cwd(),
     validate = true,
+    global = false,
   }: ToolHooksFromFileParams): Promise<HermesagentHooks> {
-    const paths = this.getSettablePaths();
+    const paths = this.getSettablePaths({ global });
     return new HermesagentHooks({
       outputRoot,
       fileContent: await readFileContent(
         join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       ),
       validate,
+      global,
     });
   }
 
-  static forDeletion({ outputRoot = process.cwd() }: ToolHooksForDeletionParams): HermesagentHooks {
-    return new HermesagentHooks({ outputRoot, fileContent: "", validate: false });
+  static forDeletion({
+    outputRoot = process.cwd(),
+    global = false,
+  }: ToolHooksForDeletionParams): HermesagentHooks {
+    return new HermesagentHooks({ outputRoot, fileContent: "", validate: false, global });
   }
 
   shouldMergeExistingFileContent(): boolean {
@@ -313,6 +325,10 @@ export class HermesagentHooks extends ToolHooks {
     const config = parseSharedConfig({ format: "yaml", fileContent: this.getFileContent() });
     const hooks = hermesHooksToCanonical(config.hooks);
     return this.toRulesyncHooksDefault({
+      outputRoot: getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: this.outputRoot,
+        global: this.global,
+      }),
       fileContent: JSON.stringify(
         buildImportedHooksConfig({ hooks, overrideKey: "hermesagent" }),
         null,
@@ -325,6 +341,7 @@ export class HermesagentHooks extends ToolHooks {
     outputRoot,
     rulesyncHooks,
     logger,
+    global = false,
   }: ToolHooksFromRulesyncHooksParams & { logger?: Logger }): HermesagentHooks {
     const config = rulesyncHooks.getJson();
     const hermesHooks = canonicalToHermesHooks({
@@ -339,6 +356,7 @@ export class HermesagentHooks extends ToolHooks {
         format: "yaml",
         document: { hooks: hermesHooks },
       }),
+      global,
     });
   }
 }

--- a/src/features/hooks/tool-hooks.ts
+++ b/src/features/hooks/tool-hooks.ts
@@ -56,11 +56,13 @@ export abstract class ToolHooks extends ToolFile {
 
   protected toRulesyncHooksDefault({
     fileContent = undefined,
+    outputRoot = this.outputRoot,
   }: {
     fileContent?: string;
+    outputRoot?: string;
   } = {}): RulesyncHooks {
     return new RulesyncHooks({
-      outputRoot: this.outputRoot,
+      outputRoot,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_HOOKS_FILE_NAME,
       fileContent: fileContent ?? this.fileContent,

--- a/src/features/mcp/hermesagent-mcp.ts
+++ b/src/features/mcp/hermesagent-mcp.ts
@@ -8,6 +8,10 @@ import { ValidationResult } from "../../types/ai-file.js";
 import { McpServers } from "../../types/mcp.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
+import {
   omitPrototypePollutionKeys,
   PROTOTYPE_POLLUTION_KEYS,
 } from "../../utils/prototype-pollution.js";
@@ -326,9 +330,12 @@ export class HermesagentMcp extends ToolMcp {
     return false;
   }
 
-  static getSettablePaths(_options?: { global?: boolean }): ToolMcpSettablePaths {
+  static getSettablePaths({ global = false }: { global?: boolean } = {}): ToolMcpSettablePaths {
     return {
-      relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      }),
       relativeFilePath: HERMESAGENT_CONFIG_FILE_NAME,
     };
   }
@@ -398,6 +405,10 @@ export class HermesagentMcp extends ToolMcp {
     const mcpServers = isRecord(this.config.mcp_servers) ? this.config.mcp_servers : {};
     const { mcpServers: servers, hermesOverrides } = convertFromHermesFormat(mcpServers);
     return this.toRulesyncMcpDefault({
+      outputRoot: getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: this.outputRoot,
+        global: this.global,
+      }),
       fileContent: JSON.stringify(
         {
           mcpServers: servers,

--- a/src/features/mcp/tool-mcp.ts
+++ b/src/features/mcp/tool-mcp.ts
@@ -65,8 +65,10 @@ export abstract class ToolMcp extends ToolFile {
 
   protected toRulesyncMcpDefault({
     fileContent = undefined,
+    outputRoot = this.outputRoot,
   }: {
     fileContent?: string;
+    outputRoot?: string;
   } = {}): RulesyncMcp {
     const content = fileContent ?? this.fileContent;
     const { $schema: _, ...json } = JSON.parse(content);
@@ -75,7 +77,7 @@ export abstract class ToolMcp extends ToolFile {
       ...json,
     };
     return new RulesyncMcp({
-      outputRoot: this.outputRoot,
+      outputRoot,
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_MCP_FILE_NAME,
       fileContent: JSON.stringify(withSchema, null, 2),

--- a/src/features/permissions/hermesagent-permissions.ts
+++ b/src/features/permissions/hermesagent-permissions.ts
@@ -15,6 +15,10 @@ import {
   RulesyncPermissionsFileSchema,
 } from "../../types/permissions.js";
 import { readFileContent } from "../../utils/file.js";
+import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
 import { isRecord, isStringArray } from "../../utils/type-guards.js";
 import {
   applySharedConfigPatch,
@@ -174,9 +178,12 @@ function buildHermesOverride(
 }
 
 export class HermesagentPermissions extends ToolPermissions {
-  static getSettablePaths() {
+  static getSettablePaths({ global = false }: { global?: boolean } = {}) {
     return {
-      relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+      }),
       relativeFilePath: HERMESAGENT_CONFIG_FILE_NAME,
     };
   }
@@ -184,7 +191,7 @@ export class HermesagentPermissions extends ToolPermissions {
   constructor(params: HermesagentPermissionsParams) {
     super({
       ...params,
-      ...HermesagentPermissions.getSettablePaths(),
+      ...HermesagentPermissions.getSettablePaths({ global: params.global }),
     });
   }
 
@@ -199,21 +206,24 @@ export class HermesagentPermissions extends ToolPermissions {
   static async fromFile({
     outputRoot = process.cwd(),
     validate = true,
+    global = false,
   }: ToolPermissionsFromFileParams): Promise<HermesagentPermissions> {
-    const paths = this.getSettablePaths();
+    const paths = this.getSettablePaths({ global });
     return new HermesagentPermissions({
       outputRoot,
       fileContent: await readFileContent(
         join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
       ),
       validate,
+      global,
     });
   }
 
   static forDeletion({
     outputRoot = process.cwd(),
+    global = false,
   }: ToolPermissionsForDeletionParams): HermesagentPermissions {
-    return new HermesagentPermissions({ outputRoot, fileContent: "", validate: false });
+    return new HermesagentPermissions({ outputRoot, fileContent: "", validate: false, global });
   }
 
   shouldMergeExistingFileContent(): boolean {
@@ -269,7 +279,10 @@ export class HermesagentPermissions extends ToolPermissions {
       ...(Object.keys(hermes).length > 0 && { hermes }),
     };
     return new RulesyncPermissions({
-      outputRoot: this.outputRoot,
+      outputRoot: getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: this.outputRoot,
+        global: this.global,
+      }),
       relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
       relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
       fileContent: JSON.stringify(imported, null, 2),
@@ -279,6 +292,7 @@ export class HermesagentPermissions extends ToolPermissions {
   static fromRulesyncPermissions({
     outputRoot,
     rulesyncPermissions,
+    global = false,
   }: ToolPermissionsFromRulesyncPermissionsParams): HermesagentPermissions {
     const permissions = rulesyncPermissions.getJson();
     const permissionBlock = permissions.permission ?? {};
@@ -324,6 +338,7 @@ export class HermesagentPermissions extends ToolPermissions {
     return new HermesagentPermissions({
       outputRoot,
       fileContent: stringifySharedConfig({ format: "yaml", document: config }),
+      global,
     });
   }
 }

--- a/src/features/shared/hermes-project-plugin-activation.test.ts
+++ b/src/features/shared/hermes-project-plugin-activation.test.ts
@@ -110,7 +110,7 @@ describe("Hermes project plugin activation", () => {
   it("writes activation to the active HERMES_HOME profile", async () => {
     const { testDir, cleanup } = await setupTestDirectory({ home: true });
     const profileDir = join(testDir, "profiles", "reviewer");
-    process.env.HOME_DIR = testDir;
+    delete process.env.HOME_DIR;
     process.env.HERMES_HOME = profileDir;
     try {
       const result = await activateHermesProjectPlugins({

--- a/src/features/shared/hermes-project-plugin-activation.ts
+++ b/src/features/shared/hermes-project-plugin-activation.ts
@@ -1,7 +1,6 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import {
-  HERMESAGENT_CONFIG_FILE_NAME,
   HERMESAGENT_CONFIG_FILE_PATH,
   HERMESAGENT_PROJECT_PLUGINS_ENV_VAR,
 } from "../../constants/hermesagent-paths.js";
@@ -12,6 +11,10 @@ import {
   readFileContentOrNull,
   writeFileContent,
 } from "../../utils/file.js";
+import {
+  getHermesagentRelativeFilePath,
+  resolveHermesagentOutputRoot,
+} from "../../utils/hermesagent.js";
 import type { Logger } from "../../utils/logger.js";
 import type { FeatureGenerateResult } from "../../utils/result.js";
 import { isPlainObject } from "../../utils/type-guards.js";
@@ -114,11 +117,14 @@ export async function activateHermesProjectPlugins({
     return { count: 0, paths: [], hasDiff: false };
   }
 
-  const configuredHermesHome = process.env.HERMES_HOME?.trim();
-  const configRoot = configuredHermesHome ? resolve(configuredHermesHome) : getHomeDirectory();
-  const relativeConfigPath = configuredHermesHome
-    ? HERMESAGENT_CONFIG_FILE_NAME
-    : HERMESAGENT_CONFIG_FILE_PATH;
+  const configRoot = resolveHermesagentOutputRoot({
+    outputRoot: getHomeDirectory(),
+    global: true,
+  });
+  const relativeConfigPath = getHermesagentRelativeFilePath({
+    global: true,
+    relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
+  });
   const configPath = join(configRoot, relativeConfigPath);
   const existingConfig = (await readFileContentOrNull(configPath)) ?? "";
   const expectedConfig = mergeEnabledPlugins({

--- a/src/features/shared/hermes-project-plugin-activation.ts
+++ b/src/features/shared/hermes-project-plugin-activation.ts
@@ -11,10 +11,7 @@ import {
   readFileContentOrNull,
   writeFileContent,
 } from "../../utils/file.js";
-import {
-  getHermesagentRelativeFilePath,
-  resolveHermesagentOutputRoot,
-} from "../../utils/hermesagent.js";
+import { getHermesagentHome, getHermesagentRelativeFilePath } from "../../utils/hermesagent.js";
 import type { Logger } from "../../utils/logger.js";
 import type { FeatureGenerateResult } from "../../utils/result.js";
 import { isPlainObject } from "../../utils/type-guards.js";
@@ -117,10 +114,7 @@ export async function activateHermesProjectPlugins({
     return { count: 0, paths: [], hasDiff: false };
   }
 
-  const configRoot = resolveHermesagentOutputRoot({
-    outputRoot: getHomeDirectory(),
-    global: true,
-  });
+  const configRoot = getHermesagentHome() ?? getHomeDirectory();
   const relativeConfigPath = getHermesagentRelativeFilePath({
     global: true,
     relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,

--- a/src/features/skills/hermesagent-skill.ts
+++ b/src/features/skills/hermesagent-skill.ts
@@ -1,6 +1,10 @@
 import { HERMESAGENT_SKILLS_DIR_PATH } from "../../constants/hermesagent-paths.js";
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
+import {
   AgentsSkillsSkill,
   type AgentsSkillsSkillParams,
   toAllowedToolsArray,
@@ -23,16 +27,19 @@ export class HermesagentSkill extends AgentsSkillsSkill {
     );
   }
 
-  static getSettablePaths() {
+  static getSettablePaths({ global = false }: { global?: boolean } = {}) {
     return {
-      relativeDirPath: HERMESAGENT_SKILLS_DIR_PATH,
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_SKILLS_DIR_PATH,
+      }),
     };
   }
 
   constructor(params: AgentsSkillsSkillParams) {
     super({
       ...params,
-      relativeDirPath: HERMESAGENT_SKILLS_DIR_PATH,
+      relativeDirPath: HermesagentSkill.getSettablePaths({ global: params.global }).relativeDirPath,
     });
   }
 
@@ -72,7 +79,7 @@ export class HermesagentSkill extends AgentsSkillsSkill {
 
     return new this({
       outputRoot,
-      relativeDirPath: HERMESAGENT_SKILLS_DIR_PATH,
+      relativeDirPath: this.getSettablePaths({ global }).relativeDirPath,
       dirName,
       frontmatter,
       body: rulesyncSkill.getBody(),
@@ -117,7 +124,10 @@ export class HermesagentSkill extends AgentsSkillsSkill {
       ...(Object.keys(hermesagent).length > 0 && { hermesagent }),
     };
     return new RulesyncSkill({
-      outputRoot: this.outputRoot,
+      outputRoot: getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: this.outputRoot,
+        global: this.global,
+      }),
       relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
       dirName: this.getDirName(),
       frontmatter: rulesyncFrontmatter,
@@ -153,7 +163,7 @@ export class HermesagentSkill extends AgentsSkillsSkill {
   }: ToolSkillForDeletionParams): HermesagentSkill {
     return new this({
       outputRoot,
-      relativeDirPath: relativeDirPath ?? HERMESAGENT_SKILLS_DIR_PATH,
+      relativeDirPath: relativeDirPath ?? this.getSettablePaths({ global }).relativeDirPath,
       dirName,
       frontmatter: { name: "", description: "" },
       body: "",

--- a/src/features/subagents/hermesagent-subagent.ts
+++ b/src/features/subagents/hermesagent-subagent.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
 
 import {
   HERMESAGENT_CONFIG_FILE_PATH,
@@ -11,6 +11,10 @@ import {
 } from "../../constants/hermesagent-paths.js";
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { type ValidationResult } from "../../types/ai-file.js";
+import {
+  getHermesagentRelativeDirPath,
+  getHermesagentRulesyncOutputRoot,
+} from "../../utils/hermesagent.js";
 import {
   applySharedConfigPatch,
   HERMES_CONFIG_SHARED_FILE_KEY,
@@ -183,18 +187,16 @@ export class HermesagentSubagent extends ToolSubagent {
     relativeFilePath,
     validate = true,
   }: ToolSubagentFromFileParams): Promise<HermesagentSubagent> {
+    const resolvedRelativeDirPath =
+      relativeDirPath ?? this.getSettablePaths({ global }).relativeDirPath;
     return new HermesagentSubagent({
       fileContent: await readFile(
-        join(
-          outputRoot,
-          relativeDirPath ?? HERMESAGENT_RULESYNC_SUBAGENTS_DIR_PATH,
-          relativeFilePath,
-        ),
+        join(outputRoot, resolvedRelativeDirPath, relativeFilePath),
         "utf8",
       ),
       global,
       outputRoot,
-      relativeDirPath: relativeDirPath ?? dirname(relativeFilePath),
+      relativeDirPath: resolvedRelativeDirPath,
       relativeFilePath: basename(relativeFilePath),
       validate,
     });
@@ -214,30 +216,43 @@ export class HermesagentSubagent extends ToolSubagent {
     return [
       ...rulesyncSubagents.map((rulesyncSubagent) =>
         HermesagentSubagent.fromRulesyncSubagent({
-          relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_DIR_PATH,
+          relativeDirPath: this.getSettablePaths({ global }).relativeDirPath,
           rulesyncSubagent,
           outputRoot,
+          global,
         }),
       ),
       new HermesagentSubagent({
-        relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
+        }),
         relativeFilePath: basename(HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_MANIFEST_PATH),
         fileContent: "",
         outputRoot,
+        global,
       }),
       new HermesagentSubagent({
-        relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
+        relativeDirPath: getHermesagentRelativeDirPath({
+          global,
+          relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
+        }),
         relativeFilePath: basename(HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_INIT_PATH),
         fileContent: "",
         outputRoot,
+        global,
       }),
       ...(global
         ? [
             new HermesagentSubagent({
-              relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+              relativeDirPath: getHermesagentRelativeDirPath({
+                global,
+                relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+              }),
               relativeFilePath: basename(HERMESAGENT_CONFIG_FILE_PATH),
               fileContent: "",
               outputRoot,
+              global,
             }),
           ]
         : []),
@@ -247,21 +262,28 @@ export class HermesagentSubagent extends ToolSubagent {
   static fromRulesyncSubagent({
     rulesyncSubagent,
     outputRoot,
+    global = false,
   }: ToolSubagentFromRulesyncSubagentParams): HermesagentSubagent {
     const spec = getSubagentSpec(rulesyncSubagent);
     const slug = String(spec.slug);
 
     return new HermesagentSubagent({
-      relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_DIR_PATH,
+      relativeDirPath: this.getSettablePaths({ global }).relativeDirPath,
       relativeFilePath: `${slug}.json`,
       fileContent: `${JSON.stringify(spec, null, 2)}\n`,
       outputRoot,
+      global,
     });
   }
 
-  static getSettablePaths(): { relativeDirPath: string } {
+  static getSettablePaths({ global = false }: { global?: boolean } = {}): {
+    relativeDirPath: string;
+  } {
     return {
-      relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_DIR_PATH,
+      relativeDirPath: getHermesagentRelativeDirPath({
+        global,
+        relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_DIR_PATH,
+      }),
     };
   }
 
@@ -278,7 +300,10 @@ export class HermesagentSubagent extends ToolSubagent {
     return global
       ? [
           {
-            relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+            relativeDirPath: getHermesagentRelativeDirPath({
+              global,
+              relativeDirPath: HERMESAGENT_GLOBAL_DIR,
+            }),
             relativeFilePath: basename(HERMESAGENT_CONFIG_FILE_PATH),
           },
         ]
@@ -307,7 +332,12 @@ export class HermesagentSubagent extends ToolSubagent {
         name: json.name ?? slug,
         description: json.description,
       },
-      outputRoot: this.global ? this.outputRoot : process.cwd(),
+      outputRoot: this.global
+        ? getHermesagentRulesyncOutputRoot({
+            nativeOutputRoot: this.outputRoot,
+            global: this.global,
+          })
+        : process.cwd(),
     });
   }
 

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -277,7 +277,7 @@ function buildCommandsStrategy(ctx: ConvertContext) {
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
       new CommandsProcessor({
-        outputRoot,
+        outputRoot: resolveToolOutputRoot({ outputRoot, toolTarget, global }),
         toolTarget,
         global,
         dryRun,
@@ -426,7 +426,13 @@ function buildChecksStrategy(ctx: ConvertContext) {
     itemLabel: "check file(s)",
     allTargets,
     createProcessor: ({ toolTarget, dryRun }) =>
-      new ChecksProcessor({ outputRoot, toolTarget, global, dryRun, logger }),
+      new ChecksProcessor({
+        outputRoot: resolveToolOutputRoot({ outputRoot, toolTarget, global }),
+        toolTarget,
+        global,
+        dryRun,
+        logger,
+      }),
     loadSource: (p) => p.loadToolFiles(),
     toRulesync: (p, files) => p.convertToolFilesToRulesyncFiles(files),
     fromRulesync: (p, files) => p.convertRulesyncFilesToToolFiles(files),

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -10,9 +10,9 @@ import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
 import type { Feature } from "../types/features.js";
 import type { ToolTarget } from "../types/tool-targets.js";
-import { resolveToolOutputRoot } from "../utils/kimi-code.js";
 import type { Logger } from "../utils/logger.js";
 import { isPackagingToolTarget } from "../utils/plugin-root.js";
+import { resolveToolOutputRoot } from "../utils/tool-output-root.js";
 
 export type ConvertResult = {
   rulesCount: number;

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -35,10 +35,10 @@ import type { RulesyncFile } from "../types/rulesync-file.js";
 import type { ToolTarget } from "../types/tool-targets.js";
 import { formatError } from "../utils/error.js";
 import { fileExists, toPosixPath } from "../utils/file.js";
-import { resolveToolOutputRoot } from "../utils/kimi-code.js";
 import type { Logger } from "../utils/logger.js";
 import { assertPluginRootSafe } from "../utils/plugin-root.js";
 import type { FeatureGenerateResult } from "../utils/result.js";
+import { resolveToolOutputRoot } from "../utils/tool-output-root.js";
 import { deriveSharedWriteSteps } from "./shared-file-derive.js";
 
 export type GenerateResult = {
@@ -876,7 +876,11 @@ async function generateCommandsCore(params: {
       }
 
       const processor = new CommandsProcessor({
-        outputRoot: outputRoot,
+        outputRoot: resolveToolOutputRoot({
+          outputRoot,
+          toolTarget,
+          global: config.getGlobal(),
+        }),
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -14,13 +14,13 @@ import { SkillsProcessor } from "../features/skills/skills-processor.js";
 import { SubagentsProcessor } from "../features/subagents/subagents-processor.js";
 import type { RulesyncFile, RulesyncFileParams } from "../types/rulesync-file.js";
 import type { ToolTarget } from "../types/tool-targets.js";
-import { resolveToolOutputRoot } from "../utils/kimi-code.js";
 import type { Logger } from "../utils/logger.js";
 import { assertPluginRootSafe, isPackagingToolTarget } from "../utils/plugin-root.js";
 import {
   resolveRulesyncSourceWritePath,
   type RulesyncSourceSettablePaths,
 } from "../utils/rulesync-source-path.js";
+import { resolveToolOutputRoot } from "../utils/tool-output-root.js";
 
 async function applyRulesyncSourcePath<T extends RulesyncFile>({
   files,

--- a/src/utils/hermesagent.test.ts
+++ b/src/utils/hermesagent.test.ts
@@ -1,0 +1,76 @@
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getHermesagentHome,
+  getHermesagentRelativeDirPath,
+  getHermesagentRelativeFilePath,
+  getHermesagentRulesyncOutputRoot,
+  resolveHermesagentOutputRoot,
+} from "./hermesagent.js";
+
+describe("Hermes Agent profile paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+  const originalHomeDir = process.env.HOME_DIR;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+    if (originalHomeDir === undefined) delete process.env.HOME_DIR;
+    else process.env.HOME_DIR = originalHomeDir;
+  });
+
+  it("falls back to the caller root when HERMES_HOME is unset or blank", () => {
+    delete process.env.HERMES_HOME;
+    expect(getHermesagentHome()).toBeUndefined();
+    expect(resolveHermesagentOutputRoot({ outputRoot: "/default-home", global: true })).toBe(
+      "/default-home",
+    );
+    expect(getHermesagentRelativeDirPath({ global: true, relativeDirPath: ".hermes/skills" })).toBe(
+      join(".hermes", "skills"),
+    );
+
+    process.env.HERMES_HOME = "   ";
+    expect(getHermesagentHome()).toBeUndefined();
+  });
+
+  it("uses HERMES_HOME as the global profile root without appending .hermes", () => {
+    process.env.HERMES_HOME = " ./custom-hermes ";
+
+    expect(getHermesagentHome()).toBe(resolve("custom-hermes"));
+    expect(resolveHermesagentOutputRoot({ outputRoot: "/default-home", global: true })).toBe(
+      resolve("custom-hermes"),
+    );
+    expect(getHermesagentRelativeDirPath({ global: true, relativeDirPath: ".hermes/skills" })).toBe(
+      "skills",
+    );
+    expect(
+      getHermesagentRelativeFilePath({
+        global: true,
+        relativeFilePath: ".hermes/config.yaml",
+      }),
+    ).toBe("config.yaml");
+  });
+
+  it("keeps project paths and the global RuleSync source root separate", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+    process.env.HOME_DIR = "/rulesync-home";
+
+    expect(resolveHermesagentOutputRoot({ outputRoot: "/project", global: false })).toBe(
+      "/project",
+    );
+    expect(
+      getHermesagentRelativeDirPath({ global: false, relativeDirPath: ".hermes/plugins" }),
+    ).toBe(join(".hermes", "plugins"));
+    expect(
+      getHermesagentRulesyncOutputRoot({
+        nativeOutputRoot: "/custom-hermes",
+        global: true,
+      }),
+    ).toBe("/rulesync-home");
+    expect(getHermesagentRulesyncOutputRoot({ nativeOutputRoot: "/project", global: false })).toBe(
+      "/project",
+    );
+  });
+});

--- a/src/utils/hermesagent.test.ts
+++ b/src/utils/hermesagent.test.ts
@@ -53,6 +53,17 @@ describe("Hermes Agent profile paths", () => {
     ).toBe("config.yaml");
   });
 
+  it("rejects paths outside .hermes when stripping the global profile prefix", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(() =>
+      getHermesagentRelativeDirPath({ global: true, relativeDirPath: "outside" }),
+    ).toThrow("Hermes Agent global path must be within .hermes");
+    expect(() =>
+      getHermesagentRelativeFilePath({ global: true, relativeFilePath: "config.yaml" }),
+    ).toThrow("Hermes Agent global path must be within .hermes");
+  });
+
   it("keeps project paths and the global RuleSync source root separate", () => {
     process.env.HERMES_HOME = "/custom-hermes";
     process.env.HOME_DIR = "/rulesync-home";

--- a/src/utils/hermesagent.ts
+++ b/src/utils/hermesagent.ts
@@ -1,0 +1,57 @@
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { HERMESAGENT_GLOBAL_DIR } from "../constants/hermesagent-paths.js";
+import { getHomeDirectory } from "./file.js";
+
+export function getHermesagentHome(): string | undefined {
+  const configuredHome = process.env.HERMES_HOME?.trim();
+  return configuredHome ? resolve(configuredHome) : undefined;
+}
+
+export function resolveHermesagentOutputRoot({
+  outputRoot,
+  global,
+}: {
+  outputRoot: string;
+  global: boolean;
+}): string {
+  return global ? (getHermesagentHome() ?? outputRoot) : outputRoot;
+}
+
+export function getHermesagentRelativeDirPath({
+  global,
+  relativeDirPath,
+}: {
+  global: boolean;
+  relativeDirPath: string;
+}): string {
+  return global && getHermesagentHome()
+    ? relative(HERMESAGENT_GLOBAL_DIR, relativeDirPath)
+    : relativeDirPath;
+}
+
+export function getHermesagentRelativeFilePath({
+  global,
+  relativeFilePath,
+}: {
+  global: boolean;
+  relativeFilePath: string;
+}): string {
+  return join(
+    getHermesagentRelativeDirPath({
+      global,
+      relativeDirPath: dirname(relativeFilePath),
+    }),
+    basename(relativeFilePath),
+  );
+}
+
+export function getHermesagentRulesyncOutputRoot({
+  nativeOutputRoot,
+  global,
+}: {
+  nativeOutputRoot: string;
+  global: boolean;
+}): string {
+  return global && getHermesagentHome() ? getHomeDirectory() : nativeOutputRoot;
+}

--- a/src/utils/hermesagent.ts
+++ b/src/utils/hermesagent.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { HERMESAGENT_GLOBAL_DIR } from "../constants/hermesagent-paths.js";
 import { getHomeDirectory } from "./file.js";
@@ -25,9 +25,15 @@ export function getHermesagentRelativeDirPath({
   global: boolean;
   relativeDirPath: string;
 }): string {
-  return global && getHermesagentHome()
-    ? relative(HERMESAGENT_GLOBAL_DIR, relativeDirPath)
-    : relativeDirPath;
+  if (!global || !getHermesagentHome()) return relativeDirPath;
+
+  const relativePath = relative(HERMESAGENT_GLOBAL_DIR, relativeDirPath);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(
+      `Hermes Agent global path must be within ${HERMESAGENT_GLOBAL_DIR}: ${relativeDirPath}`,
+    );
+  }
+  return relativePath;
 }
 
 export function getHermesagentRelativeFilePath({

--- a/src/utils/kimi-code.ts
+++ b/src/utils/kimi-code.ts
@@ -1,24 +1,11 @@
 import { join, resolve } from "node:path";
 
 import { KIMI_CODE_DIR } from "../constants/kimi-code-paths.js";
-import type { ToolTarget } from "../types/tool-targets.js";
 import { getHomeDirectory } from "./file.js";
 
 export function getKimiCodeHome(): string | undefined {
   const configuredHome = process.env.KIMI_CODE_HOME?.trim();
   return configuredHome ? resolve(configuredHome) : undefined;
-}
-
-export function resolveToolOutputRoot({
-  outputRoot,
-  toolTarget,
-  global,
-}: {
-  outputRoot: string;
-  toolTarget: ToolTarget;
-  global: boolean;
-}): string {
-  return toolTarget === "kimi-code" && global ? (getKimiCodeHome() ?? outputRoot) : outputRoot;
 }
 
 export function getKimiCodeRelativeDirPath({

--- a/src/utils/tool-output-root.ts
+++ b/src/utils/tool-output-root.ts
@@ -1,0 +1,22 @@
+import type { ToolTarget } from "../types/tool-targets.js";
+import { resolveHermesagentOutputRoot } from "./hermesagent.js";
+import { getKimiCodeHome } from "./kimi-code.js";
+
+export function resolveToolOutputRoot({
+  outputRoot,
+  toolTarget,
+  global,
+}: {
+  outputRoot: string;
+  toolTarget: ToolTarget;
+  global: boolean;
+}): string {
+  if (!global) return outputRoot;
+  if (toolTarget === "hermesagent") {
+    return resolveHermesagentOutputRoot({ outputRoot, global });
+  }
+  if (toolTarget === "kimi-code") {
+    return getKimiCodeHome() ?? outputRoot;
+  }
+  return outputRoot;
+}

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    env: {
+      NODE_ENV: "e2e",
+    },
     include: ["src/e2e/**/*.spec.ts"],
     testTimeout: 60000, // E2E tests may take longer
     hookTimeout: 60000,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    env: {
-      NODE_ENV: "e2e",
-    },
     include: ["src/e2e/**/*.spec.ts"],
     testTimeout: 60000, // E2E tests may take longer
     hookTimeout: 60000,


### PR DESCRIPTION
## Summary

- treat `HERMES_HOME` as the global Hermes profile root across MCP, hooks, permissions, skills, commands, subagents, and conversion
- keep project-scoped `.hermes` paths unchanged and canonical RuleSync sources under `$HOME/.rulesync`
- share profile-root resolution with plugin activation and cover generation, import, conversion, check, and cleanup behavior
- keep the E2E runner under `NODE_ENV=test`, using `NODE_ENV=e2e` only for subprocesses that assert user-visible output
- reject Hermes path de-prefixing outside `.hermes` and resolve the home-directory fallback lazily
- synchronize Hermes compatibility documentation

## Test plan

- `mise exec -- pnpm cicheck`
- Hermes profile unit tests: 8 passed
- Hermes profile E2E tests: 3 passed
- convert E2E tests: 14 passed
- full E2E suite: 789 passed
- `git diff --check`

Closes #2389
