### PR TITLE
chore: release v16.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.5.0",
+  "version": "16.6.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.5.0";
+const getVersion = () => "16.6.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.6.0.

## Included changes
- feat(fetch): add --skills and --interactive options for skill selection (#2565, closes #2564)
- docs(hooks): generate the hook event x tool matrix from the hooks factories (#2540)
- fix(scripts): close the docs drift gate hole and unify the marker/oxfmt plumbing (#2540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)