### PR TITLE
ci: add a scheduled Dependabot auto-merge workflow driven by OpenCode

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,88 @@
+name: Dependabot Auto Merge
+
+# Runs the `babysit-dependabot-pr` skill against every open Dependabot PR.
+#
+# Deliberately NOT triggered by the `pull_request` event: a Dependabot-originated
+# `pull_request` run receives the Dependabot secrets store rather than the regular
+# Actions secrets, so `OPENROUTER_API_KEY` would be unavailable, and
+# `pull_request_target` would widen the injection surface for event data without
+# reducing the real risk (CI executes the bumped dependencies either way).
+# `schedule` + `workflow_dispatch` avoids both: the workflow definition always runs
+# from `main`, regular secrets are available, and the prompt stays fully static —
+# the agent discovers the PRs itself, so no untrusted event data is interpolated
+# into it (see .github/workflows/AGENTS.md).
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      # A cheap pre-check so an empty run burns no model tokens.
+      - name: Check for open Dependabot pull requests
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh pr list --state open --author "app/dependabot" --json number --jq 'length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Open Dependabot pull requests: ${count}"
+
+      - name: Configure git
+        if: steps.check.outputs.count != '0'
+        uses: ./.github/actions/git-config
+
+      - name: Setup mise
+        if: steps.check.outputs.count != '0'
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          experimental: true
+
+      - name: Setup Takumi Guard npm registry
+        if: steps.check.outputs.count != '0'
+        uses: flatt-security/setup-takumi-guard-npm@6d4182745c1e474c35a023573c2612c085be45a4 # v1
+
+      - name: Install dependencies
+        if: steps.check.outputs.count != '0'
+        run: pnpm install --ignore-scripts
+
+      - name: Generate rules
+        if: steps.check.outputs.count != '0'
+        run: pnpm generate
+
+      - name: Run OpenCode to babysit Dependabot pull requests
+        if: steps.check.outputs.count != '0'
+        uses: anomalyco/opencode/github@31406ccc51b4bd2a4e1e086b2bcaa5f7f804f26d # v1.18.18
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Hard-coded rather than resolved through ./.github/actions/select-opencode-model,
+          # which maps the `deepseek` keyword to `openrouter/deepseek/deepseek-v4-pro`.
+          model: openrouter/deepseek/deepseek-v4-flash-0731
+          use_github_token: "true"
+          share: false
+          prompt: |
+            List the open Dependabot pull requests with `gh pr list --state open --author "app/dependabot"`.
+            For each one, run the `babysit-dependabot-pr` skill with that pull request number, one pull request at a time.
+            The skill verifies the author is the genuine Dependabot bot, diagnoses any CI failure, excludes or fixes a breaking bump, and merges once every check is green.
+            Do not act on any pull request whose author is not Dependabot.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,6 +25,14 @@ concurrency:
 
 jobs:
   dependabot-auto-merge:
+    # The `github.actor` gate mirrors `draft-release.yml`, so the job that receives
+    # the model key and a write-scoped token stays reachable only through the
+    # schedule — whose definition always comes from `main` — or a maintainer's own
+    # dispatch.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.actor == 'dyoshikawa' ||
+      github.actor == 'cm-dyoshikawa'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -71,7 +79,7 @@ jobs:
 
       - name: Run OpenCode to babysit Dependabot pull requests
         if: steps.check.outputs.count != '0'
-        uses: anomalyco/opencode/github@31406ccc51b4bd2a4e1e086b2bcaa5f7f804f26d # v1.18.18
+        uses: anomalyco/opencode/github@2b72179c663cadcb54f54d9f19221b3fb3d11fb6 # v1.18.19
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,3 +94,8 @@ jobs:
             For each one, run the `babysit-dependabot-pr` skill with that pull request number, one pull request at a time.
             The skill verifies the author is the genuine Dependabot bot, diagnoses any CI failure, excludes or fixes a breaking bump, and merges once every check is green.
             Do not act on any pull request whose author is not Dependabot.
+
+            This repository's `main` ruleset lists no bypass actor for the Actions app, so
+            `gh pr merge --admin` cannot force a merge from here. Merge with
+            `gh pr merge <number> --merge` instead, and if the ruleset rejects it, leave the
+            pull request open and report why rather than retrying with `--admin`.

--- a/.rulesync/rules/github-actions-security.md
+++ b/.rulesync/rules/github-actions-security.md
@@ -27,14 +27,14 @@ Reference: https://docs.github.com/ja/actions/concepts/security/script-injection
 
 Third-party GitHub Actions are pinned to a full 40-character commit SHA with a trailing `# vX.Y.Z` comment. Keep that convention when adding or bumping an action.
 
-`anomalyco/opencode/github` (used by `draft-release.yml`) is a composite action, so its SHA pin covers the wrapper only:
+`anomalyco/opencode/github` (used by `draft-release.yml` and `dependabot-auto-merge.yml`) is a composite action, so its SHA pin covers the wrapper only:
 
 - The wrapper resolves the `opencode` CLI release to `latest` at run time and installs it with `curl -fsSL https://opencode.ai/install | bash`, so the binary that actually receives the workflow secrets is not pinned by the SHA.
 - The wrapper also uses `actions/cache@v4` internally, by mutable tag.
 
