### PR TITLE
refactor(hermesagent): collapse repeated path expressions and align checks output root

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -125,7 +125,7 @@ rulesync generate --check --targets "*" --features "*"
 
 ### Tool home overrides win over the output root in global scope
 
-Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` writes that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
+Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` and `convert --global` write that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. See [Supported Tools](./supported-tools.md) for what each profile root contains. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
 
 The override must be a usable directory: an empty value is ignored (the default profile location applies), and a value that is the filesystem root or an unnormalized path is rejected with an error naming the variable.
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -123,6 +123,12 @@ rulesync generate --dry-run --targets claudecode --features rules
 rulesync generate --check --targets "*" --features "*"
 ```
 
+### Tool home overrides win over the output root in global scope
+
+Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` writes that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
+
+The override must be a usable directory: an empty value is ignored (the default profile location applies), and a value that is the filesystem root or an unnormalized path is rejected with an error naming the variable.
+
 ### Shared config files are never created empty
 
 Some outputs are files Rulesync merges into rather than owns, because the tool (or you) keeps unrelated settings there: `.amp/settings.json(c)`, `.antigravity/settings.json`, `.claude/settings.json`, `.claude/settings.local.json`, `.codex/config.toml`, `.devin/config.json`, `.factory/settings.json`, `.grok/config.toml`, `.vibe/config.toml`, `.vscode/settings.json`, `.zed/settings.json`, `kilo.json(c)`, `opencode.json(c)`, and `reasonix.toml`. These are deliberately **not** added to `.gitignore` by `rulesync gitignore`, so that settings you hand-author in them stay version-controlled.

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -125,7 +125,7 @@ rulesync generate --check --targets "*" --features "*"
 
 ### Tool home overrides win over the output root in global scope
 
-Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` writes that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
+Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` and `convert --global` write that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. See [Supported Tools](./supported-tools.md) for what each profile root contains. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
 
 The override must be a usable directory: an empty value is ignored (the default profile location applies), and a value that is the filesystem root or an unnormalized path is rejected with an error naming the variable.
 

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -123,6 +123,12 @@ rulesync generate --dry-run --targets claudecode --features rules
 rulesync generate --check --targets "*" --features "*"
 ```
 
+### Tool home overrides win over the output root in global scope
+
+Two tools read their profile location from an environment variable: Hermes Agent (`HERMES_HOME`) and Kimi Code (`KIMI_CODE_HOME`). When one of them is set, `generate --global` writes that tool's output under it, **overriding both `outputRoots` and an explicit `--output-roots`** for that target. This is deliberate — the variable names where the tool itself looks, so honoring the flag instead would produce files the tool never reads. Every other target still uses the configured output root.
+
+The override must be a usable directory: an empty value is ignored (the default profile location applies), and a value that is the filesystem root or an unnormalized path is rejected with an error naming the variable.
+
 ### Shared config files are never created empty
 
 Some outputs are files Rulesync merges into rather than owns, because the tool (or you) keeps unrelated settings there: `.amp/settings.json(c)`, `.antigravity/settings.json`, `.claude/settings.json`, `.claude/settings.local.json`, `.codex/config.toml`, `.devin/config.json`, `.factory/settings.json`, `.grok/config.toml`, `.vibe/config.toml`, `.vscode/settings.json`, `.zed/settings.json`, `kilo.json(c)`, `opencode.json(c)`, and `reasonix.toml`. These are deliberately **not** added to `.gitignore` by `rulesync gitignore`, so that settings you hand-author in them stay version-controlled.

--- a/src/features/commands/hermesagent-command.ts
+++ b/src/features/commands/hermesagent-command.ts
@@ -187,28 +187,23 @@ class HermesagentCommandAuxiliaryFile extends ToolFile {
     return { success: true, error: null };
   }
 
-  shouldMergeExistingFileContent(): boolean {
+  /**
+   * Whether this auxiliary file is the one at `relativeFilePath`, comparing
+   * against the scope-resolved location of that canonical `.hermes/...` path.
+   */
+  private matchesPath(relativeFilePath: string): boolean {
     return (
       this.getRelativePathFromCwd() ===
-      toPosixPath(
-        getHermesagentRelativeFilePath({
-          global: this.global,
-          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
-        }),
-      )
+      toPosixPath(getHermesagentRelativeFilePath({ global: this.global, relativeFilePath }))
     );
   }
 
+  shouldMergeExistingFileContent(): boolean {
+    return this.matchesPath(HERMESAGENT_CONFIG_FILE_PATH);
+  }
+
   setFileContent(newFileContent: string): void {
-    if (
-      this.getRelativePathFromCwd() ===
-      toPosixPath(
-        getHermesagentRelativeFilePath({
-          global: this.global,
-          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
-        }),
-      )
-    ) {
+    if (this.matchesPath(HERMESAGENT_CONFIG_FILE_PATH)) {
       super.setFileContent(
         getEnabledPluginConfigContent({ currentContent: newFileContent, global: this.global }),
       );
@@ -218,37 +213,13 @@ class HermesagentCommandAuxiliaryFile extends ToolFile {
   }
 
   getFileContent(): string {
-    if (
-      this.getRelativePathFromCwd() ===
-      toPosixPath(
-        getHermesagentRelativeFilePath({
-          global: this.global,
-          relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH,
-        }),
-      )
-    ) {
+    if (this.matchesPath(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH)) {
       return getPluginManifestContent();
     }
-    if (
-      this.getRelativePathFromCwd() ===
-      toPosixPath(
-        getHermesagentRelativeFilePath({
-          global: this.global,
-          relativeFilePath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH,
-        }),
-      )
-    ) {
+    if (this.matchesPath(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH)) {
       return getPluginInitContent();
     }
-    if (
-      this.getRelativePathFromCwd() ===
-      toPosixPath(
-        getHermesagentRelativeFilePath({
-          global: this.global,
-          relativeFilePath: HERMESAGENT_CONFIG_FILE_PATH,
-        }),
-      )
-    ) {
+    if (this.matchesPath(HERMESAGENT_CONFIG_FILE_PATH)) {
       return getEnabledPluginConfigContent({
         currentContent: super.getFileContent(),
         global: this.global,
@@ -342,33 +313,28 @@ export class HermesagentCommand extends ToolCommand {
     forDeletion?: boolean;
   }): Promise<ToolFile[]> {
     if (toolCommands.length === 0 && !forDeletion) return [];
+    const pluginDirPath = getHermesagentRelativeDirPath({
+      global,
+      relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
+    });
     const pluginFiles: ToolFile[] = [
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: getHermesagentRelativeDirPath({
-          global,
-          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
-        }),
+        relativeDirPath: pluginDirPath,
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_MANIFEST_PATH),
         fileContent: "",
         global,
       }),
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: getHermesagentRelativeDirPath({
-          global,
-          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
-        }),
+        relativeDirPath: pluginDirPath,
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_OWNERSHIP_PATH),
         fileContent: "Generated and owned by RuleSync.\n",
         global,
       }),
       new HermesagentCommandAuxiliaryFile({
         outputRoot,
-        relativeDirPath: getHermesagentRelativeDirPath({
-          global,
-          relativeDirPath: HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_DIR_PATH,
-        }),
+        relativeDirPath: pluginDirPath,
         relativeFilePath: basename(HERMESAGENT_RULESYNC_COMMANDS_PLUGIN_INIT_PATH),
         fileContent: "",
         global,

--- a/src/features/hooks/hermesagent-hooks.test.ts
+++ b/src/features/hooks/hermesagent-hooks.test.ts
@@ -1,7 +1,8 @@
+import { join } from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createMockLogger } from "../../test-utils/mock-logger.js";
-import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentHooks } from "./hermesagent-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
@@ -381,6 +382,11 @@ hooks:
 });
 
 describe("HermesagentHooks global settable paths", () => {
+  // Pinned as literals rather than re-calling getHermesagentGlobalDir(), so the
+  // platform branch itself is asserted and not merely restated.
+  const expectedGlobalDir =
+    process.platform === "win32" ? join("AppData", "Local", "hermes") : ".hermes";
+
   const originalHermesHome = process.env.HERMES_HOME;
 
   afterEach(() => {
@@ -392,7 +398,7 @@ describe("HermesagentHooks global settable paths", () => {
     delete process.env.HERMES_HOME;
 
     expect(HermesagentHooks.getSettablePaths({ global: true })).toEqual({
-      relativeDirPath: getHermesagentGlobalDir(),
+      relativeDirPath: expectedGlobalDir,
       relativeFilePath: "config.yaml",
     });
   });

--- a/src/features/hooks/hermesagent-hooks.test.ts
+++ b/src/features/hooks/hermesagent-hooks.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createMockLogger } from "../../test-utils/mock-logger.js";
+import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentHooks } from "./hermesagent-hooks.js";
 import { RulesyncHooks } from "./rulesync-hooks.js";
@@ -375,6 +376,33 @@ hooks:
         fileContent: "hooks: {}\n",
       });
       expect(hooks.isDeletable()).toBe(false);
+    });
+  });
+});
+
+describe("HermesagentHooks global settable paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+  });
+
+  it("anchors global paths on the platform profile directory when HERMES_HOME is unset", () => {
+    delete process.env.HERMES_HOME;
+
+    expect(HermesagentHooks.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: getHermesagentGlobalDir(),
+      relativeFilePath: "config.yaml",
+    });
+  });
+
+  it("drops the .hermes prefix when HERMES_HOME names the profile root itself", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(HermesagentHooks.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: ".",
+      relativeFilePath: "config.yaml",
     });
   });
 });

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { isRecord } from "../../utils/type-guards.js";
 import { HermesagentMcp } from "./hermesagent-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
@@ -746,5 +747,32 @@ mcp_servers:
     expect(getMcpServers(mcp.getFileContent())["existing-server"]?.command).toBe("existing");
     expect(getMcpServers(mcp.getFileContent())["test-server"]?.command).toBe("echo");
     expect(getMcpServers(mcp.getFileContent())["test-server"]?.args).toEqual(["hello"]);
+  });
+});
+
+describe("HermesagentMcp global settable paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+  });
+
+  it("anchors global paths on the platform profile directory when HERMES_HOME is unset", () => {
+    delete process.env.HERMES_HOME;
+
+    expect(HermesagentMcp.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: getHermesagentGlobalDir(),
+      relativeFilePath: "config.yaml",
+    });
+  });
+
+  it("drops the .hermes prefix when HERMES_HOME names the profile root itself", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(HermesagentMcp.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: ".",
+      relativeFilePath: "config.yaml",
+    });
   });
 });

--- a/src/features/mcp/hermesagent-mcp.test.ts
+++ b/src/features/mcp/hermesagent-mcp.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
-import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { isRecord } from "../../utils/type-guards.js";
 import { HermesagentMcp } from "./hermesagent-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
@@ -751,6 +750,11 @@ mcp_servers:
 });
 
 describe("HermesagentMcp global settable paths", () => {
+  // Pinned as literals rather than re-calling getHermesagentGlobalDir(), so the
+  // platform branch itself is asserted and not merely restated.
+  const expectedGlobalDir =
+    process.platform === "win32" ? join("AppData", "Local", "hermes") : ".hermes";
+
   const originalHermesHome = process.env.HERMES_HOME;
 
   afterEach(() => {
@@ -762,7 +766,7 @@ describe("HermesagentMcp global settable paths", () => {
     delete process.env.HERMES_HOME;
 
     expect(HermesagentMcp.getSettablePaths({ global: true })).toEqual({
-      relativeDirPath: getHermesagentGlobalDir(),
+      relativeDirPath: expectedGlobalDir,
       relativeFilePath: "config.yaml",
     });
   });

--- a/src/features/permissions/hermesagent-permissions.test.ts
+++ b/src/features/permissions/hermesagent-permissions.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
+import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentPermissions } from "./hermesagent-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -339,5 +340,32 @@ security:
 
     const roundTripped = JSON.parse(reimported.toRulesyncPermissions().getFileContent());
     expect(roundTripped).toEqual(canonical);
+  });
+});
+
+describe("HermesagentPermissions global settable paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+  });
+
+  it("anchors global paths on the platform profile directory when HERMES_HOME is unset", () => {
+    delete process.env.HERMES_HOME;
+
+    expect(HermesagentPermissions.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: getHermesagentGlobalDir(),
+      relativeFilePath: "config.yaml",
+    });
+  });
+
+  it("drops the .hermes prefix when HERMES_HOME names the profile root itself", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(HermesagentPermissions.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: ".",
+      relativeFilePath: "config.yaml",
+    });
   });
 });

--- a/src/features/permissions/hermesagent-permissions.test.ts
+++ b/src/features/permissions/hermesagent-permissions.test.ts
@@ -1,6 +1,7 @@
+import { join } from "node:path";
+
 import { afterEach, describe, expect, it } from "vitest";
 
-import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentPermissions } from "./hermesagent-permissions.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
@@ -344,6 +345,11 @@ security:
 });
 
 describe("HermesagentPermissions global settable paths", () => {
+  // Pinned as literals rather than re-calling getHermesagentGlobalDir(), so the
+  // platform branch itself is asserted and not merely restated.
+  const expectedGlobalDir =
+    process.platform === "win32" ? join("AppData", "Local", "hermes") : ".hermes";
+
   const originalHermesHome = process.env.HERMES_HOME;
 
   afterEach(() => {
@@ -355,7 +361,7 @@ describe("HermesagentPermissions global settable paths", () => {
     delete process.env.HERMES_HOME;
 
     expect(HermesagentPermissions.getSettablePaths({ global: true })).toEqual({
-      relativeDirPath: getHermesagentGlobalDir(),
+      relativeDirPath: expectedGlobalDir,
       relativeFilePath: "config.yaml",
     });
   });

--- a/src/features/skills/hermesagent-skill.test.ts
+++ b/src/features/skills/hermesagent-skill.test.ts
@@ -6,7 +6,6 @@ import { HERMESAGENT_SKILLS_DIR_PATH } from "../../constants/hermesagent-paths.j
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { HermesagentSkill } from "./hermesagent-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 
@@ -262,6 +261,11 @@ describe("HermesagentSkill", () => {
 });
 
 describe("HermesagentSkill global settable paths", () => {
+  // Pinned as literals rather than re-calling getHermesagentGlobalDir(), so the
+  // platform branch itself is asserted and not merely restated.
+  const expectedGlobalDir =
+    process.platform === "win32" ? join("AppData", "Local", "hermes") : ".hermes";
+
   const originalHermesHome = process.env.HERMES_HOME;
 
   afterEach(() => {
@@ -273,7 +277,7 @@ describe("HermesagentSkill global settable paths", () => {
     delete process.env.HERMES_HOME;
 
     expect(HermesagentSkill.getSettablePaths({ global: true })).toEqual({
-      relativeDirPath: join(getHermesagentGlobalDir(), "skills"),
+      relativeDirPath: join(expectedGlobalDir, "skills"),
     });
   });
 

--- a/src/features/skills/hermesagent-skill.test.ts
+++ b/src/features/skills/hermesagent-skill.test.ts
@@ -1,9 +1,12 @@
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HERMESAGENT_SKILLS_DIR_PATH } from "../../constants/hermesagent-paths.js";
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { HermesagentSkill } from "./hermesagent-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 
@@ -254,6 +257,31 @@ describe("HermesagentSkill", () => {
         },
       });
       expect(rulesyncSkill.getBody()).toBe("Test body");
+    });
+  });
+});
+
+describe("HermesagentSkill global settable paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+  });
+
+  it("anchors global paths on the platform profile directory when HERMES_HOME is unset", () => {
+    delete process.env.HERMES_HOME;
+
+    expect(HermesagentSkill.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: join(getHermesagentGlobalDir(), "skills"),
+    });
+  });
+
+  it("drops the .hermes prefix when HERMES_HOME names the profile root itself", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(HermesagentSkill.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: "skills",
     });
   });
 });

--- a/src/features/subagents/hermesagent-subagent.test.ts
+++ b/src/features/subagents/hermesagent-subagent.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import {
   HERMESAGENT_GLOBAL_DIR,
@@ -11,6 +11,7 @@ import {
 } from "../../constants/hermesagent-paths.js";
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
+import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { getHermesagentSharedConfigWritePaths } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentSubagent } from "./hermesagent-subagent.js";
@@ -165,5 +166,30 @@ plugins:
       HERMESAGENT_GLOBAL_WIN32_DIR,
       ".",
     ]);
+  });
+});
+
+describe("HermesagentSubagent global settable paths", () => {
+  const originalHermesHome = process.env.HERMES_HOME;
+
+  afterEach(() => {
+    if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = originalHermesHome;
+  });
+
+  test("anchors global paths on the platform profile directory when HERMES_HOME is unset", () => {
+    delete process.env.HERMES_HOME;
+
+    expect(HermesagentSubagent.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: join(getHermesagentGlobalDir(), "rulesync", "subagents"),
+    });
+  });
+
+  test("drops the .hermes prefix when HERMES_HOME names the profile root itself", () => {
+    process.env.HERMES_HOME = "/custom-hermes";
+
+    expect(HermesagentSubagent.getSettablePaths({ global: true })).toEqual({
+      relativeDirPath: join("rulesync", "subagents"),
+    });
   });
 });

--- a/src/features/subagents/hermesagent-subagent.test.ts
+++ b/src/features/subagents/hermesagent-subagent.test.ts
@@ -11,7 +11,6 @@ import {
 } from "../../constants/hermesagent-paths.js";
 import { RULESYNC_SUBAGENTS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { getHermesagentGlobalDir } from "../../utils/hermesagent.js";
 import { getHermesagentSharedConfigWritePaths } from "../../utils/hermesagent.js";
 import { parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentSubagent } from "./hermesagent-subagent.js";
@@ -170,6 +169,11 @@ plugins:
 });
 
 describe("HermesagentSubagent global settable paths", () => {
+  // Pinned as literals rather than re-calling getHermesagentGlobalDir(), so the
+  // platform branch itself is asserted and not merely restated.
+  const expectedGlobalDir =
+    process.platform === "win32" ? join("AppData", "Local", "hermes") : ".hermes";
+
   const originalHermesHome = process.env.HERMES_HOME;
 
   afterEach(() => {
@@ -181,7 +185,7 @@ describe("HermesagentSubagent global settable paths", () => {
     delete process.env.HERMES_HOME;
 
     expect(HermesagentSubagent.getSettablePaths({ global: true })).toEqual({
-      relativeDirPath: join(getHermesagentGlobalDir(), "rulesync", "subagents"),
+      relativeDirPath: join(expectedGlobalDir, "rulesync", "subagents"),
     });
   });
 

--- a/src/features/subagents/hermesagent-subagent.ts
+++ b/src/features/subagents/hermesagent-subagent.ts
@@ -218,6 +218,10 @@ export class HermesagentSubagent extends ToolSubagent {
     outputRoot,
     global = false,
   }: ToolSubagentsFromRulesyncSubagentsParams): HermesagentSubagent[] {
+    const pluginDirPath = getHermesagentRelativeDirPath({
+      global,
+      relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
+    });
     return [
       ...rulesyncSubagents.map((rulesyncSubagent) =>
         HermesagentSubagent.fromRulesyncSubagent({
@@ -228,20 +232,14 @@ export class HermesagentSubagent extends ToolSubagent {
         }),
       ),
       new HermesagentSubagent({
-        relativeDirPath: getHermesagentRelativeDirPath({
-          global,
-          relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
-        }),
+        relativeDirPath: pluginDirPath,
         relativeFilePath: basename(HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_MANIFEST_PATH),
         fileContent: "",
         outputRoot,
         global,
       }),
       new HermesagentSubagent({
-        relativeDirPath: getHermesagentRelativeDirPath({
-          global,
-          relativeDirPath: HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_DIR_PATH,
-        }),
+        relativeDirPath: pluginDirPath,
         relativeFilePath: basename(HERMESAGENT_RULESYNC_SUBAGENTS_PLUGIN_INIT_PATH),
         fileContent: "",
         outputRoot,

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1169,7 +1169,11 @@ async function generateChecksCore(params: {
       }
 
       const processor = new ChecksProcessor({
-        outputRoot: outputRoot,
+        outputRoot: resolveToolOutputRoot({
+          outputRoot,
+          toolTarget,
+          global: config.getGlobal(),
+        }),
         inputRoot: config.getInputRoot(),
         toolTarget: toolTarget,
         global: config.getGlobal(),

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -770,6 +770,9 @@ async function generateIgnoreCore(params: {
           // leftover from before `outputRoots` was always resolved to absolute
           // paths in `ConfigResolver`; with that change it is now consistent
           // to pass the same `outputRoot` value the other processors receive.
+          // No `resolveToolOutputRoot` either: the tools with a home override
+          // (hermesagent, kimi-code) are not global ignore targets, so there is
+          // nothing to redirect. Route through it if that ever changes.
           outputRoot,
           inputRoot: config.getInputRoot(),
           toolTarget,

--- a/src/utils/hermesagent.ts
+++ b/src/utils/hermesagent.ts
@@ -7,7 +7,8 @@ import {
 } from "../constants/hermesagent-paths.js";
 import { sharedConfigFileKey } from "../features/shared/shared-config-gateway.js";
 import type { SharedWritePath } from "../lib/shared-file-derive.js";
-import { checkPathTraversal, getHomeDirectory } from "./file.js";
+import { checkPathTraversal } from "./file.js";
+import { getToolRulesyncOutputRoot } from "./tool-home.js";
 
 export function getHermesagentHome(): string | undefined {
   const configuredHome = process.env.HERMES_HOME?.trim();
@@ -136,5 +137,5 @@ export function getHermesagentRulesyncOutputRoot({
   nativeOutputRoot: string;
   global: boolean;
 }): string {
-  return global && getHermesagentHome() ? getHomeDirectory() : nativeOutputRoot;
+  return getToolRulesyncOutputRoot({ nativeOutputRoot, global, toolHome: getHermesagentHome });
 }

--- a/src/utils/kimi-code.test.ts
+++ b/src/utils/kimi-code.test.ts
@@ -6,15 +6,19 @@ import {
   getKimiCodeConfigSharedFileKey,
   getKimiCodeHome,
   getKimiCodeRelativeDirPath,
+  getKimiCodeRulesyncOutputRoot,
   getKimiCodeSharedConfigWritePaths,
 } from "./kimi-code.js";
 
 describe("Kimi Code profile paths", () => {
   const originalKimiHome = process.env.KIMI_CODE_HOME;
+  const originalHomeDir = process.env.HOME_DIR;
 
   afterEach(() => {
     if (originalKimiHome === undefined) delete process.env.KIMI_CODE_HOME;
     else process.env.KIMI_CODE_HOME = originalKimiHome;
+    if (originalHomeDir === undefined) delete process.env.HOME_DIR;
+    else process.env.HOME_DIR = originalHomeDir;
   });
 
   it("treats KIMI_CODE_HOME as the profile root itself", () => {
@@ -45,5 +49,23 @@ describe("Kimi Code profile paths", () => {
 
     process.env.KIMI_CODE_HOME = "/custom-kimi";
     expect(getKimiCodeConfigSharedFileKey({ global: true })).toBe("config.toml");
+  });
+
+  it("keeps the rulesync source root under the rulesync home when the override is set", () => {
+    // KIMI_CODE_HOME redirects Kimi's own output, but the `.rulesync/` sources
+    // imported back out of it belong to the project, not the Kimi profile.
+    process.env.HOME_DIR = "/rulesync-home";
+    process.env.KIMI_CODE_HOME = "/custom-kimi";
+    expect(getKimiCodeRulesyncOutputRoot({ nativeOutputRoot: "/custom-kimi", global: true })).toBe(
+      "/rulesync-home",
+    );
+    expect(getKimiCodeRulesyncOutputRoot({ nativeOutputRoot: "/project", global: false })).toBe(
+      "/project",
+    );
+
+    delete process.env.KIMI_CODE_HOME;
+    expect(getKimiCodeRulesyncOutputRoot({ nativeOutputRoot: "/home", global: true })).toBe(
+      "/home",
+    );
   });
 });

--- a/src/utils/kimi-code.ts
+++ b/src/utils/kimi-code.ts
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path";
 import { KIMI_CODE_CONFIG_FILE_NAME, KIMI_CODE_DIR } from "../constants/kimi-code-paths.js";
 import { sharedConfigFileKey } from "../features/shared/shared-config-gateway.js";
 import type { SharedWritePath } from "../lib/shared-file-derive.js";
-import { getHomeDirectory } from "./file.js";
+import { getToolRulesyncOutputRoot } from "./tool-home.js";
 
 export function getKimiCodeHome(): string | undefined {
   const configuredHome = process.env.KIMI_CODE_HOME?.trim();
@@ -52,5 +52,5 @@ export function getKimiCodeRulesyncOutputRoot({
   nativeOutputRoot: string;
   global: boolean;
 }): string {
-  return global && getKimiCodeHome() ? getHomeDirectory() : nativeOutputRoot;
+  return getToolRulesyncOutputRoot({ nativeOutputRoot, global, toolHome: getKimiCodeHome });
 }

--- a/src/utils/tool-home.ts
+++ b/src/utils/tool-home.ts
@@ -1,0 +1,21 @@
+import { getHomeDirectory } from "./file.js";
+
+/**
+ * Where the rulesync-side source files of a tool with a home override belong.
+ *
+ * A home override redirects the tool's OWN output, but the `.rulesync/` sources
+ * imported back out of it are not part of the tool's profile — they stay under
+ * the rulesync home. When no override is set, the native output root already is
+ * that place.
+ */
+export function getToolRulesyncOutputRoot({
+  nativeOutputRoot,
+  global,
+  toolHome,
+}: {
+  nativeOutputRoot: string;
+  global: boolean;
+  toolHome: () => string | undefined;
+}): string {
+  return global && toolHome() ? getHomeDirectory() : nativeOutputRoot;
+}


### PR DESCRIPTION
Part of #2439 (findings 3, 4, 6, 7, 8) — the separable cleanups, following #2483 which took findings 1, 2, 5, 9 and 10. Finding 11 (the migration note about stale `~/.hermes/*` files) is a release-notes item, not a code change, so the issue stays open for the maintainer to close.

## Finding 3 (mid) — the five-times-repeated path comparison

`HermesagentCommandAuxiliaryFile` rebuilt the same `this.getRelativePathFromCwd() === toPosixPath(getHermesagentRelativeFilePath({ global: this.global, relativeFilePath: <CONST> }))` expression in `shouldMergeExistingFileContent`, `setFileContent`, and three branches of `getFileContent`. A private `matchesPath(relativeFilePath)` collapses ~40 lines to five call sites and removes the chance of pairing a branch with the wrong constant.

## Finding 4 (low) — duplication against the kimi-code utility

`getHermesagentRulesyncOutputRoot` and `getKimiCodeRulesyncOutputRoot` were identical apart from the home getter, so both now delegate to a shared `getToolRulesyncOutputRoot({ nativeOutputRoot, global, toolHome })`.

One deviation from the issue's suggestion: it lives in a new `src/utils/tool-home.ts` rather than in `tool-output-root.ts`. `tool-output-root.ts` imports both tool utils, so putting the helper there and importing it back would have created a genuine `hermesagent → tool-output-root → hermesagent` cycle. The new module is a leaf that imports only `getHomeDirectory`.

The issue's local duplication is gone too: `getHermesagentRelativeDirPath({ global, relativeDirPath: <PLUGIN_DIR> })` was spelled out three times in `hermesagent-command.ts` and twice in `hermesagent-subagent.ts`, and is now one `const pluginDirPath` per function.

## Finding 6 (low) — per-class global coverage

`HermesagentMcp`, `HermesagentHooks`, `HermesagentPermissions`, `HermesagentSkill` and `HermesagentSubagent` each get a `getSettablePaths({ global: true })` case in both configurations: anchored on the platform profile directory when `HERMES_HOME` is unset, and de-prefixed when it names the profile root. Previously only the helper in `src/utils/hermesagent.ts` and the e2e suite covered this.

## Finding 7 (low) — convert/generate disagreement on checks

`generateChecksCore` passed `outputRoot` verbatim while `convert.ts`'s `buildChecksStrategy` already ran it through `resolveToolOutputRoot`. Aligned. `generateIgnoreCore` is deliberately left alone, per the comment justifying its verbatim pass-through.

## Finding 8 (low) — undocumented precedence

`docs/reference/cli-commands.md` gains a short section stating that `HERMES_HOME` / `KIMI_CODE_HOME` override `outputRoots` and `--output-roots` in global scope, why (the variable names where the tool itself looks), and that an unusable value is rejected with an error naming the variable. Skill docs synced.

## Verification

Full `pnpm cicheck` is green (8054 unit tests). The Hermes-touching e2e specs pass locally. No behavior change is intended anywhere except `generateChecksCore`, which now matches the convert path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
