### PR TITLE
fix(scripts): drop the oxfmt pass on gitignored schema files

### DIFF
--- a/scripts/generate-json-schema.ts
+++ b/scripts/generate-json-schema.ts
@@ -12,7 +12,6 @@ import {
 } from "../src/constants/rulesync-paths.js";
 import { RulesyncMcpFileSchema } from "../src/features/mcp/rulesync-mcp.js";
 import { RulesyncPermissionsFileSchema } from "../src/types/permissions.js";
-import { runOxfmt } from "./run-oxfmt.js";
 
 type SchemaMeta = {
   $id: string;
@@ -69,5 +68,7 @@ generateSchema(
   permissionsOutputPath,
 );
 
-// Format generated schema files with oxfmt for consistent formatting
-runOxfmt([outputPath, mcpOutputPath, permissionsOutputPath]);
+// No oxfmt pass here: since oxfmt 0.62.0, gitignored paths are skipped even
+// when passed explicitly, and these schema files are gitignored. The
+// JSON.stringify output above is already deterministic, and no drift check
+// compares these files, so the formatter pass is unnecessary.

--- a/scripts/run-oxfmt.ts
+++ b/scripts/run-oxfmt.ts
@@ -6,7 +6,9 @@ export const repoRoot = join(import.meta.dirname, "..");
 /**
  * Format generated files with the repo's formatter so drift checks compare
  * stable output. Shared by the generator scripts (docs content, supported-tools
- * tables, JSON schemas) so a fix here reaches every call site.
+ * tables) so a fix here reaches every call site. Only pass tracked files:
+ * since oxfmt 0.62.0, gitignored paths are skipped even when passed
+ * explicitly, and the command fails with "Expected at least one target file".
  *
  * npx is npx.cmd on Windows; a shell resolves it. `--no-install` keeps npx from
  * silently fetching a different oxfmt version when the pinned devDependency is


### PR DESCRIPTION
## Problem

The `Publish Assets` workflow for the v16.9.0 release failed at the `pnpm generate:schema` step:

```
Expected at least one target file. All matched files may have been excluded by ignore rules.
Error: Command failed: npx --no-install oxfmt config-schema.json mcp-schema.json permissions-schema.json
```

Since oxfmt 0.62.0 (bumped in #2606), gitignored paths are skipped even when passed explicitly, and `--ignore-path` does not override this. The three generated schema files are gitignored, so the formatter pass now fails.

## Solution

Drop the `runOxfmt` call from `generate-json-schema.ts`. The schema files are already written with deterministic `JSON.stringify(..., null, 2)` output and have no drift check (they are gitignored release assets), so the formatter pass was cosmetic only. Also document the tracked-files-only constraint in `run-oxfmt.ts`, whose remaining callers (docs content, supported-tools tables) all format tracked files.

Unblocks the v16.9.1 release (v16.9.0 assets were never built; npm still has 16.8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)