### PR TITLE
feat(devin): model the full SKILL.md frontmatter, emit the project-root AGENTS.md Devin CLI reads

### DIFF
--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -87,6 +87,8 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 >
 > See the [Pi usage docs](https://pi.dev/docs/latest/usage).
 
+> **Devin note:** The root rule is emitted to the project-root `AGENTS.md` — the file [Devin CLI / Devin Local actually reads](https://docs.devin.ai/cli/extensibility/rules) (its rules page does not list `.devin/rules/` among its sources) — as plain markdown, while non-root rules keep going to `.devin/rules/*.md`, the Devin Desktop Cascade directory whose `trigger` activation modes (`always_on`, `glob`, `manual`, `model_decision`) are driven by the `devin` frontmatter block. Global mode is unchanged (`~/.config/devin/AGENTS.md`).
+
 > **Amp note:** Amp gates an @-mentioned guidance file on `globs:` YAML frontmatter — the file is loaded only after Amp has read a file matching one of the globs, and **without** the frontmatter it is always loaded. Rulesync therefore emits each non-root rule's `globs` as that frontmatter on the generated `.agents/memories/*.md` file (in addition to the advisory `applyTo` value in the root file's TOON table, which Amp does not enforce), and restores it into the canonical `globs` on import. Amp implicitly prefixes each glob with `**/` unless it starts with `./` or `../`, so canonical globs pass through verbatim. See [Globs in AGENTS.md](https://ampcode.com/news/globs-in-AGENTS.md).
 
 > **Junie note:** Junie CLI resolves project guidelines **first-match-wins** — `.junie/AGENTS.md` → root `AGENTS.md` → the legacy `.junie/guidelines.md` / `.junie/guidelines/` — and documents no file-inclusion mechanism, so Rulesync writes the root rule to `.junie/AGENTS.md` (project) / `~/.junie/AGENTS.md` (global, via `--global`) and folds non-root rules into that single file. The legacy `.junie/guidelines.md` is still accepted as an import fallback. Earlier Rulesync versions emitted non-root rules to `.junie/memories/*.md`, which is not a documented Junie read path; those files are no longer generated (stale outputs stay gitignored but are not cleaned up automatically). See the [Junie guidelines docs](https://junie.jetbrains.com/docs/guidelines-and-memory.html).
@@ -686,6 +688,15 @@ factorydroid: # for Factory Droid-specific parameters (optional)
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
+devin: # for Devin-specific parameters (optional; project .devin/skills/, global ~/.config/devin/skills/)
+  argument-hint: "[environment]" # (optional) hint shown after the slash-command name
+  model: "fast" # (optional) model override while the skill runs
+  subagent: true # (optional) run the skill in a subagent (string or boolean per Devin's docs)
+  agent: "deployer" # (optional) named agent profile to run the skill with
+  allowed-tools: # (optional) tools available while the skill runs (string or list)
+    - "Bash(git status:*)"
+  permissions: {} # (optional) auto-approval rules applied while the skill runs (load-bearing since Devin CLI v3000.1.23)
+  triggers: ["user"] # (optional) invocation gating; omitted = user + model. The shared disable-model-invocation / user-invocable flags map onto this when unset.
 qwencode: # for Qwen Code-specific parameters (optional; project .qwen/skills/, global ~/.qwen/skills/)
   priority: 10 # (optional) higher values appear earlier in /skills listings
   paths: # (optional) glob patterns gating model discovery to matching files (a scalar is coerced to the array Qwen Code requires)

--- a/skills/rulesync/file-formats.md
+++ b/skills/rulesync/file-formats.md
@@ -87,6 +87,8 @@ This is Rulesync, a Node.js CLI tool that automatically generates configuration 
 >
 > See the [Pi usage docs](https://pi.dev/docs/latest/usage).
 
+> **Devin note:** The root rule is emitted to the project-root `AGENTS.md` — the file [Devin CLI / Devin Local actually reads](https://docs.devin.ai/cli/extensibility/rules) (its rules page does not list `.devin/rules/` among its sources) — as plain markdown, while non-root rules keep going to `.devin/rules/*.md`, the Devin Desktop Cascade directory whose `trigger` activation modes (`always_on`, `glob`, `manual`, `model_decision`) are driven by the `devin` frontmatter block. Global mode is unchanged (`~/.config/devin/AGENTS.md`).
+
 > **Amp note:** Amp gates an @-mentioned guidance file on `globs:` YAML frontmatter — the file is loaded only after Amp has read a file matching one of the globs, and **without** the frontmatter it is always loaded. Rulesync therefore emits each non-root rule's `globs` as that frontmatter on the generated `.agents/memories/*.md` file (in addition to the advisory `applyTo` value in the root file's TOON table, which Amp does not enforce), and restores it into the canonical `globs` on import. Amp implicitly prefixes each glob with `**/` unless it starts with `./` or `../`, so canonical globs pass through verbatim. See [Globs in AGENTS.md](https://ampcode.com/news/globs-in-AGENTS.md).
 
 > **Junie note:** Junie CLI resolves project guidelines **first-match-wins** — `.junie/AGENTS.md` → root `AGENTS.md` → the legacy `.junie/guidelines.md` / `.junie/guidelines/` — and documents no file-inclusion mechanism, so Rulesync writes the root rule to `.junie/AGENTS.md` (project) / `~/.junie/AGENTS.md` (global, via `--global`) and folds non-root rules into that single file. The legacy `.junie/guidelines.md` is still accepted as an import fallback. Earlier Rulesync versions emitted non-root rules to `.junie/memories/*.md`, which is not a documented Junie read path; those files are no longer generated (stale outputs stay gitignored but are not cleaned up automatically). See the [Junie guidelines docs](https://junie.jetbrains.com/docs/guidelines-and-memory.html).
@@ -686,6 +688,15 @@ factorydroid: # for Factory Droid-specific parameters (optional)
 takt: # takt specific parameters (optional; emitted under .takt/facets/knowledge/ — frontmatter is dropped on emit)
   name: "renamed-stem" # (optional) override the emitted filename stem (no path separators or "..")
   extends: "base" # (optional) emit a leading `{extends:<parent>}` facet-inheritance directive (Takt 0.39.0+)
+devin: # for Devin-specific parameters (optional; project .devin/skills/, global ~/.config/devin/skills/)
+  argument-hint: "[environment]" # (optional) hint shown after the slash-command name
+  model: "fast" # (optional) model override while the skill runs
+  subagent: true # (optional) run the skill in a subagent (string or boolean per Devin's docs)
+  agent: "deployer" # (optional) named agent profile to run the skill with
+  allowed-tools: # (optional) tools available while the skill runs (string or list)
+    - "Bash(git status:*)"
+  permissions: {} # (optional) auto-approval rules applied while the skill runs (load-bearing since Devin CLI v3000.1.23)
+  triggers: ["user"] # (optional) invocation gating; omitted = user + model. The shared disable-model-invocation / user-invocable flags map onto this when unset.
 qwencode: # for Qwen Code-specific parameters (optional; project .qwen/skills/, global ~/.qwen/skills/)
   priority: 10 # (optional) higher values appear earlier in /skills listings
   paths: # (optional) glob patterns gating model discovery to matching files (a scalar is coerced to the array Qwen Code requires)

--- a/src/e2e/e2e-rules.spec.ts
+++ b/src/e2e/e2e-rules.spec.ts
@@ -43,6 +43,9 @@ const rulesRootTargets = [
   { target: "qwencode", outputPath: "QWEN.md" },
   { target: "junie", outputPath: join(".junie", "AGENTS.md") },
   { target: "warp", outputPath: "AGENTS.md" },
+  // The root rule goes to the project-root AGENTS.md Devin CLI/Local reads
+  // (issue #2406); .devin/rules/ holds non-root Cascade rules.
+  { target: "devin", outputPath: "AGENTS.md" },
   { target: "replit", outputPath: "replit.md" },
   { target: "pi", outputPath: "AGENTS.md" },
   { target: "zed", outputPath: ".rules" },

--- a/src/features/commands/devin-command.test.ts
+++ b/src/features/commands/devin-command.test.ts
@@ -133,4 +133,30 @@ describe("DevinCommand", () => {
       expect(DevinCommand.isTargetedByRulesyncCommand(rulesyncCommand)).toBe(expected);
     });
   });
+
+  describe("devin section passthrough (issue #2406)", () => {
+    it("should emit devin section fields into the command SKILL.md frontmatter", () => {
+      const rulesyncCommand = new RulesyncCommand({
+        relativeDirPath: RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
+        relativeFilePath: "deploy.md",
+        frontmatter: {
+          description: "Deploy",
+          devin: { "argument-hint": "[environment]", model: "fast", agent: "deployer" },
+        },
+        body: "Deploy.",
+        fileContent: "",
+      });
+
+      const command = DevinCommand.fromRulesyncCommand({
+        outputRoot: ".",
+        rulesyncCommand,
+      });
+
+      const content = command.getFileContent();
+      expect(content).toContain("argument-hint: '[environment]'");
+      expect(content).toContain("model: fast");
+      expect(content).toContain("agent: deployer");
+      expect(content).toContain("name: deploy");
+    });
+  });
 });

--- a/src/features/commands/devin-command.ts
+++ b/src/features/commands/devin-command.ts
@@ -20,11 +20,36 @@ type DevinCommandParams = AiFileParams & {
   slug?: string;
 };
 
+/**
+ * Devin SKILL.md frontmatter keys a command may author through its `devin:`
+ * section (`argument-hint`, `model`, `agent`, …).
+ * @see https://docs.devin.ai/cli/extensibility/skills/creating-skills
+ */
+const DEVIN_COMMAND_SECTION_KEYS = [
+  "argument-hint",
+  "model",
+  "subagent",
+  "agent",
+  "allowed-tools",
+  "permissions",
+  "triggers",
+] as const;
+
 function commandSkillContent(rulesyncCommand: RulesyncCommand): string {
   const slug = commandSlug(rulesyncCommand.getRelativeFilePath());
-  const description = rulesyncCommand.getFrontmatter().description ?? `${slug} command`;
+  const frontmatter = rulesyncCommand.getFrontmatter();
+  const description = frontmatter.description ?? `${slug} command`;
+
+  const devinSection = frontmatter.devin ?? {};
+  const extras: Record<string, unknown> = {};
+  for (const key of DEVIN_COMMAND_SECTION_KEYS) {
+    if (devinSection[key] !== undefined) {
+      extras[key] = devinSection[key];
+    }
+  }
 
   return stringifyFrontmatter(rulesyncCommand.getBody().trim(), {
+    ...extras,
     name: slug,
     description,
   });

--- a/src/features/rules/devin-rule.test.ts
+++ b/src/features/rules/devin-rule.test.ts
@@ -99,7 +99,12 @@ This is a test rule.`);
     it("should return nonRoot path under .devin/rules for project scope", () => {
       const paths = DevinRule.getSettablePaths();
 
-      expect("root" in paths).toBe(false);
+      // The root rule goes to the project-root AGENTS.md Devin CLI/Local
+      // reads (issue #2406); Cascade's .devin/rules/ holds non-root rules.
+      expect((paths as { root: { relativeFilePath: string } }).root).toEqual({
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+      });
       const nonRoot = (paths as { nonRoot: { relativeDirPath: string } }).nonRoot;
       expect(nonRoot.relativeDirPath).toBe(join(".devin", "rules"));
     });
@@ -620,6 +625,40 @@ This is a test rule.`);
       if (result.success) {
         expect(result.data.trigger).toBe("custom-trigger");
         expect((result.data as any).extraField).toBe("value");
+      }
+    });
+  });
+
+  describe("project-root AGENTS.md (issue #2406)", () => {
+    it("should emit the root rule to ./AGENTS.md as plain markdown", () => {
+      const rulesyncRule = new RulesyncRule({
+        relativeDirPath: ".rulesync/rules",
+        relativeFilePath: "overview.md",
+        frontmatter: { root: true, targets: ["devin"] },
+        body: "# Overview",
+      });
+
+      const rule = DevinRule.fromRulesyncRule({ rulesyncRule });
+      expect(rule.isRoot()).toBe(true);
+      expect(rule.getRelativeDirPath()).toBe(".");
+      expect(rule.getRelativeFilePath()).toBe("AGENTS.md");
+      // Devin CLI/Local reads plain markdown here - no Cascade frontmatter.
+      expect(rule.getFileContent()).toBe("# Overview");
+    });
+
+    it("should import the project-root AGENTS.md as the root rule", async () => {
+      const { testDir: rootTestDir, cleanup: rootCleanup } = await setupTestDirectory();
+      try {
+        await writeFileContent(join(rootTestDir, "AGENTS.md"), "# Overview");
+
+        const rule = await DevinRule.fromFile({
+          outputRoot: rootTestDir,
+          relativeFilePath: "AGENTS.md",
+        });
+        expect(rule.isRoot()).toBe(true);
+        expect(rule.toRulesyncRule().getFrontmatter().root).toBe(true);
+      } finally {
+        await rootCleanup();
       }
     });
   });

