### PR TITLE
docs: add build provenance verification to the installation guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -112,16 +112,24 @@ Get-FileHash rulesync.exe -Algorithm SHA256 | ForEach-Object {
 
 ### Verify build provenance
 
-Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced:
+Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced, and a signed-in CLI (`gh auth login`) — verification queries the API even for a public repository.
 
 ```bash
-# Linux/macOS — the path the steps above saved the binary to
-gh attestation verify /usr/local/bin/rulesync --repo dyoshikawa/rulesync
-
-# Windows (PowerShell)
-gh attestation verify rulesync.exe --repo dyoshikawa/rulesync
+# Linux/macOS — the path the steps above installed the binary to
+gh attestation verify /usr/local/bin/rulesync \
+  --repo dyoshikawa/rulesync \
+  --signer-workflow dyoshikawa/rulesync/.github/workflows/publish-assets.yml
 ```
 
-Pass the path you actually saved the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification.
+```powershell
+# Windows
+gh attestation verify C:\Windows\System32\rulesync.exe `
+  --repo dyoshikawa/rulesync `
+  --signer-workflow dyoshikawa/rulesync/.github/workflows/publish-assets.yml
+```
+
+Pass the path you actually installed the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification; a binary installed by `install.sh` or Homebrew is the same file and verifies the same way. `--repo` alone only proves the attestation came from this repository, so `--signer-workflow` is included to pin the workflow that signed it.
+
+This covers the release binaries. The npm package carries npm's own provenance attestation instead, which is checked with `npm audit signatures` rather than `gh attestation verify`.
 
 :::

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -110,4 +110,18 @@ Get-FileHash rulesync.exe -Algorithm SHA256 | ForEach-Object {
 }
 ```
 
+### Verify build provenance
+
+Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced:
+
+```bash
+# Linux/macOS — the path the steps above saved the binary to
+gh attestation verify /usr/local/bin/rulesync --repo dyoshikawa/rulesync
+
+# Windows (PowerShell)
+gh attestation verify rulesync.exe --repo dyoshikawa/rulesync
+```
+
+Pass the path you actually saved the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification.
+
 :::

--- a/skills/rulesync/installation.md
+++ b/skills/rulesync/installation.md
@@ -109,3 +109,17 @@ Get-FileHash rulesync.exe -Algorithm SHA256 | ForEach-Object {
   if ($actual -eq $expected) { "✓ Checksum verified" } else { "✗ Checksum mismatch" }
 }
 ```
+
+#### Verify build provenance
+
+Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced:
+
+```bash
+# Linux/macOS — the path the steps above saved the binary to
+gh attestation verify /usr/local/bin/rulesync --repo dyoshikawa/rulesync
+
+# Windows (PowerShell)
+gh attestation verify rulesync.exe --repo dyoshikawa/rulesync
+```
+
+Pass the path you actually saved the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification.

--- a/skills/rulesync/installation.md
+++ b/skills/rulesync/installation.md
@@ -112,14 +112,22 @@ Get-FileHash rulesync.exe -Algorithm SHA256 | ForEach-Object {
 
 #### Verify build provenance
 
-Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced:
+Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations), so you can check that the file you downloaded really was built by this repository's release workflow. This needs the [GitHub CLI](https://cli.github.com/) v2.49.0 or later, which is where `gh attestation` was introduced, and a signed-in CLI (`gh auth login`) — verification queries the API even for a public repository.
 
 ```bash
-# Linux/macOS — the path the steps above saved the binary to
-gh attestation verify /usr/local/bin/rulesync --repo dyoshikawa/rulesync
-
-# Windows (PowerShell)
-gh attestation verify rulesync.exe --repo dyoshikawa/rulesync
+# Linux/macOS — the path the steps above installed the binary to
+gh attestation verify /usr/local/bin/rulesync \
+  --repo dyoshikawa/rulesync \
+  --signer-workflow dyoshikawa/rulesync/.github/workflows/publish-assets.yml
 ```
 
-Pass the path you actually saved the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification.
+```powershell
+# Windows
+gh attestation verify C:\Windows\System32\rulesync.exe `
+  --repo dyoshikawa/rulesync `
+  --signer-workflow dyoshikawa/rulesync/.github/workflows/publish-assets.yml
+```
+
+Pass the path you actually installed the binary to. The command identifies the file by its contents, not by its name, so renaming it during installation — which the steps above do — does not affect verification; a binary installed by `install.sh` or Homebrew is the same file and verifies the same way. `--repo` alone only proves the attestation came from this repository, so `--signer-workflow` is included to pin the workflow that signed it.
+
+This covers the release binaries. The npm package carries npm's own provenance attestation instead, which is checked with `npm audit signatures` rather than `gh attestation verify`.


### PR DESCRIPTION
## Background

Related issue: #2390

The issue was filed as "fix the filename in an existing example", but as the maintainer noted on it, that section never landed — #2352 was closed as superseded and only its CI half is on main. So this adds the section, with the mismatch already fixed.

## Changes

Adds a **Verify build provenance** subsection to the manual-installation guide, after the checksum verification block.

The example verifies the path the preceding steps actually save the binary to — `/usr/local/bin/rulesync` on Linux/macOS, `rulesync.exe` on Windows — rather than the release asset name `rulesync-darwin-arm64`, which those steps rename away. It also states why the rename is harmless: `gh attestation verify` identifies the file by its contents, not its name.

`gh attestation` was introduced in GitHub CLI v2.49.0, so the minimum version is stated.

## Verification

I confirmed the attestation actually resolves for a renamed binary rather than assuming it. Downloading `rulesync-linux-x64` from v16.0.0 as `./rulesync` and querying its digest:

```
gh api repos/dyoshikawa/rulesync/attestations/sha256:b0087123f722f8b571918860578d9e8dfa0ffc21b1f42755275a1d396f5bdb8d
```

returns a `https://slsa.dev/provenance/v1` attestation whose subjects are `rulesync-darwin-arm64`, `rulesync-darwin-x64`, `rulesync-linux-arm64`, `rulesync-linux-x64` and `rulesync-windows-x64.exe`, built by `.github/workflows/publish-assets.yml` in this repository. Lookup is by digest, so the local filename does not matter — which is what makes the corrected example valid.

(The `gh` in this environment is 2.46.0 and predates the `attestation` command, hence the API check rather than running `gh attestation verify` itself.)

Docs-only; `skills/rulesync/installation.md` is the `scripts/sync-skill-docs.ts` output. `pnpm cicheck` passes.

Closes #2390
