### PR TITLE
chore(release): v16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -17,7 +17,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.1.0";
+const getVersion = () => "16.2.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.2.0.

- Bumps `getVersion()` in `src/cli/program.ts` and `package.json` to 16.2.0.
- Release notes: watch mode (`generate --watch`), Grok CLI commands adapter, Reasonix ignore adapter, Rovo Dev checks + permission keys, Kilo sandbox/global rules, Zed global ignore, Hermes Agent profile-root fixes, multi-root rules composition fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)