--- a/src/features/rules/devin-rule.ts
+++ b/src/features/rules/devin-rule.ts
@@ -286,10 +286,11 @@ const STRATEGIES: TriggerStrategy[] = [
 /**
  * Rule generator for Devin (Cascade memories, now Devin Desktop).
  *
- * - Project scope: one file per rule under `.devin/rules/*.md` with YAML
+ * - Project scope: the root rule goes to the project-root `AGENTS.md` (plain
+ *   markdown — the file Devin CLI / Devin Local reads); non-root rules are one
+ *   file per rule under `.devin/rules/*.md` (Devin Desktop Cascade) with YAML
  *   frontmatter carrying a `trigger` (always_on | glob | manual | model_decision)
- *   plus companion `globs`/`description` fields. (`.devin/rules/` is the
- *   pre-rebrand legacy location the tool still reads.)
+ *   plus companion `globs`/`description` fields.
  * - Global scope: a single plain-markdown, always-on file (no frontmatter) at
  *   `~/.config/devin/AGENTS.md` (Devin Local global always-on rules).
  *
@@ -476,7 +477,8 @@ export class DevinRule extends ToolRule {
 
     const frontmatter = strategy.generateFrontmatter(normalized, rulesyncFrontmatter);
 
-    // Both root and non-root rules are placed in the .devin/rules directory.
+    // Non-root rules are placed in the .devin/rules directory (the root rule
+    // returned above went to the project-root AGENTS.md).
     const kebabCaseFilename = toKebabCaseFilename(rulesyncRule.getRelativeFilePath());
 
     return new DevinRule({
@@ -492,7 +494,7 @@ export class DevinRule extends ToolRule {
 
   toRulesyncRule(): RulesyncRule {
     if (this.root) {
-      // The global AGENTS.md round-trips as a plain root rule.
+      // The global and project-root AGENTS.md round-trip as a plain root rule.
       return this.toRulesyncRuleDefault();
     }
 

--- a/src/features/rules/devin-rule.ts
+++ b/src/features/rules/devin-rule.ts
@@ -62,7 +62,11 @@ export type DevinRuleParams = Omit<ToolRuleParams, "fileContent"> & {
   body: string;
 };
 
-export type DevinRuleSettablePaths = Omit<ToolRuleSettablePaths, "root"> & {
+export type DevinRuleSettablePaths = ToolRuleSettablePaths & {
+  root: {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  };
   nonRoot: {
     relativeDirPath: string;
   };
@@ -344,6 +348,15 @@ export class DevinRule extends ToolRule {
       };
     }
     return {
+      // Devin CLI / Devin Local reads project rules from the root `AGENTS.md`
+      // (its rules page does not list `.devin/rules/` among its sources);
+      // `.devin/rules/*.md` remains the Devin Desktop Cascade directory for
+      // non-root rules with activation modes.
+      // @see https://docs.devin.ai/cli/extensibility/rules
+      root: {
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+      },
       nonRoot: {
         relativeDirPath: buildToolPath(DEVIN_DIR, "rules", excludeToolDir),
       },
@@ -366,6 +379,20 @@ export class DevinRule extends ToolRule {
         outputRoot,
         relativeDirPath: rootPath.relativeDirPath,
         relativeFilePath: rootPath.relativeFilePath,
+        frontmatter: {},
+        body: fileContent,
+        validate,
+        root: true,
+      });
+    }
+
+    if (relativeFilePath === "AGENTS.md") {
+      // The project-root AGENTS.md is plain markdown without Cascade frontmatter.
+      const fileContent = await readFileContent(join(outputRoot, relativeFilePath));
+      return new DevinRule({
+        outputRoot,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
         frontmatter: {},
         body: fileContent,
         validate,
@@ -422,6 +449,20 @@ export class DevinRule extends ToolRule {
     }
 
     const rulesyncFrontmatter = rulesyncRule.getFrontmatter();
+
+    if (rulesyncFrontmatter.root) {
+      // The root rule goes to the project-root AGENTS.md Devin CLI / Devin
+      // Local actually reads, as plain markdown without Cascade frontmatter.
+      return new DevinRule({
+        outputRoot,
+        relativeDirPath: ".",
+        relativeFilePath: "AGENTS.md",
+        frontmatter: {},
+        body: rulesyncRule.getBody(),
+        validate,
+        root: true,
+      });
+    }
 
     const storedDevin = rulesyncFrontmatter.devin;
     const normalized = normalizeStoredDevin(storedDevin);

--- a/src/features/rules/devin-rule.ts
+++ b/src/features/rules/devin-rule.ts
@@ -317,7 +317,8 @@ export class DevinRule extends ToolRule {
 
     super({
       ...rest,
-      // Global rules are a single plain-markdown file (no frontmatter);
+      // The global AGENTS.md and the project-root AGENTS.md are plain
+      // markdown (no frontmatter);
       // project rules carry Devin trigger frontmatter.
       fileContent: rest.root ? body : stringifyFrontmatter(body, frontmatter),
     });

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -790,7 +790,9 @@ export const toolRuleFactories = new Map<RulesProcessorToolTarget, ToolRuleFacto
       class: DevinRule,
       meta: {
         extension: "md",
-        // Project rules live under `.devin/rules/*.md`; global always-on rules
+        // The root rule goes to the project-root `AGENTS.md` (the file Devin
+        // CLI/Local reads); non-root rules live under `.devin/rules/*.md`
+        // (Devin Desktop Cascade); global always-on rules
         // are a single plain `~/.config/devin/AGENTS.md` file.
         supportsGlobal: true,
         ruleDiscoveryMode: "auto",

--- a/src/features/skills/devin-skill.test.ts
+++ b/src/features/skills/devin-skill.test.ts
@@ -389,6 +389,11 @@ Global skill body content.`;
         "user",
       ]);
       expect(makeGatedSkillFrontmatter({ "user-invocable": false }).triggers).toEqual(["model"]);
+      // Both flags off: an empty triggers list states "never invoked" outright.
+      expect(
+        makeGatedSkillFrontmatter({ "disable-model-invocation": true, "user-invocable": false })
+          .triggers,
+      ).toEqual([]);
       // An explicit section triggers value wins over the flags.
       expect(
         makeGatedSkillFrontmatter({

--- a/src/features/skills/devin-skill.test.ts
+++ b/src/features/skills/devin-skill.test.ts
@@ -9,6 +9,22 @@ import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { DevinSkill } from "./devin-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 
+const makeGatedSkillFrontmatter = (flags: Record<string, unknown>) =>
+  DevinSkill.fromRulesyncSkill({
+    rulesyncSkill: new RulesyncSkill({
+      relativeDirPath: ".rulesync/skills",
+      dirName: "gated",
+      frontmatter: {
+        name: "gated",
+        description: "Gated skill",
+        targets: ["devin"],
+        ...flags,
+      },
+      body: "Body.",
+      validate: false,
+    }),
+  }).getFrontmatter() as Record<string, unknown>;
+
 describe("DevinSkill", () => {
   let testDir: string;
   let cleanup: () => Promise<void>;
@@ -332,6 +348,72 @@ Global skill body content.`;
 
       expect(skill.getRelativeDirPath()).toBe(join(".config", "devin", "skills"));
       expect(skill.getGlobal()).toBe(true);
+    });
+  });
+
+  describe("devin section round-trip (issue #2406)", () => {
+    const sectionFields = {
+      "argument-hint": "[environment]",
+      model: "fast",
+      agent: "deployer",
+      "allowed-tools": ["Bash(git status:*)"],
+      permissions: { Exec: { "git status *": "allow" } },
+    };
+
+    it("should emit the devin section fields into the SKILL.md frontmatter", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        relativeDirPath: ".rulesync/skills",
+        dirName: "deploy",
+        frontmatter: {
+          name: "deploy",
+          description: "Deploy the app",
+          targets: ["devin"],
+          devin: sectionFields,
+        },
+        body: "Deploy.",
+        validate: false,
+      });
+
+      const skill = DevinSkill.fromRulesyncSkill({ rulesyncSkill });
+      const frontmatter = skill.getFrontmatter() as Record<string, unknown>;
+      expect(frontmatter["argument-hint"]).toBe("[environment]");
+      expect(frontmatter.model).toBe("fast");
+      expect(frontmatter.agent).toBe("deployer");
+      expect(frontmatter["allowed-tools"]).toEqual(["Bash(git status:*)"]);
+      expect(frontmatter.permissions).toEqual({ Exec: { "git status *": "allow" } });
+      expect(frontmatter.triggers).toBeUndefined();
+    });
+
+    it("should map the canonical invocation flags onto triggers", () => {
+      expect(makeGatedSkillFrontmatter({ "disable-model-invocation": true }).triggers).toEqual([
+        "user",
+      ]);
+      expect(makeGatedSkillFrontmatter({ "user-invocable": false }).triggers).toEqual(["model"]);
+      // An explicit section triggers value wins over the flags.
+      expect(
+        makeGatedSkillFrontmatter({
+          "disable-model-invocation": true,
+          devin: { triggers: ["user", "model"] },
+        }).triggers,
+      ).toEqual(["user", "model"]);
+      expect(makeGatedSkillFrontmatter({}).triggers).toBeUndefined();
+    });
+
+    it("should lift the fields back into the devin section on import", () => {
+      const skill = new DevinSkill({
+        dirName: "deploy",
+        frontmatter: {
+          name: "deploy",
+          description: "Deploy the app",
+          triggers: ["user"],
+          ...sectionFields,
+        },
+        body: "Deploy.",
+        validate: false,
+      });
+
+      const config = skill.toRulesyncSkill().getFrontmatter();
+      expect(config.devin).toEqual({ ...sectionFields, triggers: ["user"] });
     });
   });
 });

--- a/src/features/skills/devin-skill.ts
+++ b/src/features/skills/devin-skill.ts
@@ -20,10 +20,75 @@ import {
   ToolSkillSettablePaths,
 } from "./tool-skill.js";
 
+/**
+ * The SKILL.md frontmatter fields Devin documents beyond name/description:
+ * `argument-hint`, `model`, `subagent`, `agent`, `allowed-tools`,
+ * `permissions` (load-bearing for auto-approvals since CLI v3000.1.23 /
+ * Desktop v3.4.22), and `triggers` (`user` / `model` invocation gating).
+ * @see https://docs.devin.ai/cli/extensibility/skills/creating-skills
+ */
 const DevinSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
+  "argument-hint": z.optional(z.string()),
+  model: z.optional(z.string()),
+  subagent: z.optional(z.union([z.string(), z.boolean()])),
+  agent: z.optional(z.string()),
+  "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
+  permissions: z.optional(z.record(z.string(), z.unknown())),
+  triggers: z.optional(z.array(z.enum(["user", "model"]))),
 });
