### PR TITLE
docs(junie): document Junie CLI Extensions compatibility with claudecode-plugin bundles

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/junie.md
+++ b/.rulesync/skills/rulesync-feature-research/references/junie.md
@@ -2,17 +2,20 @@
 
 ## Official Docs
 
-| Feature       | Official docs                                                       | Upstream surface                                                             |
-| ------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| index         | `https://junie.jetbrains.com/docs/junie-ide-plugin.html`            | Junie IDE plugin and CLI documentation                                       |
-| `rules`       | `https://junie.jetbrains.com/docs/junie-ide-plugin.html`            | `.junie/AGENTS.md`, root `AGENTS.md`, legacy guidelines                      |
-| `ignore`      | `https://www.jetbrains.com/help/ai-assistant/junie-agent.html`      | `.aiignore` restrictions in JetBrains IDE integration                        |
-| `mcp`         | `https://junie.jetbrains.com/docs/junie-cli-mcp-configuration.html` | `.junie/mcp/mcp.json`, `~/.junie/mcp/mcp.json`, stdio and remote MCP servers |
-| `commands`    | `https://junie.jetbrains.com/docs/slash-commands.html`              | Custom slash commands and Junie CLI command locations                        |
-| `subagents`   | `https://junie.jetbrains.com/docs/parameters.html`                  | Agent location flags and default per-user/per-project agent discovery        |
-| `skills`      | `https://junie.jetbrains.com/docs/parameters.html`                  | Skill location flags and default per-user/per-project skill discovery        |
-| `hooks`       | No dedicated upstream hooks surface in map                          | No Rulesync-supported Junie hooks target in map                              |
-| `permissions` | `https://junie.jetbrains.com/docs/action-allowlist.html`            | Action Allowlist                                                             |
+| Feature       | Official docs                                                       | Upstream surface                                                                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| index         | `https://junie.jetbrains.com/docs/junie-ide-plugin.html`            | Junie IDE plugin and CLI documentation                                                                                                                                                                                                     |
+| `rules`       | `https://junie.jetbrains.com/docs/junie-ide-plugin.html`            | `.junie/AGENTS.md`, root `AGENTS.md`, legacy guidelines                                                                                                                                                                                    |
+| `ignore`      | `https://junie.jetbrains.com/docs/junie-ide-plugin.html`            | `.aiignore` restrictions (IDE integration)                                                                                                                                                                                                 |
+| `mcp`         | `https://junie.jetbrains.com/docs/junie-cli-mcp-configuration.html` | `.junie/mcp/mcp.json`, `~/.junie/mcp/mcp.json`, stdio and remote MCP servers                                                                                                                                                               |
+| `commands`    | `https://junie.jetbrains.com/docs/slash-commands.html`              | Custom slash commands and Junie CLI command locations                                                                                                                                                                                      |
+| `subagents`   | `https://junie.jetbrains.com/docs/junie-cli-subagents.html`         | `.junie/agents` custom agents plus `.agents/` / `~/.agents/` discovery roots                                                                                                                                                               |
+| `skills`      | `https://junie.jetbrains.com/docs/agent-skills.html`                | `.junie/skills` and Agent Skills discovery                                                                                                                                                                                                 |
+| `hooks`       | `https://junie.jetbrains.com/docs/junie-cli-hooks.html`             | Junie CLI hooks (global `~/.junie/config.json`; project `.junie/config.json` hooks are ignored unless passed via `--config-location`)                                                                                                      |
+| `permissions` | `https://junie.jetbrains.com/docs/action-allowlist.html`            | Action Allowlist                                                                                                                                                                                                                           |
+| extensions    | `https://junie.jetbrains.com/docs/junie-cli-extensions.html`        | CLI Extensions bundles (native `.junie-extension/marketplace.json` + Claude-compatible `.claude-plugin/marketplace.json`); no dedicated rulesync target — a `claudecode-plugin` bundle is installable through the Claude-compatible format |
+
+CLI docs live under `junie.jetbrains.com/docs/*` (old `jetbrains.com/help/junie/*` URLs 301-redirect; `/docs/cli`, `/docs/changelog`, `/docs/rules`, `/docs/cli/rules`, `/docs/cli/workflows` 404).
 
 ## Client Anchors
 
@@ -26,3 +29,4 @@ Common adapter paths: `rulesync-source-map.md`.
 | `commands`  | `.junie/commands` command conversion and project/global paths in `junie-command.ts`          |
 | `subagents` | `.junie/agents` custom-agent conversion in `junie-subagent.ts`                               |
 | `skills`    | `.junie/skills` Agent Skills conversion in `junie-skill.ts`                                  |
