### PR TITLE
chore: release v16.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.11.0",
+  "version": "16.12.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.11.0";
+const getVersion = () => "16.12.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release PR for v16.12.0.

## Included changes
- New `release-notes` command (#2662, closes #2661)
- Cline TaskError/SessionShutdown hook scripts with platform guards (#2672)
- Copilot cloud-agent postToolUseFailure/userPromptTransformed events (#2673)
- Amp SKILL.md residual frontmatter round-trip (#2674)
- Codex CLI async hook forwarding (#2675)
- Grok CLI matcher honoring + auto permission mode preservation (#2676)
- Kilo command variant field (#2677)
- Roo/Zoo disabledTools MCP filter fix (#2678)
- deepagents MCP tool filters + transport normalization (#2679)
- Factory Droid hooks.json shape fix + MCP disabledTools (#2680)
- Junie skill description import fallback (#2681)

🤖 Generated with [Claude Code](https://claude.com/claude-code)