### PR TITLE
chore: update Homebrew formula to v16.14.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.13.0"
+  version "16.14.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "1419cea27c1ade308b91e4575b73a56394af7f69bc81ccf4e07c14fbf58cf8cb"
+      sha256 "84d4adc87c9f9412b348acaf028096f7974982319c837ef8180581c7c98cfc2f"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "f4476da288e08c25194c692cfcbd22a2eeee996c4a3eb5f8d9e8530f9eb0227c"
+      sha256 "d26be9ee36ec7d291975e708839f5c29e165520208822a21f13023d7ef05b5fa"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "c8fa68ff9cc66379ca3a7b3d7d1f5cb171cb6b01656eb533fd28473f33a315be"
+      sha256 "767c392c971b2ef439dbf84b9d827932c4e808539a094f99e80f4f408c95f7fd"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "261288fa82ea2952222f785beda2f8489656d3b9dfe4eef52ca113602f38ad9c"
+      sha256 "ca4c73c30371b5a78a330db64d3022cbf94928974f60fe530be85bade2743014"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.14.0 release.