### PR TITLE
chore: update Homebrew formula to v16.12.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.11.0"
+  version "16.12.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "8c9e3c7246ecdba6da65a48793147509d838cd6f38eb3d23d618c5cf2c074a91"
+      sha256 "238dcc41eb47b27848d1afac812471437ff906be4e915f675144cc0f8668ea5c"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "fd9b08bf68fda62451157204ded571556a38f0328d0c6a814da86623b7c98825"
+      sha256 "adb50231ec8b903c010eb443097e8472d2261dea007bfbfaed22223024790412"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "c30e99aab3b6b0c5f379ef921c7a18f78d3a83291b50efc8e2a8160e2142a34a"
+      sha256 "a7f6162e3442d3fd14e196ef5c9cbda4c892a93664dad10125dfaf532a4d7095"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "91b300637c4a3d161f9d8eda165f95cef83c6b0f0e162642b4ab66aab3a35d5b"
+      sha256 "c26b80795797d4bfd925b46b9b2a2b8a69a8973573b2550cea7f87b38e65d2b1"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.12.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)