### PR TITLE
chore: update Homebrew formula to v16.5.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.4.0"
+  version "16.5.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "e09a10e36de3d995c85f995548c91b72151bbce781ca7e1531de4d2b84e380a4"
+      sha256 "8b81117a2a3c88159300de7ec9bf57a7d7d678d75f658ec0ba6d28f2d8877b02"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "d7a025798bc08f822ea31da0f1e52b804f1ab310571128a60dc88cbc2be133fb"
+      sha256 "5ae4bd1e9d30a30465005b699a3df91418bbd1898bdea9c72a531fd1aef486d3"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "d191c34541e29afd2458ac62707f70142f3c526f8169243d5cf65572ac77a30a"
+      sha256 "aeae05861c80429c0fd26a6992b4fb98faeb4709966da6bfebf8ba1168e5a372"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "7a6d1115c3b6a3272d91967389fb2b4087c0e78619e7f49697a4beb555a4b10a"
+      sha256 "a43b8debec0b5aeae1f4bc303a82ddb3d41e7b3c86f4f53c4450620d471c3221"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.5.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)