### PR TITLE
fix(rules): emit AGENTS.local.md for zoocode by making local-root dispatch subclass-aware

### DIFF
--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -2154,6 +2154,20 @@ Content that would fail parsing`;
       expect((localRule as RulesyncRule).getFrontmatter().localRoot).toBe(true);
     });
 
+    it("should import AGENTS.local.md as a localRoot rulesync rule for zoocode (issue #2596)", async () => {
+      await writeFileContent(join(testDir, "AGENTS.md"), "# Root");
+      await writeFileContent(join(testDir, "AGENTS.local.md"), "# Personal zoocode rules");
+
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "zoocode" });
+      const rulesyncFiles = await processor.convertToolFilesToRulesyncFiles(
+        await processor.loadToolFiles(),
+      );
+
+      const localRule = findLocalRule(rulesyncFiles, "AGENTS.local.md");
+      expect(localRule).toBeInstanceOf(RulesyncRule);
+      expect((localRule as RulesyncRule).getFrontmatter().localRoot).toBe(true);
+    });
+
     it("should import .claude/CLAUDE.local.md from the alternative root directory", async () => {
       await ensureDir(join(testDir, ".claude"));
       await writeFileContent(join(testDir, ".claude", "CLAUDE.md"), "# Root");
@@ -2543,6 +2557,42 @@ targets: ["*"]
       const rootRule = result.find((r) => r.getRelativeFilePath() === "AGENTS.md");
       expect(rootRule?.getFileContent()).not.toContain("# Local overrides");
     });
+
+    it.each(["roo", "zoocode"] as const)(
+      "should generate the same AGENTS.local.md for %s (issue #2596)",
+      async (toolTarget) => {
+        const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget });
+
+        const rulesyncRules = [
+          new RulesyncRule({
+            outputRoot: testDir,
+            relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+            relativeFilePath: "root.md",
+            frontmatter: { root: true, targets: ["*"] },
+            body: "# Root",
+          }),
+          new RulesyncRule({
+            outputRoot: testDir,
+            relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+            relativeFilePath: "local.md",
+            frontmatter: { localRoot: true, targets: ["*"] },
+            body: "# Local overrides",
+          }),
+        ];
+
+        const result = await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+        // `ZoocodeRule extends RooRule`, so the local-root dispatch must be
+        // subclass-aware; a strict class-identity check silently produced no
+        // AGENTS.local.md for zoocode while the target declared support for it.
+        const localRule = result.find((r) => r.getRelativeFilePath() === "AGENTS.local.md");
+        expect(localRule).toBeDefined();
+        expect(localRule?.getFileContent()).toBe("# Local overrides");
+        expect(
+          result.find((r) => r.getRelativeFilePath() === "AGENTS.md")?.getFileContent(),
+        ).not.toContain("# Local overrides");
+      },
+    );
 
     it("should append localRoot content to root file for other tools", async () => {
       const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "copilot" });

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -209,6 +209,19 @@ type McpInstructionsRegistrar = {
   }): Promise<ToolFile | null>;
 };
 
+/**
+ * Whether `candidate` is `base` itself or a class that extends it.
+ *
+ * Class-identity dispatch (`factory.class === Base`) is subclass-blind: a target
+ * whose adapter merely narrows another one — `ZoocodeRule extends RooRule` — fails
+ * a strict `===` and silently falls through. That is how `zoocode` ended up
+ * declaring `localRootMode: "separate-local-file"` while never emitting
+ * `AGENTS.local.md`, in both directions and without a warning.
+ */
+function isClassOrSubclassOf({ candidate, base }: { candidate: object; base: object }): boolean {
+  return candidate === base || Object.prototype.isPrototypeOf.call(base, candidate);
+}
+
 type LocalRootMode = "separate-local-file" | "append-to-root";
 type RuleCollisionPolicy = "compose" | "fold" | "preserve";
 type RuleConversion = {
@@ -1391,7 +1404,7 @@ export class RulesProcessor extends FeatureProcessor {
     /** True when importing an existing local file back to a rulesync rule. */
     localRoot?: boolean;
   }): ToolRule | null {
-    if (factory.class === ClaudecodeRule) {
+    if (isClassOrSubclassOf({ candidate: factory.class, base: ClaudecodeRule })) {
       const paths = ClaudecodeRule.getSettablePaths({ global: this.global });
       return new ClaudecodeRule({
         outputRoot: this.outputRoot,
@@ -1404,7 +1417,7 @@ export class RulesProcessor extends FeatureProcessor {
         localRoot,
       });
     }
-    if (factory.class === ClaudecodeLegacyRule) {
+    if (isClassOrSubclassOf({ candidate: factory.class, base: ClaudecodeLegacyRule })) {
       const paths = ClaudecodeLegacyRule.getSettablePaths({ global: this.global });
       return new ClaudecodeLegacyRule({
         outputRoot: this.outputRoot,
@@ -1416,7 +1429,7 @@ export class RulesProcessor extends FeatureProcessor {
         localRoot,
       });
     }
-    if (factory.class === RovodevRule) {
+    if (isClassOrSubclassOf({ candidate: factory.class, base: RovodevRule })) {
       return new RovodevRule({
         outputRoot: this.outputRoot,
         relativeDirPath: relativeDirPath ?? ".",
@@ -1427,7 +1440,7 @@ export class RulesProcessor extends FeatureProcessor {
         localRoot,
       });
     }
-    if (factory.class === RooRule) {
+    if (isClassOrSubclassOf({ candidate: factory.class, base: RooRule })) {
       return new RooRule({
         outputRoot: this.outputRoot,
         relativeDirPath: relativeDirPath ?? ".",
@@ -1438,7 +1451,7 @@ export class RulesProcessor extends FeatureProcessor {
         localRoot,
       });
     }
-    if (factory.class === QwencodeRule) {
+    if (isClassOrSubclassOf({ candidate: factory.class, base: QwencodeRule })) {
       // Qwen Code reads the personal local context file from `.qwen/`, not the
       // project root (project scope only; global handling never reaches here).
       return new QwencodeRule({


### PR DESCRIPTION
## Background

`zoocode` declares `localRootMode: "separate-local-file"` / `localRootFileName: "AGENTS.local.md"` in `rules-processor.ts`, and Zoo Code really does read that file (`src/core/prompts/sections/custom-instructions.ts` upstream). But `RulesProcessor.buildLocalRootFile` dispatched on **class identity** (`factory.class === RooRule`), and `ZoocodeRule extends RooRule`, so the strict `===` failed, execution fell through to `return null`, and no file was produced — silently, in both directions.

Reproduced before the fix:

```
pnpm run dev generate --targets roo     --features rules --dry-run  -> 6 rules, incl. AGENTS.local.md
pnpm run dev generate --targets zoocode --features rules --dry-run  -> 5 rules, no AGENTS.local.md
```

## Changes

- Add `isClassOrSubclassOf({ candidate, base })` and use it for all five local-root branches (`ClaudecodeRule`, `ClaudecodeLegacyRule`, `RovodevRule`, `RooRule`, `QwencodeRule`), so the dispatch is inheritance-safe for any future subclassed adapter rather than only for `zoocode`.
- Regression tests: a `roo`/`zoocode` parity case on the generate path, and a `zoocode` import case. Both fail on `main` and pass here (verified by reverting the source change).

No path, scope or matrix change — `zoocode` already declared the capability; this makes the declaration live.

Closes #2596
