### PR TITLE
chore: update Homebrew formula to v16.16.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.15.0"
+  version "16.16.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "2aaf8fd5dda5cbf132607a8fad22c1aaa731bc775f927b37da92b413e32e0f93"
+      sha256 "7e470a4f5c59fff8e610b93416133aa56f9a35823718c5d5f215a17fe050152e"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "c28d0052076d8f2361ac5bd80bd62fbd15aeea34a7e86a0dd51660a4722eb433"
+      sha256 "710f936e764deef1d995b7c8d7471552ec06cb2ed93bea5809a1b53fed86eb71"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "ce9fb297734b9c7c48e736de89628db785f6a4e661b48bfa8750eaec0a425274"
+      sha256 "2c2bac2d2defa5ccfb06b511bfd042a801513b0f7aff56693a028c40266dd2e0"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "b92a7880abbab4478df9a7367c9857ca53495beed45644dac541912019f49b37"
+      sha256 "cc22cc2e55b70e964312aa071ce7ce2e31bd8f32905b5b40e10d30ac90a300a6"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.16.0 release.
