### PR TITLE
feat(musecode): gitignore .muse/worktrees/ and record the .muse harness-state surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,7 @@ rulesync.local.jsonc
 **/.takt/tasks/
 **/.takt/.cache/
 **/.takt/config.yaml
+**/.muse/worktrees/
 **/.augment-guidelines
 **/.devin/workflows/
 **/.junie/memories/

--- a/cspell.json
+++ b/cspell.json
@@ -424,6 +424,7 @@
     "symref",
     "TOCTOU",
     "worktree",
+    "worktrees",
     "Worktree",
     "zedignore",
     "minisearch"

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -161,6 +161,9 @@ describe("registry derivation", () => {
       "takt::general::**/.takt/tasks/",
       "takt::general::**/.takt/.cache/",
       "takt::general::**/.takt/config.yaml",
+      // Muse Code's `--subagent-worktree-isolation` worktrees, which the
+      // runtime removes only when they are clean (issue #2727).
+      "musecode::general::**/.muse/worktrees/",
       // Legacy/aggregate/ghost outputs not produced via getSettablePaths.
       "augmentcode::rules::**/.augment-guidelines",
       "devin::commands::**/.devin/workflows/",
@@ -198,9 +201,6 @@ describe("registry derivation", () => {
       // Vibe subagent system prompts live in `.vibe/prompts/`, outside the
       // `.vibe/agents/` path `getSettablePaths` names (issue #2423).
       "vibe::subagents::**/.vibe/prompts/",
-      // Muse Code's `--subagent-worktree-isolation` worktrees, which the
-      // runtime removes only when they are clean (issue #2727).
-      "musecode::general::**/.muse/worktrees/",
       "roo::subagents::**/.roomodes",
       "codexcli::ignore::**/.codexignore",
       // Codex CLI's `.codex/rules/rulesync.rules` bash-permission file is written

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -198,6 +198,9 @@ describe("registry derivation", () => {
       // Vibe subagent system prompts live in `.vibe/prompts/`, outside the
       // `.vibe/agents/` path `getSettablePaths` names (issue #2423).
       "vibe::subagents::**/.vibe/prompts/",
+      // Muse Code's `--subagent-worktree-isolation` worktrees, which the
+      // runtime removes only when they are clean (issue #2727).
+      "musecode::general::**/.muse/worktrees/",
       "roo::subagents::**/.roomodes",
       "codexcli::ignore::**/.codexignore",
       // Codex CLI's `.codex/rules/rulesync.rules` bash-permission file is written

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -102,8 +102,9 @@ export const HAND_MAINTAINED_GITIGNORE_ENTRIES: ReadonlyArray<GitignoreEntryTag>
   { target: "takt", feature: "general", entry: "**/.takt/config.yaml" },
   // Meta Muse Code's subagent worktrees: `--subagent-worktree-isolation` checks
   // each child agent out into a repo-relative `.muse/worktrees/<child>` git
-  // worktree, and the documented `cleanup_policy: remove_if_clean` leaves a
-  // dirty one behind when a child is cancelled or crashes. Only the worktree
+  // worktree, and the documented `cleanup_policy: remove_if_clean` removes one
+  // only while it is clean, so a worktree with uncommitted work stays in the
+  // checkout. Only the worktree
   // directory is ignored, not `.muse/` as a whole: `.muse/hooks.json` is
   // committed project config.
   // https://dev.meta.ai/docs/cookbook/subagent-fanout

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -100,6 +100,14 @@ export const HAND_MAINTAINED_GITIGNORE_ENTRIES: ReadonlyArray<GitignoreEntryTag>
   { target: "takt", feature: "general", entry: "**/.takt/tasks/" },
   { target: "takt", feature: "general", entry: "**/.takt/.cache/" },
   { target: "takt", feature: "general", entry: "**/.takt/config.yaml" },
+  // Meta Muse Code's subagent worktrees: `--subagent-worktree-isolation` checks
+  // each child agent out into a repo-relative `.muse/worktrees/<child>` git
+  // worktree, and the documented `cleanup_policy: remove_if_clean` leaves a
+  // dirty one behind when a child is cancelled or crashes. Only the worktree
+  // directory is ignored, not `.muse/` as a whole: `.muse/hooks.json` is
+  // committed project config.
+  // https://dev.meta.ai/docs/cookbook/subagent-fanout
+  { target: "musecode", feature: "general", entry: "**/.muse/worktrees/" },
 
   // Augment Code's legacy single-file rules path: accepted on import but never
   // generated (so not in getSettablePaths), gitignored as a convenience.

--- a/src/constants/musecode-paths.ts
+++ b/src/constants/musecode-paths.ts
@@ -35,30 +35,38 @@ export const MUSECODE_GLOBAL_SKILLS_DIR_PATH = join(MUSECODE_GLOBAL_CONFIG_DIR_P
 // reaches the model context before any trust decision.
 // https://dev.meta.ai/docs/muse-code/configuration.md
 
-// `<repo>/.muse/` holds Muse Code's own harness state, none of which rulesync
-// writes today:
+// `<repo>/.muse/` is where Muse Code keeps its own harness state — the docs call
+// it "`.muse/` for harness state such as the saved approval policy" — and
+// rulesync writes none of it today:
 //   - `worktrees/` — the per-child git worktrees `--subagent-worktree-isolation`
-//     creates. Gitignored as a third-party by-product (see
-//     `HAND_MAINTAINED_GITIGNORE_ENTRIES`), because the documented
-//     `cleanup_policy: remove_if_clean` leaves a dirty worktree in the checkout.
+//     creates, repo-relative and documented by path. Gitignored as a
+//     third-party by-product (see `HAND_MAINTAINED_GITIGNORE_ENTRIES`), since
+//     the documented `cleanup_policy: remove_if_clean` removes a worktree only
+//     while it is clean.
 //   - `approval-policy.json` — persisted argv-prefix allow rules keyed to the
 //     workspace canonical root, with a documented three-effect precedence
 //     (a deny overrides a prompt, a prompt overrides an allow, regardless of
 //     specificity) and interpreter/wrapper prefixes barred from persistent
 //     grants. This is why the `permissions` feature stays `unsupported` on a
 //     *narrower* basis than earlier passes recorded: an allow/deny file does
-//     exist, but its exact path and entry schema are unpublished, and it is
-//     unclear whether it is committable project config or machine-local user
-//     state. Pin both from a real file before authoring an adapter — do not
-//     re-derive "Muse Code has no allow/deny file" from `permissions.md`, which
-//     documents only CLI flags.
+//     exist. Only its basename and the `.muse/` parent are published, though —
+//     not its exact path or entry schema — and it is unclear whether it is
+//     committable project config or machine-local user state. Pin both from a
+//     real file before authoring an adapter, and do not re-derive "Muse Code
+//     has no allow/deny file" from `permissions.md`, which documents only CLI
+//     flags.
 //   - `trust.json` — the per-workspace-root record of your own trust decision,
-//     i.e. machine-local user state that rulesync should never author.
-//   - `hooks.json` — committed project config, and the reason `.muse/` as a
-//     whole is not gitignored. Blocked on the unpublished per-hook entry schema.
+//     i.e. machine-local user state that rulesync should never author. Not
+//     gitignored: the docs say only that the decision is "recorded per
+//     workspace root", which does not establish that the file itself lives
+//     inside the repo. Ignore it once a real path is confirmed.
+//   - `hooks.json` — "committed to the repo at `<project-root>/.muse/hooks.json`",
+//     and the reason `.muse/` as a whole is not gitignored. A rulesync adapter
+//     for it is blocked on the unpublished per-hook entry schema.
 // https://dev.meta.ai/docs/cookbook/subagent-fanout
 // https://dev.meta.ai/docs/cookbook/staged-approvals
 // https://dev.meta.ai/docs/cookbook/immutable-guardrails
+// https://dev.meta.ai/docs/muse-code/extending.md
 
 // User settings file. Holds the `mcp_servers` block (Muse Code documents no
 // project-scoped MCP location) and MUST carry `"schema_version": 1` — a

--- a/src/constants/musecode-paths.ts
+++ b/src/constants/musecode-paths.ts
@@ -35,6 +35,31 @@ export const MUSECODE_GLOBAL_SKILLS_DIR_PATH = join(MUSECODE_GLOBAL_CONFIG_DIR_P
 // reaches the model context before any trust decision.
 // https://dev.meta.ai/docs/muse-code/configuration.md
 
+// `<repo>/.muse/` holds Muse Code's own harness state, none of which rulesync
+// writes today:
+//   - `worktrees/` — the per-child git worktrees `--subagent-worktree-isolation`
+//     creates. Gitignored as a third-party by-product (see
+//     `HAND_MAINTAINED_GITIGNORE_ENTRIES`), because the documented
+//     `cleanup_policy: remove_if_clean` leaves a dirty worktree in the checkout.
+//   - `approval-policy.json` — persisted argv-prefix allow rules keyed to the
+//     workspace canonical root, with a documented three-effect precedence
+//     (a deny overrides a prompt, a prompt overrides an allow, regardless of
+//     specificity) and interpreter/wrapper prefixes barred from persistent
+//     grants. This is why the `permissions` feature stays `unsupported` on a
+//     *narrower* basis than earlier passes recorded: an allow/deny file does
+//     exist, but its exact path and entry schema are unpublished, and it is
+//     unclear whether it is committable project config or machine-local user
+//     state. Pin both from a real file before authoring an adapter — do not
+//     re-derive "Muse Code has no allow/deny file" from `permissions.md`, which
+//     documents only CLI flags.
+//   - `trust.json` — the per-workspace-root record of your own trust decision,
+//     i.e. machine-local user state that rulesync should never author.
+//   - `hooks.json` — committed project config, and the reason `.muse/` as a
+//     whole is not gitignored. Blocked on the unpublished per-hook entry schema.
+// https://dev.meta.ai/docs/cookbook/subagent-fanout
+// https://dev.meta.ai/docs/cookbook/staged-approvals
+// https://dev.meta.ai/docs/cookbook/immutable-guardrails
+
 // User settings file. Holds the `mcp_servers` block (Muse Code documents no
 // project-scoped MCP location) and MUST carry `"schema_version": 1` — a
 // settings.json without that key fails every command at startup with


### PR DESCRIPTION
## Summary

Follows up the Meta Muse Code re-check in #2727, which found two gaps in the Cookbook section that the six reference doc pages do not cover.

- **`.muse/worktrees/` is now gitignored.** With `--subagent-worktree-isolation`, ["the runtime creates each child's worktree under a repo-relative `.muse/worktrees/` directory in detached-HEAD state, checked out from the parent's `HEAD`"](https://dev.meta.ai/docs/cookbook/subagent-fanout), and the recipe's event log gives `cleanup_policy: remove_if_clean` — so a worktree left dirty by a cancelled or crashed child persists in the checkout. Since that flag is the documented way to run any multi-agent job, this is the normal path. Nothing here is derivable from `getSettablePaths` (musecode's adapters name only `AGENTS.md`, `.agents/skills`, `~/.config/muse/skills` and `~/.config/muse/settings.json`), so it goes in `HAND_MAINTAINED_GITIGNORE_ENTRIES` as a third-party by-product, the same category as `takt::general::**/.takt/runs/`.

  Only `.muse/worktrees/` is ignored, **not** `.muse/` as a whole — `.muse/hooks.json` is committed project config that a future hooks adapter (blocked on the unpublished per-hook entry schema, #2669) will write.

- **The `permissions` rationale is corrected without changing support.** #2669 concluded `permissions` was correctly `unsupported` because there were "no documented settings keys and no allow/deny file". That premise no longer holds: [the staged-approvals recipe](https://dev.meta.ai/docs/cookbook/staged-approvals) names `approval-policy.json`, holding argv-prefix allow rules keyed to the workspace canonical root, with a documented precedence ("a deny overrides a prompt, and a prompt overrides an allow, regardless of specificity") and a list of interpreter/wrapper prefixes barred from persistent grants. The feature nevertheless stays `unsupported`, because the file's exact path and entry schema are still unpublished and it is unclear whether it is committable project config or machine-local user state like `trust.json`. `musecode-paths.ts` now records the whole `.muse/` surface, so a later pass does not re-derive the stale conclusion from `permissions.md`, which shows only CLI flags.

Both upstream claims were re-verified against the primary sources before implementing.

## Test plan

- `pnpm cicheck` — 8897 tests pass; format, lint, typecheck, docs-content, gitignore, supported-tools, cspell and secretlint all clean.
- `pnpm dev gitignore` regenerated the project `.gitignore`; the new entry lands beside the other third-party by-products.
- `gitignore-entries.test.ts` requires a justification key for every non-`common` hand-maintained entry; `musecode::general::**/.muse/worktrees/` is registered with the reason.

Closes #2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)
