### PR TITLE
chore: update Homebrew formula to v16.7.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.6.0"
+  version "16.7.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "c881b13e3c0b786e480a163220ad049d26a498a4f72f855abd0680f25f7f14a0"
+      sha256 "ec932b4ec9fbbb78db6ca2b65d2a2020384f8717420bc168a16eb29e1838281d"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "b0425183a893c64c7ec9a128eff61ae30f8895d5a1543623ca18247502372493"
+      sha256 "2acd3fb45f41c25bc51aa88e8c689f3fb0302c44d5fb56cf77a09b5ea1b458f6"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "e8badade1a7859fa02eba11de6f3a66c4cc1830b5548c6b6a5c0d653603563e0"
+      sha256 "f24c1020b1a58105afb0cc8bb2f166534ca08cd3d551ab7456bbee4117a4a049"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "3435f63185ba31092b64d9a8e20f4a7df4da594b8459221ddec3bd88c4cad69a"
+      sha256 "3f163be90b523ccfae29580b5c9f8ce23689016afaa8a34f6c792ab09103885a"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.7.0 release.