+
+/** The `devin` tool section of the canonical skill frontmatter. */
+type DevinRulesyncSection = {
+  "argument-hint"?: string;
+  model?: string;
+  subagent?: string | boolean;
+  agent?: string;
+  "allowed-tools"?: string | string[];
+  permissions?: Record<string, unknown>;
+  triggers?: ("user" | "model")[];
+};
+
+const DEVIN_SECTION_KEYS = [
+  "argument-hint",
+  "model",
+  "subagent",
+  "agent",
+  "allowed-tools",
+  "permissions",
+  "triggers",
+] as const;
+
+/**
+ * Resolve Devin's `triggers` from the canonical invocation flags when the
+ * section does not state it outright: `disable-model-invocation: true` leaves
+ * only the `user` trigger, `user-invocable: false` only the `model` trigger.
+ * With neither flag set, `triggers` is omitted (Devin's default is both).
+ */
+function resolveDevinTriggers({
+  section,
+  disableModelInvocation,
+  userInvocable,
+}: {
+  section: DevinRulesyncSection | undefined;
+  disableModelInvocation: boolean | undefined;
+  userInvocable: boolean | undefined;
+}): ("user" | "model")[] | undefined {
+  if (section?.triggers !== undefined) {
+    return section.triggers;
+  }
+  if (disableModelInvocation === true && userInvocable === false) {
+    return [];
+  }
+  if (disableModelInvocation === true) {
+    return ["user"];
+  }
+  if (userInvocable === false) {
+    return ["model"];
+  }
+  return undefined;
+}
 
 export type DevinSkillFrontmatter = z.infer<typeof DevinSkillFrontmatterSchema>;
 
