### PR TITLE
docs(musecode): record .agents/memory/ as a deliberately excluded surface

### DIFF
--- a/src/constants/musecode-paths.ts
+++ b/src/constants/musecode-paths.ts
@@ -26,6 +26,15 @@ export const MUSECODE_SKILLS_DIR_PATH = join(".agents", "skills");
 export const MUSECODE_GLOBAL_CONFIG_DIR_PATH = join(".config", "muse");
 export const MUSECODE_GLOBAL_SKILLS_DIR_PATH = join(MUSECODE_GLOBAL_CONFIG_DIR_PATH, "skills");
 
+// Deliberately NOT emitted: committed project memory at `<repo>/.agents/memory/`
+// (an `MEMORY.md` index plus one Markdown file per topic). It is agent-maintained
+// durable memory rather than an author-written instruction file, and rulesync has
+// no canonical memory dimension to map onto, so it stays out of scope. If it is
+// ever brought in scope, note that Muse Code injects `MEMORY.md` even in an
+// untrusted workspace — unlike rules, skills and hooks — so anything written there
+// reaches the model context before any trust decision.
+// https://dev.meta.ai/docs/muse-code/configuration.md
+
 // User settings file. Holds the `mcp_servers` block (Muse Code documents no
 // project-scoped MCP location) and MUST carry `"schema_version": 1` — a
 // settings.json without that key fails every command at startup with


### PR DESCRIPTION
## Background

The 2026-08-17 re-check on #2669 found no new gap — the per-hook entry schema is still unpublished upstream, so the issue's own blocking condition is unchanged — but it did surface one previously unexamined surface: committed **project memory** at `<repo>/.agents/memory/`, documented under "Local memory" in https://dev.meta.ai/docs/muse-code/configuration.md.

The recommendation was to keep it out of scope and record why, so a later pass does not re-derive it. That is the only concrete follow-up the re-check produced.

## Changes

Adds a comment in `src/constants/musecode-paths.ts` recording `.agents/memory/` as a known, deliberately excluded upstream surface: it is agent-maintained durable memory rather than an author-written instruction file, and no rulesync target has a memory dimension to map it onto. The note also carries the reason it would need care if ever brought in scope — Muse Code injects `MEMORY.md` even in an untrusted workspace, unlike rules, skills and hooks, so anything written there is a prompt-injection surface by design.

No behavior change.

Closes #2669
