### PR TITLE
docs(deepagents): correct the rules anchor in the research reference

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/deepagents.md
+++ b/.rulesync/skills/rulesync-feature-research/references/deepagents.md
@@ -18,10 +18,10 @@
 
 Common adapter paths: `rulesync-source-map.md`.
 
-| Surface     | Anchor                                                                                                     |
-| ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `rules`     | `.deepagents/AGENTS.md` root file and `.deepagents/memories` non-root memories in `deepagents-rule.ts`     |
-| `mcp`       | `.deepagents/.mcp.json`, `mcpServers`, and project/global handling in `deepagents-mcp.ts`                  |
-| `subagents` | `.deepagents/agents` project subagent directory in `deepagents-subagent.ts`                                |
-| `skills`    | `.deepagents/skills` project skill directory in `deepagents-skill.ts`                                      |
-| `hooks`     | `.deepagents/hooks.json`, flat hook entries, and `DEEPAGENTS_HOOK_EVENTS` mapping in `deepagents-hooks.ts` |
+| Surface     | Anchor                                                                                                               |
+| ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `rules`     | `.deepagents/AGENTS.md` (project) and `~/.deepagents/<agent>/AGENTS.md` (global), root-only, in `deepagents-rule.ts` |
+| `mcp`       | `.deepagents/.mcp.json`, `mcpServers`, and project/global handling in `deepagents-mcp.ts`                            |
+| `subagents` | `.deepagents/agents` project subagent directory in `deepagents-subagent.ts`                                          |
+| `skills`    | `.deepagents/skills` project skill directory in `deepagents-skill.ts`                                                |
+| `hooks`     | `.deepagents/hooks.json`, flat hook entries, and `DEEPAGENTS_HOOK_EVENTS` mapping in `deepagents-hooks.ts`           |


### PR DESCRIPTION
## Summary

Corrects the `rules` row of the client-anchors table in the deepagents research reference (`.rulesync/skills/rulesync-feature-research/references/deepagents.md`). The row claimed a `.deepagents/memories` non-root surface that `deepagents-rule.ts` has never emitted; it now states what the adapter actually does — project `.deepagents/AGENTS.md` and global `~/.deepagents/<agent>/AGENTS.md`, root-only, with non-root content folded into the root file.

Refs #2416 — this is the only actionable slice of that issue today. The main gap it tracks (Hooks v2 emission) stays gated on upstream: re-verified at deepagents-code 0.1.49 that hook dispatch still goes through the legacy flat-list loader (`hooks/__init__.py` re-exports `dispatch_hook` from `legacy.py`), which treats an object-shaped `hooks.json` as an empty config — so emitting v2 today would silently disable every hook. The issue stays open as the tracking issue; details in an issue comment.

## Changes

- `.rulesync/skills/rulesync-feature-research/references/deepagents.md`: fix the stale `rules` anchor row (table realigned by the formatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
