### PR TITLE
feat(mcp): warn when a target drops a per-server tool filter

### DIFF
--- a/src/features/mcp/mcp-processor.test.ts
+++ b/src/features/mcp/mcp-processor.test.ts
@@ -119,6 +119,9 @@ describe("McpProcessor", () => {
     // (no-op for mocked tests)
     (RulesyncMcp.prototype as any).stripMcpServerFields = vi.fn().mockReturnThis();
     (RulesyncMcp.prototype as any).forTarget = vi.fn().mockReturnThis();
+    // The class is auto-mocked, so `fileContent` is never parsed here: tests
+    // that care about the server map override this per case.
+    (RulesyncMcp.prototype as any).getJson = vi.fn().mockReturnValue({ mcpServers: {} });
   });
 
   afterEach(async () => {
@@ -1074,6 +1077,66 @@ describe("McpProcessor", () => {
         expect(rulesyncMcp.stripMcpServerFields).toHaveBeenCalledWith(["enabledTools"]);
       },
     );
+
+    it("should warn which servers lose a tool filter the target does not read", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: {} }),
+      });
+      vi.mocked(rulesyncMcp.getJson).mockReturnValue({
+        mcpServers: {
+          filtered: { command: "server", enabledTools: ["read"] },
+          denied: { command: "server", disabledTools: ["write"] },
+          plain: { command: "server" },
+        },
+      } as any);
+
+      vi.spyOn(RooMcp, "fromRulesyncMcp").mockReturnValue({} as RooMcp);
+
+      const logger = createMockLogger();
+      const processor = new McpProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "zoocode",
+      });
+
+      await processor.convertRulesyncFilesToToolFiles([rulesyncMcp]);
+
+      // Zoo Code reads `disabledTools` but has no allowlist key, so only the
+      // `enabledTools` server is reported and the untouched ones stay quiet.
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "zoocode does not read the per-server `enabledTools` MCP tool filter; dropping it from filtered.",
+      );
+    });
+
+    it("should not warn when no server authored a dropped tool filter", async () => {
+      const rulesyncMcp = new RulesyncMcp({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: ".mcp.json",
+        fileContent: JSON.stringify({ mcpServers: {} }),
+      });
+      vi.mocked(rulesyncMcp.getJson).mockReturnValue({
+        mcpServers: { plain: { command: "server" } },
+      } as any);
+
+      vi.spyOn(RooMcp, "fromRulesyncMcp").mockReturnValue({} as RooMcp);
+
+      const logger = createMockLogger();
+      const processor = new McpProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "zoocode",
+      });
+
+      await processor.convertRulesyncFilesToToolFiles([rulesyncMcp]);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it("should preserve disabledTools but strip enabledTools for Factory Droid", async () => {
       // Droid documents a per-server `disabledTools` exclusion list and no
       // allowlist, so only `enabledTools` may be stripped.

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -669,6 +669,48 @@ const defaultGetFactory: GetFactory = (target) => {
   return factory;
 };
 
+/**
+ * Warn about per-server tool filters the target tool cannot express.
+ *
+ * `enabledTools`/`disabledTools` are canonical fields, so a single
+ * `.rulesync/.mcp.json` can carry a filter that only some targets read. The
+ * unsupported ones are stripped before generation (writing them would produce a
+ * key the tool discards on load), which used to happen silently — the filter
+ * simply did not apply and nothing said so. Warning names the servers whose
+ * filter is being dropped for this target so the gap is visible at generate
+ * time rather than in the tool's behavior.
+ *
+ * Only fields actually present are reported, so a config that never authored
+ * the filter stays quiet.
+ */
+function warnStrippedMcpServerFields({
+  mcpServers,
+  fields,
+  toolTarget,
+  logger,
+}: {
+  // The parsed `mcpServers` block. Typed optional because this reads the raw
+  // parsed JSON: a file that omits the block entirely (or was constructed with
+  // `validate: false`) has no map to inspect, and that is not a reason to fail
+  // a generate.
+  mcpServers: Record<string, Record<string, unknown>> | undefined;
+  fields: string[];
+  toolTarget: ToolTarget;
+  logger: Logger;
+}): void {
+  for (const field of fields) {
+    const serverNames = Object.entries(mcpServers ?? {})
+      .filter(([, serverConfig]) => serverConfig[field] !== undefined)
+      .map(([serverName]) => serverName);
+    if (serverNames.length === 0) {
+      continue;
+    }
+    logger.warn(
+      `${toolTarget} does not read the per-server \`${field}\` MCP tool filter; dropping it from ${serverNames.join(", ")}.`,
+    );
+  }
+}
+
 export class McpProcessor extends FeatureProcessor {
   private readonly toolTarget: McpProcessorToolTarget;
   private readonly global: boolean;
@@ -791,6 +833,12 @@ export class McpProcessor extends FeatureProcessor {
         const fieldsToStrip: string[] = [];
         if (!factory.meta.supportsEnabledTools) fieldsToStrip.push("enabledTools");
         if (!factory.meta.supportsDisabledTools) fieldsToStrip.push("disabledTools");
+        warnStrippedMcpServerFields({
+          mcpServers: targetedRulesyncMcp.getJson().mcpServers,
+          fields: fieldsToStrip,
+          toolTarget: this.toolTarget,
+          logger: this.logger,
+        });
         const filteredRulesyncMcp = targetedRulesyncMcp.stripMcpServerFields(fieldsToStrip);
 
         return await factory.class.fromRulesyncMcp({


### PR DESCRIPTION
## Background

Part of #2596 (its 2026-08-13 re-check comment, MCP gap 2).

The issue reported that a canonical `enabledTools` array reaches `.roo/mcp.json` and is then silently discarded by Zoo Code's zod schema. That half is already fixed: `mcp-processor.ts` sets `supportsEnabledTools: false` for both `roo` and `zoocode` and strips the field before `RooMcp` ever sees it, so nothing unreadable is written today.

What remains is the second half of the issue's own proposal — *"drop **or warn**"*. The strip is silent for every target, so a user who authors an allowlist for a denylist-only tool gets no signal at all: the filter simply does not apply.

## Changes

- `mcp-processor.ts`: before stripping, name the servers that actually carried a dropped filter and warn once per field, e.g.

  ```
  zoocode does not read the per-server `enabledTools` MCP tool filter; dropping it from filtered.
  ```

- Only fields that are present are reported, so configs that never authored the filter stay quiet.
- The check is generic, so it covers every target/field pair the strip list already computes, not just the Zoo Code case that surfaced it.

## Tests

- New: the warning names only the server carrying the unsupported field (the `disabledTools` server, which Zoo Code does read, and a plain server are both left out) and fires exactly once.
- New: no warning when no server authored a dropped filter.
