### PR TITLE
chore: release v16.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.14.0",
+  "version": "16.15.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.14.0";
+const getVersion = () => "16.15.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## What's Changed

### Permissions

- **Claude Code `settings.json` keys are now authorable from `.rulesync/permissions.jsonc`.** Any top-level key that is not owned by another feature — `editorMode`, `env`, `model`, `outputStyle`, and everything Claude Code adds next — is deep-merged into the generated `.claude/settings.json` verbatim, so new settings stay authorable without waiting for an allowlist update. `hooks` (owned by the hooks feature) and `$schema` are still excluded. (#2720, closes #2715)
- **Codex CLI `[tui]` is now a passthrough table.** `tui.vim_mode_default`, `tui.keymap.*`, and the rest of the table are written to `config.toml` verbatim, on the same terms as the existing `apps` passthrough. (#2720, closes #2715)
- **Keys the target file cannot honor are dropped with a warning instead of written where they would never apply.** `Managed`-only keys, `~/.claude.json`-only keys, and user-scope keys encountered at project scope are reported as skipped rather than silently emitted into a file Claude Code ignores.
- **Keys whose value is a command Claude Code executes are refused in both directions.** `apiKeyHelper`, `statusLine`, `awsAuthRefresh`, `awsCredentialExport`, and the sandbox paths that run a command are rejected on generate and on import. `.rulesync/permissions.jsonc` is shareable through `rulesync fetch`, and a file named for restricting things is not where an executed command belongs — author those in `.rulesync/hooks.jsonc` instead.
- **Trust-widening settings now warn before they are written.** Keys that loosen the trust boundary rather than tighten it — `enableAllProjectMcpServers`, `enabledMcpjsonServers`, `allowedMcpServers`, `enabledPlugins`, `extraKnownMarketplaces`, `allowedHttpHookUrls`, `disableAllHooks`, `autoMode`, the `skip*` permission-prompt keys, a `permissions.defaultMode` of `acceptEdits` / `auto` / `bypassPermissions`, a non-empty `permissions.additionalDirectories`, and `disableSkillShellExecution: false` — are still written, but each one is named on stderr first.
- **Sandbox keys that can only widen the policy warn too.** Claude Code merges array-valued sandbox settings across every settings scope rather than replacing them, so a project-scope `allow*` list can only ever open the sandbox further. All sixteen such paths (`sandbox.enabled`, `sandbox.excludedCommands`, `sandbox.filesystem.allowRead` / `allowWrite`, the `sandbox.network.allow*` family, `sandbox.ignoreViolations`, and the rest) now warn when present. The `deny*` lists merge as well, but adding to them only narrows the policy, so they stay quiet.

### Security

- **Control-character stripping is shared and stricter.** `rulesync doctor` and `rulesync fetch` had two separate, differently-scoped strippers; both now use one helper that also removes the bidirectional overrides and isolates, `LRM`/`RLM`, and the Unicode line and paragraph separators. A name or value copied out of an untrusted config file or a fetched repository can no longer reorder or forge the diagnostic line it appears in.
- **Prototype-pollution keys are filtered out of the `permissions` passthrough** on both the generate and the import path.

### Dependencies

- Bumped the `all-dependencies` group with 77 updates. (#2717)
- Bumped `anomalyco/opencode/github` in the `all-actions` group. (#2716)

## Contributors

- @dyoshikawa

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v16.14.0...v16.15.0
