### PR TITLE
fix(devcontainer): activate mise shims so pnpm resolves in init.sh

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 
 # `~/.bashrc` returns early for non-interactive shells, and `mise activate` only
 # updates PATH from PROMPT_COMMAND, which never runs in a script. Use shims so
-# mise-managed tools (pnpm, node, go, ...) are directly callable here.
-eval "$(mise activate bash --shims)"
+# mise-managed tools (pnpm, node, go, ...) are directly callable here. Note that
+# shims only apply to processes started through them: if `mise.toml` ever grows
+# an `[env]` section, this script needs `mise env` / `mise exec` for it.
+# Assigning before `eval` keeps `set -e` able to catch a mise failure, which it
+# cannot do for `eval "$(...)"`.
+mise_shims_env="$(/home/node/.local/bin/mise activate bash --shims)"
+eval "$mise_shims_env"
 
 # Ensure node_modules and pnpm-store volumes have correct ownership for non-root user
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
@@ -14,10 +19,18 @@ sudo chown -R node:node /home/node/.pnpm-store 2>/dev/null || true
 sudo mkdir -p /workspace-worktrees
 sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
 
+# Set up the git credential helper before the slower steps below, so a failure
+# there cannot leave it unconfigured. `gh auth setup-git` errors out when no
+# GitHub credentials are present (GITHUB_TOKEN is optional for contributors), and
+# that must not fail container creation.
+if gh auth status >/dev/null 2>&1; then
+  gh auth setup-git
+else
+  echo "init.sh: no GitHub credentials found, skipping 'gh auth setup-git'" >&2
+fi
+
 # Configure pnpm store directory for devcontainer
 pnpm config set store-dir /home/node/.pnpm-store
 
 # Install project dependencies
 pnpm install
-
-gh auth setup-git

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -22,8 +22,10 @@ sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
 # Set up the git credential helper before the slower steps below, so a failure
 # there cannot leave it unconfigured. `gh auth setup-git` errors out when no
 # GitHub credentials are present (GITHUB_TOKEN is optional for contributors), and
-# that must not fail container creation.
-if gh auth status >/dev/null 2>&1; then
+# that must not fail container creation. `gh auth token` is the guard rather than
+# `gh auth status` because it resolves locally, so a network hiccup cannot make us
+# skip the setup while reporting missing credentials.
+if gh auth token >/dev/null 2>&1; then
   gh auth setup-git
 else
   echo "init.sh: no GitHub credentials found, skipping 'gh auth setup-git'" >&2

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
-. ~/.bashrc
+# `~/.bashrc` returns early for non-interactive shells, and `mise activate` only
+# updates PATH from PROMPT_COMMAND, which never runs in a script. Use shims so
+# mise-managed tools (pnpm, node, go, ...) are directly callable here.
+eval "$(mise activate bash --shims)"
 
 # Ensure node_modules and pnpm-store volumes have correct ownership for non-root user
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
@@ -14,6 +18,6 @@ sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
 pnpm config set store-dir /home/node/.pnpm-store
 
 # Install project dependencies
-mise exec -c "pnpm i"
+pnpm install
 
 gh auth setup-git


### PR DESCRIPTION
## Problem

The devcontainer `postCreateCommand` (`init.sh`) emitted this warning on every container setup, yet still reported success:

```
/home/node/bin/init.sh: line 14: pnpm: command not found
```

`pnpm` is a mise-managed tool, so it is only on `PATH` once mise has set it up. Two things prevented that in `init.sh`:

1. **`. ~/.bashrc` is effectively a no-op here.** `postCreateCommand` runs the script in a non-interactive shell, and `~/.bashrc` starts with an early return for non-interactive shells — so the `mise activate bash` line further down is never reached.
2. **Even if it were reached, it would not help.** `mise activate` updates `PATH` from a `_mise_hook` registered in `PROMPT_COMMAND`, which only fires when an interactive shell draws a prompt. It never runs inside a script.

That is why line 17 (`mise exec -c "pnpm i"`) worked while line 14 (bare `pnpm config set store-dir`) failed. Since the script had no error handling, the store-dir configuration was silently skipped and setup still completed as "done", leaving the `pnpm-store` volume mount ineffective.

## Fix

- Replace `. ~/.bashrc` with `eval "$(mise activate bash --shims)"`. Shims rewrite `PATH` immediately, which is the approach mise documents for non-interactive shells, so every mise-managed tool (`pnpm`, `node`, `go`, ...) is directly callable.
- Simplify `mise exec -c "pnpm i"` to `pnpm install`, now that the wrapper is no longer needed.
- Add `set -euo pipefail` so a failure like this surfaces instead of being swallowed. The `chown` calls were already guarded with `|| true`, so they are unaffected.

## Verification

Ran the updated script inside the container: no warning, exit code 0, and `pnpm config get store-dir` now returns `/home/node/.pnpm-store`.

Note that the fix takes effect on the next devcontainer rebuild, since the running container has the old `init.sh` baked into its image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
