### PR TITLE
feat(kilo): model variant in the command frontmatter schema

### DIFF
--- a/src/features/commands/kilo-command.test.ts
+++ b/src/features/commands/kilo-command.test.ts
@@ -124,6 +124,31 @@ describe("KiloCommand", () => {
       });
       expect(rulesyncCommand.getRelativeDirPath()).toBe(RULESYNC_COMMANDS_RELATIVE_DIR_PATH);
     });
+
+    it("should round-trip variant, the reasoning-effort override", async () => {
+      const filePath = join(testDir, ".kilo", "commands", "effort.md");
+      await ensureDir(join(testDir, ".kilo", "commands"));
+      await writeFileContent(
+        filePath,
+        stringifyFrontmatter("Do the thing", { description: "Effort", variant: "high" }),
+      );
+
+      const command = await KiloCommand.fromFile({
+        outputRoot: testDir,
+        relativeFilePath: "effort.md",
+      });
+      expect(command.getFrontmatter()).toEqual({ description: "Effort", variant: "high" });
+
+      const rulesyncCommand = command.toRulesyncCommand();
+      expect(rulesyncCommand.getFrontmatter()).toEqual({
+        targets: ["*"],
+        description: "Effort",
+        kilo: { variant: "high" },
+      });
+
+      const regenerated = KiloCommand.fromRulesyncCommand({ outputRoot: testDir, rulesyncCommand });
+      expect(regenerated.getFrontmatter()).toEqual({ description: "Effort", variant: "high" });
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/commands/kilo-command.ts
+++ b/src/features/commands/kilo-command.ts
@@ -24,6 +24,11 @@ export const KiloCommandFrontmatterSchema = z.looseObject({
   agent: z.optional(z.string()),
   subtask: z.optional(z.boolean()),
   model: z.optional(z.string()),
+  // Reasoning-effort override (e.g. `low` / `high`) for models that support
+  // variants — the fifth field of Kilo's command schema, and the same key
+  // `KiloSubagentFrontmatterSchema` models.
+  // https://kilo.ai/docs/customize/workflows
+  variant: z.optional(z.string()),
 });
 
 export type KiloCommandFrontmatter = z.infer<typeof KiloCommandFrontmatterSchema>;


### PR DESCRIPTION
## Summary

Adds `variant: z.optional(z.string())` to `KiloCommandFrontmatterSchema`, which modeled only `description` / `agent` / `subtask` / `model`. `variant` is the reasoning-effort override ("for example `low` or `high`, for models that support variants") and is the fifth field of Kilo's command schema — mirroring how `KiloSubagentFrontmatterSchema` already models the same key.

## Scope: completeness, not a functional fix

Worth being explicit, since the branch name suggests a data-loss bug: **`variant` already round-trips today.** The schema is a `z.looseObject` and both conversion directions spread residual keys (`toRulesyncCommand` lifts them into the `kilo:` section, `fromRulesyncCommand` spreads them back), so a `variant` authored under a rulesync command's `kilo:` section already reached `.kilo/commands/*.md`. I verified this against the adapter before changing anything, and #2499's own 2026-08-06 comment says the same. The value here is typing and validation completeness plus a regression test pinning the behaviour.

## Verification

Confirmed on both upstream surfaces:

- Runtime schema — [`packages/core/src/config/command.ts`](https://github.com/Kilo-Org/kilocode/blob/main/packages/core/src/config/command.ts): `variant: Schema.String.pipe(Schema.optional)`
- Docs — [kilo.ai/docs/customize/workflows](https://kilo.ai/docs/customize/workflows) lists it alongside the other four

## Checks

- `pnpm cicheck` — green
- `npx vitest run --config vitest.e2e.config.ts src/e2e/e2e-commands.spec.ts` — 93 passed

No docs prose change: nothing in `file-formats.md` enumerates the Kilo command frontmatter fields.

Part of #2499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
