### PR TITLE
fix(generate): refuse to sweep a directory outside the root it was found in

### DIFF
--- a/src/features/skills/skills-processor.test.ts
+++ b/src/features/skills/skills-processor.test.ts
@@ -1715,11 +1715,8 @@ Content that would fail parsing`;
       // every enumerated candidate. Sweeping the root when the run generated no
       // takt skill deleted it outright, along with anything the user had put
       // there by hand.
-      const processor = new SkillsProcessor({
-        logger: createMockLogger(),
-        outputRoot: testDir,
-        toolTarget: "takt",
-      });
+      const logger = createMockLogger();
+      const processor = new SkillsProcessor({ logger, outputRoot: testDir, toolTarget: "takt" });
 
       const knowledgeDir = join(testDir, ".takt", "facets", "knowledge");
       const handAuthoredDir = join(knowledgeDir, "my-notes");
@@ -1732,6 +1729,13 @@ Content that would fail parsing`;
       expect(removedCount).toBe(0);
       expect(await directoryExists(knowledgeDir)).toBe(true);
       expect(await directoryExists(handAuthoredDir)).toBe(true);
+      // A tool that flattens into a shared root is an expected shape, not a
+      // contract mismatch, so it is skipped quietly: the positional backstop
+      // added for #2786 must not turn this path into a user-facing warning.
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("is a shared root, not a directory of its own"),
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it("should never list an importOnlySkillRoots skill for deletion", async () => {

--- a/src/lib/generate.test.ts
+++ b/src/lib/generate.test.ts
@@ -32,7 +32,6 @@ const logger = createMockLogger();
 
 const createMockSkillsProcessor = () => ({
   loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-  removeAiDirs: vi.fn().mockResolvedValue(undefined),
   ...mockProcessorBase(),
   loadRulesyncDirs: vi.fn().mockResolvedValue([]),
   convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
@@ -373,7 +372,6 @@ describe("generate", () => {
       });
       const mockSkillsProcessor = {
         loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-        removeAiDirs: vi.fn().mockResolvedValue(undefined),
         ...mockProcessorBase(),
         loadRulesyncDirs: vi.fn().mockResolvedValue([mockSkill]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
@@ -757,7 +755,6 @@ describe("generate", () => {
 
       const mockSkillsProcessor = {
         loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-        removeAiDirs: vi.fn().mockResolvedValue(undefined),
         ...mockProcessorBase(),
         loadRulesyncDirs: vi.fn().mockResolvedValue([]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([
@@ -810,7 +807,6 @@ describe("generate", () => {
       });
       const mockSkillsProcessor = {
         loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-        removeAiDirs: vi.fn().mockResolvedValue(undefined),
         ...mockProcessorBase(),
         loadRulesyncDirs: vi.fn().mockResolvedValue([mockSkill]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
@@ -992,7 +988,6 @@ describe("generate", () => {
 
       const mockSkillsProcessor = {
         loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-        removeAiDirs: vi.fn().mockResolvedValue(undefined),
         ...mockProcessorBase(),
         loadRulesyncDirs: vi.fn().mockResolvedValue([]),
         convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),
@@ -1448,7 +1443,6 @@ describe("generate", () => {
       vi.mocked(SkillsProcessor).mockImplementation(function () {
         return {
           loadToolDirsToDelete: vi.fn().mockResolvedValue([]),
-          removeAiDirs: vi.fn().mockResolvedValue(undefined),
           ...mockProcessorBase(),
           loadRulesyncDirs: vi.fn().mockResolvedValue([makeRulesyncSkill(params.skillName)]),
           convertRulesyncDirsToToolDirs: vi.fn().mockResolvedValue([]),

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -272,8 +272,32 @@ describe("DirFeatureProcessor", () => {
       expect(count).toBe(0);
       expect(removeDirectory).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Refusing to delete "/elsewhere/root/orphan"'),
+        'Refusing to delete "/elsewhere/root/orphan": the root "/elsewhere/root" it was found ' +
+          'in is not inside "/path/to", the directory this run writes to',
       );
+    });
+
+    it("should say the root is out of reach even when the candidate disowns it", async () => {
+      // A root outside the directory this run writes to is reported for its own
+      // reason: the candidate's position within that root — which is what the
+      // `ownsDirTree()` branch describes — says nothing about whether the root
+      // is one this run may delete from.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const sharedRoot = "/elsewhere/facets/knowledge";
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir(sharedRoot, false, sharedRoot)],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Refusing to delete "${sharedRoot}": the root "${sharedRoot}" it was found in is not ` +
+          'inside "/path/to", the directory this run writes to',
+      );
+      expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining("shared root"));
     });
 
     it("should not remove any dirs when all existing dirs are in generated", async () => {
@@ -359,6 +383,10 @@ describe("DirFeatureProcessor", () => {
       expect(count).toBe(0);
       expect(removeDirectory).not.toHaveBeenCalled();
       expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining(sharedRoot));
+      expect(logger.debug).toHaveBeenCalledWith(
+        `Skipping orphan sweep for "knowledge": "${sharedRoot}" is a shared root, not a ` +
+          "directory of its own",
+      );
     });
 
     it("should still sweep a real orphan alongside a shared-root candidate", async () => {

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -28,15 +28,20 @@ vi.mock("../utils/file.js", async () => {
   };
 });
 
-function createMockDir(
-  dirPath: string,
+function createMockDir({
+  dirPath,
   ownsDirTree = true,
   // The root the directory was found in, as a real `AiDir` carries it: an
   // output root plus a relative directory path. It defaults to the parent,
   // which is where a real `AiDir` puts it — the sweep checks that positionally.
   outputRoot = dirname(dirPath),
   relativeDirPath = ".",
-): AiDir {
+}: {
+  dirPath: string;
+  ownsDirTree?: boolean;
+  outputRoot?: string;
+  relativeDirPath?: string;
+}): AiDir {
   return {
     getDirPath: () => dirPath,
     getDirName: () => basename(dirPath),
@@ -60,6 +65,12 @@ function createMockDirWithFiles({
 }): AiDir {
   return {
     getDirPath: () => dirPath,
+    // The same three values `createMockDir` supplies: the orphan sweep reads
+    // them positionally, so a mock without them fails at run time rather than
+    // in the type checker, which the cast below has already given up on.
+    getOutputRoot: () => dirname(dirPath),
+    getRelativeDirPath: () => ".",
+    getDirName: () => basename(dirPath),
     getMainFile: () =>
       mainFileBody !== undefined
         ? { name: "SKILL.md", body: mainFileBody, frontmatter: {} }
@@ -112,12 +123,12 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const existingDirs = [
-        createMockDir("/path/to/orphan1"),
-        createMockDir("/path/to/orphan2"),
-        createMockDir("/path/to/kept"),
+        createMockDir({ dirPath: "/path/to/orphan1" }),
+        createMockDir({ dirPath: "/path/to/orphan2" }),
+        createMockDir({ dirPath: "/path/to/kept" }),
       ];
 
-      const generatedDirs = [createMockDir("/path/to/kept")];
+      const generatedDirs = [createMockDir({ dirPath: "/path/to/kept" })];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
 
@@ -130,6 +141,9 @@ describe("DirFeatureProcessor", () => {
       expect(logger.info).toHaveBeenCalledWith('Deleted directory: "/path/to/orphan1"');
       expect(logger.info).toHaveBeenCalledWith('Deleted directory: "/path/to/orphan2"');
       expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("kept"));
+      // The backstop must stay invisible on the ordinary path: a warning here
+      // would mean every `--delete` run tells the user it refused something.
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it("should strip control characters from the deletion log", async () => {
@@ -138,7 +152,7 @@ describe("DirFeatureProcessor", () => {
 
       // The path is an on-disk name rulesync did not choose, so a name carrying
       // `\x1b[2K\r` must not be able to rewrite the line and hide the deletion.
-      const existingDirs = [createMockDir("/path/to/\u001b[2K\r-innocent")];
+      const existingDirs = [createMockDir({ dirPath: "/path/to/\u001b[2K\r-innocent" })];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, []);
 
@@ -156,7 +170,7 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/root", true, "/path/to/root")],
+        [createMockDir({ dirPath: "/path/to/root", outputRoot: "/path/to/root" })],
         [],
       );
 
@@ -173,7 +187,7 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/elsewhere", true, "/path/to/root")],
+        [createMockDir({ dirPath: "/path/to/elsewhere", outputRoot: "/path/to/root" })],
         [],
       );
 
@@ -193,7 +207,7 @@ describe("DirFeatureProcessor", () => {
       });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/root/..cache", true, "/path/to/root")],
+        [createMockDir({ dirPath: "/path/to/root/..cache", outputRoot: "/path/to/root" })],
         [],
       );
 
@@ -209,7 +223,7 @@ describe("DirFeatureProcessor", () => {
       });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/root/nested/orphan", true, "/path/to/root")],
+        [createMockDir({ dirPath: "/path/to/root/nested/orphan", outputRoot: "/path/to/root" })],
         [],
       );
 
@@ -226,7 +240,13 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/root/elsewhere", false, "/path/to/root")],
+        [
+          createMockDir({
+            dirPath: "/path/to/root/elsewhere",
+            ownsDirTree: false,
+            outputRoot: "/path/to/root",
+          }),
+        ],
         [],
       );
 
@@ -246,7 +266,13 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/other/orphan", true, "/path/to", "root")],
+        [
+          createMockDir({
+            dirPath: "/path/to/other/orphan",
+            outputRoot: "/path/to",
+            relativeDirPath: "root",
+          }),
+        ],
         [],
       );
 
@@ -265,7 +291,7 @@ describe("DirFeatureProcessor", () => {
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/elsewhere/root/orphan", true, "/elsewhere/root")],
+        [createMockDir({ dirPath: "/elsewhere/root/orphan", outputRoot: "/elsewhere/root" })],
         [],
       );
 
@@ -287,7 +313,7 @@ describe("DirFeatureProcessor", () => {
 
       const sharedRoot = "/elsewhere/facets/knowledge";
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir(sharedRoot, false, sharedRoot)],
+        [createMockDir({ dirPath: sharedRoot, ownsDirTree: false, outputRoot: sharedRoot })],
         [],
       );
 
@@ -300,15 +326,60 @@ describe("DirFeatureProcessor", () => {
       expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining("shared root"));
     });
 
+    it("should refuse a candidate whose relative directory path climbs out", async () => {
+      // The half of the root the candidate supplies as a relative path is the
+      // one that can climb: a root reached by `..` would otherwise vouch for
+      // every directory below wherever it landed.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir({ dirPath: "/orphan", outputRoot: "/path/to", relativeDirPath: "../.." })],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('the root "/" it was found in is not inside "/path/to"'),
+      );
+    });
+
+    it("should still sweep a real orphan alongside a refused candidate", async () => {
+      // Refusing one candidate must not turn `--delete` off for the rest of the
+      // run, the same way the shared-root case does not.
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
+
+      const count = await processor.removeOrphanAiDirs(
+        [
+          createMockDir({ dirPath: "/elsewhere/root/orphan", outputRoot: "/elsewhere/root" }),
+          createMockDir({ dirPath: "/path/to/orphan" }),
+        ],
+        [],
+      );
+
+      expect(count).toBe(1);
+      expect(removeDirectory).toHaveBeenCalledExactlyOnceWith("/path/to/orphan");
+    });
+
     it("should not remove any dirs when all existing dirs are in generated", async () => {
       const processor = new TestDirProcessor({
         logger: createMockLogger(),
         outputRoot: "/path/to",
       });
 
-      const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+      const existingDirs = [
+        createMockDir({ dirPath: "/path/to/dir1" }),
+        createMockDir({ dirPath: "/path/to/dir2" }),
+      ];
 
-      const generatedDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+      const generatedDirs = [
+        createMockDir({ dirPath: "/path/to/dir1" }),
+        createMockDir({ dirPath: "/path/to/dir2" }),
+      ];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
 
@@ -322,7 +393,10 @@ describe("DirFeatureProcessor", () => {
         outputRoot: "/path/to",
       });
 
-      const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
+      const existingDirs = [
+        createMockDir({ dirPath: "/path/to/dir1" }),
+        createMockDir({ dirPath: "/path/to/dir2" }),
+      ];
 
       const generatedDirs: AiDir[] = [];
 
@@ -343,12 +417,12 @@ describe("DirFeatureProcessor", () => {
       });
 
       const existingDirs = [
-        createMockDir("/path/to/orphan1"),
-        createMockDir("/path/to/orphan2"),
-        createMockDir("/path/to/kept"),
+        createMockDir({ dirPath: "/path/to/orphan1" }),
+        createMockDir({ dirPath: "/path/to/orphan2" }),
+        createMockDir({ dirPath: "/path/to/kept" }),
       ];
 
-      const generatedDirs = [createMockDir("/path/to/kept")];
+      const generatedDirs = [createMockDir({ dirPath: "/path/to/kept" })];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
 
@@ -374,8 +448,8 @@ describe("DirFeatureProcessor", () => {
 
       const sharedRoot = "/path/to/.takt/facets/knowledge";
       const existingDirs = [
-        createMockDir(sharedRoot, false, sharedRoot),
-        createMockDir(sharedRoot, false, sharedRoot),
+        createMockDir({ dirPath: sharedRoot, ownsDirTree: false, outputRoot: sharedRoot }),
+        createMockDir({ dirPath: sharedRoot, ownsDirTree: false, outputRoot: sharedRoot }),
       ];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, []);
@@ -400,12 +474,12 @@ describe("DirFeatureProcessor", () => {
 
       const count = await processor.removeOrphanAiDirs(
         [
-          createMockDir(
-            "/path/to/.takt/facets/knowledge",
-            false,
-            "/path/to/.takt/facets/knowledge",
-          ),
-          createMockDir("/path/to/orphan"),
+          createMockDir({
+            dirPath: "/path/to/.takt/facets/knowledge",
+            ownsDirTree: false,
+            outputRoot: "/path/to/.takt/facets/knowledge",
+          }),
+          createMockDir({ dirPath: "/path/to/orphan" }),
         ],
         [],
       );
@@ -427,11 +501,11 @@ describe("DirFeatureProcessor", () => {
 
       const count = await processor.removeOrphanAiDirs(
         [
-          createMockDir(
-            "/path/to/.takt/facets/knowledge",
-            false,
-            "/path/to/.takt/facets/knowledge",
-          ),
+          createMockDir({
+            dirPath: "/path/to/.takt/facets/knowledge",
+            ownsDirTree: false,
+            outputRoot: "/path/to/.takt/facets/knowledge",
+          }),
         ],
         [],
       );
@@ -447,7 +521,7 @@ describe("DirFeatureProcessor", () => {
       });
 
       const existingDirs: AiDir[] = [];
-      const generatedDirs = [createMockDir("/path/to/dir1")];
+      const generatedDirs = [createMockDir({ dirPath: "/path/to/dir1" })];
 
       await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
 

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -145,10 +145,11 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should refuse a candidate that reports the root it was found in", async () => {
-      // What #2784 actually hit: a subclass overrode `getDirPath()` to return
-      // the shared root, so every candidate reported the same directory and the
-      // sweep deleted the root with every sibling in it. `ownsDirTree()` is the
-      // subclass's own answer, so the sweep does not take it as the last word.
+      // The shape #2777 hit: a subclass overrode `getDirPath()` to return the
+      // shared root, so every candidate reported the same directory and the
+      // sweep deleted the root with every sibling in it. There it was
+      // `ownsDirTree()` that stopped the deletion; this pins that a candidate
+      // which claims the tree as its own anyway does not get through either.
       const logger = createMockLogger();
       const processor = new TestDirProcessor({ logger, outputRoot: testDir });
 
@@ -160,7 +161,8 @@ describe("DirFeatureProcessor", () => {
       expect(count).toBe(0);
       expect(removeDirectory).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Refusing to delete "/path/to/root"'),
+        'Refusing to delete "/path/to/root": it is the root it was found in, not a directory ' +
+          "inside that root",
       );
     });
 
@@ -176,8 +178,22 @@ describe("DirFeatureProcessor", () => {
       expect(count).toBe(0);
       expect(removeDirectory).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Refusing to delete "/path/to/elsewhere"'),
+        'Refusing to delete "/path/to/elsewhere": it is not inside "/path/to/root", the root it ' +
+          "was found in",
       );
+    });
+
+    it("should still remove a directory whose name merely starts with dots", async () => {
+      // `..cache` is an ordinary directory name, not a climb out of the root.
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/root/..cache", true, "/path/to/root")],
+        [],
+      );
+
+      expect(count).toBe(1);
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/root/..cache");
     });
 
     it("should still remove a directory nested below the root it was found in", async () => {

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -31,17 +31,19 @@ vi.mock("../utils/file.js", async () => {
 function createMockDir(
   dirPath: string,
   ownsDirTree = true,
-  // The root the directory was found in. It defaults to the parent, which is
-  // where a real `AiDir` puts it: the sweep now checks that positionally.
-  root = dirname(dirPath),
+  // The root the directory was found in, as a real `AiDir` carries it: an
+  // output root plus a relative directory path. It defaults to the parent,
+  // which is where a real `AiDir` puts it — the sweep checks that positionally.
+  outputRoot = dirname(dirPath),
+  relativeDirPath = ".",
 ): AiDir {
   return {
     getDirPath: () => dirPath,
     getDirName: () => basename(dirPath),
     getMainFile: () => undefined,
     getOtherFiles: () => [],
-    getOutputRoot: () => root,
-    getRelativeDirPath: () => ".",
+    getOutputRoot: () => outputRoot,
+    getRelativeDirPath: () => relativeDirPath,
     getRelativePathFromCwd: () => dirPath,
     ownsDirTree: () => ownsDirTree,
   } as unknown as AiDir;
@@ -107,7 +109,7 @@ describe("DirFeatureProcessor", () => {
   describe("removeOrphanAiDirs", () => {
     it("should remove dirs that exist in existing but not in generated", async () => {
       const logger = createMockLogger();
-      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const existingDirs = [
         createMockDir("/path/to/orphan1"),
@@ -125,14 +127,14 @@ describe("DirFeatureProcessor", () => {
       expect(removeDirectory).toHaveBeenCalledWith("/path/to/orphan2");
       // Symmetric with the dry-run case below: a real `--delete` run has to
       // report the directories it removed.
-      expect(logger.info).toHaveBeenCalledWith("Deleted directory: /path/to/orphan1");
-      expect(logger.info).toHaveBeenCalledWith("Deleted directory: /path/to/orphan2");
+      expect(logger.info).toHaveBeenCalledWith('Deleted directory: "/path/to/orphan1"');
+      expect(logger.info).toHaveBeenCalledWith('Deleted directory: "/path/to/orphan2"');
       expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("kept"));
     });
 
     it("should strip control characters from the deletion log", async () => {
       const logger = createMockLogger();
-      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       // The path is an on-disk name rulesync did not choose, so a name carrying
       // `\x1b[2K\r` must not be able to rewrite the line and hide the deletion.
@@ -141,7 +143,7 @@ describe("DirFeatureProcessor", () => {
       const count = await processor.removeOrphanAiDirs(existingDirs, []);
 
       expect(count).toBe(1);
-      expect(logger.info).toHaveBeenCalledWith("Deleted directory: /path/to/[2K-innocent");
+      expect(logger.info).toHaveBeenCalledWith('Deleted directory: "/path/to/[2K-innocent"');
     });
 
     it("should refuse a candidate that reports the root it was found in", async () => {
@@ -151,7 +153,7 @@ describe("DirFeatureProcessor", () => {
       // `ownsDirTree()` that stopped the deletion; this pins that a candidate
       // which claims the tree as its own anyway does not get through either.
       const logger = createMockLogger();
-      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
         [createMockDir("/path/to/root", true, "/path/to/root")],
@@ -168,7 +170,7 @@ describe("DirFeatureProcessor", () => {
 
     it("should refuse a candidate that climbs out of the root it was found in", async () => {
       const logger = createMockLogger();
-      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const count = await processor.removeOrphanAiDirs(
         [createMockDir("/path/to/elsewhere", true, "/path/to/root")],
@@ -185,7 +187,10 @@ describe("DirFeatureProcessor", () => {
 
     it("should still remove a directory whose name merely starts with dots", async () => {
       // `..cache` is an ordinary directory name, not a climb out of the root.
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const count = await processor.removeOrphanAiDirs(
         [createMockDir("/path/to/root/..cache", true, "/path/to/root")],
@@ -198,7 +203,10 @@ describe("DirFeatureProcessor", () => {
 
     it("should still remove a directory nested below the root it was found in", async () => {
       // A tool that keeps its skills one level deeper is not the case above.
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const count = await processor.removeOrphanAiDirs(
         [createMockDir("/path/to/root/nested/orphan", true, "/path/to/root")],
@@ -209,8 +217,70 @@ describe("DirFeatureProcessor", () => {
       expect(removeDirectory).toHaveBeenCalledWith("/path/to/root/nested/orphan");
     });
 
+    it("should report a candidate that disowns a directory which is not the root", async () => {
+      // `ownsDirTree()` is false for two shapes: a tool that flattens into a
+      // shared root, and an override of `getDirPath()` that was never kept in
+      // agreement with it. Only the first reports the root, so calling the
+      // second a shared root would say something untrue about it.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/root/elsewhere", false, "/path/to/root")],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Refusing to delete "/path/to/root/elsewhere": it does not own that directory, and it ' +
+          'is not the shared root "/path/to/root" it was found in either',
+      );
+      expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining("shared root, not"));
+    });
+
+    it("should build the root from both halves the candidate carries", async () => {
+      // `relativeDirPath` is part of the root, and dropping it would widen the
+      // root to the output root and let a sibling tree through.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/other/orphan", true, "/path/to", "root")],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('it is not inside "/path/to/root"'),
+      );
+    });
+
+    it("should refuse a candidate whose own root is outside the processor's", async () => {
+      // The root a candidate reports is its own claim. One that climbs out of
+      // the directory the processor writes to would otherwise vouch for
+      // everything below it.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/elsewhere/root/orphan", true, "/elsewhere/root")],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Refusing to delete "/elsewhere/root/orphan"'),
+      );
+    });
+
     it("should not remove any dirs when all existing dirs are in generated", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
 
@@ -223,7 +293,10 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should remove all dirs when generated is empty", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const existingDirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
 
@@ -241,7 +314,7 @@ describe("DirFeatureProcessor", () => {
       const logger = createMockLogger();
       const processor = new TestDirProcessor({
         logger,
-        outputRoot: testDir,
+        outputRoot: "/path/to",
         dryRun: true,
       });
 
@@ -258,10 +331,10 @@ describe("DirFeatureProcessor", () => {
       expect(count).toBe(2);
       expect(removeDirectory).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
-        "[DRY RUN] Would delete directory: /path/to/orphan1",
+        '[DRY RUN] Would delete directory: "/path/to/orphan1"',
       );
       expect(logger.info).toHaveBeenCalledWith(
-        "[DRY RUN] Would delete directory: /path/to/orphan2",
+        '[DRY RUN] Would delete directory: "/path/to/orphan2"',
       );
       expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("kept"));
     });
@@ -273,10 +346,13 @@ describe("DirFeatureProcessor", () => {
       // skill was generated deleted the root itself, taking hand-authored files
       // in it with it.
       const logger = createMockLogger();
-      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
 
       const sharedRoot = "/path/to/.takt/facets/knowledge";
-      const existingDirs = [createMockDir(sharedRoot, false), createMockDir(sharedRoot, false)];
+      const existingDirs = [
+        createMockDir(sharedRoot, false, sharedRoot),
+        createMockDir(sharedRoot, false, sharedRoot),
+      ];
 
       const count = await processor.removeOrphanAiDirs(existingDirs, []);
 
@@ -289,10 +365,20 @@ describe("DirFeatureProcessor", () => {
       // The guard has to work per candidate. Stopping the whole sweep the moment
       // one flat-file tool appears in the list would silently turn `--delete`
       // off for everything else in the same run.
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/.takt/facets/knowledge", false), createMockDir("/path/to/orphan")],
+        [
+          createMockDir(
+            "/path/to/.takt/facets/knowledge",
+            false,
+            "/path/to/.takt/facets/knowledge",
+          ),
+          createMockDir("/path/to/orphan"),
+        ],
         [],
       );
 
@@ -307,12 +393,18 @@ describe("DirFeatureProcessor", () => {
       const logger = createMockLogger();
       const processor = new TestDirProcessor({
         logger,
-        outputRoot: testDir,
+        outputRoot: "/path/to",
         dryRun: true,
       });
 
       const count = await processor.removeOrphanAiDirs(
-        [createMockDir("/path/to/.takt/facets/knowledge", false)],
+        [
+          createMockDir(
+            "/path/to/.takt/facets/knowledge",
+            false,
+            "/path/to/.takt/facets/knowledge",
+          ),
+        ],
         [],
       );
 
@@ -321,7 +413,10 @@ describe("DirFeatureProcessor", () => {
     });
 
     it("should not remove any dirs when existing is empty", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
 
       const existingDirs: AiDir[] = [];
       const generatedDirs = [createMockDir("/path/to/dir1")];
@@ -578,20 +673,6 @@ describe("DirFeatureProcessor", () => {
       });
       expect(ensureDir).not.toHaveBeenCalled();
       expect(writeFileContent).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("removeAiDirs", () => {
-    it("should remove all dirs", async () => {
-      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
-
-      const dirs = [createMockDir("/path/to/dir1"), createMockDir("/path/to/dir2")];
-
-      await processor.removeAiDirs(dirs);
-
-      expect(removeDirectory).toHaveBeenCalledTimes(2);
-      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir1");
-      expect(removeDirectory).toHaveBeenCalledWith("/path/to/dir2");
     });
   });
 });

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -1,4 +1,4 @@
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,12 +28,20 @@ vi.mock("../utils/file.js", async () => {
   };
 });
 
-function createMockDir(dirPath: string, ownsDirTree = true): AiDir {
+function createMockDir(
+  dirPath: string,
+  ownsDirTree = true,
+  // The root the directory was found in. It defaults to the parent, which is
+  // where a real `AiDir` puts it: the sweep now checks that positionally.
+  root = dirname(dirPath),
+): AiDir {
   return {
     getDirPath: () => dirPath,
     getDirName: () => basename(dirPath),
     getMainFile: () => undefined,
     getOtherFiles: () => [],
+    getOutputRoot: () => root,
+    getRelativeDirPath: () => ".",
     getRelativePathFromCwd: () => dirPath,
     ownsDirTree: () => ownsDirTree,
   } as unknown as AiDir;
@@ -134,6 +142,55 @@ describe("DirFeatureProcessor", () => {
 
       expect(count).toBe(1);
       expect(logger.info).toHaveBeenCalledWith("Deleted directory: /path/to/[2K-innocent");
+    });
+
+    it("should refuse a candidate that reports the root it was found in", async () => {
+      // What #2784 actually hit: a subclass overrode `getDirPath()` to return
+      // the shared root, so every candidate reported the same directory and the
+      // sweep deleted the root with every sibling in it. `ownsDirTree()` is the
+      // subclass's own answer, so the sweep does not take it as the last word.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/root", true, "/path/to/root")],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Refusing to delete "/path/to/root"'),
+      );
+    });
+
+    it("should refuse a candidate that climbs out of the root it was found in", async () => {
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/elsewhere", true, "/path/to/root")],
+        [],
+      );
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Refusing to delete "/path/to/elsewhere"'),
+      );
+    });
+
+    it("should still remove a directory nested below the root it was found in", async () => {
+      // A tool that keeps its skills one level deeper is not the case above.
+      const processor = new TestDirProcessor({ logger: createMockLogger(), outputRoot: testDir });
+
+      const count = await processor.removeOrphanAiDirs(
+        [createMockDir("/path/to/root/nested/orphan", true, "/path/to/root")],
+        [],
+      );
+
+      expect(count).toBe(1);
+      expect(removeDirectory).toHaveBeenCalledWith("/path/to/root/nested/orphan");
     });
 
     it("should not remove any dirs when all existing dirs are in generated", async () => {

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -24,26 +24,43 @@ import { RulesyncSourceConsumer } from "./rulesync-source-consumer.js";
 import { ToolTarget } from "./tool-targets.js";
 
 /**
- * Whether the directory a candidate reports really is one of the directories
- * inside the root it was enumerated from.
+ * Where a candidate's directory sits relative to the root it was enumerated
+ * from: `inside` it, `equal` to it, or `outside` it altogether.
  *
  * Positional rather than delegated: a subclass that overrides
  * {@link AiDir.getDirPath} without keeping {@link AiDir.ownsDirTree} in
  * agreement with it is caught here, since the answer comes from comparing the
- * path against the root instead of from asking the candidate whether its path
- * is its own. Equal paths fail it too — a candidate that reports the root is
- * the shared root, and deleting that takes every sibling in it.
+ * path against the root instead of from asking the candidate whether the path
+ * is its own. `equal` is called out separately because a candidate that reports
+ * the root is never swept — deleting that takes every sibling in it — but
+ * for a tool that flattens into a shared root it is the expected shape rather
+ * than a mismatch.
  *
  * It is a backstop, not the guard: the comparison is lexical, so a root that is
  * itself a link into another tree still passes it, and the caller-side
  * `assertWritablePathInsideRoot` — which resolves the real path — is what rules
- * that out. The three values it reads are the candidate's own, so it is a
- * consistency check across them rather than a fact about the filesystem.
+ * that out.
  */
-function isInsideOwnRoot(aiDir: AiDir): boolean {
-  const root = resolve(join(aiDir.getOutputRoot(), aiDir.getRelativeDirPath()));
-  const relativeToRoot = relative(root, resolve(aiDir.getDirPath()));
-  return relativeToRoot !== "" && !pathEscapesRoot(relativeToRoot);
+function locateInOwnRoot(params: { aiDir: AiDir; dirPath: string; outputRoot: string }): {
+  verdict: "inside" | "equal" | "outside";
+  root: string;
+} {
+  const { aiDir, dirPath, outputRoot } = params;
+  const root = join(aiDir.getOutputRoot(), aiDir.getRelativeDirPath());
+  // The candidate's own root has to sit in the processor's output root as well.
+  // Both halves of it are values the candidate carries, and a `relativeDirPath`
+  // that climbs out would otherwise make everything below it look contained.
+  if (pathEscapesRoot(relative(resolve(outputRoot), resolve(root)))) {
+    return { verdict: "outside", root };
+  }
+  // One `relative()` decides both questions, so the equal case cannot be
+  // classified one way here and the other way in the message: on Windows the
+  // comparison ignores case, and a direct string equality test would not.
+  const relativeToRoot = relative(resolve(root), resolve(dirPath));
+  if (relativeToRoot === "") {
+    return { verdict: "equal", root };
+  }
+  return { verdict: pathEscapesRoot(relativeToRoot) ? "outside" : "inside", root };
 }
 
 export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
@@ -217,58 +234,72 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     return { count: changedCount, paths: changedPaths };
   }
 
-  async removeAiDirs(aiDirs: AiDir[]): Promise<void> {
-    for (const aiDir of aiDirs) {
-      await removeDirectory(aiDir.getDirPath());
-    }
-  }
-
   /**
    * Remove orphan directories that exist in the tool directory but not in the generated directories.
    * This only deletes directories that are no longer in the rulesync source, not directories that will be overwritten.
    */
   async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<number> {
     const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
-    const orphanDirs = existingDirs.filter((d) => {
-      // A candidate that does not own its directory tree cannot be an orphan of
-      // itself: its path is a root it merely flattens into, so deleting it would
-      // take every sibling in that root with it (see `AiDir.ownsDirTree`).
-      // Checked first, because a tool that flattens says so here and reports
-      // the root as its path — an expected shape, not the mismatch below.
-      if (!d.ownsDirTree()) {
-        this.logger.debug(
-          // Quoted by the serializer: the name comes off disk, and while the
-          // strip above rules out forging a whole line, an unquoted name like
-          // `Deleted directory: /home/you/important` still reads as one.
-          `Skipping orphan sweep for ${JSON.stringify(stripControlCharacters(d.getDirName()))}: ` +
-            `${stripControlCharacters(d.getDirPath())} is a shared root, not a directory of its own`,
-        );
-        return false;
+    const orphanPaths: string[] = [];
+
+    for (const aiDir of existingDirs) {
+      // Read once, and check and delete that one value: `getDirPath()` is a
+      // method a subclass supplies, so calling it again could answer
+      // differently and delete something the checks below never saw.
+      const dirPath = aiDir.getDirPath();
+      const { verdict, root } = locateInOwnRoot({ aiDir, dirPath, outputRoot: this.outputRoot });
+      // Quoted by the serializer: these names come off disk, and while the
+      // strip rules out forging a whole line, an unquoted name like
+      // `Deleted directory: /home/you/important` still reads as one.
+      const quotedDirPath = JSON.stringify(stripControlCharacters(dirPath));
+      const quotedRoot = JSON.stringify(stripControlCharacters(root));
+
+      if (!aiDir.ownsDirTree()) {
+        // False for two different shapes. A tool that flattens into a shared
+        // root reports that root as its path: expected, and quiet, since the
+        // root is never swept anyway — deleting it takes every sibling in it.
+        // Anything else is a `getDirPath()` override that was not kept in
+        // agreement with `ownsDirTree()`, and calling that a shared root would
+        // be untrue, so it is reported rather than passed over in silence.
+        if (verdict === "equal") {
+          this.logger.debug(
+            `Skipping orphan sweep for ` +
+              `${JSON.stringify(stripControlCharacters(aiDir.getDirName()))}: ` +
+              `${stripControlCharacters(dirPath)} is a shared root, not a directory of its own`,
+          );
+        } else {
+          this.logger.warn(
+            `Refusing to delete ${quotedDirPath}: it does not own that directory, and it is not ` +
+              `the shared root ${quotedRoot} it was found in either`,
+          );
+        }
+        continue;
       }
+
       // Checked here rather than trusted from the caller: this method is public
       // on the base class and takes any `AiDir`, so a future caller inherits the
       // recursive deletion without the caller-side guards `SkillsProcessor`
       // applies. A candidate that claims its directory as its own and reports a
       // path that is not in the root it was found in has a contract mismatch,
       // and this is where that stops being a deletion the user cannot undo.
-      if (!isInsideOwnRoot(d)) {
-        const dirPath = JSON.stringify(stripControlCharacters(d.getDirPath()));
-        const root = join(d.getOutputRoot(), d.getRelativeDirPath());
+      if (verdict !== "inside") {
         this.logger.warn(
-          resolve(root) === resolve(d.getDirPath())
-            ? `Refusing to delete ${dirPath}: it is the root it was found in, not a directory ` +
-                `inside that root`
-            : `Refusing to delete ${dirPath}: it is not inside ` +
-                `${JSON.stringify(stripControlCharacters(root))}, the root it was found in`,
+          verdict === "equal"
+            ? `Refusing to delete ${quotedDirPath}: it is the root it was found in, not a ` +
+                `directory inside that root`
+            : `Refusing to delete ${quotedDirPath}: it is not inside ${quotedRoot}, the root it ` +
+                `was found in`,
         );
-        return false;
+        continue;
       }
-      return !generatedPaths.has(d.getDirPath());
-    });
 
-    for (const aiDir of orphanDirs) {
-      const dirPath = aiDir.getDirPath();
-      const loggedPath = stripControlCharacters(dirPath);
+      if (!generatedPaths.has(dirPath)) {
+        orphanPaths.push(dirPath);
+      }
+    }
+
+    for (const dirPath of orphanPaths) {
+      const loggedPath = JSON.stringify(stripControlCharacters(dirPath));
       if (this.dryRun) {
         this.logger.info(`[DRY RUN] Would delete directory: ${loggedPath}`);
       } else {
@@ -277,6 +308,6 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       }
     }
 
-    return orphanDirs.length;
+    return orphanPaths.length;
   }
 }

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";
 import {
@@ -9,6 +9,7 @@ import { stripControlCharacters } from "../utils/control-characters.js";
 import {
   addTrailingNewline,
   ensureDir,
+  pathEscapesRoot,
   readFileBufferOrNull,
   readFileContentOrNull,
   removeDirectory,
@@ -26,18 +27,23 @@ import { ToolTarget } from "./tool-targets.js";
  * Whether the directory a candidate reports really is one of the directories
  * inside the root it was enumerated from.
  *
- * Deliberately structural: it asks nothing of the candidate beyond the three
- * values it was built with, so it holds even when {@link AiDir.getDirPath} is
- * overridden and {@link AiDir.ownsDirTree} is not kept in agreement with it.
- * Equal paths fail it too — a candidate that reports the root is the shared
- * root, and deleting that takes every sibling in it.
+ * Positional rather than delegated: a subclass that overrides
+ * {@link AiDir.getDirPath} without keeping {@link AiDir.ownsDirTree} in
+ * agreement with it is caught here, since the answer comes from comparing the
+ * path against the root instead of from asking the candidate whether its path
+ * is its own. Equal paths fail it too — a candidate that reports the root is
+ * the shared root, and deleting that takes every sibling in it.
+ *
+ * It is a backstop, not the guard: the comparison is lexical, so a root that is
+ * itself a link into another tree still passes it, and the caller-side
+ * `assertWritablePathInsideRoot` — which resolves the real path — is what rules
+ * that out. The three values it reads are the candidate's own, so it is a
+ * consistency check across them rather than a fact about the filesystem.
  */
 function isInsideOwnRoot(aiDir: AiDir): boolean {
   const root = resolve(join(aiDir.getOutputRoot(), aiDir.getRelativeDirPath()));
   const relativeToRoot = relative(root, resolve(aiDir.getDirPath()));
-  // An absolute result means the two are on different Windows drives, and a
-  // leading `..` means the candidate climbs out of the root.
-  return relativeToRoot !== "" && !relativeToRoot.startsWith("..") && !isAbsolute(relativeToRoot);
+  return relativeToRoot !== "" && !pathEscapesRoot(relativeToRoot);
 }
 
 export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
@@ -224,24 +230,11 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
   async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<number> {
     const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
     const orphanDirs = existingDirs.filter((d) => {
-      // Checked here rather than trusted from the caller: this method is public
-      // on the base class and takes any `AiDir`, so a future caller inherits the
-      // recursive deletion without the caller-side guards `SkillsProcessor`
-      // applies. What it refuses is positional — the candidate has to sit
-      // strictly below the root it was enumerated from — so a subclass that
-      // reports the root itself, or a path in another tree entirely, cannot
-      // turn a contract mismatch into a deletion the user cannot undo.
-      if (!isInsideOwnRoot(d)) {
-        this.logger.warn(
-          `Refusing to delete ${JSON.stringify(stripControlCharacters(d.getDirPath()))}: it is ` +
-            `not inside ${JSON.stringify(stripControlCharacters(join(d.getOutputRoot(), d.getRelativeDirPath())))}, ` +
-            `the directory it was found in`,
-        );
-        return false;
-      }
       // A candidate that does not own its directory tree cannot be an orphan of
       // itself: its path is a root it merely flattens into, so deleting it would
       // take every sibling in that root with it (see `AiDir.ownsDirTree`).
+      // Checked first, because a tool that flattens says so here and reports
+      // the root as its path — an expected shape, not the mismatch below.
       if (!d.ownsDirTree()) {
         this.logger.debug(
           // Quoted by the serializer: the name comes off disk, and while the
@@ -249,6 +242,24 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
           // `Deleted directory: /home/you/important` still reads as one.
           `Skipping orphan sweep for ${JSON.stringify(stripControlCharacters(d.getDirName()))}: ` +
             `${stripControlCharacters(d.getDirPath())} is a shared root, not a directory of its own`,
+        );
+        return false;
+      }
+      // Checked here rather than trusted from the caller: this method is public
+      // on the base class and takes any `AiDir`, so a future caller inherits the
+      // recursive deletion without the caller-side guards `SkillsProcessor`
+      // applies. A candidate that claims its directory as its own and reports a
+      // path that is not in the root it was found in has a contract mismatch,
+      // and this is where that stops being a deletion the user cannot undo.
+      if (!isInsideOwnRoot(d)) {
+        const dirPath = JSON.stringify(stripControlCharacters(d.getDirPath()));
+        const root = join(d.getOutputRoot(), d.getRelativeDirPath());
+        this.logger.warn(
+          resolve(root) === resolve(d.getDirPath())
+            ? `Refusing to delete ${dirPath}: it is the root it was found in, not a directory ` +
+                `inside that root`
+            : `Refusing to delete ${dirPath}: it is not inside ` +
+                `${JSON.stringify(stripControlCharacters(root))}, the root it was found in`,
         );
         return false;
       }

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { RULESYNC_RELATIVE_DIR_PATH } from "../constants/rulesync-paths.js";
 import {
@@ -21,6 +21,24 @@ import type { WriteResult } from "../utils/result.js";
 import { AiDir, AiDirFile } from "./ai-dir.js";
 import { RulesyncSourceConsumer } from "./rulesync-source-consumer.js";
 import { ToolTarget } from "./tool-targets.js";
+
+/**
+ * Whether the directory a candidate reports really is one of the directories
+ * inside the root it was enumerated from.
+ *
+ * Deliberately structural: it asks nothing of the candidate beyond the three
+ * values it was built with, so it holds even when {@link AiDir.getDirPath} is
+ * overridden and {@link AiDir.ownsDirTree} is not kept in agreement with it.
+ * Equal paths fail it too — a candidate that reports the root is the shared
+ * root, and deleting that takes every sibling in it.
+ */
+function isInsideOwnRoot(aiDir: AiDir): boolean {
+  const root = resolve(join(aiDir.getOutputRoot(), aiDir.getRelativeDirPath()));
+  const relativeToRoot = relative(root, resolve(aiDir.getDirPath()));
+  // An absolute result means the two are on different Windows drives, and a
+  // leading `..` means the candidate climbs out of the root.
+  return relativeToRoot !== "" && !relativeToRoot.startsWith("..") && !isAbsolute(relativeToRoot);
+}
 
 export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
   protected readonly outputRoot: string;
@@ -206,6 +224,21 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
   async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<number> {
     const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
     const orphanDirs = existingDirs.filter((d) => {
+      // Checked here rather than trusted from the caller: this method is public
+      // on the base class and takes any `AiDir`, so a future caller inherits the
+      // recursive deletion without the caller-side guards `SkillsProcessor`
+      // applies. What it refuses is positional — the candidate has to sit
+      // strictly below the root it was enumerated from — so a subclass that
+      // reports the root itself, or a path in another tree entirely, cannot
+      // turn a contract mismatch into a deletion the user cannot undo.
+      if (!isInsideOwnRoot(d)) {
+        this.logger.warn(
+          `Refusing to delete ${JSON.stringify(stripControlCharacters(d.getDirPath()))}: it is ` +
+            `not inside ${JSON.stringify(stripControlCharacters(join(d.getOutputRoot(), d.getRelativeDirPath())))}, ` +
+            `the directory it was found in`,
+        );
+        return false;
+      }
       // A candidate that does not own its directory tree cannot be an orphan of
       // itself: its path is a root it merely flattens into, so deleting it would
       // take every sibling in that root with it (see `AiDir.ownsDirTree`).

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -25,7 +25,9 @@ import { ToolTarget } from "./tool-targets.js";
 
 /**
  * Where a candidate's directory sits relative to the root it was enumerated
- * from: `inside` it, `equal` to it, or `outside` it altogether.
+ * from: `inside` it, `equal` to it, or `outside` it altogether — or
+ * `root-outside`, when that root is not even in the directory this run writes
+ * to, which says nothing about where the directory sits within it.
  *
  * Positional rather than delegated: a subclass that overrides
  * {@link AiDir.getDirPath} without keeping {@link AiDir.ownsDirTree} in
@@ -42,7 +44,7 @@ import { ToolTarget } from "./tool-targets.js";
  * that out.
  */
 function locateInOwnRoot(params: { aiDir: AiDir; dirPath: string; outputRoot: string }): {
-  verdict: "inside" | "equal" | "outside";
+  verdict: "inside" | "equal" | "outside" | "root-outside";
   root: string;
 } {
   const { aiDir, dirPath, outputRoot } = params;
@@ -51,7 +53,7 @@ function locateInOwnRoot(params: { aiDir: AiDir; dirPath: string; outputRoot: st
   // Both halves of it are values the candidate carries, and a `relativeDirPath`
   // that climbs out would otherwise make everything below it look contained.
   if (pathEscapesRoot(relative(resolve(outputRoot), resolve(root)))) {
-    return { verdict: "outside", root };
+    return { verdict: "root-outside", root };
   }
   // One `relative()` decides both questions, so the equal case cannot be
   // classified one way here and the other way in the message: on Windows the
@@ -254,6 +256,19 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       const quotedDirPath = JSON.stringify(stripControlCharacters(dirPath));
       const quotedRoot = JSON.stringify(stripControlCharacters(root));
 
+      const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
+      // Reported before anything about the directory's position, because a root
+      // that is not in the directory this run writes to makes that position
+      // meaningless: the directory can sit squarely inside a root that is
+      // itself somewhere else entirely.
+      if (verdict === "root-outside") {
+        this.logger.warn(
+          `Refusing to delete ${quotedDirPath}: the root ${quotedRoot} it was found in is not ` +
+            `inside ${quotedOutputRoot}, the directory this run writes to`,
+        );
+        continue;
+      }
+
       if (!aiDir.ownsDirTree()) {
         // False for two different shapes. A tool that flattens into a shared
         // root reports that root as its path: expected, and quiet, since the
@@ -265,7 +280,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
           this.logger.debug(
             `Skipping orphan sweep for ` +
               `${JSON.stringify(stripControlCharacters(aiDir.getDirName()))}: ` +
-              `${stripControlCharacters(dirPath)} is a shared root, not a directory of its own`,
+              `${quotedDirPath} is a shared root, not a directory of its own`,
           );
         } else {
           this.logger.warn(

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -242,7 +242,10 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
    */
   async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<number> {
     const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
-    const orphanPaths: string[] = [];
+    // A set, so two candidates that report the same directory delete it once
+    // and are counted once.
+    const orphanPaths = new Set<string>();
+    const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
 
     for (const aiDir of existingDirs) {
       // Read once, and check and delete that one value: `getDirPath()` is a
@@ -250,13 +253,13 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       // differently and delete something the checks below never saw.
       const dirPath = aiDir.getDirPath();
       const { verdict, root } = locateInOwnRoot({ aiDir, dirPath, outputRoot: this.outputRoot });
-      // Quoted by the serializer: these names come off disk, and while the
-      // strip rules out forging a whole line, an unquoted name like
-      // `Deleted directory: /home/you/important` still reads as one.
+      // Quoted by the serializer: the last segment of `dirPath` is a name that
+      // came off disk, and while the strip rules out forging a whole line, an
+      // unquoted path like `Deleted directory: /home/you/important` still reads
+      // as one. The root is quoted with it so one line reads consistently.
       const quotedDirPath = JSON.stringify(stripControlCharacters(dirPath));
       const quotedRoot = JSON.stringify(stripControlCharacters(root));
 
-      const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
       // Reported before anything about the directory's position, because a root
       // that is not in the directory this run writes to makes that position
       // meaningless: the directory can sit squarely inside a root that is
@@ -309,7 +312,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       }
 
       if (!generatedPaths.has(dirPath)) {
-        orphanPaths.push(dirPath);
+        orphanPaths.add(dirPath);
       }
     }
 
@@ -323,6 +326,6 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       }
     }
 
-    return orphanPaths.length;
+    return orphanPaths.size;
   }
 }


### PR DESCRIPTION
`DirFeatureProcessor.removeOrphanAiDirs()` decided what to recursively delete from `AiDir.ownsDirTree()` alone — the subclass's own answer about a path the subclass also computes. The positional checks (`assertWritablePathInsideRoot`) live in `SkillsProcessor.loadToolDirsToDelete()`, on the caller side, so any other caller of this public base-class method inherits the deletion without them, and #2777 showed what a contract mismatch costs: an override of `getDirPath()` made every candidate report the shared root, and the sweep deleted it.

The sweep now checks the position itself, before anything is removed. The order matters:

1. `ownsDirTree()` first. A tool that flattens its output into a shared root says so here and reports that root as its path — an expected shape, not a mismatch, and it stays on the quiet `debug` path added for #2777. `TaktSkill` is the one such tool in the tree today (`src/features/skills/takt-skill.ts`).
2. The positional backstop second. A candidate that claims the tree as its own must sit strictly below `join(outputRoot, relativeDirPath)`, the root it was enumerated from. One that reports that root, or a path in another tree, is warned about and skipped.

The check is positional rather than delegated, so it holds even when `getDirPath()` is overridden and `ownsDirTree()` is not kept in agreement with it. It is a backstop, not the guard: the comparison is lexical, so a root that is itself a symlink into another tree still passes it, and the caller-side `assertWritablePathInsideRoot` — which resolves the real path — remains required.

It also drops `removeAiDirs()`, a public recursive-delete method on the same base class with no caller in `src/` and none of these guards.

Closes #2786