### PR TITLE
fix(hermesagent): remove stale delegation toolsets

### DIFF
--- a/src/features/commands/hermesagent-command.test.ts
+++ b/src/features/commands/hermesagent-command.test.ts
@@ -73,6 +73,7 @@ describe("HermesagentCommand", () => {
 
     expect(init?.getFileContent()).toContain("ctx.register_command(slug, handler, description)");
     expect(init?.getFileContent()).toContain('ctx.dispatch_tool(\n            "delegate_task"');
+    expect(init?.getFileContent()).not.toContain('"toolsets"');
     expect(init?.getFileContent()).toContain(
       'Path(__file__).resolve().parents[2] / "rulesync" / "commands"',
     );

--- a/src/features/commands/hermesagent-command.ts
+++ b/src/features/commands/hermesagent-command.ts
@@ -110,7 +110,6 @@ def _register_command(ctx, command):
             {
                 "goal": description,
                 "context": "\\n\\n".join(context_parts),
-                "toolsets": ["terminal", "file", "web"],
             },
         )
 

--- a/src/features/subagents/hermesagent-subagent.test.ts
+++ b/src/features/subagents/hermesagent-subagent.test.ts
@@ -71,7 +71,8 @@ describe("HermesagentSubagent", () => {
     );
 
     const subagentSpec = files.find((file) => file.getRelativeFilePath() === `reviewer.json`);
-    expect(JSON.parse(subagentSpec?.getFileContent() ?? "{}")).toMatchObject({
+    const parsedSubagentSpec = JSON.parse(subagentSpec?.getFileContent() ?? "{}");
+    expect(parsedSubagentSpec).toMatchObject({
       slug: "reviewer",
       name: "Reviewer",
       description: "Review code changes",
@@ -81,10 +82,12 @@ describe("HermesagentSubagent", () => {
         dispatch: "delegate_task",
       },
     });
+    expect(parsedSubagentSpec).not.toHaveProperty("toolsets");
 
     const plugin = files.find((file) => file.getRelativeFilePath() === `__init__.py`);
     expect(plugin?.getFileContent()).toContain("ctx.dispatch_tool(");
     expect(plugin?.getFileContent()).toContain('"delegate_task"');
+    expect(plugin?.getFileContent()).not.toContain('"toolsets"');
     expect(plugin?.getFileContent()).toContain("ctx.register_command");
     expect(plugin?.getFileContent()).toContain(
       'Path(__file__).resolve().parents[2] / "rulesync" / "subagents"',

--- a/src/features/subagents/hermesagent-subagent.ts
+++ b/src/features/subagents/hermesagent-subagent.ts
@@ -82,7 +82,6 @@ def _register_subagent(ctx, subagent):
     name = subagent.get("name") or slug
     description = subagent.get("description") or f"Delegate work to the {name} RuleSync subagent."
     system_prompt = subagent.get("prompt") or ""
-    toolsets = subagent.get("toolsets") or ["terminal", "file", "web"]
 
     def handler(args=None, **kwargs):
         del kwargs
@@ -103,7 +102,6 @@ def _register_subagent(ctx, subagent):
             {
                 "goal": description,
                 "context": "\\n\\n".join(context_parts),
-                "toolsets": toolsets,
             },
         )
 
@@ -151,7 +149,6 @@ function getSubagentSpec(rulesyncSubagent: RulesyncSubagent): Record<string, unk
     name,
     description,
     prompt: rulesyncSubagent.getBody(),
-    toolsets: ["terminal", "file", "web"],
     hermes: {
       command: hermesCommandName(slug),
       dispatch: "delegate_task",


### PR DESCRIPTION
## Summary

- stop emitting the removed `toolsets` field in generated Hermes subagent specs
- omit `toolsets` from both subagent and command `delegate_task` dispatch payloads
- add regression assertions for generated JSON and Python plugin content

## Validation

- focused Vitest cases for both Hermes generators (2 passed)
- targeted `oxfmt --check`
- `pnpm typecheck`
- repository pre-commit secretlint hook

Addresses the stale `delegate_task` toolsets portion of #2414.