### PR TITLE
chore: release v16.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.9.1",
+  "version": "16.10.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.9.1";
+const getVersion = () => "16.10.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.10.0.

## What's Changed

See the draft release notes: https://github.com/dyoshikawa/rulesync/releases

- Version bump: 16.9.1 -> 16.10.0 (`getVersion()` and `package.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)