### PR TITLE
feat(generate): add --watch flag that regenerates on source changes

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -103,6 +103,7 @@ The `generate` command reads source files from `.rulesync/` and writes AI tool c
 | `--simulate-subagents`      | Generate simulated subagents for tools that do not support them natively                                                   | `false`               |
 | `--simulate-skills`         | Generate simulated skills for tools that do not support them natively                                                      | `false`               |
 | `--delete`                  | Delete existing generated files before writing                                                                             | From `rulesync.jsonc` |
+| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                           | `false`               |
 
 ### Examples
 
@@ -121,7 +122,21 @@ rulesync generate --dry-run --targets claudecode --features rules
 
 # CI check: fail if generated files are not up to date
 rulesync generate --check --targets "*" --features "*"
+
+# Watch mode: regenerate on every change to the sources
+rulesync generate --watch
 ```
+
+### Watch mode
+
+`generate --watch` runs one generation immediately and then keeps running, regenerating whenever the rulesync sources change. It is meant for iterating on rules, commands, subagents or skills without re-running the command by hand.
+
+- **What is watched**: the `.rulesync/` source tree (recursively) plus the configuration files next to it (`rulesync.jsonc` and `rulesync.local.jsonc`, or the file passed to `--config`). Generated output is never watched, so a regeneration cannot re-trigger the watcher.
+- **Debouncing**: bursts of file-system events (editor save storms, `git checkout` switching many files) are coalesced into a single regeneration after a short quiet period. Changes that arrive while a generation is running trigger exactly one follow-up run.
+- **Errors keep the watcher alive**: a failing generation (e.g. invalid frontmatter saved mid-edit) is reported and watching continues; the process does not exit.
+- **Configuration changes**: editing the configuration file triggers a regeneration, and the new values apply to it because the configuration is re-resolved on every run. The **set of watched paths is fixed at startup**, so changing `inputRoot` (or the location of the configuration file itself) requires restarting the command. A warning is printed whenever the configuration file changes as a reminder.
+- **Incompatible flags**: `--watch` cannot be combined with `--check`, `--dry-run` or `--json`. The first two are one-shot verification modes and `--json` emits a single result document when the command exits, which never happens while watching.
+- **Stopping**: `Ctrl+C` (`SIGINT`) or `SIGTERM` closes the watchers and exits normally.
 
 ### Tool home overrides win over the output root in global scope
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -103,7 +103,7 @@ The `generate` command reads source files from `.rulesync/` and writes AI tool c
 | `--simulate-subagents`      | Generate simulated subagents for tools that do not support them natively                                                   | `false`               |
 | `--simulate-skills`         | Generate simulated skills for tools that do not support them natively                                                      | `false`               |
 | `--delete`                  | Delete existing generated files before writing                                                                             | From `rulesync.jsonc` |
-| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                           | `false`               |
+| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                          | `false`               |
 
 ### Examples
 

--- a/scripts/sync-skill-docs.ts
+++ b/scripts/sync-skill-docs.ts
@@ -233,6 +233,7 @@ export function syncSkillDocs(): void {
     "| `rulesync install`                               | Install skill sources declared in rulesync.jsonc |",
     "| `rulesync generate --check`                      | CI check that generated files are up to date     |",
     "| `rulesync generate --dry-run`                    | Preview changes without writing files            |",
+    "| `rulesync generate --watch`                      | Regenerate whenever source files change          |",
     "",
     "## Detailed Reference",
     "",

--- a/skills/rulesync/SKILL.md
+++ b/skills/rulesync/SKILL.md
@@ -48,6 +48,7 @@ rulesync generate --targets "*" --features "*"
 | `rulesync install`                               | Install skill sources declared in rulesync.jsonc |
 | `rulesync generate --check`                      | CI check that generated files are up to date     |
 | `rulesync generate --dry-run`                    | Preview changes without writing files            |
+| `rulesync generate --watch`                      | Regenerate whenever source files change          |
 
 ## Detailed Reference
 

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -103,6 +103,7 @@ The `generate` command reads source files from `.rulesync/` and writes AI tool c
 | `--simulate-subagents`      | Generate simulated subagents for tools that do not support them natively                                                   | `false`               |
 | `--simulate-skills`         | Generate simulated skills for tools that do not support them natively                                                      | `false`               |
 | `--delete`                  | Delete existing generated files before writing                                                                             | From `rulesync.jsonc` |
+| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                           | `false`               |
 
 ### Examples
 
@@ -121,7 +122,21 @@ rulesync generate --dry-run --targets claudecode --features rules
 
 # CI check: fail if generated files are not up to date
 rulesync generate --check --targets "*" --features "*"
+
+# Watch mode: regenerate on every change to the sources
+rulesync generate --watch
 ```
+
+### Watch mode
+
+`generate --watch` runs one generation immediately and then keeps running, regenerating whenever the rulesync sources change. It is meant for iterating on rules, commands, subagents or skills without re-running the command by hand.
+
+- **What is watched**: the `.rulesync/` source tree (recursively) plus the configuration files next to it (`rulesync.jsonc` and `rulesync.local.jsonc`, or the file passed to `--config`). Generated output is never watched, so a regeneration cannot re-trigger the watcher.
+- **Debouncing**: bursts of file-system events (editor save storms, `git checkout` switching many files) are coalesced into a single regeneration after a short quiet period. Changes that arrive while a generation is running trigger exactly one follow-up run.
+- **Errors keep the watcher alive**: a failing generation (e.g. invalid frontmatter saved mid-edit) is reported and watching continues; the process does not exit.
+- **Configuration changes**: editing the configuration file triggers a regeneration, and the new values apply to it because the configuration is re-resolved on every run. The **set of watched paths is fixed at startup**, so changing `inputRoot` (or the location of the configuration file itself) requires restarting the command. A warning is printed whenever the configuration file changes as a reminder.
+- **Incompatible flags**: `--watch` cannot be combined with `--check`, `--dry-run` or `--json`. The first two are one-shot verification modes and `--json` emits a single result document when the command exits, which never happens while watching.
+- **Stopping**: `Ctrl+C` (`SIGINT`) or `SIGTERM` closes the watchers and exits normally.
 
 ### Tool home overrides win over the output root in global scope
 

--- a/skills/rulesync/cli-commands.md
+++ b/skills/rulesync/cli-commands.md
@@ -103,7 +103,7 @@ The `generate` command reads source files from `.rulesync/` and writes AI tool c
 | `--simulate-subagents`      | Generate simulated subagents for tools that do not support them natively                                                   | `false`               |
 | `--simulate-skills`         | Generate simulated skills for tools that do not support them natively                                                      | `false`               |
 | `--delete`                  | Delete existing generated files before writing                                                                             | From `rulesync.jsonc` |
-| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                           | `false`               |
+| `--watch, -w`               | Keep running and regenerate whenever rulesync source files change                                                          | `false`               |
 
 ### Examples
 

--- a/src/cli/commands/generate.test.ts
+++ b/src/cli/commands/generate.test.ts
@@ -8,10 +8,10 @@ import { McpProcessor } from "../../features/mcp/mcp-processor.js";
 import { RulesProcessor } from "../../features/rules/rules-processor.js";
 import { SubagentsProcessor } from "../../features/subagents/subagents-processor.js";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