+| `hooks`     | Global `~/.junie/config.json` hooks conversion in `junie-hooks.ts`                           |

--- a/docs/guide/plugin-packaging.md
+++ b/docs/guide/plugin-packaging.md
@@ -73,3 +73,9 @@ The `convert` command does not accept packaging targets because it has no separa
 | `antigravity-plugin` | `rules/*.md` | `mcp_config.json` | —               | —             | `skills/*/SKILL.md` | `hooks.json`       |
 
 Claude-specific frontmatter and hook overrides continue to use the `claudecode` sections in Rulesync source files. Antigravity plugin output uses the `antigravity-ide` conversion model and override sections because its plugin components follow the Antigravity IDE format.
+
+## Installing a `claudecode-plugin` bundle in JetBrains Junie
+
+[Junie CLI Extensions](https://junie.jetbrains.com/docs/junie-cli-extensions.html) — Junie's bundle system for skills, MCP servers, subagents, slash commands, and guidelines — accept two marketplace manifest formats: the native `.junie-extension/marketplace.json` and Claude Code's `.claude-plugin/marketplace.json`. A plugin generated with the `claudecode-plugin` target and published in a Claude-compatible plugin marketplace is therefore installable in Junie via `/extensions`, without a Junie-specific rulesync target.
+
+As with Claude Code, rulesync manages only the component files (`commands/`, `agents/`, `skills/`, `.mcp.json`, `hooks/hooks.json`); the `.claude-plugin/plugin.json` and marketplace catalog remain hand-authored. Junie's documentation confirms the manifest-format compatibility but does not enumerate a directory-level mapping for Claude plugin contents, so verify the components you care about after installing.

--- a/skills/rulesync/plugin-packaging.md
+++ b/skills/rulesync/plugin-packaging.md
@@ -73,3 +73,9 @@ The `convert` command does not accept packaging targets because it has no separa
 | `antigravity-plugin` | `rules/*.md` | `mcp_config.json` | —               | —             | `skills/*/SKILL.md` | `hooks.json`       |
 
 Claude-specific frontmatter and hook overrides continue to use the `claudecode` sections in Rulesync source files. Antigravity plugin output uses the `antigravity-ide` conversion model and override sections because its plugin components follow the Antigravity IDE format.
+
+## Installing a `claudecode-plugin` bundle in JetBrains Junie
+
+[Junie CLI Extensions](https://junie.jetbrains.com/docs/junie-cli-extensions.html) — Junie's bundle system for skills, MCP servers, subagents, slash commands, and guidelines — accept two marketplace manifest formats: the native `.junie-extension/marketplace.json` and Claude Code's `.claude-plugin/marketplace.json`. A plugin generated with the `claudecode-plugin` target and published in a Claude-compatible plugin marketplace is therefore installable in Junie via `/extensions`, without a Junie-specific rulesync target.
+
+As with Claude Code, rulesync manages only the component files (`commands/`, `agents/`, `skills/`, `.mcp.json`, `hooks/hooks.json`); the `.claude-plugin/plugin.json` and marketplace catalog remain hand-authored. Junie's documentation confirms the manifest-format compatibility but does not enumerate a directory-level mapping for Claude plugin contents, so verify the components you care about after installing.


### PR DESCRIPTION
## Summary

Resolves the Junie follow-up via the issue's own "cheapest first" path: [Junie CLI Extensions](https://junie.jetbrains.com/docs/junie-cli-extensions.html) accept both the native `.junie-extension/marketplace.json` manifest and Claude Code's `.claude-plugin/marketplace.json`, so a plugin generated with rulesync's existing `claudecode-plugin` target and published in a Claude-compatible marketplace is installable in Junie via `/extensions` — delivering the bundle capability without a Junie-specific target.

## Changes

- `docs/guide/plugin-packaging.md`: new section documenting the Junie compatibility, including the honest caveat that JetBrains' docs confirm the manifest-format compatibility but do not enumerate a directory-level mapping for Claude plugin contents.
- `.rulesync/skills/rulesync-feature-research/references/junie.md`: refreshed the stale map — docs host move to `junie.jetbrains.com/docs/*` (with the known-404 paths recorded), hooks row now points at `junie-cli-hooks.html` and `junie-hooks.ts` (the map claimed hooks were unsupported), subagents/skills rows point at their dedicated pages, and the extensions surface is recorded.

A native `junie-extension` target (mirroring `claudecode-plugin` with the `.junie-extension/marketplace.json` manifest) remains possible follow-up territory, coordinated with the cross-tool plugin-packaging design (#329/#382) as the issue notes.

Closes #2508

🤖 Generated with [Claude Code](https://claude.com/claude-code)