### PR TITLE
chore(release): v16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "15.1.0",
+  "version": "16.0.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -17,7 +17,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "15.1.0";
+const getVersion = () => "16.0.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.0.0.

Version bump commits only:
- getVersion() in src/cli/program.ts: 15.1.0 -> 16.0.0
- package.json version: 15.1.0 -> 16.0.0

Release notes are on the draft GitHub release v16.0.0. MAJOR bump per the breaking changes since v15.1.0 (Goose .gooseignore target removal and subagent surface move, Junie permissions global-only + object rule groups, Devin project root rule to AGENTS.md, Zed MCP translation + Windows path, Cline required agent description, Vibe/Rovo Dev/Reasonix upstream-drift corrections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)