### PR TITLE
chore(release): v16.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.4.0",
+  "version": "16.5.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.4.0";
+const getVersion = () => "16.5.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.5.0.

Highlights: new `zoocode` target, Rovodev project-scoped config.yml/mcp.json, Reasonix v1.18.0 follow-up (exact Bash rules + nested instruction files), Warp execution-profile autonomy keys, local-root rule import round-trip, lenient Agent Skills interop imports, OpenCode global instructions, Claude Code nested skills import, committed check outputs no longer gitignored, plus Vibe/OpenCode/Kilo correctness fixes and fail-closed generate behavior.

See the draft release notes for the full changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)