### PR TITLE
fix(generate): fail the run when the permissions feature errors

### DIFF
--- a/src/e2e/e2e-permissions.spec.ts
+++ b/src/e2e/e2e-permissions.spec.ts
@@ -119,6 +119,29 @@ describe("E2E: permissions", () => {
     },
   );
 
+  it.each([{ features: "permissions" }, { features: "mcp" }])(
+    "should fail $features generation on a malformed .vibe/config.toml instead of reporting success",
+    async ({ features }) => {
+      const testDir = getTestDir();
+
+      await writeFileContent(join(testDir, ".vibe", "config.toml"), "mcp: [unclosed");
+      await writeFileContent(
+        join(testDir, RULESYNC_PERMISSIONS_RELATIVE_FILE_PATH),
+        JSON.stringify({ permission: { bash: { "*": "allow" } } }),
+      );
+      await writeFileContent(
+        join(testDir, ".rulesync", "mcp.json"),
+        JSON.stringify({ mcpServers: { srv: { command: "node" } } }),
+      );
+
+      // Both features read the same shared file and must agree on what a
+      // malformed file means: fail the run, never a silent "up to date".
+      await expect(runGenerate({ target: "vibe", features })).rejects.toMatchObject({
+        code: 1,
+      });
+    },
+  );
+
   it("should generate rovodev permissions into the repo-committed .rovodev/config.yml", async () => {
     const testDir = getTestDir();
 

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -671,9 +671,7 @@ describe("generate", () => {
         throw new Error("Test error");
       });
 
-      await expect(generate({ logger, config: mockConfig as never })).rejects.toThrow(
-        "Test error",
-      );
+      await expect(generate({ logger, config: mockConfig as never })).rejects.toThrow("Test error");
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("Test error"));
     });
   });

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -662,15 +662,19 @@ describe("generate", () => {
       );
     });
 
-    it("should handle errors gracefully and continue", async () => {
+    it("should fail the run on a permissions error instead of reporting success", async () => {
+      // A malformed shared config used to be swallowed with a warning while
+      // the run exited 0 "up to date" — the MCP feature failed on the same
+      // file. Both features must agree that a broken file fails the run.
       mockConfig.getFeatures.mockReturnValue(["permissions"]);
       vi.mocked(PermissionsProcessor).mockImplementation(function () {
         throw new Error("Test error");
       });
 
-      const result = await generate({ logger, config: mockConfig as never });
-
-      expect(result.permissionsCount).toBe(0);
+      await expect(generate({ logger, config: mockConfig as never })).rejects.toThrow(
+        "Test error",
+      );
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("Test error"));
     });
   });
 

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1134,10 +1134,14 @@ async function generatePermissionsCore(params: {
         allPaths.push(...result.paths);
         if (result.hasDiff) hasDiff = true;
       } catch (error) {
-        logger.warn(
+        // A malformed shared config (e.g. .vibe/config.toml) must fail the run
+        // the same way the MCP feature does — swallowing it reported
+        // "All files are up to date" while the user's permission changes were
+        // silently not applied.
+        logger.error(
           `Failed to generate ${toolTarget} permissions files for ${outputRoot}: ${formatError(error)}`,
         );
-        continue;
+        throw error;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2486: with a malformed `.vibe/config.toml` on disk, `generate --features mcp` exited 1 with a parse error while `--features permissions` swallowed the same failure (`logger.warn` + `continue` in `generatePermissionsCore`) and exited 0 reporting "All files are up to date" — a silent false-success.

- The permissions loop now logs the failure at **error** level and rethrows, so both features agree that a malformed shared file fails the run (reproduced both before/after: exit-perm 0→1, exit-mcp stays 1).
- Regression tests: an e2e `it.each` asserts **both** features exit 1 on the same malformed fixture, and the generate unit test that pinned the old swallow-and-continue behavior now pins fail-the-run.

## Testing

- `pnpm cicheck` green; targeted e2e cases pass locally.

Closes #2486

🤖 Generated with [Claude Code](https://claude.com/claude-code)