### PR TITLE
fix(skills): lenient per-skill validation on agentsskills import

### DIFF
--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -7,6 +7,7 @@ import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-path
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
+import { AgentsSkillsSkill } from "./agentsskills-skill.js";
 import { ClaudecodeSkill } from "./claudecode-skill.js";
 import { RovodevSkill } from "./rovodev-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
@@ -645,6 +646,98 @@ ${body}`,
       const skill = toolDirs[0] as RovodevSkill;
       expect(skill.getBody()).toBe("from-rovo");
       expect(skill.getRelativeDirPath()).toBe(join(".rovodev", "skills"));
+    });
+
+    it("should skip an agentsskills skill with invalid frontmatter and import the rest", async () => {
+      const logger = createMockLogger();
+      const processor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "agentsskills",
+      });
+      const goodDir = join(testDir, ".agents", "skills", "good-skill");
+      const badDir = join(testDir, ".agents", "skills", "bad-skill");
+      await ensureDir(goodDir);
+      await ensureDir(badDir);
+      await writeFileContent(
+        join(goodDir, "SKILL.md"),
+        `---
+name: good-skill
+description: A conformant skill
+---
+Good body`,
+      );
+      await writeFileContent(
+        join(badDir, "SKILL.md"),
+        `---
+name: bad-skill
+---
+Missing description`,
+      );
+
+      const toolDirs = await processor.loadToolDirs();
+
+      expect(toolDirs).toHaveLength(1);
+      expect((toolDirs[0] as AgentsSkillsSkill).getBody()).toBe("Good body");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(join(".agents", "skills", "bad-skill")),
+      );
+    });
+
+    it("should skip an agentsskills skill with unparseable YAML and import the rest", async () => {
+      const logger = createMockLogger();
+      const processor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "agentsskills",
+      });
+      const goodDir = join(testDir, ".agents", "skills", "good-skill");
+      const badDir = join(testDir, ".agents", "skills", "bad-yaml");
+      await ensureDir(goodDir);
+      await ensureDir(badDir);
+      await writeFileContent(
+        join(goodDir, "SKILL.md"),
+        `---
+name: good-skill
+description: A conformant skill
+---
+Good body`,
+      );
+      await writeFileContent(
+        join(badDir, "SKILL.md"),
+        `---
+name: bad-yaml
+description: Use this skill when: the user asks about PDFs
+---
+Unquoted colon`,
+      );
+
+      const toolDirs = await processor.loadToolDirs();
+
+      expect(toolDirs).toHaveLength(1);
+      expect((toolDirs[0] as AgentsSkillsSkill).getBody()).toBe("Good body");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(join(".agents", "skills", "bad-yaml")),
+      );
+    });
+
+    it("should still abort import for non-lenient tools when a declared-root skill is invalid", async () => {
+      const processor = new SkillsProcessor({
+        logger: createMockLogger(),
+        outputRoot: testDir,
+        toolTarget: "rovodev",
+      });
+      const badDir = join(testDir, ".rovodev", "skills", "bad-skill");
+      await ensureDir(badDir);
+      await writeFileContent(
+        join(badDir, "SKILL.md"),
+        `---
+name: bad-skill
+---
+Missing description`,
+      );
+
+      await expect(processor.loadToolDirs()).rejects.toThrow();
     });
   });
 

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -682,6 +682,7 @@ Missing description`,
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(join(".agents", "skills", "bad-skill")),
       );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("description"));
     });
 
     it("should skip an agentsskills skill with unparseable YAML and import the rest", async () => {
@@ -719,6 +720,7 @@ Unquoted colon`,
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining(join(".agents", "skills", "bad-yaml")),
       );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("indentation"));
     });
 
     it("should still abort import for non-lenient tools when a declared-root skill is invalid", async () => {
@@ -737,7 +739,7 @@ name: bad-skill
 Missing description`,
       );
 
-      await expect(processor.loadToolDirs()).rejects.toThrow();
+      await expect(processor.loadToolDirs()).rejects.toThrow(/Invalid frontmatter/);
     });
   });
 

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -120,9 +120,11 @@ type ToolSkillFactory = {
     /** Whether the tool supports global (user-level) skills */
     supportsGlobal: boolean;
     /**
-     * When true, a skill directory that fails to load on import (unparseable
-     * YAML, invalid frontmatter) is warned about and skipped instead of
-     * aborting the whole import run.
+     * When true, a skill directory that fails to load on import — for any
+     * reason (unparseable YAML, invalid frontmatter, unreadable files) — is
+     * warned about and skipped instead of aborting the whole import run.
+     * Applies to directory-form skills only; `fromFlatFile` loaders are not
+     * covered.
      */
     lenientImport?: boolean;
   };

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -119,6 +119,12 @@ type ToolSkillFactory = {
     supportsSimulated: boolean;
     /** Whether the tool supports global (user-level) skills */
     supportsGlobal: boolean;
+    /**
+     * When true, a skill directory that fails to load on import (unparseable
+     * YAML, invalid frontmatter) is warned about and skipped instead of
+     * aborting the whole import run.
+     */
+    lenientImport?: boolean;
   };
 };
 
