### PR TITLE
chore: release v16.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.16.0",
+  "version": "16.17.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.16.0";
+const getVersion = () => "16.17.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## What's Changed

### New Features

* **skills: carry hidden companion files and recover malformed skill frontmatter** by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2745
  * Hidden (dot-prefixed) companion files inside a skill directory — `.env.example`, `.config/`, and the like — are now discovered and carried through both `import` and `generate`. The Agent Skills specification allows a skill directory to contain any files beyond the required `SKILL.md`, but glob discovery previously left them invisible. `.git` (as a directory prefix and as a bare submodule/worktree pointer file) and `.DS_Store` are still never carried, and skipping a nested repository is warned about.
  * Malformed YAML frontmatter is retried once instead of being dropped. A value such as `description: Use this skill when: the user asks about PDFs` — the case the Agent Skills client-implementation guide names — is now quoted and re-parsed, so the skill imports rather than being silently skipped. The repair is deliberately narrow: one pass, top-level entries only, values already starting as another YAML construct left alone, and `homepage: https://example.com` untouched. If the repair does not help, the original parse error is what surfaces.
  * A skill with an empty `description` is now imported with a warning rather than dropped, matching what the generate side already did with the same violation.
  * Fixed a gray-matter cache-poisoning bug: a throwing parse left a poisoned cache entry that made the next identical parse silently return empty frontmatter.

### CI

* **Add a scheduled Dependabot auto-merge workflow driven by OpenCode** by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2702
  * Runs the `babysit-dependabot-pr` procedure daily against every open Dependabot pull request. Triggered by `schedule` plus a maintainer-gated `workflow_dispatch`, so the prompt stays fully static and no untrusted event data is interpolated into it.

## Contributors

* @dyoshikawa

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v16.16.0...v16.17.0