@@ -125,10 +190,18 @@ export class DevinSkill extends ToolSkill {
 
   toRulesyncSkill(): RulesyncSkill {
     const frontmatter = this.getFrontmatter();
+    const devinSection: DevinRulesyncSection = {};
+    for (const key of DEVIN_SECTION_KEYS) {
+      const value = frontmatter[key];
+      if (value !== undefined) {
+        (devinSection as Record<string, unknown>)[key] = value;
+      }
+    }
     const rulesyncFrontmatter: RulesyncSkillFrontmatterInput = {
       name: frontmatter.name,
       description: frontmatter.description,
       targets: ["*"],
+      ...(Object.keys(devinSection).length > 0 && { devin: devinSection }),
     };
 
     return new RulesyncSkill({
@@ -151,10 +224,27 @@ export class DevinSkill extends ToolSkill {
   }: ToolSkillFromRulesyncSkillParams): DevinSkill {
     const settablePaths = DevinSkill.getSettablePaths({ global });
     const rulesyncFrontmatter = rulesyncSkill.getFrontmatter();
+    const devinSection = (rulesyncFrontmatter as { devin?: DevinRulesyncSection }).devin;
+    const triggers = resolveDevinTriggers({
+      section: devinSection,
+      disableModelInvocation: rulesyncFrontmatter["disable-model-invocation"],
+      userInvocable: rulesyncFrontmatter["user-invocable"],
+    });
 
     const devinFrontmatter: DevinSkillFrontmatter = {
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
+      ...(devinSection?.["argument-hint"] !== undefined && {
+        "argument-hint": devinSection["argument-hint"],
+      }),
+      ...(devinSection?.model !== undefined && { model: devinSection.model }),
+      ...(devinSection?.subagent !== undefined && { subagent: devinSection.subagent }),
+      ...(devinSection?.agent !== undefined && { agent: devinSection.agent }),
+      ...(devinSection?.["allowed-tools"] !== undefined && {
+        "allowed-tools": devinSection["allowed-tools"],
+      }),
+      ...(devinSection?.permissions !== undefined && { permissions: devinSection.permissions }),
+      ...(triggers !== undefined && { triggers }),
     };
 
     return new DevinSkill({

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -151,6 +151,20 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   ),
   cline: z.optional(z.looseObject({})),
   roo: z.optional(z.looseObject({})),
+  devin: z.optional(
+    z.looseObject({
+      "argument-hint": z.optional(z.string()),
+      model: z.optional(z.string()),
+      subagent: z.optional(z.union([z.string(), z.boolean()])),
+      agent: z.optional(z.string()),
+      "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
+      // Load-bearing for auto-approvals since Devin CLI v3000.1.23.
+      permissions: z.optional(z.looseObject({})),
+      // Omitted = both; the canonical disable-model-invocation/user-invocable
+      // flags map onto this when the section does not state it outright.
+      triggers: z.optional(z.array(z.enum(["user", "model"]))),
+    }),
+  ),
   qwencode: z.optional(
     z.looseObject({
       priority: z.optional(z.number()),
@@ -331,6 +345,15 @@ export type RulesyncSkillFrontmatterInput = {
   };
   roo?: Record<string, unknown>;
   cline?: Record<string, unknown>;
+  devin?: {
+    "argument-hint"?: string;
+    model?: string;
+    subagent?: string | boolean;
+    agent?: string;
+    "allowed-tools"?: string | string[];
+    permissions?: Record<string, unknown>;
+    triggers?: ("user" | "model")[];
+  };
   qwencode?: {
     priority?: number;
     paths?: string | string[];


### PR DESCRIPTION
## Summary

Closes #2406 — both gaps.

**Gap 1 — SKILL.md frontmatter beyond `name`/`description` dropped.** Devin documents `argument-hint`, `model`, `subagent`, `agent`, `allowed-tools`, `permissions` (load-bearing for auto-approvals since CLI v3000.1.23 / Desktop v3.4.22), and `triggers` (`user`/`model`). A typed `devin` section of the canonical skill frontmatter (mirroring the `claudecode`/`qwencode` sections) now carries all seven in both directions in `devin-skill.ts`; the canonical `disable-model-invocation` / `user-invocable` flags map onto `triggers` when the section does not state it outright (an explicit section value wins); and `devin-command.ts` passes the same section through, so a command emitted as a Devin skill can finally carry `argument-hint`/`model`/`agent`.

**Gap 2 — project rules never reached Devin CLI/Local.** The [CLI rules page](https://docs.devin.ai/cli/extensibility/rules) enumerates its project rule sources — `AGENTS.md` first — and does not list `.devin/rules/`, which is documented only as the Devin Desktop Cascade directory. The root rule is now emitted to the project-root `AGENTS.md` as plain markdown (joining the multi-owner AGENTS.md targets), while non-root rules keep going to `.devin/rules/*.md` so Cascade activation modes still work; the root file imports back as the root rule. Global mode unchanged.

Docs: Devin rules note added, Devin skills section documented in the skill-frontmatter example; e2e rules matrix moved `devin` into the root-AGENTS.md list and kept a non-root row.

## Verification

- Upstream claims are from the issue's research (two days old): the skill field list from [Creating Skills](https://docs.devin.ai/cli/extensibility/skills/creating-skills), the auto-approval change from the CLI changelog, the rule-source enumeration from the CLI rules page.
- `pnpm cicheck` green; `e2e-rules` passes locally with the moved matrix row; unit tests cover section emit/lift, the triggers mapping (both flags, explicit-section precedence), the command passthrough, and root-AGENTS.md generate/import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
