### PR TITLE
chore: release v16.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.8.0",
+  "version": "16.9.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.8.0";
+const getVersion = () => "16.9.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
# v16.9.0

## What's Changed

### New Features

- feat(hooks): add a Cline file-based hooks adapter and register cline as a hooks target by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2628
- feat(rules): let Pi rules emit AGENTS.override.md by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2627
- feat(commands): register generated Goose recipes as slash commands by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2626
- feat(permissions): warn that Warp's command_denylist replaces the built-in one by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2625
- feat(mcp): pass through the Reasonix per-server startup_timeout_seconds by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2620
- feat(ignore): support global scope for the Devin ignore file by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2618
- feat(hooks): map notification, permissionDenied and beforeSubmitPrompt for OpenCode and Kilo by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2617
- feat(claudecode): support the DirectoryAdded matcher and the Agent Skills frontmatter fields by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2613
- feat(hooks): let Kimi Code emit the four hook events added in 0.32.0 by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2612
- feat(permissions): map the websearch category onto Grok CLI's WebSearch tool by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2611
- feat(qwencode): support the SessionDelete hook event and HTTP-hook security keys by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2607

### Bug Fixes

- fix(permissions): stop writing global-only keys into a Cursor project config by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2623
- fix(hooks): emit env and stop picking the Copilot command field by platform by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2621
- fix(vibe): drop the obsolete shadowed-global config warning by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2614
- fix(hermesagent): stop destroying hooks.outbound and model the v0.20.0 MCP keys by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2610
- fix(kiro-cli): emit the standalone hooks format Kiro CLI 3.0 reads by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2609
- fix(codexcli): translate the MCP keys Codex reads under different names by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2608

### Documentation

- docs(plugin-packaging): document antigravity-plugin subagent output by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2624

### Dependencies

- chore(deps): bump the all-dependencies group with 106 updates by @dependabot in https://github.com/dyoshikawa/rulesync/pull/2606
- ci(deps): bump the all-actions group with 3 updates by @dependabot in https://github.com/dyoshikawa/rulesync/pull/2603

## Contributors

- @dyoshikawa
- @dependabot[bot]

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v16.8.0...v16.9.0
