### PR TITLE
chore: update Homebrew formula to v16.0.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "15.1.0"
+  version "16.0.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "1555a940873b308765f127f807b000741248e56485ec18870662aa1295c9e3c2"
+      sha256 "725d5d46e72de8ed5e1fa932ba1b3153020dd6a8929df117dcb7e6c239063891"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "94664a21747d9554012a5444cedc8dd755bfd7498a2b0821ba71bf5b822e23c0"
+      sha256 "ab62e7a8f11a76140d623e79bef302720537c22307066c9032c05d2b6026ccc2"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "69dd9875243199a87262298d29a10524494b8f08060e6e64cef97a3f0f1e7f78"
+      sha256 "91b02890b16ea246101e92f30e104fafb8bd56a7fde4442c9e686d9465cce15c"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "4ee044bbdb7443e3b9475270040f65aea8ed1a2fd6df0b2d2d16d4b42c65227a"
+      sha256 "b0087123f722f8b571918860578d9e8dfa0ffc21b1f42755275a1d396f5bdb8d"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)