### PR TITLE
docs(warp): correct the global MCP path in the research reference map

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/warp.md
+++ b/.rulesync/skills/rulesync-feature-research/references/warp.md
@@ -7,7 +7,7 @@
 | index         | `https://docs.warp.dev/`                                             | Warp documentation index                                                                                 |
 | `rules`       | `https://docs.warp.dev/agent-platform/capabilities/rules`            | Global Rules, Project Rules, `AGENTS.md`, `WARP.md`, global `~/.agents/AGENTS.md`, imported legacy rules |
 | `ignore`      | `https://docs.warp.dev/agent-platform/capabilities/codebase-context` | `.warpindexingignore` (project root, gitignore syntax)                                                   |
-| `mcp`         | `https://docs.warp.dev/agent-platform/mcp`                           | `.warp/.mcp.json` (project) and `~/.agents/.mcp.json` (global)                                           |
+| `mcp`         | `https://docs.warp.dev/agent-platform/mcp`                           | `.warp/.mcp.json` (project) and `~/.warp/.mcp.json` (global)                                             |
 | `commands`    | `https://docs.warp.dev/agent-platform/capabilities/skills`           | Emitted onto the native skills surface (`/{skill-name}` invocation)                                      |
 | `subagents`   | No dedicated upstream subagents surface in map                       | No Rulesync-supported Warp subagents target in map (child agents are runtime constructs, no file format) |
 | `skills`      | `https://docs.warp.dev/agent-platform/capabilities/skills`           | `.warp/skills/` (first in local discovery precedence) and `.agents/skills/`                              |


### PR DESCRIPTION
One-line correction to the research-skill reference map. No behavior change.

`.rulesync/skills/rulesync-feature-research/references/warp.md` listed the global MCP path as `~/.agents/.mcp.json`. No code path produces that: `WarpMcp.getSettablePaths` takes `global` as an ignored parameter and always returns `.warp` / `.mcp.json`, which the processor resolves under the home directory in global mode. Upstream agrees that Warp keeps MCP config (and skills) under `~/.warp/` on every platform — see the [Warp file locations docs](https://docs.warp.dev/terminal/settings/file-locations/).

Corrected the row to `~/.warp/.mcp.json`. The map is what the `rulesync-feature-research` skill consults, so a wrong row there can send a future research pass chasing a path that does not exist.

Scope note: this is only the stale-map row. The `warpcli` target itself remains design-gated on record and is deliberately not started here.

`pnpm cicheck` passes.

Part of #2598 (housekeeping row from the issue)
