### PR TITLE
chore: update Homebrew formula to v16.13.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.12.0"
+  version "16.13.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "238dcc41eb47b27848d1afac812471437ff906be4e915f675144cc0f8668ea5c"
+      sha256 "1419cea27c1ade308b91e4575b73a56394af7f69bc81ccf4e07c14fbf58cf8cb"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "adb50231ec8b903c010eb443097e8472d2261dea007bfbfaed22223024790412"
+      sha256 "f4476da288e08c25194c692cfcbd22a2eeee996c4a3eb5f8d9e8530f9eb0227c"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "a7f6162e3442d3fd14e196ef5c9cbda4c892a93664dad10125dfaf532a4d7095"
+      sha256 "c8fa68ff9cc66379ca3a7b3d7d1f5cb171cb6b01656eb533fd28473f33a315be"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "c26b80795797d4bfd925b46b9b2a2b8a69a8973573b2550cea7f87b38e65d2b1"
+      sha256 "261288fa82ea2952222f785beda2f8489656d3b9dfe4eef52ca113602f38ad9c"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.13.0 release.