@@ -150,7 +156,18 @@ export const toolSkillFactories = new Map<SkillsProcessorToolTarget, ToolSkillFa
       // The Agent Skills standard defines `~/.agents/skills/` as the personal/global
       // location in addition to project `.agents/skills/`. https://agentskills.io/specification
       class: AgentsSkillsSkill,
-      meta: { supportsProject: true, supportsSimulated: false, supportsGlobal: true },
+      // The Agent Skills client-implementation guide prescribes lenient
+      // per-skill validation: skip a skill whose YAML is unparseable or whose
+      // description is missing, log the error, and keep loading the rest.
+      // `.agents/skills/` is the cross-vendor directory, so foreign-authored
+      // skills are the most likely to be non-conformant.
+      // https://agentskills.io/client-implementation/adding-skills-support
+      meta: {
+        supportsProject: true,
+        supportsSimulated: false,
+        supportsGlobal: true,
+        lenientImport: true,
+      },
     },
   ],
   [
@@ -678,13 +695,15 @@ export class SkillsProcessor extends DirFeatureProcessor {
                 global: this.global,
               });
             } catch (error) {
-              if (!isConfiguredRoot) {
+              if (!isConfiguredRoot && !factory.meta.lenientImport) {
                 throw error;
               }
               // A root the tool's own config points at is arbitrary user
               // territory — a folder of skills may sit next to folders that are
               // not skills at all. One of those must not take the whole import,
-              // and every feature after it, down.
+              // and every feature after it, down. Tools flagged `lenientImport`
+              // extend the same tolerance to their declared roots, per the
+              // Agent Skills guide's lenient-validation prescription.
               this.logger.warn(`Skipping ${join(relativeDirPath, dirName)}: ${formatError(error)}`);
               return null;
             }


### PR DESCRIPTION
## Summary

Resolves the AgentsSkills follow-up: rulesync's skills import aborted the entire run when one non-conformant `SKILL.md` sat in `.agents/skills/` — a single malformed neighbor blocked importing every valid sibling.

The Agent Skills [client-implementation guide](https://agentskills.io/client-implementation/adding-skills-support) prescribes lenient per-skill validation on read: "Description is missing or empty → skip the skill, log the error"; "YAML is completely unparseable → skip the skill, log the error". `.agents/skills/` is the cross-vendor interoperability directory, exactly where foreign-authored (potentially non-conformant) skills are most likely to live.

## Changes

- Add an optional `lenientImport` flag to the skills-processor factory `meta` and enable it for the `agentsskills` target.
- The import loop's existing configured-root warn-and-skip tolerance now also applies to declared roots of lenient targets: a skill directory that fails to load (unparseable YAML or invalid frontmatter) is warned about with its path and reason, skipped, and the rest of the import continues.
- Tests: missing-`description` sibling and unquoted-colon YAML sibling each import the valid skill and warn; non-lenient targets (e.g. rovodev) still abort on an invalid declared-root skill.

Generate-side behavior is unchanged — `collectAgentSkillViolations` already warns rather than fails there.

Closes #2513

🤖 Generated with [Claude Code](https://claude.com/claude-code)