### PR TITLE
chore: update Homebrew formula to v16.3.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.2.0"
+  version "16.3.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "af99ffe2d5dfa0f7db631c575eedb1e7e5d95b60f6f9a4d4c36023e81d3ecf52"
+      sha256 "c5a8e922aa0b91c36db9f07ac99ddf19561be0e5e82567edcec11260cd45e7b7"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "f7463d904a8b942fcee677db8e49c2fd76f71cf958b63ab7bf425675cc3ed1ef"
+      sha256 "867720831c3d977dc58b714708a4f5c4bce7b04557d0b4f997371ed300720d56"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "f92233265a55968598862d1d9c65bfb586cf8485eda80da44f9d4f7ddbd3bcc7"
+      sha256 "f7a35ea48d93091eee9ab120efeaaffcef37a805b41cbfd70dd7d43154dc024d"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "55714d352fc59ecf8fa4afd4bd9778d037e2b781af72259a9f58ff3d335b620b"
+      sha256 "49b650386b1d99cbc473a55891da68df479f2a2973f3a49708b92fa4f71344f7"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.3.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)