### PR TITLE
chore: release v16.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.10.0",
+  "version": "16.11.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,7 +19,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.10.0";
+const getVersion = () => "16.11.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release PR for v16.11.0.

## Included changes
- feat(hermesagent): author fail_closed hooks and preserve MCP trust/identity_header (#2655)
- feat(copilot): add preCompact and subagentStart hook events (#2656)
- docs(roo): mark the roo target deprecated and document the EOL (#2657)
- docs(research): rewrite the Antigravity reference for Antigravity 2.0 (#2658)

🤖 Generated with [Claude Code](https://claude.com/claude-code)