-The accepted stance is to treat `https://opencode.ai/install` as a trusted install path rather than vendoring a pinned installer, because `draft-release.yml` is `workflow_dispatch`-only and gated on `github.actor`, so an outside contributor cannot trigger it. Bumping the pin is still worthwhile for the wrapper itself, but do not read it as a guarantee about the CLI version.
+The accepted stance is to treat `https://opencode.ai/install` as a trusted install path rather than vendoring a pinned installer, because the workflows that reach it cannot be triggered by an outside contributor: `draft-release.yml` is `workflow_dispatch`-only and gated on `github.actor`, and `dependabot-auto-merge.yml` runs on a `schedule` — whose definition always comes from `main` — plus a `workflow_dispatch` carrying the same actor gate. Bumping the pin is still worthwhile for the wrapper itself, but do not read it as a guarantee about the CLI version.
 
-The residual risk this stance accepts is that a compromise of the distribution endpoint would expose whatever the workflow hands the CLI — the model API keys and a `GITHUB_TOKEN` with `contents: write`, `pull-requests: write`, and `issues: write`. The `github.actor` gate limits _who can trigger_ the workflow; it does not reduce that exposure on a maintainer-triggered run. Revisit this if the workflow ever becomes externally triggerable, if the token or secret scope it receives grows, or if upstream adds a `version` input that lets the CLI itself be pinned.
+The residual risk this stance accepts is that a compromise of the distribution endpoint would expose whatever the workflow hands the CLI — the model API keys and a `GITHUB_TOKEN` with `contents: write`, `pull-requests: write`, and `issues: write`. The `github.actor` gate limits _who can trigger_ the workflow; it does not reduce that exposure on a maintainer-triggered run, and a scheduled run has no triggering actor to gate at all. Revisit this if either workflow ever becomes externally triggerable, if the token or secret scope it receives grows, or if upstream adds a `version` input that lets the CLI itself be pinned.
 
 ## OIDC Permissions
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Please review and merge this one by hand.** It adds a GitHub Actions workflow, which the autonomous batch flow does not auto-merge, and it has one open question (below) that only you can settle.

## Background

Dependabot opens grouped bump PRs weekly for npm, GitHub Actions and Docker, and each one is babysat by hand today. The `babysit-dependabot-pr` skill already encodes that whole procedure, and `draft-release.yml` already runs OpenCode inside Actions, so this wires the two together.

## Changes

Adds `.github/workflows/dependabot-auto-merge.yml`:

- `schedule` (daily, 03:00 UTC) + `workflow_dispatch`. Deliberately **not** the `pull_request` event: a Dependabot-originated run gets the Dependabot secrets store, so `OPENROUTER_API_KEY` would be unavailable, and `pull_request_target` would widen the injection surface for event data without reducing the real risk (CI executes the bumped dependencies either way). On a schedule the workflow definition always runs from `main`, regular secrets are available, and the prompt stays fully **static** — the agent discovers the PRs itself with `gh pr list --author "app/dependabot"`, so no untrusted event data is interpolated, per `.github/workflows/AGENTS.md`.
- A cheap `gh pr list` pre-check gates every later step, so an empty run burns no model tokens.
- Setup steps mirror `draft-release.yml` (checkout `fetch-depth: 0`, `git-config`, mise, Takumi Guard npm registry, `pnpm install --ignore-scripts`, `pnpm generate`), all SHA-pinned to the same versions.
- `concurrency` group and `timeout-minutes: 60` so overlapping runs cannot push to the same branches.
- Model hard-coded to `openrouter/deepseek/deepseek-v4-flash-0731` — verified present on models.dev under the `openrouter` provider. `./.github/actions/select-opencode-model` cannot be reused as-is, since it maps the `deepseek` keyword to `openrouter/deepseek/deepseek-v4-pro`.
- Job permissions are `contents: write`, `pull-requests: write`, `issues: write`, with the workflow-level default kept at `contents: read`.

`actionlint` runs on this PR (it is path-triggered on `.github/workflows/**`), which covers step 3 of the issue.

## The merge path (issue step 2)

I read the ruleset (`repos/dyoshikawa/rulesync/rulesets/6248659`) rather than leaving this open:

- Its only bypass actor is `RepositoryRole` id 5 with `bypass_mode: pull_request`, so the workflow `GITHUB_TOKEN` is **not** a bypass actor and `gh pr merge --admin` cannot force a merge from Actions. The prompt now tells the agent to use `gh pr merge <number> --merge` and to report rather than retry with `--admin` if the ruleset refuses — that keeps the shared `babysit-dependabot-pr` skill untouched for interactive use.
- The ruleset sets `required_approving_review_count: 0` and there is no `CODEOWNERS` file, so `require_code_owner_review` has no owners to demand. A plain `--merge` on a green PR should therefore satisfy it, and no PAT or new bypass actor is needed today.

If reviews ever become mandatory on `main`, this will need either a PAT secret or an Actions bypass actor — worth revisiting then, not now.

## Also in this update

- The job is gated on `github.actor` for `workflow_dispatch`, mirroring `draft-release.yml`, so the step holding the model key and a write-scoped token is reachable only through the schedule (whose definition always comes from `main`) or a maintainer's own dispatch.
- `.rulesync/rules/github-actions-security.md` now names this workflow in the `anomalyco/opencode/github` pinning stance, since that stance was written around `draft-release.yml` being the only workflow reaching `https://opencode.ai/install`.
- The action pin is bumped to v1.18.19 to match `draft-release.yml` on `main`.
- Rebased onto current `main`.

## Verification

- `actionlint` 1.7.11 (the version CI pins) reports no findings.
- `pnpm cicheck` passes.
- A manual `workflow_dispatch` validation run has **not** been performed — it needs the repository secrets and would act on live PRs, so it is left to you.

Closes #2686

