### PR TITLE
fix(watch): poll liveness on a timer, report detach as a change

### DIFF
--- a/src/lib/watch.test.ts
+++ b/src/lib/watch.test.ts
@@ -3,11 +3,15 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { statSyncMock } = vi.hoisted(() => ({ statSyncMock: vi.fn() }));
+const { statSyncMock, fsWatchMock } = vi.hoisted(() => ({
+  statSyncMock: vi.fn(),
+  fsWatchMock: vi.fn(),
+}));
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   statSyncMock.mockImplementation(actual.statSync);
-  return { ...actual, statSync: statSyncMock };
+  fsWatchMock.mockImplementation(actual.watch);
+  return { ...actual, statSync: statSyncMock, watch: fsWatchMock };
 });
 
 import {
@@ -416,6 +420,48 @@ describe("watchTargets", () => {
       }
     },
   );
+
+  it("detects a deleted directory by polling even when no fs event is ever delivered", async () => {
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      const watchedDir = join(testDir, RULESYNC_RELATIVE_DIR_PATH);
+      await mkdir(watchedDir, { recursive: true });
+
+      // Simulate an OS that never delivers events for this watcher (observed
+      // on loaded CI runners): the returned watcher is inert, so only the
+      // periodic liveness sweep can notice the deletion.
+      fsWatchMock.mockImplementation(
+        () =>
+          ({
+            close: () => {},
+            on: () => {},
+          }) as unknown as ReturnType<typeof actual.watch>,
+      );
+
+      const changed: string[] = [];
+      const handle = watchTargets({
+        targets: [{ directory: watchedDir, recursive: true }],
+        onChange: ({ path }) => {
+          changed.push(path);
+        },
+        onError: () => {},
+        rearmIntervalMs: 25,
+      });
+
+      try {
+        await rm(watchedDir, { recursive: true, force: true });
+        // The inert watcher emits nothing; the liveness timer must detach and
+        // report the disappearance on its own.
+        await waitFor(() => changed.includes(watchedDir));
+      } finally {
+        fsWatchMock.mockImplementation(actual.watch);
+        handle.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
 
   it("re-attaches when the watched directory is replaced before its delete event arrives", async () => {
     const actual = await vi.importActual<typeof import("node:fs")>("node:fs");

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -263,7 +263,7 @@ function watchTargetWithRearm({
     // Report the disappearance the same way an OS delete event would have —
     // liveness may have detected it purely by polling, with no event ever
     // delivered. The scheduler debounces, so an extra notification after an
-    // evented detection is harmless.
+    // event-driven detection is harmless.
     onChange({ path: target.directory });
     scheduleRearm();
   };

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -260,14 +260,32 @@ function watchTargetWithRearm({
     }
     watcher.close();
     watcher = undefined;
+    // Report the disappearance the same way an OS delete event would have —
+    // liveness may have detected it purely by polling, with no event ever
+    // delivered. The scheduler debounces, so an extra notification after an
+    // evented detection is harmless.
+    onChange({ path: target.directory });
     scheduleRearm();
   };
 
   attach();
 
+  // Event-driven liveness checks alone are not enough: OS event delivery for
+  // a deleted watched directory can be arbitrarily late or dropped entirely
+  // (observed on loaded CI runners), leaving a dead watcher attached forever.
+  // A periodic sweep runs the same inode-based check on a timer, so a
+  // replaced or removed directory is detected within `rearmIntervalMs` even
+  // when no event ever arrives. `unref()` keeps the interval from holding the
+  // process open on its own.
+  const livenessTimer = setInterval(() => {
+    verifyStillWatching();
+  }, rearmIntervalMs);
+  livenessTimer.unref?.();
+
   return {
     close: () => {
       closed = true;
+      clearInterval(livenessTimer);
       if (rearmTimer !== undefined) {
         clearInterval(rearmTimer);
         rearmTimer = undefined;


### PR DESCRIPTION
## Summary

Third and hopefully final round on the flaky `watch.test.ts` re-attach tests, which have kept failing on CI (latest: PR #2529 run 30605141246, where `waitFor`'s own 10s budget expired — i.e. the deletion event never arrived at all, not just late).

## Root cause

Liveness checks ran only inside `fs.watch` event callbacks. When the OS delivers no event for a deleted watched directory (observed on loaded CI runners), the dead watcher stays attached forever regardless of the inode fix (#2516) or longer timeouts (#2520).

## Fix

- Run the same inode-based `verifyStillWatching` sweep on a periodic timer (every `rearmIntervalMs`, `unref()`'d so it never holds the process open). A replaced or removed directory is now detected within one interval even with zero events delivered.
- On detach, report the disappearance through `onChange` the way an OS delete event would have — a purely poll-detected deletion now reaches watch mode's scheduler (which debounces the occasional double notification after an evented detection).

Existing tests cover the behavior and become deterministic (5 consecutive local runs green; full unit suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)