### PR TITLE
feat(init): add Playwright MCP to the scaffolded .rulesync/.mcp.json

### DIFF
--- a/src/lib/feature-scaffold.ts
+++ b/src/lib/feature-scaffold.ts
@@ -291,6 +291,16 @@ function singletonTemplate(feature: ScaffoldFeature): string {
         "mcp"
       ],
       "env": {}
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "@playwright/mcp",
+        "--headless"
+      ],
+      "env": {}
     }
   }
 }

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -211,6 +211,13 @@ describe("init", () => {
       expect(writeCall).toBeDefined();
       const content = writeCall?.[1] ?? "";
       expect(content).toContain('"mcpServers"');
+      // The scaffolded defaults: docs lookup, rulesync's own server, and
+      // browser automation for SPA pages (issue #2432).
+      expect(content).toContain('"deepwiki"');
+      expect(content).toContain('"rulesync"');
+      expect(content).toContain('"playwright"');
+      expect(content).toContain('"@playwright/mcp"');
+      expect(content).toContain('"--headless"');
     });
 
     it("should not create a command sample file", async () => {


### PR DESCRIPTION
## Summary

Closes #2432 — adds the proposed `playwright` server to `singletonTemplate("mcp")` in `src/lib/feature-scaffold.ts`, matching the issue's requested shape.

Decisions on the issue's open points:
- **`env: {}`**: mirrored from the existing entries for template consistency.
- **`--headless`**: kept — no visible browser window in agent runs.
- **First-run browser download**: accepted for a default scaffold; the entry is trivially removable, and the repo already dogfoods a Playwright fallback per its own CLAUDE.md.
- **`pnpm` vs `npx`**: kept `pnpm dlx` for consistency with the existing `rulesync` entry; switching both to a more neutral runner is the separate follow-up the issue itself suggests.

Tests: the init MCP scaffold assertion now pins all three servers (docs did not embed the template verbatim, so no doc sync needed).

## Verification

- `pnpm cicheck` green; `e2e-init` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)