### PR TITLE
fix(skills): enumerate skill directories with readdir instead of a glob

### DIFF
--- a/src/features/commands/grokcli-command.test.ts
+++ b/src/features/commands/grokcli-command.test.ts
@@ -332,6 +332,26 @@ describe("GrokcliCommand", () => {
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("review"));
     });
 
+    it("should not read a backslash in a skill directory name as a separator", async () => {
+      // Globbed, `back\\review` came back as `back/review`, so the trailing
+      // segment matched the `review` command and a collision that does not
+      // exist was reported.
+      await ensureDir(join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "back\\review"));
+      await writeFileContent(
+        join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "back\\review", "SKILL.md"),
+        ["---", "name: review", "description: d", "---", "", "body"].join("\n"),
+      );
+      const logger = { warn: vi.fn() };
+
+      await GrokcliCommand.validateRulesyncCommands({
+        inputRoots: [join(testDir, RULESYNC_RELATIVE_DIR_PATH)],
+        rulesyncCommands: [commandNamed("review")],
+        logger: logger as unknown as Logger,
+      });
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it("should stay quiet when no skill matches a command name", async () => {
       await ensureDir(join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "deploy"));
       await writeFileContent(

--- a/src/features/commands/grokcli-command.ts
+++ b/src/features/commands/grokcli-command.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
 
 import { z } from "zod/mini";
 
@@ -6,9 +6,10 @@ import { GROKCLI_COMMANDS_DIR_PATH } from "../../constants/grokcli-paths.js";
 import { SKILLS_FEATURE_SUBDIR } from "../../constants/rulesync-paths.js";
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import { formatError } from "../../utils/error.js";
-import { findFilesByGlobs, readFileContent } from "../../utils/file.js";
+import { readFileContent } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import type { Logger } from "../../utils/logger.js";
+import { listSkillDirNames } from "../skills/skills-utils.js";
 import { RulesyncCommand, RulesyncCommandFrontmatter } from "./rulesync-command.js";
 import {
   ToolCommand,
@@ -197,15 +198,13 @@ export class GrokcliCommand extends ToolCommand {
 
     // Skills from any input root can shadow the command, so scan them all;
     // duplicates by directory name are naturally deduped via the Set below.
-    const perRootSkillFiles = await Promise.all(
-      inputRoots.map((root) =>
-        findFilesByGlobs(join(root, SKILLS_FEATURE_SUBDIR, "**", "SKILL.md")),
-      ),
+    // Read rather than globbed, so a skill directory whose name holds a
+    // backslash is compared under the name it has on disk instead of the
+    // trailing segment a glob rewrites it into.
+    const perRootSkillNames = await Promise.all(
+      inputRoots.map((root) => listSkillDirNames(join(root, SKILLS_FEATURE_SUBDIR))),
     );
-    const skillFiles = perRootSkillFiles.flat();
-    const shadowed = skillFiles
-      .map((filePath) => basename(dirname(filePath)))
-      .filter((skillName) => commandNames.has(skillName));
+    const shadowed = perRootSkillNames.flat().filter((skillName) => commandNames.has(skillName));
 
     if (shadowed.length > 0) {
       logger.warn(

--- a/src/features/commands/hermesagent-command.test.ts
+++ b/src/features/commands/hermesagent-command.test.ts
@@ -182,6 +182,57 @@ describe("HermesagentCommand", () => {
     ).resolves.toBeDefined();
   });
 
+  it("ignores a skill directory whose name it cannot address", async () => {
+    // Globbed, `back\\slash` came back as two segments and `RulesyncSkill.fromDir`
+    // threw over `.../skills/back/slash` — a directory that does not exist —
+    // failing the whole run. The skills processor only reports such a name, so
+    // the collision check must not be the thing that stops generation.
+    const skillDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "back\\slash");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      '---\nname: review\ndescription: Review changes\ntargets: ["hermesagent"]\n---\n',
+      "utf8",
+    );
+    const processor = new CommandsProcessor({
+      inputRoots: [join(testDir, RULESYNC_RELATIVE_DIR_PATH)],
+      toolTarget: "hermesagent",
+      global: true,
+      logger: createMockLogger(),
+    });
+
+    await expect(
+      processor.convertRulesyncFilesToToolFiles([rulesyncCommand()]),
+    ).resolves.toBeDefined();
+  });
+
+  it("ignores a SKILL.md nested below a skill directory", async () => {
+    // The `**` glob this used to walk built the name `review/examples`, which no
+    // `AiDir` accepts, so a skill shipping an example of its own broke the run.
+    const nestedDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "review", "examples");
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, "SKILL.md"),
+      '---\nname: examples\ndescription: An example\ntargets: ["hermesagent"]\n---\n',
+      "utf8",
+    );
+    await writeFile(
+      join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH, "review", "SKILL.md"),
+      '---\nname: review\ndescription: Review changes\ntargets: ["claudecode"]\n---\n',
+      "utf8",
+    );
+    const processor = new CommandsProcessor({
+      inputRoots: [join(testDir, RULESYNC_RELATIVE_DIR_PATH)],
+      toolTarget: "hermesagent",
+      global: true,
+      logger: createMockLogger(),
+    });
+
+    await expect(
+      processor.convertRulesyncFilesToToolFiles([rulesyncCommand()]),
+    ).resolves.toBeDefined();
+  });
+
   it("lets a later root's case-variant skill directory shadow an earlier root's skill", async () => {
     // The skills processor treats `Review` and `review` as one directory, so
     // the collision check must resolve the same single winner instead of

--- a/src/features/commands/hermesagent-command.ts
+++ b/src/features/commands/hermesagent-command.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { basename, dirname, join, relative } from "node:path";
+import { basename, join } from "node:path";
 
 import { z } from "zod/mini";
 
@@ -20,7 +20,7 @@ import type { SharedWritePath } from "../../lib/shared-file-derive.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { caseFoldIdentity } from "../../types/feature-processor.js";
 import { ToolFile } from "../../types/tool-file.js";
-import { findFilesByGlobs, readFileContentOrNull, toPosixPath } from "../../utils/file.js";
+import { readFileContentOrNull, toPosixPath } from "../../utils/file.js";
 import {
   getHermesagentConfigSharedFileKey,
   getHermesagentRelativeDirPath,
@@ -31,6 +31,7 @@ import {
 import { applySharedConfigPatch, parseSharedConfig } from "../shared/shared-config-gateway.js";
 import { HermesagentSkill } from "../skills/hermesagent-skill.js";
 import { RulesyncSkill } from "../skills/rulesync-skill.js";
+import { listSkillDirNames } from "../skills/skills-utils.js";
 import { RulesyncCommand } from "./rulesync-command.js";
 import {
   ToolCommand,
@@ -289,12 +290,15 @@ export class HermesagentCommand extends ToolCommand {
     >();
     for (const rootPath of inputRoots) {
       const skillsRoot = join(rootPath, SKILLS_FEATURE_SUBDIR);
-      const skillFiles = await findFilesByGlobs(join(skillsRoot, "**", "SKILL.md"));
+      // Read rather than globbed: a glob for a nested `SKILL.md` builds a
+      // two-segment directory name that no `AiDir` accepts, and it spells a
+      // name holding a backslash as two segments as well, so a repository
+      // holding either used to fail the whole run here.
+      const dirNames = await listSkillDirNames(skillsRoot);
       // Roots stay sequential so a later root still shadows an earlier one, but
       // the skills inside one root are independent and load concurrently.
       const loaded = await Promise.all(
-        skillFiles.map(async (filePath) => {
-          const dirName = toPosixPath(relative(skillsRoot, dirname(filePath)));
+        dirNames.map(async (dirName) => {
           const rulesyncSkill = await RulesyncSkill.fromDir({
             outputRoot: rootPath,
             relativeDirPath: SKILLS_FEATURE_SUBDIR,

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -1460,6 +1460,32 @@ Test skill content`;
       expect(dirsToDelete[0]?.getDirName()).toBe("test-skill");
     });
 
+    it("should report a skill directory whose name contains a backslash", async () => {
+      // A `*` glob rewrites the backslash into a separator, so the candidate it
+      // used to yield was `<root>/slash` — a directory that does not exist. The
+      // real one cannot be swept either, since a directory name may not hold a
+      // separator, so the run says so instead of quietly building a candidate
+      // for nothing. The skill beside it is still swept.
+      const logger = createMockLogger();
+      const processor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const skillsDir = join(testDir, ".claude", "skills");
+      const frontmatter = "---\nname: a-skill\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "back\\slash", "SKILL.md"), frontmatter);
+      await writeFileContent(join(skillsDir, "plain", "SKILL.md"), frontmatter);
+
+      const dirsToDelete = await processor.loadToolDirsToDelete();
+
+      expect(dirsToDelete.map((dir) => dir.getDirName())).toEqual(["plain"]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("a skill directory name cannot contain a path separator"),
+      );
+    });
+
     it("should succeed even when SKILL.md has broken frontmatter", async () => {
       const processor = new SkillsProcessor({
         logger: createMockLogger(),

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -323,6 +323,32 @@ describe("SkillsProcessor", () => {
       );
     });
 
+    it("should report a skill it cannot load without letting the name rewrite the line", async () => {
+      // The name comes off disk, so it can carry the escape sequence that
+      // erases the line it is printed on and passes the rest off as output of
+      // rulesync's own. Quoting the stripped path is what the rest of the
+      // codebase does with such a name.
+      const logger = createMockLogger();
+      const loggingProcessor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "amp",
+      });
+      // An interop root is read leniently, so a directory without a SKILL.md is
+      // reported instead of failing the import.
+      await ensureDir(join(testDir, ".agents", "skills", "ok\u001b[2K\r-fake-line"));
+
+      await loggingProcessor.loadToolDirs();
+
+      const reported = logger.warn.mock.calls
+        .map((call) => String(call[0]))
+        .filter((message) => message.startsWith("Skipping "));
+      expect(reported).toHaveLength(1);
+      expect(reported[0]).toContain('"' + join(".agents", "skills", "ok[2K-fake-line") + '"');
+      expect(reported[0]).not.toContain("\u001b");
+      expect(reported[0]).not.toContain("\r");
+    });
+
     it("should throw error for unsupported tool target", async () => {
       // Create processor with mock tool target (bypassing constructor validation)
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -298,6 +298,31 @@ describe("SkillsProcessor", () => {
       expect(toolDirs).toEqual([]);
     });
 
+    it("should skip a directory it cannot name, or a hidden one, when importing", async () => {
+      // Same two directories the sweep leaves alone, on the read side: the
+      // backslash name is reported, and the hidden directory — which has no
+      // SKILL.md and would otherwise fail the import of this native root — is
+      // passed over silently, as the glob used to do.
+      const logger = createMockLogger();
+      const loggingProcessor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
+      const skillsDir = join(testDir, ".claude", "skills");
+      const frontmatter = "---\nname: plain\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "back\\slash", "SKILL.md"), frontmatter);
+      await writeFileContent(join(skillsDir, "plain", "SKILL.md"), frontmatter);
+      await ensureDir(join(skillsDir, ".git"));
+
+      const toolDirs = await loggingProcessor.loadToolDirs();
+
+      expect(toolDirs.map((dir) => dir.getDirName())).toEqual(["plain"]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("a skill directory name cannot contain a path separator"),
+      );
+    });
+
     it("should throw error for unsupported tool target", async () => {
       // Create processor with mock tool target (bypassing constructor validation)
       const processorWithMockTarget = Object.create(SkillsProcessor.prototype);
@@ -641,6 +666,44 @@ Linked skill content`,
         expect(rulesyncSkill.getFrontmatter().description).toBe("Skill shared via a symbolic link");
       },
     );
+
+    it("should skip a rulesync skill directory whose name contains a backslash", async () => {
+      // The glob this enumeration replaced rewrote the backslash into a
+      // separator, so it reported a directory that does not exist and missed
+      // the real one. A name holding a separator cannot be carried through
+      // `AiDir`, so the run reports it and generates the skill beside it.
+      const warningLogger = createMockLogger();
+      const loggingProcessor = new SkillsProcessor({
+        logger: warningLogger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
+      const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      const frontmatter = "---\nname: plain\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "back\\slash", "SKILL.md"), frontmatter);
+      await writeFileContent(join(skillsDir, "plain", "SKILL.md"), frontmatter);
+
+      const rulesyncDirs = await loggingProcessor.loadRulesyncDirs();
+
+      expect(rulesyncDirs.map((dir) => dir.getDirName())).toEqual(["plain"]);
+      expect(warningLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("a skill directory name cannot contain a path separator"),
+      );
+    });
+
+    it("should ignore a hidden directory beside the rulesync skills", async () => {
+      // `.ipynb_checkpoints`, `.venv` and their kind are not skills, and the
+      // loader throws on a directory without a SKILL.md — reading them would
+      // stop `generate` over somebody else's by-product.
+      const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      const frontmatter = "---\nname: plain\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "plain", "SKILL.md"), frontmatter);
+      await ensureDir(join(skillsDir, ".ipynb_checkpoints"));
+
+      const rulesyncDirs = await processor.loadRulesyncDirs();
+
+      expect(rulesyncDirs.map((dir) => dir.getDirName())).toEqual(["plain"]);
+    });
 
     it("should throw error when directory without SKILL.md file is found", async () => {
       const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
@@ -1484,6 +1547,27 @@ Test skill content`;
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("a skill directory name cannot contain a path separator"),
       );
+    });
+
+    it("should not sweep a hidden directory beside the skills", async () => {
+      // A user who keeps `.claude/skills/` under its own version control has a
+      // `.git` there. The glob this replaced never returned a hidden entry, and
+      // `generate --delete` removes every candidate it is handed, so including
+      // one here would delete a tree rulesync never wrote.
+      const processor = new SkillsProcessor({
+        logger: createMockLogger(),
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      });
+
+      const skillsDir = join(testDir, ".claude", "skills");
+      const frontmatter = "---\nname: plain\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "plain", "SKILL.md"), frontmatter);
+      await ensureDir(join(skillsDir, ".git"));
+
+      const dirsToDelete = await processor.loadToolDirsToDelete();
+
+      expect(dirsToDelete.map((dir) => dir.getDirName())).toEqual(["plain"]);
     });
 
     it("should succeed even when SKILL.md has broken frontmatter", async () => {

--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -1243,6 +1243,56 @@ Broken YAML`,
       );
     });
 
+    it("should skip a flat-file skill whose name contains a backslash", async () => {
+      // The name a flat skill carries is its file name minus the extension, and
+      // it reaches `AiDir` like a directory name does. Reporting it keeps one
+      // file from failing the import of the whole root.
+      const logger = createMockLogger();
+      const processor = new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "kimi-code",
+      });
+      const interopDir = join(testDir, ".agents", "skills");
+      const flatSkill = "---\nname: flat\ndescription: A conformant flat skill\n---\nBody";
+      await writeFileContent(join(interopDir, "good-flat.md"), flatSkill);
+      await writeFileContent(join(interopDir, "back\\slash.md"), flatSkill);
+
+      const toolDirs = await processor.loadToolDirs();
+
+      expect(toolDirs).toHaveLength(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("a skill name cannot contain a path separator"),
+      );
+    });
+
+    it("should report a skill directory it cannot name once per run", async () => {
+      // A processor is built per enabled tool target, and each one enumerates
+      // the same directory. A message naming that directory would otherwise be
+      // printed once per target.
+      const logger = createMockLogger();
+      const skillsDir = join(testDir, ".claude", "skills");
+      const frontmatter = "---\nname: plain\ndescription: Test skill\n---\nContent";
+      await writeFileContent(join(skillsDir, "back\\slash", "SKILL.md"), frontmatter);
+
+      await new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      }).loadToolDirs();
+      await new SkillsProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "claudecode",
+      }).loadToolDirs();
+
+      expect(
+        logger.warn.mock.calls.filter(([message]) =>
+          String(message).includes("a skill directory name cannot contain a path separator"),
+        ),
+      ).toHaveLength(1);
+    });
+
     it("should import skills from nested .claude/skills directories (v2.1.178)", async () => {
       const logger = createMockLogger();
       const processor = new SkillsProcessor({

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -18,6 +18,7 @@ import {
 } from "../../types/feature-processor.js";
 import { skillsProcessorToolTargetTuple } from "../../types/tool-target-tuples.js";
 import { ToolTarget } from "../../types/tool-targets.js";
+import { stripControlCharacters } from "../../utils/control-characters.js";
 import { formatError } from "../../utils/error.js";
 import {
   assertWritablePathInsideRoot,
@@ -27,6 +28,7 @@ import {
   listSubdirectoryNames,
 } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import { warnOnceWithFallback } from "../../utils/logger.js";
 import { AgentsmdSkill } from "./agentsmd-skill.js";
 import { AgentsSkillsSkill } from "./agentsskills-skill.js";
 import { AiassistantSkill } from "./aiassistant-skill.js";
@@ -947,10 +949,15 @@ export class SkillsProcessor extends DirFeatureProcessor {
       if (isAddressableDirName(dirName)) {
         return true;
       }
-      this.logger.warn(
-        `Skipping ${join(relativeDirPath, dirName)}: a skill directory name cannot contain a path ` +
-          `separator, so this directory is neither generated from nor swept as an orphan. Rename ` +
-          `or remove it by hand.`,
+      // Once per run, not once per tool target: the message names a directory
+      // on disk, and every enabled target enumerates that same directory.
+      // Quoted and stripped like every other message naming a path that came
+      // off disk — the name is chosen by whoever wrote the repository.
+      warnOnceWithFallback(
+        this.logger,
+        `Skipping ${JSON.stringify(stripControlCharacters(join(relativeDirPath, dirName)))}: a ` +
+          `skill directory name cannot contain a path separator, so this directory is neither ` +
+          `generated from nor swept as an orphan. Rename or remove it by hand.`,
       );
       return false;
     });

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -561,7 +561,7 @@ export const skillsProcessorToolTargetsGlobal: ToolTarget[] = allToolTargetKeys.
  * reported rather than passed on, since the alternative is a candidate built
  * from a name that belongs to no directory at all.
  */
-function isAddressableDirName(dirName: string): boolean {
+function isAddressableName(dirName: string): boolean {
   return !dirName.includes("/") && !dirName.includes("\\");
 }
 
@@ -666,10 +666,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const treeName = basename(sourceTree);
     const treeSkillsDirPath = join(treeName, SKILLS_FEATURE_SUBDIR);
     const treeCuratedSkillsDirPath = join(treeName, CURATED_SKILLS_FEATURE_SUBDIR);
-    const localDirNames = this.keepAddressableDirNames(
-      [...(await getLocalSkillDirNames(sourceTree))],
-      treeSkillsDirPath,
-    );
+    const localDirNames = this.keepAddressableNames({
+      names: [...(await getLocalSkillDirNames(sourceTree))],
+      dirPath: join(treeParent, treeSkillsDirPath),
+      kind: "directory",
+    });
 
     const localSkills = await Promise.all(
       localDirNames.map((dirName) =>
@@ -693,10 +694,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
     // curated tree that cannot be resolved must not read as "no curated
     // skills".
     if (await directoryExistsStrict(curatedDirPath)) {
-      const curatedDirNames = this.keepAddressableDirNames(
-        await listSubdirectoryNames(curatedDirPath),
-        treeCuratedSkillsDirPath,
-      );
+      const curatedDirNames = this.keepAddressableNames({
+        names: await listSubdirectoryNames(curatedDirPath),
+        dirPath: curatedDirPath,
+        kind: "directory",
+      });
 
       const nonConflicting = curatedDirNames.filter((name) => {
         const spellings = localSkillNamesByIdentity.get(caseFoldIdentity(name));
@@ -839,10 +841,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
         continue;
       }
       const ownedDirNames: string[] = [];
-      const candidateDirNames = this.keepAddressableDirNames(
-        await listSubdirectoryNames(skillsDirPath),
-        relativeDirPath,
-      );
+      const candidateDirNames = this.keepAddressableNames({
+        names: await listSubdirectoryNames(skillsDirPath),
+        dirPath: skillsDirPath,
+        kind: "directory",
+      });
       for (const dirName of candidateDirNames) {
         // Directories owned by another feature (see the `isDirOwned` factory
         // hook) are skipped so e.g. a Reasonix subagent profile is not
@@ -899,12 +902,13 @@ export class SkillsProcessor extends DirFeatureProcessor {
       }
       const fromFlatFile = factory.class.fromFlatFile;
       const directoryStems = new Set(ownedDirNames);
-      const flatFileNames = this.keepAddressableFileNames(
-        (await listFileNames(skillsDirPath)).filter(
+      const flatFileNames = this.keepAddressableNames({
+        names: (await listFileNames(skillsDirPath)).filter(
           (fileName) => fileName.endsWith(".md") && !directoryStems.has(basename(fileName, ".md")),
         ),
-        relativeDirPath,
-      );
+        dirPath: skillsDirPath,
+        kind: "file",
+      });
       const flatSkills = (
         await Promise.all(
           flatFileNames.map(async (fileName) => {
@@ -944,46 +948,40 @@ export class SkillsProcessor extends DirFeatureProcessor {
   }
 
   /**
-   * Drop the directory names nothing here can address, reporting each one. See
-   * {@link isAddressableDirName} for why such a directory can exist at all.
+   * Drop the names nothing here can address, reporting each one. A flat-file
+   * skill is named by its file name minus the extension, and that name reaches
+   * `AiDir` exactly as a directory name does. See {@link isAddressableName} for
+   * why such an entry can exist at all.
+   *
+   * The path reported is the one on disk rather than the name alone: the same
+   * relative root exists in both the project and the home directory, and a run
+   * that reads both would otherwise report only whichever it reached first.
    */
-  private keepAddressableDirNames(dirNames: string[], relativeDirPath: string): string[] {
-    return dirNames.filter((dirName) => {
-      if (isAddressableDirName(dirName)) {
+  private keepAddressableNames(params: {
+    names: string[];
+    dirPath: string;
+    kind: "directory" | "file";
+  }): string[] {
+    const { names, dirPath, kind } = params;
+    return names.filter((name) => {
+      if (isAddressableName(kind === "file" ? basename(name, ".md") : name)) {
         return true;
       }
-      // Once per run, not once per tool target: the message names a directory
-      // on disk, and every enabled target enumerates that same directory.
-      // Quoted and stripped like every other message naming a path that came
-      // off disk — the name is chosen by whoever wrote the repository. The
-      // quoting doubles the backslash the message is about, which is what
-      // reading a quoted string means.
+      const consequence =
+        kind === "file"
+          ? `skill name cannot contain a path separator, so this file is not imported. Rename it ` +
+            `by hand.`
+          : `skill directory name cannot contain a path separator, so this directory is neither ` +
+            `generated from nor swept as an orphan. Rename or remove it by hand.`;
+      // Once per run, not once per tool target: the message names an entry on
+      // disk, and every enabled target enumerates that same directory. Quoted
+      // and stripped like every other message naming a path that came off disk
+      // — the name is chosen by whoever wrote the repository. The quoting
+      // doubles the backslash the message is about, which is what reading a
+      // quoted string means.
       warnOnceWithFallback(
         this.logger,
-        `Skipping ${JSON.stringify(stripControlCharacters(join(relativeDirPath, dirName)))}: a ` +
-          `skill directory name cannot contain a path separator, so this directory is neither ` +
-          `generated from nor swept as an orphan. Rename or remove it by hand.`,
-      );
-      return false;
-    });
-  }
-
-  /**
-   * The flat-file counterpart of {@link keepAddressableDirNames}. A flat skill
-   * is named by its file name minus the extension, and that name reaches
-   * `AiDir` too — on POSIX, `back\\slash.md` would hand it a name it refuses,
-   * failing the import of a whole root over one file.
-   */
-  private keepAddressableFileNames(fileNames: string[], relativeDirPath: string): string[] {
-    return fileNames.filter((fileName) => {
-      if (isAddressableDirName(basename(fileName, ".md"))) {
-        return true;
-      }
-      warnOnceWithFallback(
-        this.logger,
-        `Skipping ${JSON.stringify(stripControlCharacters(join(relativeDirPath, fileName)))}: a ` +
-          `skill name cannot contain a path separator, so this file is not imported. Rename it ` +
-          `by hand.`,
+        `Skipping ${JSON.stringify(stripControlCharacters(join(dirPath, name)))}: a ${consequence}`,
       );
       return false;
     });
@@ -1004,10 +1002,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
         rootPath: this.outputRoot,
         targetPath: skillsDirPath,
       });
-      const dirNames = this.keepAddressableDirNames(
-        await listSubdirectoryNames(skillsDirPath, { followSymbolicLinks: false }),
-        root,
-      );
+      const dirNames = this.keepAddressableNames({
+        names: await listSubdirectoryNames(skillsDirPath, { followSymbolicLinks: false }),
+        dirPath: skillsDirPath,
+        kind: "directory",
+      });
       for (const dirName of dirNames) {
         await assertWritablePathInsideRoot({
           rootPath: skillsDirPath,

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -23,7 +23,8 @@ import {
   assertWritablePathInsideRoot,
   directoryExists,
   directoryExistsStrict,
-  findFilesByGlobs,
+  listFileNames,
+  listSubdirectoryNames,
 } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { AgentsmdSkill } from "./agentsmd-skill.js";
@@ -547,6 +548,21 @@ export const skillsProcessorToolTargetsGlobal: ToolTarget[] = allToolTargetKeys.
   return factory?.meta.supportsGlobal ?? false;
 });
 
+/**
+ * Whether a directory on disk can be addressed by its name.
+ *
+ * `AiDir` refuses a name holding a path separator, and rightly so: most tools
+ * take that name from a skill's frontmatter, and a repository written on one
+ * platform is read on the other, where a backslash is a separator. POSIX still
+ * lets a directory be *created* with a backslash in its name, so such a
+ * directory can sit in a skills root that nothing here can name — it is
+ * reported rather than passed on, since the alternative is a candidate built
+ * from a name that belongs to no directory at all.
+ */
+function isAddressableDirName(dirName: string): boolean {
+  return !dirName.includes("/") && !dirName.includes("\\");
+}
+
 export class SkillsProcessor extends DirFeatureProcessor {
   private readonly toolTarget: SkillsProcessorToolTarget;
   private readonly global: boolean;
@@ -648,7 +664,10 @@ export class SkillsProcessor extends DirFeatureProcessor {
     const treeName = basename(sourceTree);
     const treeSkillsDirPath = join(treeName, SKILLS_FEATURE_SUBDIR);
     const treeCuratedSkillsDirPath = join(treeName, CURATED_SKILLS_FEATURE_SUBDIR);
-    const localDirNames = [...(await getLocalSkillDirNames(sourceTree))];
+    const localDirNames = this.keepAddressableDirNames(
+      [...(await getLocalSkillDirNames(sourceTree))],
+      treeSkillsDirPath,
+    );
 
     const localSkills = await Promise.all(
       localDirNames.map((dirName) =>
@@ -672,8 +691,10 @@ export class SkillsProcessor extends DirFeatureProcessor {
     // curated tree that cannot be resolved must not read as "no curated
     // skills".
     if (await directoryExistsStrict(curatedDirPath)) {
-      const curatedDirPaths = await findFilesByGlobs(join(curatedDirPath, "*"), { type: "dir" });
-      const curatedDirNames = curatedDirPaths.map((path) => basename(path));
+      const curatedDirNames = this.keepAddressableDirNames(
+        await listSubdirectoryNames(curatedDirPath),
+        treeCuratedSkillsDirPath,
+      );
 
       const nonConflicting = curatedDirNames.filter((name) => {
         const spellings = localSkillNamesByIdentity.get(caseFoldIdentity(name));
@@ -815,10 +836,12 @@ export class SkillsProcessor extends DirFeatureProcessor {
       if (!(await directoryExists(skillsDirPath))) {
         continue;
       }
-      const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), { type: "dir" });
       const ownedDirNames: string[] = [];
-      for (const dirPath of dirPaths) {
-        const dirName = basename(dirPath);
+      const candidateDirNames = this.keepAddressableDirNames(
+        await listSubdirectoryNames(skillsDirPath),
+        relativeDirPath,
+      );
+      for (const dirName of candidateDirNames) {
         // Directories owned by another feature (see the `isDirOwned` factory
         // hook) are skipped so e.g. a Reasonix subagent profile is not
         // imported as a regular skill.
@@ -874,21 +897,19 @@ export class SkillsProcessor extends DirFeatureProcessor {
       }
       const fromFlatFile = factory.class.fromFlatFile;
       const directoryStems = new Set(ownedDirNames);
-      const flatFilePaths = (
-        await findFilesByGlobs(join(skillsDirPath, "*.md"), {
-          type: "file",
-        })
-      ).filter((filePath) => !directoryStems.has(basename(filePath, ".md")));
+      const flatFileNames = (await listFileNames(skillsDirPath)).filter(
+        (fileName) => fileName.endsWith(".md") && !directoryStems.has(basename(fileName, ".md")),
+      );
       const flatSkills = (
         await Promise.all(
-          flatFilePaths.map(async (filePath) => {
-            const sourcePath = join(relativeDirPath, basename(filePath));
+          flatFileNames.map(async (fileName) => {
+            const sourcePath = join(relativeDirPath, fileName);
             try {
               return {
                 skill: await fromFlatFile({
                   outputRoot: rootOutputRoot,
                   relativeDirPath,
-                  relativeFilePath: basename(filePath),
+                  relativeFilePath: fileName,
                   global: this.global,
                 }),
                 sourcePath,
@@ -917,6 +938,24 @@ export class SkillsProcessor extends DirFeatureProcessor {
     return toolSkills;
   }
 
+  /**
+   * Drop the directory names nothing here can address, reporting each one. See
+   * {@link isAddressableDirName} for why such a directory can exist at all.
+   */
+  private keepAddressableDirNames(dirNames: string[], relativeDirPath: string): string[] {
+    return dirNames.filter((dirName) => {
+      if (isAddressableDirName(dirName)) {
+        return true;
+      }
+      this.logger.warn(
+        `Skipping ${join(relativeDirPath, dirName)}: a skill directory name cannot contain a path ` +
+          `separator, so this directory is neither generated from nor swept as an orphan. Rename ` +
+          `or remove it by hand.`,
+      );
+      return false;
+    });
+  }
+
   async loadToolDirsToDelete(): Promise<AiDir[]> {
     const factory = this.getFactory(this.toolTarget);
     const paths = factory.class.getSettablePaths({ global: this.global });
@@ -932,16 +971,15 @@ export class SkillsProcessor extends DirFeatureProcessor {
         rootPath: this.outputRoot,
         targetPath: skillsDirPath,
       });
-      const dirPaths = await findFilesByGlobs(join(skillsDirPath, "*"), {
-        type: "dir",
-        followSymbolicLinks: false,
-      });
-      for (const dirPath of dirPaths) {
+      const dirNames = this.keepAddressableDirNames(
+        await listSubdirectoryNames(skillsDirPath, { followSymbolicLinks: false }),
+        root,
+      );
+      for (const dirName of dirNames) {
         await assertWritablePathInsideRoot({
           rootPath: skillsDirPath,
-          targetPath: dirPath,
+          targetPath: join(skillsDirPath, dirName),
         });
-        const dirName = basename(dirPath);
         // Directories owned by another feature (see the `isDirOwned` factory
         // hook) must never be deleted as orphan skills — e.g. a Reasonix
         // subagent profile generated into the shared `.reasonix/skills/`, or

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -899,8 +899,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
       }
       const fromFlatFile = factory.class.fromFlatFile;
       const directoryStems = new Set(ownedDirNames);
-      const flatFileNames = (await listFileNames(skillsDirPath)).filter(
-        (fileName) => fileName.endsWith(".md") && !directoryStems.has(basename(fileName, ".md")),
+      const flatFileNames = this.keepAddressableFileNames(
+        (await listFileNames(skillsDirPath)).filter(
+          (fileName) => fileName.endsWith(".md") && !directoryStems.has(basename(fileName, ".md")),
+        ),
+        relativeDirPath,
       );
       const flatSkills = (
         await Promise.all(
@@ -952,12 +955,35 @@ export class SkillsProcessor extends DirFeatureProcessor {
       // Once per run, not once per tool target: the message names a directory
       // on disk, and every enabled target enumerates that same directory.
       // Quoted and stripped like every other message naming a path that came
-      // off disk — the name is chosen by whoever wrote the repository.
+      // off disk — the name is chosen by whoever wrote the repository. The
+      // quoting doubles the backslash the message is about, which is what
+      // reading a quoted string means.
       warnOnceWithFallback(
         this.logger,
         `Skipping ${JSON.stringify(stripControlCharacters(join(relativeDirPath, dirName)))}: a ` +
           `skill directory name cannot contain a path separator, so this directory is neither ` +
           `generated from nor swept as an orphan. Rename or remove it by hand.`,
+      );
+      return false;
+    });
+  }
+
+  /**
+   * The flat-file counterpart of {@link keepAddressableDirNames}. A flat skill
+   * is named by its file name minus the extension, and that name reaches
+   * `AiDir` too — on POSIX, `back\\slash.md` would hand it a name it refuses,
+   * failing the import of a whole root over one file.
+   */
+  private keepAddressableFileNames(fileNames: string[], relativeDirPath: string): string[] {
+    return fileNames.filter((fileName) => {
+      if (isAddressableDirName(basename(fileName, ".md"))) {
+        return true;
+      }
+      warnOnceWithFallback(
+        this.logger,
+        `Skipping ${JSON.stringify(stripControlCharacters(join(relativeDirPath, fileName)))}: a ` +
+          `skill name cannot contain a path separator, so this file is not imported. Rename it ` +
+          `by hand.`,
       );
       return false;
     });

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -66,7 +66,7 @@ import { RooSkill } from "./roo-skill.js";
 import { RovodevSkill } from "./rovodev-skill.js";
 import { RulesyncSkill } from "./rulesync-skill.js";
 import { SimulatedSkill } from "./simulated-skill.js";
-import { getLocalSkillDirNames } from "./skills-utils.js";
+import { getLocalSkillDirNames, isAddressableSkillName } from "./skills-utils.js";
 import { TaktSkill } from "./takt-skill.js";
 import {
   ToolSkill,
@@ -550,21 +550,6 @@ export const skillsProcessorToolTargetsGlobal: ToolTarget[] = allToolTargetKeys.
   return factory?.meta.supportsGlobal ?? false;
 });
 
-/**
- * Whether a directory on disk can be addressed by its name.
- *
- * `AiDir` refuses a name holding a path separator, and rightly so: most tools
- * take that name from a skill's frontmatter, and a repository written on one
- * platform is read on the other, where a backslash is a separator. POSIX still
- * lets a directory be *created* with a backslash in its name, so such a
- * directory can sit in a skills root that nothing here can name — it is
- * reported rather than passed on, since the alternative is a candidate built
- * from a name that belongs to no directory at all.
- */
-function isAddressableName(dirName: string): boolean {
-  return !dirName.includes("/") && !dirName.includes("\\");
-}
-
 export class SkillsProcessor extends DirFeatureProcessor {
   private readonly toolTarget: SkillsProcessorToolTarget;
   private readonly global: boolean;
@@ -885,7 +870,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
               if (!isLenientRoot) {
                 throw error;
               }
-              this.logger.warn(`Skipping ${sourcePath}: ${formatError(error)}`);
+              this.logger.warn(
+                `Skipping ${JSON.stringify(stripControlCharacters(sourcePath))}: ` +
+                  // The error names the same path, so it is stripped too.
+                  stripControlCharacters(formatError(error)),
+              );
               return null;
             }
           }),
@@ -903,9 +892,12 @@ export class SkillsProcessor extends DirFeatureProcessor {
       const fromFlatFile = factory.class.fromFlatFile;
       const directoryStems = new Set(ownedDirNames);
       const flatFileNames = this.keepAddressableNames({
-        names: (await listFileNames(skillsDirPath)).filter(
-          (fileName) => fileName.endsWith(".md") && !directoryStems.has(basename(fileName, ".md")),
-        ),
+        // The suffix is applied while reading rather than after, so a `.md`
+        // name that stands for a file of another name is not collapsed onto
+        // that file and dropped by the filter.
+        names: (
+          await listFileNames(skillsDirPath, { nameFilter: (name) => name.endsWith(".md") })
+        ).filter((fileName) => !directoryStems.has(basename(fileName, ".md"))),
         dirPath: skillsDirPath,
         kind: "file",
       });
@@ -928,7 +920,11 @@ export class SkillsProcessor extends DirFeatureProcessor {
               if (!isLenientRoot) {
                 throw error;
               }
-              this.logger.warn(`Skipping ${sourcePath}: ${formatError(error)}`);
+              this.logger.warn(
+                `Skipping ${JSON.stringify(stripControlCharacters(sourcePath))}: ` +
+                  // The error names the same path, so it is stripped too.
+                  stripControlCharacters(formatError(error)),
+              );
               return null;
             }
           }),
@@ -964,7 +960,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
   }): string[] {
     const { names, dirPath, kind } = params;
     return names.filter((name) => {
-      if (isAddressableName(kind === "file" ? basename(name, ".md") : name)) {
+      if (isAddressableSkillName(kind === "file" ? basename(name, ".md") : name)) {
         return true;
       }
       const consequence =

--- a/src/features/skills/skills-utils.ts
+++ b/src/features/skills/skills-utils.ts
@@ -1,10 +1,58 @@
 import { basename, join } from "node:path";
 
+import { SKILL_FILE_NAME } from "../../constants/general.js";
 import {
   CURATED_SKILLS_FEATURE_SUBDIR,
   SKILLS_FEATURE_SUBDIR,
 } from "../../constants/rulesync-paths.js";
-import { directoryExistsStrict, listSubdirectoryNames } from "../../utils/file.js";
+import {
+  directoryExists,
+  directoryExistsStrict,
+  fileExists,
+  listSubdirectoryNames,
+} from "../../utils/file.js";
+
+/**
+ * Whether a directory on disk can be addressed by its name.
+ *
+ * `AiDir` refuses a name holding a path separator, and rightly so: most tools
+ * take that name from a skill's frontmatter, and a repository written on one
+ * platform is read on the other, where a backslash is a separator. POSIX still
+ * lets a directory be *created* with a backslash in its name, so such a
+ * directory can sit in a skills root that nothing here can name — it is
+ * reported rather than passed on, since the alternative is a candidate built
+ * from a name that belongs to no directory at all.
+ */
+export function isAddressableSkillName(name: string): boolean {
+  return !name.includes("/") && !name.includes("\\");
+}
+
+/**
+ * The names of the skill directories directly under `skillsRoot`.
+ *
+ * A `**` glob for `SKILL.md` cannot stand in for this on two counts. It reads a
+ * backslash as a path separator, so a directory literally named `back\\slash`
+ * yields the two-segment name `back/slash`, which no `AiDir` accepts — and a
+ * `SKILL.md` nested deeper inside a skill yields a two-segment name for the
+ * same reason. Both turn a validation pass into a hard failure over a skill the
+ * skills processor itself only reports and skips.
+ *
+ * A root that does not exist is an empty root, matching what the glob returned.
+ */
+export async function listSkillDirNames(skillsRoot: string): Promise<string[]> {
+  if (!(await directoryExists(skillsRoot))) {
+    return [];
+  }
+  const names = await listSubdirectoryNames(skillsRoot);
+  const found = await Promise.all(
+    names.map(async (name) =>
+      isAddressableSkillName(name) && (await fileExists(join(skillsRoot, name, SKILL_FILE_NAME)))
+        ? name
+        : undefined,
+    ),
+  );
+  return found.filter((name) => name !== undefined);
+}
 
 /**
  * Returns the set of local skill directory names (excluding `.curated`)

--- a/src/features/skills/skills-utils.ts
+++ b/src/features/skills/skills-utils.ts
@@ -4,7 +4,7 @@ import {
   CURATED_SKILLS_FEATURE_SUBDIR,
   SKILLS_FEATURE_SUBDIR,
 } from "../../constants/rulesync-paths.js";
-import { directoryExistsStrict, findFilesByGlobs } from "../../utils/file.js";
+import { directoryExistsStrict, listSubdirectoryNames } from "../../utils/file.js";
 
 /**
  * Returns the set of local skill directory names (excluding `.curated`)
@@ -22,9 +22,7 @@ export async function getLocalSkillDirNames(sourceTree: string): Promise<Set<str
     return names;
   }
 
-  const dirPaths = await findFilesByGlobs(join(skillsDir, "*"), { type: "dir" });
-  for (const dirPath of dirPaths) {
-    const name = basename(dirPath);
+  for (const name of await listSubdirectoryNames(skillsDir)) {
     // Skip the .curated directory itself
     if (name === basename(CURATED_SKILLS_FEATURE_SUBDIR)) continue;
     names.add(name);

--- a/src/lib/sources.test.ts
+++ b/src/lib/sources.test.ts
@@ -13,6 +13,7 @@ import {
   directoryExists,
   fileExists,
   findFilesByGlobs,
+  listSubdirectoryNames,
   readFileContent,
   removeDirectoryStrict as removeDirectory,
   removeFileStrict as removeFile,
@@ -66,6 +67,7 @@ vi.mock("../utils/file.js", async (importOriginal) => {
     directoryExistsStrict: directoryExistsMock,
     fileExists: vi.fn(),
     findFilesByGlobs: vi.fn(),
+    listSubdirectoryNames: vi.fn(),
     readFileContent: vi.fn(),
     removeDirectoryStrict: vi.fn(),
     removeFileStrict: vi.fn(),
@@ -153,6 +155,7 @@ describe("resolveAndFetchSources", () => {
     vi.mocked(directoryExists).mockResolvedValue(false);
     vi.mocked(fileExists).mockResolvedValue(false);
     vi.mocked(findFilesByGlobs).mockResolvedValue([]);
+    vi.mocked(listSubdirectoryNames).mockResolvedValue([]);
     vi.mocked(readFileContent).mockResolvedValue("");
     vi.mocked(removeDirectory).mockResolvedValue(undefined);
     vi.mocked(removeFile).mockResolvedValue(undefined);
@@ -1026,7 +1029,7 @@ describe("resolveAndFetchSources", () => {
       if (path.endsWith("skills")) return true;
       return false;
     });
-    vi.mocked(findFilesByGlobs).mockResolvedValue([join(testDir, ".rulesync/skills/my-skill")]);
+    vi.mocked(listSubdirectoryNames).mockResolvedValue(["my-skill"]);
 
     // Remote has same skill name
     mockClientInstance.listDirectory.mockImplementation(
@@ -1747,7 +1750,7 @@ describe("resolveAndFetchSources", () => {
       if (path.endsWith("skills")) return true;
       return false;
     });
-    vi.mocked(findFilesByGlobs).mockResolvedValue([join(testDir, ".rulesync/skills/local-skill")]);
+    vi.mocked(listSubdirectoryNames).mockResolvedValue(["local-skill"]);
 
     // remote-skill doesn't exist on disk, so SHA-match skip fails and re-fetch happens
     // Remote has only remote-skill
@@ -1933,7 +1936,7 @@ describe("resolveAndFetchSources", () => {
       if (path.endsWith("skills")) return true;
       return false;
     });
-    vi.mocked(findFilesByGlobs).mockResolvedValue([join(testDir, ".rulesync/skills/local-skill")]);
+    vi.mocked(listSubdirectoryNames).mockResolvedValue(["local-skill"]);
 
     const result = await resolveAndFetchSources({
       logger,

--- a/src/mcp/skills.test.ts
+++ b/src/mcp/skills.test.ts
@@ -20,6 +20,7 @@ describe("MCP Skills Tools", () => {
   afterEach(async () => {
     await cleanup();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe("listSkills", () => {
@@ -31,6 +32,49 @@ describe("MCP Skills Tools", () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.skills).toEqual([]);
+    });
+
+    it("should say nothing when the skills directory has not been created", async () => {
+      // The ordinary state of a project that has no skills yet. Reading the
+      // directory fails, and this tool's logger prints an error however quiet
+      // it is asked to be, so the listing checks the directory exists first.
+      // Errors are held back under `NODE_ENV=test`, so this asks for the
+      // behavior a user would see.
+      vi.stubEnv("NODE_ENV", "production");
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await skillTools.listSkills.execute();
+
+      expect(JSON.parse(result).skills).toEqual([]);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should report the real directory name when a skill cannot be read", async () => {
+      // The glob this listing used rewrote a backslash into a path separator,
+      // so the failure it reported named `slash` — a directory that does not
+      // exist — and never mentioned the real one. Such a name cannot be carried
+      // by `AiDir` either way, so the listing skips it, but it now says which
+      // directory it means.
+      vi.stubEnv("NODE_ENV", "production");
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const skillsDir = join(testDir, RULESYNC_SKILLS_RELATIVE_DIR_PATH);
+      const frontmatter = `---
+name: plain
+description: A plain skill
+---
+Body`;
+      await writeFileContent(join(skillsDir, "back\\slash", SKILL_FILE_NAME), frontmatter);
+      await writeFileContent(join(skillsDir, "plain", SKILL_FILE_NAME), frontmatter);
+
+      const result = await skillTools.listSkills.execute();
+      const parsed = JSON.parse(result);
+
+      expect(
+        parsed.skills.map((skill: { frontmatter: { name: string } }) => skill.frontmatter.name),
+      ).toEqual(["plain"]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to read skill directory back\\slash"),
+      );
     });
 
     it("should list all skills with their frontmatter", async () => {

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -158,8 +158,12 @@ async function listSkills(): Promise<
             frontmatter,
           };
         } catch (error) {
+          // The name is stripped in both halves of the line: the error carries
+          // the same name back, and a control character left in either can
+          // erase the line and pass what follows off as rulesync's own output.
           logger.error(
-            `Failed to read skill directory ${stripControlCharacters(dirName)}: ${formatError(error)}`,
+            `Failed to read skill directory ${stripControlCharacters(dirName)}: ` +
+              stripControlCharacters(formatError(error)),
           );
           return null;
         }

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -130,6 +130,13 @@ async function listSkills(): Promise<
 
   const skillsDir = join(process.cwd(), RULESYNC_SKILLS_RELATIVE_DIR_PATH);
 
+  // A project that has not created any skill yet is the ordinary case, not a
+  // read failure: reading the directory reports that as an error, and this
+  // logger prints an error however quiet it is asked to be.
+  if (!(await directoryExists(skillsDir))) {
+    return [];
+  }
+
   try {
     // Find all skill directories (directories containing SKILL.md). Read rather
     // than globbed, so a name holding a backslash is the name on disk and not

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -10,12 +10,13 @@ import {
   RulesyncSkillFrontmatterSchema,
 } from "../features/skills/rulesync-skill.js";
 import { AiDirFile } from "../types/ai-dir.js";
+import { stripControlCharacters } from "../utils/control-characters.js";
 import { formatError } from "../utils/error.js";
 import {
   checkPathTraversal,
   directoryExists,
   ensureDir,
-  findFilesByGlobs,
+  listSubdirectoryNames,
   removeDirectory,
   writeFileBuffer,
   writeFileContent,
@@ -130,13 +131,13 @@ async function listSkills(): Promise<
   const skillsDir = join(process.cwd(), RULESYNC_SKILLS_RELATIVE_DIR_PATH);
 
   try {
-    // Find all skill directories (directories containing SKILL.md)
-    const skillDirPaths = await findFilesByGlobs(join(skillsDir, "*"), { type: "dir" });
+    // Find all skill directories (directories containing SKILL.md). Read rather
+    // than globbed, so a name holding a backslash is the name on disk and not
+    // the two-segment path a glob rewrites it into.
+    const dirNames = await listSubdirectoryNames(skillsDir);
 
     const skills = await Promise.all(
-      skillDirPaths.map(async (dirPath) => {
-        const dirName = basename(dirPath);
-        if (!dirName) return null;
+      dirNames.map(async (dirName) => {
         try {
           // Read the skill using RulesyncSkill
           const skill = await RulesyncSkill.fromDir({
@@ -150,7 +151,9 @@ async function listSkills(): Promise<
             frontmatter,
           };
         } catch (error) {
-          logger.error(`Failed to read skill directory ${dirName}: ${formatError(error)}`);
+          logger.error(
+            `Failed to read skill directory ${stripControlCharacters(dirName)}: ${formatError(error)}`,
+          );
           return null;
         }
       }),

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -656,6 +656,19 @@ describe("file utilities", () => {
         expect(await listFileNames(root)).toEqual(["zzz.md"]);
       });
 
+      it("should keep a name the caller asked for over the one it stands for", async () => {
+        // The filter runs before the entries are folded onto one name, so a
+        // `.md` link is not collapsed onto the file of another name it points
+        // at — and then dropped by a caller filtering the result for `.md`.
+        const root = join(testDir, "root");
+        await writeFileContent(join(root, "notes.txt"), "content");
+        await symlink(join(root, "notes.txt"), join(root, "notes.md"));
+
+        expect(await listFileNames(root, { nameFilter: (name) => name.endsWith(".md") })).toEqual([
+          "notes.md",
+        ]);
+      });
+
       it("should keep a link whose target is not among the entries", async () => {
         const root = join(testDir, "root");
         await ensureDir(join(root, "real"));

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -1,5 +1,5 @@
 import { realpath, symlink } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -630,6 +630,30 @@ describe("file utilities", () => {
         await symlink(join(root, "zzz"), join(root, "aaa"));
 
         expect(await listSubdirectoryNames(root)).toEqual(["zzz"]);
+      });
+
+      it("should report the real name even when the directory is not reached directly", async () => {
+        // Deciding which name is the real one by comparing the path against
+        // what `realpath` returns only holds when the caller passes an already
+        // resolved absolute path. A relative path — the shape `outputRoot: "."`
+        // produces — and a path leading through a link of its own must pick the
+        // same name, or `import` reads the entry under its alias and the sweep
+        // then treats the real one as an orphan.
+        const root = join(testDir, "root");
+        await ensureDir(join(root, "zzz"));
+        await symlink(join(root, "zzz"), join(root, "aaa"));
+        await symlink(root, join(testDir, "via-link"));
+
+        expect(await listSubdirectoryNames(relative(process.cwd(), root))).toEqual(["zzz"]);
+        expect(await listSubdirectoryNames(join(testDir, "via-link"))).toEqual(["zzz"]);
+      });
+
+      it("should report a file once when a link beside it stands for it", async () => {
+        const root = join(testDir, "root");
+        await writeFileContent(join(root, "zzz.md"), "content");
+        await symlink(join(root, "zzz.md"), join(root, "aaa.md"));
+
+        expect(await listFileNames(root)).toEqual(["zzz.md"]);
       });
 
       it("should keep a link whose target is not among the entries", async () => {

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -590,6 +590,57 @@ describe("file utilities", () => {
         expect(await listFileNames(root)).toEqual([]);
       });
 
+      it("should follow a symbolic link to a file by default and not when told not to", async () => {
+        const root = join(testDir, "root");
+        await writeFileContent(join(testDir, "outside", "shared.md"), "content");
+        await writeFileContent(join(root, "real.md"), "content");
+        await symlink(join(testDir, "outside", "shared.md"), join(root, "linked.md"));
+
+        expect(await listFileNames(root)).toEqual(["linked.md", "real.md"]);
+        expect(await listFileNames(root, { followSymbolicLinks: false })).toEqual(["real.md"]);
+      });
+
+      it("should leave hidden entries out unless asked for them", async () => {
+        // The glob these replaced ran with `dot: false`. Callers sweep what they
+        // are given, so a `.git` beside the entries must not appear by default.
+        const root = join(testDir, "root");
+        await ensureDir(join(root, ".git"));
+        await ensureDir(join(root, "plain"));
+        await writeFileContent(join(root, ".hidden.md"), "content");
+        await writeFileContent(join(root, "plain.md"), "content");
+
+        expect(await listSubdirectoryNames(root)).toEqual(["plain"]);
+        expect(await listFileNames(root)).toEqual(["plain.md"]);
+        expect(await listSubdirectoryNames(root, { includeHidden: true })).toEqual([
+          ".git",
+          "plain",
+        ]);
+        expect(await listFileNames(root, { includeHidden: true })).toEqual([
+          ".hidden.md",
+          "plain.md",
+        ]);
+      });
+
+      it("should report a directory once when a link beside it stands for it", async () => {
+        // `findFilesByGlobs` collapses the paths that resolve to one entry, and a
+        // caller that lost that would read the same skill twice. The real name
+        // wins over the link, so the entry keeps the name it is stored under.
+        const root = join(testDir, "root");
+        await ensureDir(join(root, "zzz"));
+        await symlink(join(root, "zzz"), join(root, "aaa"));
+
+        expect(await listSubdirectoryNames(root)).toEqual(["zzz"]);
+      });
+
+      it("should keep a link whose target is not among the entries", async () => {
+        const root = join(testDir, "root");
+        await ensureDir(join(root, "real"));
+        await ensureDir(join(testDir, "outside", "shared"));
+        await symlink(join(testDir, "outside", "shared"), join(root, "linked"));
+
+        expect(await listSubdirectoryNames(root)).toEqual(["linked", "real"]);
+      });
+
       it("should reject a directory it cannot read", async () => {
         await expect(listSubdirectoryNames(join(testDir, "missing"))).rejects.toThrow();
       });

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -29,6 +29,8 @@ import {
   isFileSystemError,
   isPresentButUnresolvable,
   listDirectoryFiles,
+  listFileNames,
+  listSubdirectoryNames,
   readFileBufferOrNull,
   readFileContent,
   readJsonFile,
@@ -543,6 +545,53 @@ describe("file utilities", () => {
       it("should return empty array for non-existent directory", async () => {
         const files = await findFiles(join(testDir, "nonexistent"));
         expect(files).toEqual([]);
+      });
+    });
+
+    describe("listSubdirectoryNames and listFileNames", () => {
+      it("should keep a name containing a backslash, which a glob rewrites", async () => {
+        // The bug this exists for: globby reads the backslash as a separator and
+        // returns `<root>/back/slash`, whose basename names nothing on disk.
+        await ensureDir(join(testDir, "back\\slash"));
+        await ensureDir(join(testDir, "plain"));
+        await writeFileContent(join(testDir, "back\\slash.md"), "content");
+
+        expect(await listSubdirectoryNames(testDir)).toEqual(["back\\slash", "plain"]);
+        expect(await listFileNames(testDir)).toEqual(["back\\slash.md"]);
+      });
+
+      it("should follow a symbolic link to a directory by default", async () => {
+        const shared = join(testDir, "outside", "shared");
+        await ensureDir(shared);
+        const root = join(testDir, "root");
+        await ensureDir(root);
+        await symlink(shared, join(root, "linked"));
+
+        expect(await listSubdirectoryNames(root)).toEqual(["linked"]);
+      });
+
+      it("should leave a symbolic link out when told not to follow", async () => {
+        const shared = join(testDir, "outside", "shared");
+        await ensureDir(shared);
+        const root = join(testDir, "root");
+        await ensureDir(root);
+        await symlink(shared, join(root, "linked"));
+        await ensureDir(join(root, "real"));
+
+        expect(await listSubdirectoryNames(root, { followSymbolicLinks: false })).toEqual(["real"]);
+      });
+
+      it("should leave out a link that leads nowhere", async () => {
+        const root = join(testDir, "root");
+        await ensureDir(root);
+        await symlink(join(testDir, "gone"), join(root, "dangling"));
+
+        expect(await listSubdirectoryNames(root)).toEqual([]);
+        expect(await listFileNames(root)).toEqual([]);
+      });
+
+      it("should reject a directory it cannot read", async () => {
+        await expect(listSubdirectoryNames(join(testDir, "missing"))).rejects.toThrow();
       });
     });
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -18,6 +18,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { kebabCase } from "es-toolkit";
 import { globbySync, isGitIgnoredSync } from "globby";
 
+import { mapWithConcurrency } from "./concurrency.js";
 import { formatError } from "./error.js";
 import { isEnvTest } from "./vitest.js";
 
@@ -698,46 +699,107 @@ export async function findFilesByGlobs(
   return representatives.toSorted();
 }
 
+/** How many entries are read back from disk at once while classifying a directory. */
+const ENTRY_CLASSIFY_CONCURRENCY = 32;
+
 /**
- * The immediate subdirectory names of `dirPath`, spelled the way the filesystem
- * spells them.
+ * The entry names of `dirPath` that are of `kind`, deduplicated and sorted.
  *
- * A `*` glob cannot stand in for this. Globby reads a backslash as a path
- * separator, so a directory literally named `back\\slash` comes back as
- * `.../back/slash`, and the name recovered from that — `slash` — belongs to a
- * directory that does not exist. Whatever the caller does next with the name
- * then quietly misses the real directory: loading it, or sweeping it as an
- * orphan. Windows is not affected, since a backslash cannot appear in a name
- * there, which is what makes the glob look correct everywhere it is tested.
+ * The shared implementation behind {@link listSubdirectoryNames} and
+ * {@link listFileNames}; see the former for why these read the directory
+ * rather than glob it.
  */
 async function listEntryNames(params: {
   dirPath: string;
   kind: "dir" | "file";
   followSymbolicLinks: boolean;
+  includeHidden: boolean;
 }): Promise<string[]> {
-  const { dirPath, kind, followSymbolicLinks } = params;
+  const { dirPath, kind, followSymbolicLinks, includeHidden } = params;
   const matches = (stats: { isDirectory: () => boolean; isFile: () => boolean }): boolean =>
     kind === "dir" ? stats.isDirectory() : stats.isFile();
   const entries = await readdir(dirPath, { withFileTypes: true });
-  const names = await Promise.all(
-    entries.map(async (entry) => {
+  // Hidden entries are left out by default, matching the `dot: false` the glob
+  // this replaced ran with. It is not cosmetic: the deletion sweep takes every
+  // directory it is handed, so a `.git` or `.venv` beside the skills would be
+  // removed by a change that only meant to spell names correctly.
+  const visible = includeHidden
+    ? entries
+    : entries.filter((entry) => !isHiddenPathSegment(entry.name));
+  const classified = await mapWithConcurrency({
+    items: visible,
+    limit: ENTRY_CLASSIFY_CONCURRENCY,
+    mapper: async (entry): Promise<string | undefined> => {
       if (matches(entry)) {
         return entry.name;
       }
+      if (entry.isDirectory() || entry.isFile()) {
+        return undefined;
+      }
       // `readdir` reports a link as a link and never as what it stands for, so
       // a link is the one entry kind that needs a second look — and only when
-      // the caller follows links at all.
-      if (!followSymbolicLinks || !entry.isSymbolicLink()) {
+      // the caller follows links at all. An entry of no kind at all needs the
+      // same second look: a filesystem that does not fill in the entry type
+      // (some network and FUSE mounts) reports every predicate as false, and
+      // taking that at face value would empty the directory.
+      const kindUnknown = !entry.isSymbolicLink();
+      if (!kindUnknown && !followSymbolicLinks) {
         return undefined;
       }
       // A link that leads nowhere is not an entry to report.
-      const target = await stat(join(dirPath, entry.name)).catch(() => undefined);
+      const readStats = kindUnknown && !followSymbolicLinks ? lstat : stat;
+      const target = await readStats(join(dirPath, entry.name)).catch(() => undefined);
       return target !== undefined && matches(target) ? entry.name : undefined;
+    },
+  });
+  const names = classified.filter((name) => name !== undefined).toSorted();
+  return followSymbolicLinks ? await dedupeNamesByFileIdentity({ dirPath, names }) : names;
+}
+
+/**
+ * Collapse the names that lead to one and the same entry onto a single name.
+ *
+ * `findFilesByGlobs` does this for the paths it returns, and dropping it here
+ * would change what a caller sees: a directory link named `aaa` beside the
+ * directory `zzz` it stands for is one skill, and reporting both would import
+ * it twice. The real name wins over a link to it, for the reason spelled out
+ * in {@link chooseRepresentative}. `names` arrives sorted, so ties are stable.
+ */
+async function dedupeNamesByFileIdentity(params: {
+  dirPath: string;
+  names: string[];
+}): Promise<string[]> {
+  const { dirPath, names } = params;
+  const identities = await mapWithConcurrency({
+    items: names,
+    limit: ENTRY_CLASSIFY_CONCURRENCY,
+    mapper: async (name) => await realFileIdentity(join(dirPath, name)),
+  });
+  const namesByIdentity = new Map<string, string[]>();
+  for (const [index, name] of names.entries()) {
+    const identity = identities[index];
+    if (identity === undefined) {
+      continue;
+    }
+    const group = namesByIdentity.get(identity);
+    if (group === undefined) {
+      namesByIdentity.set(identity, [name]);
+    } else {
+      group.push(name);
+    }
+  }
+  const representatives = [...namesByIdentity.entries()].map(([identity, group]) =>
+    group.reduce((best, candidate) => {
+      if (toPosixPath(join(dirPath, best)) === identity) {
+        return best;
+      }
+      if (toPosixPath(join(dirPath, candidate)) === identity) {
+        return candidate;
+      }
+      return isHiddenPathSegment(best) && !isHiddenPathSegment(candidate) ? candidate : best;
     }),
   );
-  // Sorted for the same reason `findFilesByGlobs` sorts: the order entries come
-  // off the filesystem in is not one a caller should have to depend on.
-  return names.filter((name) => name !== undefined).toSorted();
+  return representatives.toSorted();
 }
 
 /**
@@ -751,15 +813,19 @@ async function listEntryNames(params: {
  * then quietly misses the real directory: loading it, or sweeping it as an
  * orphan. Windows is not affected, since a backslash cannot appear in a name
  * there, which is what makes the glob look correct everywhere it is tested.
+ *
+ * Rejects if the directory cannot be read, so a root that is there but
+ * unreadable is never mistaken for an empty one.
  */
 export async function listSubdirectoryNames(
   dirPath: string,
-  options: { followSymbolicLinks?: boolean } = {},
+  options: { followSymbolicLinks?: boolean; includeHidden?: boolean } = {},
 ): Promise<string[]> {
   return await listEntryNames({
     dirPath,
     kind: "dir",
     followSymbolicLinks: options.followSymbolicLinks ?? true,
+    includeHidden: options.includeHidden ?? false,
   });
 }
 
@@ -770,12 +836,13 @@ export async function listSubdirectoryNames(
  */
 export async function listFileNames(
   dirPath: string,
-  options: { followSymbolicLinks?: boolean } = {},
+  options: { followSymbolicLinks?: boolean; includeHidden?: boolean } = {},
 ): Promise<string[]> {
   return await listEntryNames({
     dirPath,
     kind: "file",
     followSymbolicLinks: options.followSymbolicLinks ?? true,
+    includeHidden: options.includeHidden ?? false,
   });
 }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -698,6 +698,87 @@ export async function findFilesByGlobs(
   return representatives.toSorted();
 }
 
+/**
+ * The immediate subdirectory names of `dirPath`, spelled the way the filesystem
+ * spells them.
+ *
+ * A `*` glob cannot stand in for this. Globby reads a backslash as a path
+ * separator, so a directory literally named `back\\slash` comes back as
+ * `.../back/slash`, and the name recovered from that — `slash` — belongs to a
+ * directory that does not exist. Whatever the caller does next with the name
+ * then quietly misses the real directory: loading it, or sweeping it as an
+ * orphan. Windows is not affected, since a backslash cannot appear in a name
+ * there, which is what makes the glob look correct everywhere it is tested.
+ */
+async function listEntryNames(params: {
+  dirPath: string;
+  kind: "dir" | "file";
+  followSymbolicLinks: boolean;
+}): Promise<string[]> {
+  const { dirPath, kind, followSymbolicLinks } = params;
+  const matches = (stats: { isDirectory: () => boolean; isFile: () => boolean }): boolean =>
+    kind === "dir" ? stats.isDirectory() : stats.isFile();
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const names = await Promise.all(
+    entries.map(async (entry) => {
+      if (matches(entry)) {
+        return entry.name;
+      }
+      // `readdir` reports a link as a link and never as what it stands for, so
+      // a link is the one entry kind that needs a second look — and only when
+      // the caller follows links at all.
+      if (!followSymbolicLinks || !entry.isSymbolicLink()) {
+        return undefined;
+      }
+      // A link that leads nowhere is not an entry to report.
+      const target = await stat(join(dirPath, entry.name)).catch(() => undefined);
+      return target !== undefined && matches(target) ? entry.name : undefined;
+    }),
+  );
+  // Sorted for the same reason `findFilesByGlobs` sorts: the order entries come
+  // off the filesystem in is not one a caller should have to depend on.
+  return names.filter((name) => name !== undefined).toSorted();
+}
+
+/**
+ * The immediate subdirectory names of `dirPath`, spelled the way the filesystem
+ * spells them.
+ *
+ * A `*` glob cannot stand in for this. Globby reads a backslash as a path
+ * separator, so a directory literally named `back\\slash` comes back as
+ * `.../back/slash`, and the name recovered from that — `slash` — belongs to a
+ * directory that does not exist. Whatever the caller does next with the name
+ * then quietly misses the real directory: loading it, or sweeping it as an
+ * orphan. Windows is not affected, since a backslash cannot appear in a name
+ * there, which is what makes the glob look correct everywhere it is tested.
+ */
+export async function listSubdirectoryNames(
+  dirPath: string,
+  options: { followSymbolicLinks?: boolean } = {},
+): Promise<string[]> {
+  return await listEntryNames({
+    dirPath,
+    kind: "dir",
+    followSymbolicLinks: options.followSymbolicLinks ?? true,
+  });
+}
+
+/**
+ * The immediate file names of `dirPath`, spelled the way the filesystem spells
+ * them. The counterpart of {@link listSubdirectoryNames}, and the same reason
+ * to prefer it over a `*` glob applies.
+ */
+export async function listFileNames(
+  dirPath: string,
+  options: { followSymbolicLinks?: boolean } = {},
+): Promise<string[]> {
+  return await listEntryNames({
+    dirPath,
+    kind: "file",
+    followSymbolicLinks: options.followSymbolicLinks ?? true,
+  });
+}
+
 export async function findRuleFiles(aiRulesDir: string): Promise<string[]> {
   const rulesDir = join(aiRulesDir, "rules");
   return findFiles(rulesDir, ".md");

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -717,8 +717,9 @@ async function listEntryNames(params: {
   kind: "dir" | "file";
   followSymbolicLinks: boolean;
   includeHidden: boolean;
+  nameFilter: ((name: string) => boolean) | undefined;
 }): Promise<string[]> {
-  const { dirPath, kind, followSymbolicLinks, includeHidden } = params;
+  const { dirPath, kind, followSymbolicLinks, includeHidden, nameFilter } = params;
   const matches = (stats: { isDirectory: () => boolean; isFile: () => boolean }): boolean =>
     kind === "dir" ? stats.isDirectory() : stats.isFile();
   const entries = await readdir(dirPath, { withFileTypes: true });
@@ -726,9 +727,14 @@ async function listEntryNames(params: {
   // this replaced ran with. It is not cosmetic: the deletion sweep takes every
   // directory it is handed, so a `.git` or `.venv` beside the skills would be
   // removed by a change that only meant to spell names correctly.
+  // The caller's filter runs here rather than on the result, so a name it does
+  // not want cannot become the representative of an entry a wanted name also
+  // reaches — which would drop that entry from the listing entirely.
+  const wanted =
+    nameFilter === undefined ? entries : entries.filter((entry) => nameFilter(entry.name));
   const visible = includeHidden
-    ? entries
-    : entries.filter((entry) => !isHiddenPathSegment(entry.name));
+    ? wanted
+    : wanted.filter((entry) => !isHiddenPathSegment(entry.name));
   const classified = await mapWithConcurrency({
     items: visible,
     limit: ENTRY_CLASSIFY_CONCURRENCY,
@@ -844,16 +850,24 @@ async function dedupeNamesByFileIdentity(params: {
  *
  * Rejects if the directory cannot be read, so a root that is there but
  * unreadable is never mistaken for an empty one.
+ *
+ * `nameFilter` narrows the listing while it is read rather than afterwards; see
+ * {@link listEntryNames} for why the difference matters.
  */
 export async function listSubdirectoryNames(
   dirPath: string,
-  options: { followSymbolicLinks?: boolean; includeHidden?: boolean } = {},
+  options: {
+    followSymbolicLinks?: boolean;
+    includeHidden?: boolean;
+    nameFilter?: (name: string) => boolean;
+  } = {},
 ): Promise<string[]> {
   return await listEntryNames({
     dirPath,
     kind: "dir",
     followSymbolicLinks: options.followSymbolicLinks ?? true,
     includeHidden: options.includeHidden ?? false,
+    nameFilter: options.nameFilter,
   });
 }
 
@@ -864,13 +878,18 @@ export async function listSubdirectoryNames(
  */
 export async function listFileNames(
   dirPath: string,
-  options: { followSymbolicLinks?: boolean; includeHidden?: boolean } = {},
+  options: {
+    followSymbolicLinks?: boolean;
+    includeHidden?: boolean;
+    nameFilter?: (name: string) => boolean;
+  } = {},
 ): Promise<string[]> {
   return await listEntryNames({
     dirPath,
     kind: "file",
     followSymbolicLinks: options.followSymbolicLinks ?? true,
     includeHidden: options.includeHidden ?? false,
+    nameFilter: options.nameFilter,
   });
 }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -748,8 +748,11 @@ async function listEntryNames(params: {
       const entryStats = entry.isSymbolicLink()
         ? undefined
         : await lstat(entryPath).catch(() => undefined);
-      if (entryStats !== undefined) {
-        return matches(entryStats) ? { name: entry.name, isLink: false } : undefined;
+      const isLink = entry.isSymbolicLink() || (entryStats?.isSymbolicLink() ?? false);
+      if (!isLink) {
+        return entryStats !== undefined && matches(entryStats)
+          ? { name: entry.name, isLink: false }
+          : undefined;
       }
       if (!followSymbolicLinks) {
         return undefined;
@@ -797,8 +800,9 @@ async function dedupeNamesByFileIdentity(params: {
   });
   const entriesByIdentity = new Map<string, ClassifiedEntry[]>();
   for (const [index, entry] of entries.entries()) {
-    // An identity that could not be read falls back to the literal path, so the
-    // entry stands on its own rather than being dropped from the listing.
+    // `realFileIdentity` falls back to the literal path rather than failing, so
+    // an entry whose identity cannot be read stands on its own here instead of
+    // dropping out of the listing.
     const identity = identities[index] ?? toPosixPath(join(dirPath, entry.name));
     const group = entriesByIdentity.get(identity);
     if (group === undefined) {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -702,6 +702,9 @@ export async function findFilesByGlobs(
 /** How many entries are read back from disk at once while classifying a directory. */
 const ENTRY_CLASSIFY_CONCURRENCY = 32;
 
+/** An entry of the requested kind, and whether the name reaches it through a link. */
+type ClassifiedEntry = { name: string; isLink: boolean };
+
 /**
  * The entry names of `dirPath` that are of `kind`, deduplicated and sorted.
  *
@@ -729,31 +732,44 @@ async function listEntryNames(params: {
   const classified = await mapWithConcurrency({
     items: visible,
     limit: ENTRY_CLASSIFY_CONCURRENCY,
-    mapper: async (entry): Promise<string | undefined> => {
+    mapper: async (entry): Promise<ClassifiedEntry | undefined> => {
       if (matches(entry)) {
-        return entry.name;
+        return { name: entry.name, isLink: false };
       }
       if (entry.isDirectory() || entry.isFile()) {
         return undefined;
       }
       // `readdir` reports a link as a link and never as what it stands for, so
-      // a link is the one entry kind that needs a second look — and only when
-      // the caller follows links at all. An entry of no kind at all needs the
-      // same second look: a filesystem that does not fill in the entry type
-      // (some network and FUSE mounts) reports every predicate as false, and
-      // taking that at face value would empty the directory.
-      const kindUnknown = !entry.isSymbolicLink();
-      if (!kindUnknown && !followSymbolicLinks) {
+      // a link is the one entry kind that needs a second look. An entry of no
+      // kind at all needs the same one: a filesystem that does not fill the
+      // entry type in (some network and FUSE mounts) reports every predicate as
+      // false, and taking that at face value would empty the directory.
+      const entryPath = join(dirPath, entry.name);
+      const entryStats = entry.isSymbolicLink()
+        ? undefined
+        : await lstat(entryPath).catch(() => undefined);
+      if (entryStats !== undefined) {
+        return matches(entryStats) ? { name: entry.name, isLink: false } : undefined;
+      }
+      if (!followSymbolicLinks) {
         return undefined;
       }
       // A link that leads nowhere is not an entry to report.
-      const readStats = kindUnknown && !followSymbolicLinks ? lstat : stat;
-      const target = await readStats(join(dirPath, entry.name)).catch(() => undefined);
-      return target !== undefined && matches(target) ? entry.name : undefined;
+      const target = await stat(entryPath).catch(() => undefined);
+      return target !== undefined && matches(target)
+        ? { name: entry.name, isLink: true }
+        : undefined;
     },
   });
-  const names = classified.filter((name) => name !== undefined).toSorted();
-  return followSymbolicLinks ? await dedupeNamesByFileIdentity({ dirPath, names }) : names;
+  const found = classified
+    .filter((entry) => entry !== undefined)
+    // Sorted for the same reason `findFilesByGlobs` sorts: the order entries
+    // come off the filesystem in is not one a caller should have to depend on.
+    .toSorted((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+  if (!found.some((entry) => entry.isLink)) {
+    return found.map((entry) => entry.name);
+  }
+  return await dedupeNamesByFileIdentity({ dirPath, entries: found });
 }
 
 /**
@@ -762,42 +778,50 @@ async function listEntryNames(params: {
  * `findFilesByGlobs` does this for the paths it returns, and dropping it here
  * would change what a caller sees: a directory link named `aaa` beside the
  * directory `zzz` it stands for is one skill, and reporting both would import
- * it twice. The real name wins over a link to it, for the reason spelled out
- * in {@link chooseRepresentative}. `names` arrives sorted, so ties are stable.
+ * it twice. The name that reaches the entry directly wins, for the reason
+ * spelled out in {@link chooseRepresentative} — but decided from the entry
+ * itself rather than by comparing paths, since the path a caller passes in may
+ * be relative or lead through a link of its own, and neither spelling equals
+ * the real path `realpath` returns. `entries` arrives sorted, so ties are
+ * stable.
  */
 async function dedupeNamesByFileIdentity(params: {
   dirPath: string;
-  names: string[];
+  entries: readonly ClassifiedEntry[];
 }): Promise<string[]> {
-  const { dirPath, names } = params;
+  const { dirPath, entries } = params;
   const identities = await mapWithConcurrency({
-    items: names,
+    items: entries,
     limit: ENTRY_CLASSIFY_CONCURRENCY,
-    mapper: async (name) => await realFileIdentity(join(dirPath, name)),
+    mapper: async (entry) => await realFileIdentity(join(dirPath, entry.name)),
   });
-  const namesByIdentity = new Map<string, string[]>();
-  for (const [index, name] of names.entries()) {
-    const identity = identities[index];
-    if (identity === undefined) {
-      continue;
-    }
-    const group = namesByIdentity.get(identity);
+  const entriesByIdentity = new Map<string, ClassifiedEntry[]>();
+  for (const [index, entry] of entries.entries()) {
+    // An identity that could not be read falls back to the literal path, so the
+    // entry stands on its own rather than being dropped from the listing.
+    const identity = identities[index] ?? toPosixPath(join(dirPath, entry.name));
+    const group = entriesByIdentity.get(identity);
     if (group === undefined) {
-      namesByIdentity.set(identity, [name]);
+      entriesByIdentity.set(identity, [entry]);
     } else {
-      group.push(name);
+      group.push(entry);
     }
   }
-  const representatives = [...namesByIdentity.entries()].map(([identity, group]) =>
-    group.reduce((best, candidate) => {
-      if (toPosixPath(join(dirPath, best)) === identity) {
-        return best;
-      }
-      if (toPosixPath(join(dirPath, candidate)) === identity) {
-        return candidate;
-      }
-      return isHiddenPathSegment(best) && !isHiddenPathSegment(candidate) ? candidate : best;
-    }),
+  const representatives = [...entriesByIdentity.values()].map(
+    (group) =>
+      group.reduce((best, candidate) => {
+        if (!best.isLink) {
+          return best;
+        }
+        if (!candidate.isLink) {
+          return candidate;
+        }
+        // Only links left: the named one represents the entry rather than a
+        // hidden alias, which a hidden-entry rule may then drop.
+        return isHiddenPathSegment(best.name) && !isHiddenPathSegment(candidate.name)
+          ? candidate
+          : best;
+      }).name,
   );
   return representatives.toSorted();
 }


### PR DESCRIPTION
## Problem

Globby (via fast-glob) reads a backslash as a path separator on every platform, and rewrites it in the paths it returns. A skills root holding a directory literally named `back\slash` — a perfectly legal POSIX name — came back from the `*` glob as `.../back/slash`, so the name recovered with `basename()` was `slash`: a directory that does not exist.

That fed the skills processor a phantom candidate and, symmetrically, hid the real directory from the orphan sweep. Windows is not affected, since a backslash cannot appear in a name there — which is what makes the glob look correct everywhere it is normally tested.

## Fix

Skill roots are now enumerated with `readdir`, through two new helpers in `src/utils/file.ts`:

- `listSubdirectoryNames(dirPath, { followSymbolicLinks })`
- `listFileNames(dirPath, { followSymbolicLinks })`

Both report names the way the filesystem spells them, resolve symbolic links only when asked (a dangling link is never reported), and sort — for the same reason `findFilesByGlobs` sorts: the order entries come off the filesystem in is not one a caller should have to depend on.

Four call sites in `skills-processor.ts` plus `getLocalSkillDirNames` in `skills-utils.ts` were converted. The flat-file `*.md` glob became `listFileNames` + an extension check.

## Why such a directory is reported, not swept

`AiDir` refuses a name containing a path separator, and rightly so: most tools take that name from a skill's frontmatter, and a repository written on one platform is read on the other, where a backslash *is* a separator — relaxing the guard would let a frontmatter-supplied `..\..\evil` become a literal POSIX name that traverses when the same repository is processed on Windows.

So an unaddressable directory is logged and skipped:

> Skipping `.claude/skills/back\slash`: a skill directory name cannot contain a path separator, so this directory is neither generated from nor swept as an orphan. Rename or remove it by hand.

The alternative — building a candidate from a name that belongs to no directory at all — is what this PR removes.

Closes #2787