-import { ErrorCodes } from "../../types/json-output.js";
+import { CLIError, ErrorCodes } from "../../types/json-output.js";
 import { fileExists } from "../../utils/file.js";
 import type { GenerateOptions } from "./generate.js";
-import { generateCommand } from "./generate.js";
+import { assertWatchModeCompatible, generateCommand } from "./generate.js";
 
 // Mock all dependencies
 vi.mock("../../config/config-resolver.js");
@@ -1346,5 +1346,34 @@ describe("generateCommand", () => {
         "🎉 All done! Written 4 file(s) total (4 rules)",
       );
     });
+  });
+});
+
+describe("assertWatchModeCompatible", () => {
+  it("accepts a plain watch run", () => {
+    expect(() =>
+      assertWatchModeCompatible({ isCheck: false, isDryRun: false, isJsonMode: false }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    { params: { isCheck: true, isDryRun: false, isJsonMode: false }, expected: "--check" },
+    { params: { isCheck: false, isDryRun: true, isJsonMode: false }, expected: "--dry-run" },
+    { params: { isCheck: false, isDryRun: false, isJsonMode: true }, expected: "--json" },
+  ])("rejects $expected", ({ params, expected }) => {
+    try {
+      assertWatchModeCompatible(params);
+      expect.unreachable("assertWatchModeCompatible should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CLIError);
+      expect((error as CLIError).code).toBe(ErrorCodes.VALIDATION_FAILED);
+      expect((error as CLIError).message).toContain(expected);
+    }
+  });
+
+  it("lists every conflicting flag", () => {
+    expect(() =>
+      assertWatchModeCompatible({ isCheck: true, isDryRun: true, isJsonMode: true }),
+    ).toThrow("--watch cannot be combined with --check, --dry-run, --json.");
   });
 });

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,12 +1,8 @@
-import { basename, resolve } from "node:path";
-
 import { ConfigResolver, type ConfigResolverResolveParams } from "../../config/config-resolver.js";
-import {
-  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
-  RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
-} from "../../constants/rulesync-paths.js";
+import type { Config } from "../../config/config.js";
 import { checkRulesyncDirExists, generate, type GenerateResult } from "../../lib/generate.js";
 import {
+  buildConfigFilePaths,
   buildWatchTargets,
   formatTriggerPaths,
   WatchScheduler,
@@ -114,8 +110,18 @@ export async function generateCommand(logger: Logger, options: GenerateOptions):
   await generateOnce(logger, options);
 }
 
-async function generateOnce(logger: Logger, options: GenerateOptions): Promise<void> {
-  const config = await ConfigResolver.resolve(options, { logger });
+/**
+ * Runs one generation. `resolvedConfig` lets a caller that already resolved
+ * the configuration (watch mode's startup validation) reuse it instead of
+ * paying for a second resolution — and, more importantly, instead of emitting
+ * the resolver's warnings twice.
+ */
+async function generateOnce(
+  logger: Logger,
+  options: GenerateOptions,
+  { resolvedConfig }: { resolvedConfig?: Config } = {},
+): Promise<void> {
+  const config = resolvedConfig ?? (await ConfigResolver.resolve(options, { logger }));
 
   const check = config.getCheck();
 
@@ -255,25 +261,21 @@ async function generateWatchCommand(logger: Logger, options: GenerateOptions): P
   });
 
   const inputRoot = config.getInputRoot();
-  const configFilePath = resolve(
-    inputRoot,
-    options.configPath ?? RULESYNC_CONFIG_RELATIVE_FILE_PATH,
-  );
-  const configFileNames = new Set([
-    basename(configFilePath),
-    RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
-  ]);
+  // Take the path the resolver actually loaded rather than re-deriving it:
+  // the two differ when `inputRoot` comes from the configuration file itself.
+  const configFilePath = config.getConfigFilePath();
+  const configFilePaths = buildConfigFilePaths({ configFilePath });
 
   // Run once before watching so a missing `.rulesync` directory (or any other
   // configuration error) fails fast instead of starting an idle watcher.
-  await generateOnce(logger, options);
+  await generateOnce(logger, options, { resolvedConfig: config });
 
   const targets = buildWatchTargets({ inputRoot, configFilePath });
 
   const scheduler = new WatchScheduler({
     run: async ({ triggers }) => {
       logger.info(`\nChange detected: ${formatTriggerPaths({ triggers, baseDir: inputRoot })}`);
-      if (triggers.some((trigger) => configFileNames.has(basename(trigger)))) {
+      if (triggers.some((trigger) => configFilePaths.has(trigger))) {
         logger.warn(
           "Configuration file changed. The set of watched paths is fixed at startup — restart 'rulesync generate --watch' if you changed 'inputRoot' or the configuration file location.",
         );
@@ -306,10 +308,15 @@ async function generateWatchCommand(logger: Logger, options: GenerateOptions): P
       process.off("SIGINT", shutdown);
       process.off("SIGTERM", shutdown);
       handle.close();
-      void scheduler.close().then(() => {
-        logger.info("\nStopped watching.");
-        resolveShutdown();
-      });
+      void scheduler
+        .close()
+        .catch((error: unknown) => {
+          logger.error(`Failed to stop the watcher cleanly: ${formatError(error)}`);
+        })
+        .finally(() => {
+          logger.info("\nStopped watching.");
+          resolveShutdown();
+        });
     };
     process.once("SIGINT", shutdown);
     process.once("SIGTERM", shutdown);

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,10 +1,26 @@
+import { basename, resolve } from "node:path";
+
 import { ConfigResolver, type ConfigResolverResolveParams } from "../../config/config-resolver.js";
+import {
+  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+} from "../../constants/rulesync-paths.js";
 import { checkRulesyncDirExists, generate, type GenerateResult } from "../../lib/generate.js";
+import {
+  buildWatchTargets,
+  formatTriggerPaths,
+  WatchScheduler,
+  watchTargets,
+} from "../../lib/watch.js";
 import { CLIError, ErrorCodes } from "../../types/json-output.js";
+import { formatError } from "../../utils/error.js";
 import type { Logger } from "../../utils/logger.js";
 import { calculateTotalCount } from "../../utils/result.js";
 
-export type GenerateOptions = ConfigResolverResolveParams;
+export type GenerateOptions = ConfigResolverResolveParams & {
+  /** Keep running and regenerate whenever a rulesync source file changes. */
+  watch?: boolean;
+};
 
 /**
  * Log feature generation result with appropriate prefix based on dry run mode.
@@ -91,6 +107,14 @@ function buildSummaryParts(result: GenerateResult): string[] {
 }
 
 export async function generateCommand(logger: Logger, options: GenerateOptions): Promise<void> {
+  if (options.watch) {
+    await generateWatchCommand(logger, options);
+    return;
+  }
+  await generateOnce(logger, options);
+}
+
+async function generateOnce(logger: Logger, options: GenerateOptions): Promise<void> {
   const config = await ConfigResolver.resolve(options, { logger });
 
   const check = config.getCheck();
@@ -189,4 +213,105 @@ export async function generateCommand(logger: Logger, options: GenerateOptions):
   } else {
     logger.success(`🎉 All done! Written ${totalGenerated} file(s) total (${parts.join(" + ")})`);
   }
+}
+
+/**
+ * Rejects flag combinations that contradict a long-running watch: `--check`
+ * and `--dry-run` are one-shot verification modes (the former is meant to exit
+ * non-zero), and `--json` buffers a single result document until the command
+ * returns, which never happens while watching.
+ */
+export function assertWatchModeCompatible({
+  isCheck,
+  isDryRun,
+  isJsonMode,
+}: {
+  isCheck: boolean;
+  isDryRun: boolean;
+  isJsonMode: boolean;
+}): void {
+  const conflicts = [
+    isCheck ? "--check" : undefined,
+    isDryRun ? "--dry-run" : undefined,
+    isJsonMode ? "--json" : undefined,
+  ].filter((flag): flag is string => flag !== undefined);
+
+  if (conflicts.length > 0) {
+    throw new CLIError(
+      `--watch cannot be combined with ${conflicts.join(", ")}.`,
+      ErrorCodes.VALIDATION_FAILED,
+    );
+  }
+}
+
+async function generateWatchCommand(logger: Logger, options: GenerateOptions): Promise<void> {
+  // Resolve once up front so the incompatible-mode check also covers values
+  // coming from the config file, not just CLI flags.
+  const config = await ConfigResolver.resolve(options, { logger });
+  assertWatchModeCompatible({
+    isCheck: config.getCheck(),
+    isDryRun: config.getDryRun(),
+    isJsonMode: logger.jsonMode,
+  });
+
+  const inputRoot = config.getInputRoot();
+  const configFilePath = resolve(
+    inputRoot,
+    options.configPath ?? RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  );
+  const configFileNames = new Set([
+    basename(configFilePath),
+    RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+  ]);
+
+  // Run once before watching so a missing `.rulesync` directory (or any other
+  // configuration error) fails fast instead of starting an idle watcher.
+  await generateOnce(logger, options);
+
+  const targets = buildWatchTargets({ inputRoot, configFilePath });
+
+  const scheduler = new WatchScheduler({
+    run: async ({ triggers }) => {
+      logger.info(`\nChange detected: ${formatTriggerPaths({ triggers, baseDir: inputRoot })}`);
+      if (triggers.some((trigger) => configFileNames.has(basename(trigger)))) {
+        logger.warn(
+          "Configuration file changed. The set of watched paths is fixed at startup — restart 'rulesync generate --watch' if you changed 'inputRoot' or the configuration file location.",
+        );
+      }
+      await generateOnce(logger, options);
+    },
+    onError: ({ error }) => {
+      logger.error(`Generation failed: ${formatError(error)}`);
+      logger.info("Still watching for changes...");
+    },
+  });
+
+  const handle = watchTargets({
+    targets,
+    onChange: ({ path }) => {
+      scheduler.notify({ path });
+    },
+    onError: ({ error, directory }) => {
+      logger.error(`Watch error on ${directory}: ${formatError(error)}`);
+    },
+  });
+
+  logger.info(
+    `\nWatching for changes in:\n${targets.map((target) => `    ${target.directory}`).join("\n")}`,
+  );
+  logger.info("Press Ctrl+C to stop.");
+
+  await new Promise<void>((resolveShutdown) => {
+    const shutdown = (): void => {
+      process.off("SIGINT", shutdown);
+      process.off("SIGTERM", shutdown);
+      handle.close();
+      void scheduler.close().then(() => {
+        logger.info("\nStopped watching.");
+        resolveShutdown();
+      });
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -290,6 +290,10 @@ export function createProgram(): Command {
     )
     .option("--dry-run", "Dry run: show changes without writing files")
     .option("--check", "Check if files are up to date (exits with code 1 if changes needed)")
+    .option(
+      "-w, --watch",
+      "Keep running and regenerate whenever rulesync source files change (cannot be combined with --check, --dry-run or --json)",
+    )
     .action(
       wrapCommand("generate", "GENERATION_FAILED", async (logger, options) => {
         await generateCommand(logger, options as GenerateOptions);

--- a/src/config/config-resolver.ts
+++ b/src/config/config-resolver.ts
@@ -389,6 +389,10 @@ export class ConfigResolver {
       // neither CLI nor config file supplied an inputRoot, fall back to the
       // captured `cwd` so the value is still deterministic.
       inputRoot: resolvedInputRoot !== undefined ? resolve(resolvedInputRoot) : cwd,
+      // The path actually loaded above, so callers that need to observe the
+      // configuration file (e.g. `generate --watch`) never have to re-derive
+      // it and risk diverging from this resolution.
+      configFilePath: validatedConfigPath,
       sources: configByFile.sources ?? getDefaults().sources,
       flattenedCommandNaming:
         configByFile.flattenedCommandNaming ?? getDefaults().flattenedCommandNaming,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,7 +1,8 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { RULESYNC_CONFIG_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
 import { ALL_FEATURES } from "../types/features.js";
 import { ALL_TOOL_TARGETS } from "../types/tool-targets.js";
 import {
@@ -438,6 +439,25 @@ describe("Config", () => {
       const parent = resolve(originalCwd, "..");
       process.chdir(parent);
       expect(config.getInputRoot()).toBe(expected);
+    });
+  });
+
+  describe("getConfigFilePath", () => {
+    it("keeps the absolute path supplied by the resolver", () => {
+      const configFilePath = resolve(process.cwd(), "packages", "app", "rulesync.jsonc");
+      const config = createConfig({ configFilePath });
+      expect(config.getConfigFilePath()).toBe(configFilePath);
+    });
+
+    it("falls back to the conventional location next to the input root", () => {
+      const inputRoot = resolve(process.cwd(), "central-rules");
+      const config = createConfig({ inputRoot });
+      expect(config.getConfigFilePath()).toBe(join(inputRoot, RULESYNC_CONFIG_RELATIVE_FILE_PATH));
+    });
+
+    it("resolves a relative path to absolute", () => {
+      const config = createConfig({ configFilePath: "./nested/rulesync.jsonc" });
+      expect(config.getConfigFilePath()).toBe(resolve(process.cwd(), "nested/rulesync.jsonc"));
     });
   });
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,7 +1,8 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import { minLength, optional, refine, z } from "zod/mini";
 
+import { RULESYNC_CONFIG_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
 import {
   ALL_FEATURES,
   Feature,
@@ -150,6 +151,11 @@ export type ConfigParams = Omit<InferredConfigParams, "targets" | "features"> & 
   targets?: RulesyncConfigTargets;
   features?: RulesyncFeatures;
   configFileTargets?: ToolTarget[];
+  // Absolute path of the configuration file this config was loaded from. Set
+  // by `ConfigResolver`; it is process state rather than a user-settable
+  // option, so it deliberately stays out of `ConfigParamsSchema` (and thus out
+  // of the `rulesync.jsonc` schema).
+  configFilePath?: string;
 };
 
 const PartialConfigParamsSchema = z.partial(ConfigParamsSchema);
@@ -179,6 +185,26 @@ export type RequiredConfigParams = Omit<InferredRequiredConfigParams, "targets" 
   targets?: RulesyncConfigTargets;
   features?: RulesyncFeatures;
 };
+
+/**
+ * Normalizes the configuration file location to an absolute path.
+ *
+ * `ConfigResolver` always supplies the path it actually loaded; the fallback
+ * only covers direct programmatic construction, where the conventional
+ * location next to the input root is the best guess.
+ */
+function normalizeConfigFilePath({
+  configFilePath,
+  inputRoot,
+}: {
+  configFilePath: string | undefined;
+  inputRoot: string;
+}): string {
+  if (configFilePath === undefined) {
+    return join(inputRoot, RULESYNC_CONFIG_RELATIVE_FILE_PATH);
+  }
+  return isAbsolute(configFilePath) ? configFilePath : resolve(configFilePath);
+}
 
 /**
  * Conflicting target pairs that cannot be used together
@@ -283,6 +309,7 @@ export class Config {
   private readonly dryRun: boolean;
   private readonly check: boolean;
   private readonly inputRoot: string;
+  private readonly configFilePath: string;
   private readonly sources: SourceEntry[];
 
   constructor({
@@ -302,6 +329,7 @@ export class Config {
     dryRun,
     check,
     inputRoot,
+    configFilePath,
     sources,
     configFileTargets,
   }: ConfigParams) {
@@ -375,6 +403,10 @@ export class Config {
         : isAbsolute(inputRoot)
           ? inputRoot
           : resolve(inputRoot);
+    this.configFilePath = normalizeConfigFilePath({
+      configFilePath,
+      inputRoot: this.inputRoot,
+    });
     this.sources = sources ?? [];
   }
 
@@ -678,6 +710,15 @@ export class Config {
    */
   public getInputRoot(): string {
     return this.inputRoot;
+  }
+
+  /**
+   * Returns the absolute path of the configuration file this config was
+   * resolved from. The file itself may not exist — `rulesync` runs fine
+   * without one — so callers must treat this as a location, not a guarantee.
+   */
+  public getConfigFilePath(): string {
+    return this.configFilePath;
   }
 
   public getSources(): SourceEntry[] {

--- a/src/e2e/e2e-watch.spec.ts
+++ b/src/e2e/e2e-watch.spec.ts
@@ -90,8 +90,18 @@ describe("E2E: generate --watch", () => {
     }
 
     const exitCode = await waitForExit(child);
-    expect(exitCode).toBe(0);
-    expect(output).toContain("Stopped watching.");
+
+    // Windows has no signal delivery: `child.kill("SIGINT")` terminates the
+    // process outright, so the handler never runs and the exit code is null.
+    // A real Ctrl+C in a Windows console still reaches Node as SIGINT, which
+    // is the path the graceful-shutdown handler exists for; only this
+    // programmatic kill cannot exercise it.
+    if (process.platform === "win32") {
+      expect(exitCode).toBeNull();
+    } else {
+      expect(exitCode).toBe(0);
+      expect(output).toContain("Stopped watching.");
+    }
   });
 
   it("rejects --watch combined with --check", async () => {

--- a/src/e2e/e2e-watch.spec.ts
+++ b/src/e2e/e2e-watch.spec.ts
@@ -1,0 +1,131 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  RULESYNC_OVERVIEW_FILE_NAME,
+  RULESYNC_RULES_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+import { fileExists, readFileContent, writeFileContent } from "../utils/file.js";
+import { rulesyncArgs, rulesyncCmd, useTestDirectory } from "./e2e-helper.js";
+
+const WAIT_TIMEOUT_MS = 30000;
+
+function buildRuleContent(body: string): string {
+  return `---
+root: true
+targets: ["*"]
+description: "Watch mode rule"
+globs: ["**/*"]
+---
+
+# Watch Mode Rule
+
+${body}
+`;
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  { message }: { message: string },
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!(await predicate())) {
+    if (Date.now() - startedAt > WAIT_TIMEOUT_MS) {
+      throw new Error(`Timed out waiting for ${message}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+function waitForExit(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve) => {
+    child.on("close", (code) => {
+      resolve(code);
+    });
+  });
+}
+
+describe("E2E: generate --watch", () => {
+  const { getTestDir } = useTestDirectory();
+
+  it("regenerates when a rule file changes and stops cleanly on SIGINT", async () => {
+    const testDir = getTestDir();
+    const rulePath = join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME);
+    const outputPath = join(testDir, "CLAUDE.md");
+
+    await writeFileContent(rulePath, buildRuleContent("Initial body."));
+
+    let output = "";
+    const child = spawn(
+      rulesyncCmd,
+      [...rulesyncArgs, "generate", "--watch", "--targets", "claudecode", "--features", "rules"],
+      { cwd: testDir, env: { ...process.env, NODE_ENV: "e2e" } },
+    );
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    try {
+      await waitFor(() => output.includes("Watching for changes"), {
+        message: `the watcher to start. Output so far:\n${output}`,
+      });
+
+      expect(await fileExists(outputPath)).toBe(true);
+      expect(await readFileContent(outputPath)).toContain("Initial body.");
+
+      await writeFileContent(rulePath, buildRuleContent("Updated body."));
+
+      await waitFor(async () => (await readFileContent(outputPath)).includes("Updated body."), {
+        message: `the regenerated output. Output so far:\n${output}`,
+      });
+
+      expect(output).toContain("Change detected");
+    } finally {
+      child.kill("SIGINT");
+    }
+
+    const exitCode = await waitForExit(child);
+    expect(exitCode).toBe(0);
+    expect(output).toContain("Stopped watching.");
+  });
+
+  it("rejects --watch combined with --check", async () => {
+    const testDir = getTestDir();
+    await writeFileContent(
+      join(testDir, RULESYNC_RULES_RELATIVE_DIR_PATH, RULESYNC_OVERVIEW_FILE_NAME),
+      buildRuleContent("Initial body."),
+    );
+
+    let output = "";
+    const child = spawn(
+      rulesyncCmd,
+      [
+        ...rulesyncArgs,
+        "generate",
+        "--watch",
+        "--check",
+        "--targets",
+        "claudecode",
+        "--features",
+        "rules",
+      ],
+      { cwd: testDir, env: { ...process.env, NODE_ENV: "e2e" } },
+    );
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+
+    const exitCode = await waitForExit(child);
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain("--watch cannot be combined with --check");
+  });
+});

--- a/src/lib/watch.test.ts
+++ b/src/lib/watch.test.ts
@@ -347,6 +347,51 @@ describe("watchTargets", () => {
     }
   });
 
+  it("re-attaches a filtered target after its directory is deleted and recreated", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const configDir = join(testDir, "packages", "app");
+      await mkdir(configDir, { recursive: true });
+
+      const changed: string[] = [];
+      const handle = watchTargets({
+        targets: [
+          {
+            directory: configDir,
+            recursive: false,
+            include: (relativePath) => relativePath === RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+          },
+        ],
+        onChange: ({ path }) => {
+          changed.push(path);
+        },
+        onError: () => {},
+        rearmIntervalMs: 25,
+      });
+
+      try {
+        // The last event a deleted directory emits names the directory
+        // itself, which the include filter rejects — re-arming must still
+        // kick in.
+        await rm(configDir, { recursive: true, force: true });
+        await mkdir(configDir, { recursive: true });
+
+        changed.length = 0;
+        await waitFor(() => changed.length > 0);
+
+        changed.length = 0;
+        await writeFile(join(configDir, RULESYNC_CONFIG_RELATIVE_FILE_PATH), "{}\n", "utf8");
+        await waitFor(() =>
+          changed.some((path) => path.endsWith(RULESYNC_CONFIG_RELATIVE_FILE_PATH)),
+        );
+      } finally {
+        handle.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("closes already-started watchers when a later target cannot be watched", async () => {
     const { testDir, cleanup } = await setupTestDirectory();
     try {

--- a/src/lib/watch.test.ts
+++ b/src/lib/watch.test.ts
@@ -1,0 +1,310 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+import { setupTestDirectory } from "../test-utils/test-directories.js";
+import {
+  buildWatchTargets,
+  DEFAULT_WATCH_DEBOUNCE_MS,
+  formatTriggerPaths,
+  WatchScheduler,
+  watchTargets,
+} from "./watch.js";
+
+/**
+ * Resolves once `predicate` holds, polling on real timers. Used for the
+ * `fs.watch` integration test, where event delivery latency is platform
+ * dependent.
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 10000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+describe("WatchScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("coalesces a burst of notifications into a single run", async () => {
+    vi.useFakeTimers();
+    const runs: string[][] = [];
+    const scheduler = new WatchScheduler({
+      run: async ({ triggers }) => {
+        runs.push(triggers);
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    scheduler.notify({ path: "/b.md" });
+    scheduler.notify({ path: "/a.md" });
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(runs).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runs).toEqual([["/a.md", "/b.md"]]);
+
+    await scheduler.close();
+  });
+
+  it("restarts the debounce window while events keep arriving", async () => {
+    vi.useFakeTimers();
+    const runs: string[][] = [];
+    const scheduler = new WatchScheduler({
+      run: async ({ triggers }) => {
+        runs.push(triggers);
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    await vi.advanceTimersByTimeAsync(40);
+    scheduler.notify({ path: "/b.md" });
+    await vi.advanceTimersByTimeAsync(40);
+    expect(runs).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(runs).toEqual([["/a.md", "/b.md"]]);
+
+    await scheduler.close();
+  });
+
+  it("never overlaps runs and re-runs once for changes that arrive mid-run", async () => {
+    vi.useFakeTimers();
+    const runs: string[][] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let releaseFirstRun: (() => void) | undefined;
+
+    const scheduler = new WatchScheduler({
+      run: async ({ triggers }) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        runs.push(triggers);
+        if (runs.length === 1) {
+          await new Promise<void>((resolve) => {
+            releaseFirstRun = resolve;
+          });
+        }
+        inFlight -= 1;
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(runs).toEqual([["/a.md"]]);
+
+    // Two more bursts land while the first run is still in flight.
+    scheduler.notify({ path: "/b.md" });
+    await vi.advanceTimersByTimeAsync(50);
+    scheduler.notify({ path: "/c.md" });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(runs).toHaveLength(1);
+
+    releaseFirstRun?.();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(runs).toEqual([["/a.md"], ["/b.md", "/c.md"]]);
+    expect(maxInFlight).toBe(1);
+
+    await scheduler.close();
+  });
+
+  it("reports a failing run and keeps accepting further changes", async () => {
+    vi.useFakeTimers();
+    const errors: unknown[] = [];
+    const runs: string[][] = [];
+    const scheduler = new WatchScheduler({
+      run: async ({ triggers }) => {
+        runs.push(triggers);
+        if (runs.length === 1) {
+          throw new Error("invalid frontmatter");
+        }
+      },
+      onError: ({ error }) => {
+        errors.push(error);
+      },
+      debounceMs: 50,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    await vi.advanceTimersByTimeAsync(50);
+    scheduler.notify({ path: "/b.md" });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(runs).toEqual([["/a.md"], ["/b.md"]]);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("invalid frontmatter");
+
+    await scheduler.close();
+  });
+
+  it("ignores notifications after close and drops pending ones", async () => {
+    vi.useFakeTimers();
+    const runs: string[][] = [];
+    const scheduler = new WatchScheduler({
+      run: async ({ triggers }) => {
+        runs.push(triggers);
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    await scheduler.close();
+    scheduler.notify({ path: "/b.md" });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(runs).toEqual([]);
+  });
+
+  it("defaults to a 300ms debounce window", () => {
+    expect(DEFAULT_WATCH_DEBOUNCE_MS).toBe(300);
+  });
+});
+
+describe("buildWatchTargets", () => {
+  it("watches the .rulesync tree recursively and the config files only", () => {
+    const inputRoot = join("/", "repo");
+    const targets = buildWatchTargets({
+      inputRoot,
+      configFilePath: join(inputRoot, RULESYNC_CONFIG_RELATIVE_FILE_PATH),
+    });
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toEqual({
+      directory: join(inputRoot, RULESYNC_RELATIVE_DIR_PATH),
+      recursive: true,
+    });
+
+    const configTarget = targets[1];
+    expect(configTarget?.directory).toBe(inputRoot);
+    expect(configTarget?.recursive).toBe(false);
+    expect(configTarget?.include?.(RULESYNC_CONFIG_RELATIVE_FILE_PATH)).toBe(true);
+    expect(configTarget?.include?.(RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH)).toBe(true);
+    // Generated output next to the config file must not trigger a regeneration.
+    expect(configTarget?.include?.("AGENTS.md")).toBe(false);
+    expect(configTarget?.include?.("CLAUDE.md")).toBe(false);
+  });
+
+  it("watches the directory holding a config file outside the input root", () => {
+    const inputRoot = join("/", "repo");
+    const targets = buildWatchTargets({
+      inputRoot,
+      configFilePath: join(inputRoot, "config", "custom.jsonc"),
+    });
+
+    const configTarget = targets[1];
+    expect(configTarget?.directory).toBe(join(inputRoot, "config"));
+    expect(configTarget?.include?.("custom.jsonc")).toBe(true);
+    expect(configTarget?.include?.(RULESYNC_CONFIG_RELATIVE_FILE_PATH)).toBe(false);
+  });
+});
+
+describe("formatTriggerPaths", () => {
+  const baseDir = join("/", "repo");
+
+  it("renders paths relative to the base directory", () => {
+    expect(
+      formatTriggerPaths({
+        triggers: [join(baseDir, ".rulesync", "rules", "a.md")],
+        baseDir,
+      }),
+    ).toBe(join(".rulesync", "rules", "a.md"));
+  });
+
+  it("truncates long bursts", () => {
+    const triggers = Array.from({ length: 7 }, (_, index) =>
+      join(baseDir, ".rulesync", "rules", `rule-${index}.md`),
+    );
+
+    const formatted = formatTriggerPaths({ triggers, baseDir, max: 2 });
+
+    expect(formatted).toBe(
+      `${join(".rulesync", "rules", "rule-0.md")}, ${join(".rulesync", "rules", "rule-1.md")} (+5 more)`,
+    );
+  });
+
+  it("falls back to the absolute path when it equals the base directory", () => {
+    expect(formatTriggerPaths({ triggers: [baseDir], baseDir })).toBe(baseDir);
+  });
+});
+
+describe("watchTargets", () => {
+  it("forwards changes under a recursively watched directory", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const rulesDir = join(testDir, RULESYNC_RELATIVE_DIR_PATH, "rules");
+      await mkdir(rulesDir, { recursive: true });
+
+      const changed: string[] = [];
+      const handle = watchTargets({
+        targets: [{ directory: join(testDir, RULESYNC_RELATIVE_DIR_PATH), recursive: true }],
+        onChange: ({ path }) => {
+          changed.push(path);
+        },
+        onError: () => {},
+      });
+
+      try {
+        await writeFile(join(rulesDir, "watched.md"), "# watched\n", "utf8");
+        await waitFor(() => changed.some((path) => path.includes("watched.md")));
+      } finally {
+        handle.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips events that the include filter rejects", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const changed: string[] = [];
+      const handle = watchTargets({
+        targets: [
+          {
+            directory: testDir,
+            recursive: false,
+            include: (relativePath) => relativePath === RULESYNC_CONFIG_RELATIVE_FILE_PATH,
+          },
+        ],
+        onChange: ({ path }) => {
+          changed.push(path);
+        },
+        onError: () => {},
+      });
+
+      try {
+        await writeFile(join(testDir, "AGENTS.md"), "# generated\n", "utf8");
+        await writeFile(join(testDir, RULESYNC_CONFIG_RELATIVE_FILE_PATH), "{}\n", "utf8");
+        await waitFor(() =>
+          changed.some((path) => path.endsWith(RULESYNC_CONFIG_RELATIVE_FILE_PATH)),
+        );
+        expect(changed.some((path) => path.endsWith("AGENTS.md"))).toBe(false);
+      } finally {
+        handle.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/lib/watch.test.ts
+++ b/src/lib/watch.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +10,7 @@ import {
 } from "../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
 import {
+  buildConfigFilePaths,
   buildWatchTargets,
   DEFAULT_WATCH_DEBOUNCE_MS,
   formatTriggerPaths,
@@ -176,6 +177,30 @@ describe("WatchScheduler", () => {
     expect(runs).toEqual([]);
   });
 
+  it("waits for an in-flight run to settle on close", async () => {
+    let finished = false;
+    let releaseRun: (() => void) | undefined;
+    const scheduler = new WatchScheduler({
+      run: async () => {
+        await new Promise<void>((resolve) => {
+          releaseRun = resolve;
+        });
+        finished = true;
+      },
+      onError: () => {},
+      debounceMs: 1,
+    });
+
+    scheduler.notify({ path: "/a.md" });
+    await waitFor(() => releaseRun !== undefined);
+
+    const closed = scheduler.close();
+    releaseRun?.();
+    await closed;
+
+    expect(finished).toBe(true);
+  });
+
   it("defaults to a 300ms debounce window", () => {
     expect(DEFAULT_WATCH_DEBOUNCE_MS).toBe(300);
   });
@@ -216,6 +241,16 @@ describe("buildWatchTargets", () => {
     expect(configTarget?.directory).toBe(join(inputRoot, "config"));
     expect(configTarget?.include?.("custom.jsonc")).toBe(true);
     expect(configTarget?.include?.(RULESYNC_CONFIG_RELATIVE_FILE_PATH)).toBe(false);
+  });
+});
+
+describe("buildConfigFilePaths", () => {
+  it("covers the base config file and the local override next to it", () => {
+    const configFilePath = join("/", "repo", RULESYNC_CONFIG_RELATIVE_FILE_PATH);
+
+    expect(buildConfigFilePaths({ configFilePath })).toEqual(
+      new Set([configFilePath, join("/", "repo", RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH)]),
+    );
   });
 });
 
@@ -270,6 +305,72 @@ describe("watchTargets", () => {
       } finally {
         handle.close();
       }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("re-attaches after the watched directory is deleted and recreated", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const watchedDir = join(testDir, RULESYNC_RELATIVE_DIR_PATH);
+      await mkdir(join(watchedDir, "rules"), { recursive: true });
+
+      const changed: string[] = [];
+      const handle = watchTargets({
+        targets: [{ directory: watchedDir, recursive: true }],
+        onChange: ({ path }) => {
+          changed.push(path);
+        },
+        onError: () => {},
+        rearmIntervalMs: 25,
+      });
+
+      try {
+        // A branch switch that drops `.rulesync/` kills the underlying inode
+        // watch; without re-arming, nothing below would ever be reported.
+        await rm(watchedDir, { recursive: true, force: true });
+        await waitFor(() => changed.length > 0);
+
+        changed.length = 0;
+        await mkdir(join(watchedDir, "rules"), { recursive: true });
+        await waitFor(() => changed.length > 0);
+
+        changed.length = 0;
+        await writeFile(join(watchedDir, "rules", "after-rearm.md"), "# after\n", "utf8");
+        await waitFor(() => changed.some((path) => path.includes("after-rearm.md")));
+      } finally {
+        handle.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("closes already-started watchers when a later target cannot be watched", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const watchedDir = join(testDir, RULESYNC_RELATIVE_DIR_PATH);
+      await mkdir(watchedDir, { recursive: true });
+
+      const changed: string[] = [];
+      expect(() =>
+        watchTargets({
+          targets: [
+            { directory: watchedDir, recursive: true },
+            { directory: join(testDir, "missing-directory"), recursive: false },
+          ],
+          onChange: ({ path }) => {
+            changed.push(path);
+          },
+          onError: () => {},
+        }),
+      ).toThrow();
+
+      // The first watcher must have been closed, so later writes are silent.
+      await writeFile(join(watchedDir, "orphan.md"), "# orphan\n", "utf8");
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(changed).toEqual([]);
     } finally {
       await cleanup();
     }

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -177,6 +177,11 @@ function watchTargetWithRearm({
         }
         const relativePath = filename.toString();
         if (target.include && !target.include(relativePath)) {
+          // Still check liveness: the final event a deleted directory emits
+          // names the directory itself, which every `include` predicate here
+          // rejects. Returning early would leave the dead watcher attached
+          // and re-arming would never start.
+          verifyStillWatching();
           return;
         }
         onChange({ path: join(target.directory, relativePath) });

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -1,0 +1,237 @@
+import { type FSWatcher, watch as fsWatch } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+
+import {
+  RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+  RULESYNC_RELATIVE_DIR_PATH,
+} from "../constants/rulesync-paths.js";
+
+/**
+ * Trailing debounce window applied to file-system events before a regeneration
+ * is started. Editor save storms and `git checkout` emit many events within a
+ * few milliseconds; coalescing them into a single run keeps the terminal
+ * readable and avoids redundant work.
+ */
+export const DEFAULT_WATCH_DEBOUNCE_MS = 300;
+
+export type WatchSchedulerParams = {
+  /**
+   * Runs one regeneration for the paths that changed since the previous run.
+   */
+  run: (params: { triggers: string[] }) => Promise<void>;
+  /**
+   * Called when `run` rejects. Watching continues afterwards, so this must not
+   * rethrow.
+   */
+  onError: (params: { error: unknown; triggers: string[] }) => void;
+  debounceMs?: number;
+};
+
+/**
+ * Coalesces file-system change notifications into debounced, non-overlapping
+ * runs.
+ *
+ * Guarantees:
+ * - At most one `run` is in flight at any time.
+ * - Every notified path is reported to exactly one `run` as a trigger.
+ * - Notifications that arrive while a run is in flight schedule exactly one
+ *   follow-up run after it finishes, so a change is never lost and never
+ *   causes a run per event.
+ */
+export class WatchScheduler {
+  private readonly run: (params: { triggers: string[] }) => Promise<void>;
+  private readonly onError: (params: { error: unknown; triggers: string[] }) => void;
+  private readonly debounceMs: number;
+  private readonly pending = new Set<string>();
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private running: Promise<void> | undefined;
+  private closed = false;
+
+  constructor({ run, onError, debounceMs = DEFAULT_WATCH_DEBOUNCE_MS }: WatchSchedulerParams) {
+    this.run = run;
+    this.onError = onError;
+    this.debounceMs = debounceMs;
+  }
+
+  public notify({ path }: { path: string }): void {
+    if (this.closed) {
+      return;
+    }
+    this.pending.add(path);
+    this.schedule();
+  }
+
+  /**
+   * Stops accepting notifications and waits for an in-flight run to settle.
+   * Pending (not yet started) changes are dropped.
+   */
+  public async close(): Promise<void> {
+    this.closed = true;
+    this.clearTimer();
+    this.pending.clear();
+    await this.running;
+  }
+
+  /**
+   * Resolves once no run is in flight. Only meant for tests.
+   */
+  public async waitForIdle(): Promise<void> {
+    await this.running;
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private schedule(): void {
+    this.clearTimer();
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.flush();
+    }, this.debounceMs);
+  }
+
+  private async flush(): Promise<void> {
+    // A run started by an earlier flush re-schedules itself when it finds
+    // pending triggers, so bailing out here never drops a change.
+    if (this.closed || this.running !== undefined || this.pending.size === 0) {
+      return;
+    }
+
+    const triggers = [...this.pending];
+    this.pending.clear();
+
+    const running = (async () => {
+      try {
+        await this.run({ triggers });
+      } catch (error) {
+        this.onError({ error, triggers });
+      }
+    })();
+    this.running = running;
+    await running;
+    this.running = undefined;
+
+    if (!this.closed && this.pending.size > 0) {
+      this.schedule();
+    }
+  }
+}
+
+export type WatchTarget = {
+  /** Absolute path of the directory to watch. */
+  directory: string;
+  recursive: boolean;
+  /**
+   * When set, only events whose path relative to `directory` satisfies the
+   * predicate are forwarded. Used to watch a directory that also holds
+   * unrelated files (e.g. the project root, which holds `rulesync.jsonc` next
+   * to generated output).
+   */
+  include?: (relativePath: string) => boolean;
+};
+
+export type WatchHandle = {
+  close: () => void;
+};
+
+/**
+ * Starts one `fs.watch` per target and forwards matching events to `onChange`
+ * as absolute paths.
+ *
+ * `fs.watch` reports a `null` filename on some platforms; those events are
+ * forwarded as the watched directory itself, which is enough to trigger a
+ * regeneration.
+ */
+export function watchTargets({
+  targets,
+  onChange,
+  onError,
+}: {
+  targets: readonly WatchTarget[];
+  onChange: (params: { path: string }) => void;
+  onError: (params: { error: unknown; directory: string }) => void;
+}): WatchHandle {
+  const watchers: FSWatcher[] = [];
+
+  for (const target of targets) {
+    const watcher = fsWatch(
+      target.directory,
+      { recursive: target.recursive, persistent: true },
+      (_eventType, filename) => {
+        if (filename === null || filename === undefined) {
+          onChange({ path: target.directory });
+          return;
+        }
+        const relativePath = filename.toString();
+        if (target.include && !target.include(relativePath)) {
+          return;
+        }
+        onChange({ path: join(target.directory, relativePath) });
+      },
+    );
+    watcher.on("error", (error) => {
+      onError({ error, directory: target.directory });
+    });
+    watchers.push(watcher);
+  }
+
+  return {
+    close: () => {
+      for (const watcher of watchers) {
+        watcher.close();
+      }
+    },
+  };
+}
+
+/**
+ * Builds the set of directories watch mode observes: the `.rulesync/` source
+ * tree (recursively) and, filtered down to the configuration files themselves,
+ * the directory holding `rulesync.jsonc`.
+ *
+ * Only input paths are watched. Generated output lives outside `.rulesync/`, so
+ * a regeneration cannot re-trigger the watcher.
+ */
+export function buildWatchTargets({
+  inputRoot,
+  configFilePath,
+}: {
+  inputRoot: string;
+  configFilePath: string;
+}): WatchTarget[] {
+  const configFileNames = new Set([
+    basename(configFilePath),
+    RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
+  ]);
+
+  return [
+    { directory: join(inputRoot, RULESYNC_RELATIVE_DIR_PATH), recursive: true },
+    {
+      directory: dirname(configFilePath),
+      recursive: false,
+      include: (relativePath) => configFileNames.has(relativePath),
+    },
+  ];
+}
+
+/**
+ * Renders trigger paths relative to `baseDir` for logging, truncating long
+ * bursts so a `git checkout` does not flood the terminal.
+ */
+export function formatTriggerPaths({
+  triggers,
+  baseDir,
+  max = 5,
+}: {
+  triggers: readonly string[];
+  baseDir: string;
+  max?: number;
+}): string {
+  const displayed = triggers.slice(0, max).map((trigger) => relative(baseDir, trigger) || trigger);
+  const remaining = triggers.length - displayed.length;
+  return remaining > 0 ? `${displayed.join(", ")} (+${remaining} more)` : displayed.join(", ");
+}

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -1,5 +1,5 @@
-import { type FSWatcher, watch as fsWatch } from "node:fs";
-import { basename, dirname, join, relative } from "node:path";
+import { existsSync, type FSWatcher, watch as fsWatch } from "node:fs";
+import { dirname, join, relative } from "node:path";
 
 import {
   RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
@@ -72,13 +72,6 @@ export class WatchScheduler {
     await this.running;
   }
 
-  /**
-   * Resolves once no run is in flight. Only meant for tests.
-   */
-  public async waitForIdle(): Promise<void> {
-    await this.running;
-  }
-
   private clearTimer(): void {
     if (this.timer !== undefined) {
       clearTimeout(this.timer);
@@ -139,31 +132,47 @@ export type WatchHandle = {
 };
 
 /**
- * Starts one `fs.watch` per target and forwards matching events to `onChange`
- * as absolute paths.
- *
- * `fs.watch` reports a `null` filename on some platforms; those events are
- * forwarded as the watched directory itself, which is enough to trigger a
- * regeneration.
+ * How often a watcher whose directory disappeared polls for its return.
  */
-export function watchTargets({
-  targets,
+export const DEFAULT_WATCH_REARM_INTERVAL_MS = 500;
+
+/**
+ * Watches one directory, re-attaching the underlying `fs.watch` if the
+ * directory is deleted and later recreated.
+ *
+ * Without this, a `git checkout` to a branch without `.rulesync/` (or any
+ * tool that replaces the directory rather than its contents) would silently
+ * kill the watcher: the deleted inode emits no further events and no error,
+ * so watch mode would keep running while never regenerating again.
+ *
+ * The first attach is not guarded — a missing directory at startup is a real
+ * configuration error and must surface to the caller.
+ */
+function watchTargetWithRearm({
+  target,
   onChange,
   onError,
+  rearmIntervalMs,
 }: {
-  targets: readonly WatchTarget[];
+  target: WatchTarget;
   onChange: (params: { path: string }) => void;
   onError: (params: { error: unknown; directory: string }) => void;
+  rearmIntervalMs: number;
 }): WatchHandle {
-  const watchers: FSWatcher[] = [];
+  let watcher: FSWatcher | undefined;
+  let rearmTimer: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
 
-  for (const target of targets) {
-    const watcher = fsWatch(
+  const attach = (): void => {
+    const created = fsWatch(
       target.directory,
       { recursive: target.recursive, persistent: true },
       (_eventType, filename) => {
+        // `fs.watch` reports a null filename on some platforms; treat those as
+        // a change to the watched directory itself.
         if (filename === null || filename === undefined) {
           onChange({ path: target.directory });
+          verifyStillWatching();
           return;
         }
         const relativePath = filename.toString();
@@ -171,21 +180,97 @@ export function watchTargets({
           return;
         }
         onChange({ path: join(target.directory, relativePath) });
+        verifyStillWatching();
       },
     );
-    watcher.on("error", (error) => {
+    created.on("error", (error) => {
       onError({ error, directory: target.directory });
+      verifyStillWatching();
     });
-    watchers.push(watcher);
-  }
+    watcher = created;
+  };
+
+  const scheduleRearm = (): void => {
+    if (closed || rearmTimer !== undefined) {
+      return;
+    }
+    rearmTimer = setInterval(() => {
+      if (closed || !existsSync(target.directory)) {
+        return;
+      }
+      clearInterval(rearmTimer);
+      rearmTimer = undefined;
+      try {
+        attach();
+      } catch (error) {
+        // Lost another race with a delete; keep polling.
+        onError({ error, directory: target.directory });
+        scheduleRearm();
+        return;
+      }
+      // The directory came back with unknown contents, so regenerate.
+      onChange({ path: target.directory });
+    }, rearmIntervalMs);
+  };
+
+  const verifyStillWatching = (): void => {
+    if (closed || watcher === undefined || existsSync(target.directory)) {
+      return;
+    }
+    watcher.close();
+    watcher = undefined;
+    scheduleRearm();
+  };
+
+  attach();
 
   return {
     close: () => {
-      for (const watcher of watchers) {
-        watcher.close();
+      closed = true;
+      if (rearmTimer !== undefined) {
+        clearInterval(rearmTimer);
+        rearmTimer = undefined;
       }
+      watcher?.close();
+      watcher = undefined;
     },
   };
+}
+
+/**
+ * Starts one watcher per target and forwards matching events to `onChange` as
+ * absolute paths. If any target fails to attach, the watchers started so far
+ * are closed before the error propagates, so no descriptor is leaked.
+ */
+export function watchTargets({
+  targets,
+  onChange,
+  onError,
+  rearmIntervalMs = DEFAULT_WATCH_REARM_INTERVAL_MS,
+}: {
+  targets: readonly WatchTarget[];
+  onChange: (params: { path: string }) => void;
+  onError: (params: { error: unknown; directory: string }) => void;
+  rearmIntervalMs?: number;
+}): WatchHandle {
+  const handles: WatchHandle[] = [];
+
+  const closeAll = (): void => {
+    for (const handle of handles) {
+      handle.close();
+    }
+  };
+
+  try {
+    for (const target of targets) {
+      handles.push(watchTargetWithRearm({ target, onChange, onError, rearmIntervalMs }));
+    }
+  } catch (error) {
+    closeAll();
+    throw error;
+  }
+
+  return { close: closeAll };
 }
 
 /**
@@ -203,19 +288,28 @@ export function buildWatchTargets({
   inputRoot: string;
   configFilePath: string;
 }): WatchTarget[] {
-  const configFileNames = new Set([
-    basename(configFilePath),
-    RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH,
-  ]);
+  const configFilePaths = buildConfigFilePaths({ configFilePath });
 
   return [
     { directory: join(inputRoot, RULESYNC_RELATIVE_DIR_PATH), recursive: true },
     {
       directory: dirname(configFilePath),
       recursive: false,
-      include: (relativePath) => configFileNames.has(relativePath),
+      include: (relativePath) => configFilePaths.has(join(dirname(configFilePath), relativePath)),
     },
   ];
+}
+
+/**
+ * The absolute paths of the configuration files watch mode observes: the base
+ * configuration file and the `rulesync.local.jsonc` sitting next to it, which
+ * is exactly what `ConfigResolver` loads.
+ */
+export function buildConfigFilePaths({ configFilePath }: { configFilePath: string }): Set<string> {
+  return new Set([
+    configFilePath,
+    join(dirname(configFilePath), RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH),
+  ]);
 }
 
 /**


### PR DESCRIPTION
## Background

Closes #2477

Editing rulesync sources meant remembering to re-run `rulesync generate` after every change, so generated tool configurations silently drifted from the sources while iterating on rule wording or a skill.

## What this PR does

Adds a `--watch` (`-w`) flag to `rulesync generate`. It runs one generation immediately, then keeps running and regenerates whenever the rulesync sources change.

- **Watcher**: `node:fs` `fs.watch` with `{ recursive: true }` on `.rulesync/`, plus a non-recursive watch of the directory holding the configuration file filtered down to `rulesync.jsonc` / `rulesync.local.jsonc` (or the `--config` file). No new dependency; `engines` already requires Node >= 22, where recursive watch works on Linux, macOS and Windows.
- **No feedback loop**: only input paths are watched, so generated output cannot re-trigger a run. The config-directory watch is filename-filtered exactly so neighbouring generated files (`AGENTS.md`, `CLAUDE.md`, ...) are ignored.
- **Debounce and coalescing** (`WatchScheduler` in `src/lib/watch.ts`): a 300 ms trailing debounce collapses save storms and `git checkout` bursts into one regeneration; at most one generation is in flight at a time, and changes arriving mid-run schedule exactly one follow-up run.
- **Errors keep watching**: a failed generation (e.g. invalid frontmatter mid-edit) is reported via `formatError` and the watcher stays alive.
- **Clean shutdown**: `SIGINT`/`SIGTERM` closes the watchers, waits for an in-flight generation, and exits 0.
- **Rejected combinations**: `--watch` with `--check`, `--dry-run` or `--json` fails with a `VALIDATION_FAILED` CLI error. The first two are one-shot verification modes, and `--json` only emits its document when the command exits.

## Deviation from the planned design (config re-resolution)

The plan called for not re-resolving the configuration and documenting "restart required". Since each regeneration calls the same code path as a manual run, the configuration is in fact re-resolved every time, so config edits do take effect — for free, with less code. What is genuinely fixed at startup is the *set of watched paths*, so changing `inputRoot` or the config file location still requires a restart. A warning is printed whenever the configuration file changes, and the docs state this precisely.

## Robustness: watcher re-arming

`fs.watch` follows the inode, so deleting the watched directory (a `git checkout` to a branch without `.rulesync/`, a worktree switch, a tool that replaces the directory rather than its contents) kills watching silently — no further events, no error. Each target therefore re-attaches: when an event arrives and the directory is gone, the watcher is closed and a short poll re-attaches once it reappears, then triggers a regeneration. This is covered by tests for both plain and `include`-filtered targets.


## Tests

- `src/lib/watch.test.ts`: unit tests for the debounce window, burst coalescing, non-overlapping runs with a single follow-up, error isolation, post-close behavior, watch-target construction (including the generated-file filter), trigger formatting; plus two integration tests driving real `fs.watch` in a temp directory.
- `src/config/config.test.ts`: `Config.getConfigFilePath()` — the resolver-supplied path, the fallback next to the input root, and relative-path normalization.
- `src/cli/commands/generate.test.ts`: `assertWatchModeCompatible` accepts a plain watch run and rejects each incompatible flag.
- `src/e2e/e2e-watch.spec.ts`: e2e happy path — spawns `generate --watch` as a child process, waits for the watcher, edits the rule file, polls the regenerated `CLAUDE.md`, then `SIGINT`s and asserts exit code 0; plus an e2e case asserting the `--watch --check` rejection.

Full `pnpm cicheck` passes, and the new e2e spec passes under `vitest.e2e.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
