### PR TITLE
chore: release v16.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.15.0",
+  "version": "16.16.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.15.0";
+const getVersion = () => "16.16.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.16.0.

Bumps `getVersion()` in `src/cli/program.ts` and the `package.json` version to 16.16.0.

See the draft GitHub release for the full change list.
