### PR TITLE
chore: release v16.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.7.0",
+  "version": "16.8.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.7.0";
+const getVersion = () => "16.8.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.8.0.

## What's Changed

- **DeepAgents**: Migrate hooks generation to the Hooks v2 document format (#2591)
- **Zed**: Translate MCP permission categories to Zed tool names with a lossless round-trip (#2590)
- **Hooks**: Honor commandOnly on import, skip un-importable hooks, sharpen drop warnings (#2585, #2602)
- **Kiro**: Translate MCP keys, round-trip hook enabled, keep skill metadata (#2589)
- **Copilot**: Keep unmodeled SKILL.md frontmatter through the round-trip (#2587)
- **Docs**: Hermes migration note (#2586), Homebrew formula v16.7.0 (#2584)

Full Changelog: https://github.com/dyoshikawa/rulesync/compare/v16.7.0...v16.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)