### PR TITLE
refactor(checks): extract a shared base class for the aggregated checks adapters

### DIFF
--- a/src/features/checks/aggregated-tool-check.test.ts
+++ b/src/features/checks/aggregated-tool-check.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { AggregatedToolCheck, type AggregatedToolCheckConfig } from "./aggregated-tool-check.js";
+import { type ToolCheckSettablePaths } from "./tool-check.js";
+
+/**
+ * A subclass that forgets `getAggregatedCheckConfig`. TypeScript cannot demand
+ * a static, so the base throws instead — these cover that the throw is reached
+ * rather than a default silently taken.
+ */
+class ForgetfulCheck extends AggregatedToolCheck {
+  static override getSettablePaths(): ToolCheckSettablePaths {
+    return { relativeDirPath: ".forgetful", relativeFilePath: "CHECKS.md" };
+  }
+}
+
+/** A subclass that names a directory but not the one file it writes. */
+class UnnamedFileCheck extends AggregatedToolCheck {
+  static override getSettablePaths(): ToolCheckSettablePaths {
+    return { relativeDirPath: ".unnamed" };
+  }
+
+  protected static override getAggregatedCheckConfig(): AggregatedToolCheckConfig {
+    return {
+      displayName: "Unnamed",
+      toolTarget: "cursor",
+      fallbackCheckName: "unnamed",
+      handWrittenPreamble: "replace",
+    };
+  }
+}
+
+describe("AggregatedToolCheck", () => {
+  it("refuses to build one output from one check", () => {
+    expect(() =>
+      UnnamedFileCheck.fromRulesyncCheck({
+        relativeDirPath: ".unnamed",
+        rulesyncCheck: undefined as never,
+      }),
+    ).toThrow("Unnamed checks are built from all checks at once");
+  });
+
+  it("tells a subclass that skipped the config to implement it", () => {
+    expect(() => ForgetfulCheck.isTargetedByRulesyncCheck(undefined as never)).toThrow(
+      "Please implement this method in the subclass.",
+    );
+  });
+
+  it("tells a subclass that left the aggregated file unnamed to name it", async () => {
+    await expect(UnnamedFileCheck.canDeleteAuxiliaryFiles({ outputRoot: "." })).rejects.toThrow(
+      "UnnamedFileCheck writes one aggregated file, so getSettablePaths must name it.",
+    );
+  });
+});

--- a/src/features/checks/aggregated-tool-check.ts
+++ b/src/features/checks/aggregated-tool-check.ts
@@ -1,0 +1,260 @@
+import { join } from "node:path";
+
+import { type ValidationResult } from "../../types/ai-file.js";
+import { ToolTarget } from "../../types/tool-targets.js";
+import { readFileContentOrNull } from "../../utils/file.js";
+import {
+  hasHandWrittenPreamble,
+  isOnlyGeneratedSections,
+  renderCheckFile,
+  splitCheckFile,
+} from "./aggregated-check-file.js";
+import { RulesyncCheck } from "./rulesync-check.js";
+import {
+  ToolCheck,
+  type ToolCheckForDeletionParams,
+  type ToolCheckFromFileParams,
+  type ToolCheckFromRulesyncCheckParams,
+  type ToolCheckFromRulesyncChecksParams,
+} from "./tool-check.js";
+
+/**
+ * What generating does to a file that holds instructions rulesync did not
+ * write, which is the one place the three aggregated adapters genuinely differ.
+ *
+ * `replace` warns and writes anyway: the path is one only the tool's reviewer
+ * reads, so rewriting it replaces review instructions with review instructions.
+ * `skip` warns and writes nothing: the path is shared with something else — an
+ * ordinary skill directory, say — so a file there may have nothing to do with
+ * reviews and rulesync cannot rebuild what it would overwrite.
+ */
+export type AggregatedCheckHandWrittenPolicy = "replace" | "skip";
+
+export type AggregatedToolCheckConfig = {
+  /**
+   * The tool's name as it appears in messages this base builds — "Rovo Dev"
+   * rather than the `rovodev` target the same messages put in a command line.
+   */
+  displayName: string;
+  toolTarget: ToolTarget;
+  /** Name given to a check recovered from a file with no marked section. */
+  fallbackCheckName: string;
+  /**
+   * Applied to the file before it is split into checks. Set only where the
+   * output path can also hold something that is not just check sections.
+   */
+  transformImportedContent?: (fileContent: string) => string;
+} & (
+  | { handWrittenPreamble: "replace" }
+  | {
+      handWrittenPreamble: "skip";
+      /**
+       * Required for `skip` because the message has to say what to do about a
+       * file that keeps blocking generation, which is tool-specific. The
+       * `replace` wording is uniform and this base writes it.
+       */
+      handWrittenWarning: (params: { filePath: string }) => string;
+    }
+);
+
+/**
+ * Shared skeleton for the checks adapters whose output is a single aggregated
+ * instruction file — one file whose sections are the marked blocks
+ * `aggregated-check-file.ts` renders and splits, rather than a directory with a
+ * file per check.
+ *
+ * That module already held the rendering and the splitting; what is here is the
+ * adapter around it, which was near-verbatim in Cursor Bugbot, Rovo Dev and
+ * Factory Droid. A subclass supplies {@link ToolCheck.getSettablePaths} and
+ * {@link getAggregatedCheckConfig}, and inherits the rest — so a fix to how
+ * these files are read or written lands once instead of three times.
+ *
+ * `fromRulesyncCheck` is refused here rather than implemented: sections share
+ * one file, so an output cannot be produced from one check in isolation and the
+ * processor calls {@link fromRulesyncChecks} instead.
+ *
+ * Not declared `abstract`, even though nothing instantiates it directly: the
+ * statics below build the subclass with `new this(...)`, which an abstract
+ * constructor type forbids. What a subclass owes is enforced the way the rest
+ * of this codebase enforces it on a static — {@link getAggregatedCheckConfig}
+ * throws until it is overridden.
+ */
+export class AggregatedToolCheck extends ToolCheck {
+  /**
+   * The per-tool values the shared skeleton reads. Thrown rather than abstract
+   * because TypeScript has no abstract statics; a subclass that forgets it
+   * fails on its first use rather than silently taking a default.
+   */
+  protected static getAggregatedCheckConfig(): AggregatedToolCheckConfig {
+    throw new Error("Please implement this method in the subclass.");
+  }
+
+  /**
+   * The settable paths with the file name required. An aggregated adapter names
+   * the one file it writes — that is what keeps consumers which would otherwise
+   * claim the whole tool directory, the gitignore derivation among them,
+   * narrowed to it — so a missing name is a mistake in the subclass rather than
+   * a case to fall back for.
+   */
+  protected static getAggregatedPaths({ global = false }: { global?: boolean } = {}): {
+    relativeDirPath: string;
+    relativeFilePath: string;
+  } {
+    const paths = this.getSettablePaths({ global });
+    if (!paths.relativeFilePath) {
+      throw new Error(`${this.name} writes one aggregated file, so getSettablePaths must name it.`);
+    }
+    return { relativeDirPath: paths.relativeDirPath, relativeFilePath: paths.relativeFilePath };
+  }
+
+  private static getAggregatedFilePath({
+    outputRoot,
+    global = false,
+  }: {
+    outputRoot: string;
+    global?: boolean;
+  }): { relativeDirPath: string; relativeFilePath: string; filePath: string } {
+    const paths = this.getAggregatedPaths({ global });
+    return {
+      ...paths,
+      filePath: join(outputRoot, paths.relativeDirPath, paths.relativeFilePath),
+    };
+  }
+
+  static override isTargetedByRulesyncCheck(rulesyncCheck: RulesyncCheck): boolean {
+    return this.isTargetedByRulesyncCheckDefault({
+      rulesyncCheck,
+      toolTarget: this.getAggregatedCheckConfig().toolTarget,
+    });
+  }
+
+  /**
+   * Ownership guard the processor consults before it deletes anything for this
+   * tool. Every one of these paths is a file the tool's own documentation tells
+   * users to hand-write, so anything in it that rulesync did not write is not
+   * rulesync's to remove — dropping the last check targeting the tool must not
+   * take somebody's review instructions with it. Deletion is therefore allowed
+   * only for a file that is nothing but generated sections: one that carries no
+   * marker at all, or that carries hand-written text ahead of the first marker,
+   * stays.
+   */
+  static async canDeleteAuxiliaryFiles({ outputRoot }: { outputRoot: string }): Promise<boolean> {
+    const { filePath } = this.getAggregatedFilePath({ outputRoot });
+    const fileContent = await readFileContentOrNull(filePath);
+    if (fileContent === null) {
+      return true;
+    }
+    return isOnlyGeneratedSections(fileContent);
+  }
+
+  static override fromRulesyncCheck(_params: ToolCheckFromRulesyncCheckParams): ToolCheck {
+    // Sections share one file, so they are only ever built as a set.
+    const { displayName } = this.getAggregatedCheckConfig();
+    throw new Error(
+      `${displayName} checks are built from all checks at once; use fromRulesyncChecks.`,
+    );
+  }
+
+  static async fromRulesyncChecks({
+    outputRoot = process.cwd(),
+    rulesyncChecks,
+    global = false,
+    logger,
+  }: ToolCheckFromRulesyncChecksParams): Promise<AggregatedToolCheck[]> {
+    if (rulesyncChecks.length === 0) {
+      // No section to write. A stale file from an earlier generate is removed by
+      // the processor's deletion pass rather than by an empty file written here.
+      return [];
+    }
+
+    const config = this.getAggregatedCheckConfig();
+    const { relativeDirPath, relativeFilePath, filePath } = this.getAggregatedFilePath({
+      outputRoot,
+      global,
+    });
+
+    // The file is written from `.rulesync/checks/` rather than merged into, so
+    // instructions rulesync did not write are either replaced with a warning or
+    // left alone — the deletion guard protects them from a sweep, but generating
+    // is the direction it cannot speak for.
+    const existingContent = (await readFileContentOrNull(filePath)) ?? "";
+    if (hasHandWrittenPreamble(existingContent)) {
+      if (config.handWrittenPreamble === "skip") {
+        logger?.warn(config.handWrittenWarning({ filePath }));
+        return [];
+      }
+      logger?.warn(
+        `${config.displayName} checks: ${filePath} holds instructions rulesync did not write, ` +
+          `and generating replaces the whole file. Run \`rulesync import --targets ` +
+          `${config.toolTarget} --features checks\` first to keep them.`,
+      );
+    }
+
+    return [
+      new this({
+        outputRoot,
+        relativeDirPath,
+        relativeFilePath,
+        fileContent: renderCheckFile(rulesyncChecks),
+        global,
+      }),
+    ];
+  }
+
+  static override async fromFile({
+    outputRoot = process.cwd(),
+    global = false,
+  }: ToolCheckFromFileParams): Promise<AggregatedToolCheck> {
+    const { relativeDirPath, relativeFilePath, filePath } = this.getAggregatedFilePath({
+      outputRoot,
+      global,
+    });
+    return new this({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: (await readFileContentOrNull(filePath)) ?? "",
+      global,
+    });
+  }
+
+  static override forDeletion({
+    outputRoot = process.cwd(),
+    relativeDirPath,
+    relativeFilePath,
+    global = false,
+  }: ToolCheckForDeletionParams): AggregatedToolCheck {
+    return new this({
+      outputRoot,
+      relativeDirPath,
+      relativeFilePath,
+      fileContent: "",
+      validate: false,
+      global,
+    });
+  }
+
+  validate(): ValidationResult {
+    return { success: true, error: null };
+  }
+
+  toRulesyncCheck(): RulesyncCheck {
+    const checks = this.toRulesyncChecks();
+    const first = checks[0];
+    if (!first) {
+      throw new Error(
+        `No check instructions found in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}.`,
+      );
+    }
+    return first;
+  }
+
+  override toRulesyncChecks(): RulesyncCheck[] {
+    const config = (this.constructor as typeof AggregatedToolCheck).getAggregatedCheckConfig();
+    const fileContent = this.getFileContent();
+    return splitCheckFile({
+      fileContent: config.transformImportedContent?.(fileContent) ?? fileContent,
+      fallbackName: config.fallbackCheckName,
+    });
+  }
+}

--- a/src/features/checks/aggregated-tool-check.ts
+++ b/src/features/checks/aggregated-tool-check.ts
@@ -18,18 +18,6 @@ import {
   type ToolCheckFromRulesyncChecksParams,
 } from "./tool-check.js";
 
-/**
- * What generating does to a file that holds instructions rulesync did not
- * write, which is the one place the three aggregated adapters genuinely differ.
- *
- * `replace` warns and writes anyway: the path is one only the tool's reviewer
- * reads, so rewriting it replaces review instructions with review instructions.
- * `skip` warns and writes nothing: the path is shared with something else — an
- * ordinary skill directory, say — so a file there may have nothing to do with
- * reviews and rulesync cannot rebuild what it would overwrite.
- */
-export type AggregatedCheckHandWrittenPolicy = "replace" | "skip";
-
 export type AggregatedToolCheckConfig = {
   /**
    * The tool's name as it appears in messages this base builds — "Rovo Dev"
@@ -44,18 +32,36 @@ export type AggregatedToolCheckConfig = {
    * output path can also hold something that is not just check sections.
    */
   transformImportedContent?: (fileContent: string) => string;
-} & (
-  | { handWrittenPreamble: "replace" }
-  | {
-      handWrittenPreamble: "skip";
-      /**
-       * Required for `skip` because the message has to say what to do about a
-       * file that keeps blocking generation, which is tool-specific. The
-       * `replace` wording is uniform and this base writes it.
-       */
-      handWrittenWarning: (params: { filePath: string }) => string;
-    }
-);
+} &
+  /**
+   * What generating does to a file that holds instructions rulesync did not
+   * write, which is the one place the three adapters genuinely differ.
+   *
+   * `replace` warns and writes anyway: the path is one only the tool's reviewer
+   * reads, so rewriting it replaces review instructions with review
+   * instructions.
+   */
+  (
+    | { handWrittenPreamble: "replace" }
+    /**
+     * `skip` warns and writes nothing: the path is shared with something else —
+     * an ordinary skill directory, say — so a file there may have nothing to do
+     * with reviews and rulesync cannot rebuild what it would overwrite.
+     */
+    | {
+        handWrittenPreamble: "skip";
+        /**
+         * Required for `skip` because the message has to say what to do about a
+         * file that keeps blocking generation, which is tool-specific. The
+         * `replace` wording is uniform and this base writes it.
+         */
+        handWrittenWarning: (params: {
+          filePath: string;
+          displayName: string;
+          toolTarget: ToolTarget;
+        }) => string;
+      }
+  );
 
 /**
  * Shared skeleton for the checks adapters whose output is a single aggregated
@@ -130,8 +136,10 @@ export class AggregatedToolCheck extends ToolCheck {
 
   /**
    * Ownership guard the processor consults before it deletes anything for this
-   * tool. Every one of these paths is a file the tool's own documentation tells
-   * users to hand-write, so anything in it that rulesync did not write is not
+   * tool. Every one of these paths is one a user may well have written by hand
+   * — the tool's own documentation says to for the two review-instruction
+   * files, and the third is an ordinary skill directory shared with Droid's
+   * skill loader — so anything in it that rulesync did not write is not
    * rulesync's to remove — dropping the last check targeting the tool must not
    * take somebody's review instructions with it. Deletion is therefore allowed
    * only for a file that is nothing but generated sections: one that carries no
@@ -180,7 +188,13 @@ export class AggregatedToolCheck extends ToolCheck {
     const existingContent = (await readFileContentOrNull(filePath)) ?? "";
     if (hasHandWrittenPreamble(existingContent)) {
       if (config.handWrittenPreamble === "skip") {
-        logger?.warn(config.handWrittenWarning({ filePath }));
+        logger?.warn(
+          config.handWrittenWarning({
+            filePath,
+            displayName: config.displayName,
+            toolTarget: config.toolTarget,
+          }),
+        );
         return [];
       }
       logger?.warn(

--- a/src/features/checks/aggregated-tool-check.ts
+++ b/src/features/checks/aggregated-tool-check.ts
@@ -136,11 +136,10 @@ export class AggregatedToolCheck extends ToolCheck {
 
   /**
    * Ownership guard the processor consults before it deletes anything for this
-   * tool. Every one of these paths is one a user may well have written by hand
-   * — the tool's own documentation says to for the two review-instruction
-   * files, and the third is an ordinary skill directory shared with Droid's
-   * skill loader — so anything in it that rulesync did not write is not
-   * rulesync's to remove — dropping the last check targeting the tool must not
+   * tool. Every one of these paths is one a user may well have written by hand,
+   * whether because the tool documents it as the place to write review
+   * instructions or because it is shared with something else the tool loads, so
+   * anything in it that rulesync did not write is not rulesync's to remove — dropping the last check targeting the tool must not
    * take somebody's review instructions with it. Deletion is therefore allowed
    * only for a file that is nothing but generated sections: one that carries no
    * marker at all, or that carries hand-written text ahead of the first marker,

--- a/src/features/checks/cursor-check.test.ts
+++ b/src/features/checks/cursor-check.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CURSOR_BUGBOT_FILE_NAME, CURSOR_DIR } from "../../constants/cursor-paths.js";
 import { RULESYNC_CHECKS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
+import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { writeFileContent } from "../../utils/file.js";
 import { CursorCheck } from "./cursor-check.js";
@@ -242,6 +243,9 @@ describe("CursorCheck.fromFile", () => {
       });
 
       expect(check.getFileContent()).toBe("Never log secrets.\n");
+      // The shared base builds the instance with `new this(...)`, so what comes
+      // back is this adapter rather than the base.
+      expect(check).toBeInstanceOf(CursorCheck);
     } finally {
       await cleanup();
     }
@@ -324,6 +328,29 @@ describe("CursorCheck.canDeleteAuxiliaryFiles", () => {
 
   afterEach(async () => {
     await cleanup();
+  });
+
+  it("names Cursor when it warns about replacing hand-written instructions", async () => {
+    await writeFileContent(
+      join(testDir, CURSOR_DIR, CURSOR_BUGBOT_FILE_NAME),
+      "Hand-written review notes.\n",
+    );
+    const logger = createMockLogger();
+
+    const [check] = await CursorCheck.fromRulesyncChecks({
+      outputRoot: testDir,
+      relativeDirPath: RULESYNC_CHECKS_RELATIVE_DIR_PATH,
+      rulesyncChecks: [rulesyncCheck({ name: "style", body: "Prefer const." })],
+      logger,
+    });
+
+    // Written anyway — `.cursor/BUGBOT.md` is a path only the reviewer reads.
+    expect(check?.getFileContent()).toContain("Prefer const.");
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("rulesync did not write"));
+    // The tool's own name and target come from this adapter's config rather
+    // than from a literal in the message, so the message is read back whole.
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Cursor checks:"));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--targets cursor"));
   });
 
   it("refuses to delete a hand-written file carrying no marker", async () => {

--- a/src/features/checks/cursor-check.test.ts
+++ b/src/features/checks/cursor-check.test.ts
@@ -85,6 +85,34 @@ describe("CursorCheck.fromRulesyncCheck", () => {
 });
 
 describe("CursorCheck.fromRulesyncChecks", () => {
+  it("names Cursor when it warns about replacing hand-written instructions", async () => {
+    const { testDir, cleanup } = await setupTestDirectory();
+    try {
+      await writeFileContent(
+        join(testDir, CURSOR_DIR, CURSOR_BUGBOT_FILE_NAME),
+        "Hand-written review notes.\n",
+      );
+      const logger = createMockLogger();
+
+      const [check] = await CursorCheck.fromRulesyncChecks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_CHECKS_RELATIVE_DIR_PATH,
+        rulesyncChecks: [rulesyncCheck({ name: "style", body: "Prefer const." })],
+        logger,
+      });
+
+      // Written anyway — `.cursor/BUGBOT.md` is a path only the reviewer reads.
+      expect(check?.getFileContent()).toContain("Prefer const.");
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("rulesync did not write"));
+      // The tool's own name and target come from this adapter's config rather
+      // than from a literal in the message, so the message is read back whole.
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Cursor checks:"));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--targets cursor"));
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("collapses every check into one marked-up BUGBOT.md", async () => {
     const [check] = await CursorCheck.fromRulesyncChecks({
       relativeDirPath: RULESYNC_CHECKS_RELATIVE_DIR_PATH,
@@ -328,29 +356,6 @@ describe("CursorCheck.canDeleteAuxiliaryFiles", () => {
 
   afterEach(async () => {
     await cleanup();
-  });
-
-  it("names Cursor when it warns about replacing hand-written instructions", async () => {
-    await writeFileContent(
-      join(testDir, CURSOR_DIR, CURSOR_BUGBOT_FILE_NAME),
-      "Hand-written review notes.\n",
-    );
-    const logger = createMockLogger();
-
-    const [check] = await CursorCheck.fromRulesyncChecks({
-      outputRoot: testDir,
-      relativeDirPath: RULESYNC_CHECKS_RELATIVE_DIR_PATH,
-      rulesyncChecks: [rulesyncCheck({ name: "style", body: "Prefer const." })],
-      logger,
-    });
-
-    // Written anyway — `.cursor/BUGBOT.md` is a path only the reviewer reads.
-    expect(check?.getFileContent()).toContain("Prefer const.");
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("rulesync did not write"));
-    // The tool's own name and target come from this adapter's config rather
-    // than from a literal in the message, so the message is read back whole.
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Cursor checks:"));
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--targets cursor"));
   });
 
   it("refuses to delete a hand-written file carrying no marker", async () => {

--- a/src/features/checks/cursor-check.ts
+++ b/src/features/checks/cursor-check.ts
@@ -1,36 +1,17 @@
-import { join } from "node:path";
-
 import { CURSOR_BUGBOT_FILE_NAME, CURSOR_DIR } from "../../constants/cursor-paths.js";
-import type { ValidationResult } from "../../types/ai-file.js";
-import { readFileContentOrNull } from "../../utils/file.js";
-import {
-  hasHandWrittenPreamble,
-  isOnlyGeneratedSections,
-  renderCheckFile,
-  splitCheckFile,
-} from "./aggregated-check-file.js";
-import { RulesyncCheck } from "./rulesync-check.js";
-import {
-  ToolCheck,
-  type ToolCheckForDeletionParams,
-  type ToolCheckFromFileParams,
-  type ToolCheckFromRulesyncCheckParams,
-  type ToolCheckFromRulesyncChecksParams,
-  type ToolCheckSettablePaths,
-} from "./tool-check.js";
-
-const FALLBACK_CHECK_NAME = "bugbot";
+import { AggregatedToolCheck, type AggregatedToolCheckConfig } from "./aggregated-tool-check.js";
+import { type ToolCheckSettablePaths } from "./tool-check.js";
 
 /**
  * Checks adapter for Cursor Bugbot (`.cursor/BUGBOT.md`).
  *
  * Bugbot takes one aggregated instruction file per directory rather than a file
  * per check, so every `.rulesync/checks/*.md` targeting Cursor collapses into
- * the repository-root `.cursor/BUGBOT.md` — hence {@link fromRulesyncChecks}
- * rather than the usual per-check conversion. Each check becomes one section:
- * an HTML-comment marker carrying the check name, an `## <name>` heading, and
- * the check body as the instruction text (the `description` is used when the
- * body is empty).
+ * the repository-root `.cursor/BUGBOT.md` — hence `fromRulesyncChecks` rather
+ * than the usual per-check conversion, which {@link AggregatedToolCheck}
+ * provides. Each check becomes one section: an HTML-comment marker carrying the
+ * check name, an `## <name>` heading, and the check body as the instruction
+ * text (the `description` is used when the body is empty).
  *
  * Bugbot reads the file as free prose, so a check's `severity` and `tools` have
  * no equivalent there: they are not written and do not come back on import. So
@@ -46,12 +27,12 @@ const FALLBACK_CHECK_NAME = "bugbot";
  * before the first marker — and a hand-written file with no markers at all —
  * becomes a single `bugbot` check, so nothing in the file is dropped. A file
  * holding anything rulesync did not write is never deleted either (see
- * {@link canDeleteAuxiliaryFiles}), though generating checks for Cursor does
- * replace it — import first to keep what is there, which is warned about.
+ * `canDeleteAuxiliaryFiles` on the base), though generating checks for Cursor
+ * does replace it — import first to keep what is there, which is warned about.
  *
  * @see https://cursor.com/docs/bugbot
  */
-export class CursorCheck extends ToolCheck {
+export class CursorCheck extends AggregatedToolCheck {
   static getSettablePaths(_options: { global?: boolean } = {}): ToolCheckSettablePaths {
     // Naming the file keeps consumers that would otherwise claim the whole
     // `.cursor/` tree — the gitignore derivation, for one — narrowed to the one
@@ -59,131 +40,15 @@ export class CursorCheck extends ToolCheck {
     return { relativeDirPath: CURSOR_DIR, relativeFilePath: CURSOR_BUGBOT_FILE_NAME };
   }
 
-  static isTargetedByRulesyncCheck(rulesyncCheck: RulesyncCheck): boolean {
-    return this.isTargetedByRulesyncCheckDefault({ rulesyncCheck, toolTarget: "cursor" });
-  }
-
-  /**
-   * Ownership guard the processor consults before it deletes anything for this
-   * tool. `.cursor/BUGBOT.md` is a file Cursor's own documentation tells users
-   * to hand-write, so anything in it that rulesync did not write is not
-   * rulesync's to remove — dropping the last check targeting Cursor must not
-   * take somebody's hand-written review instructions with it. Deletion is
-   * therefore allowed only for a file that is nothing but generated sections:
-   * one that carries no marker at all, or that carries hand-written text ahead
-   * of the first marker, stays.
-   */
-  static async canDeleteAuxiliaryFiles({ outputRoot }: { outputRoot: string }): Promise<boolean> {
-    const paths = CursorCheck.getSettablePaths();
-    const filePath = join(
-      outputRoot,
-      paths.relativeDirPath,
-      paths.relativeFilePath ?? CURSOR_BUGBOT_FILE_NAME,
-    );
-    const fileContent = await readFileContentOrNull(filePath);
-    if (fileContent === null) {
-      return true;
-    }
-    return isOnlyGeneratedSections(fileContent);
-  }
-
-  static override fromRulesyncCheck(_params: ToolCheckFromRulesyncCheckParams): CursorCheck {
-    // Sections share one file, so they are only ever built as a set.
-    throw new Error("Cursor checks are built from all checks at once; use fromRulesyncChecks.");
-  }
-
-  static async fromRulesyncChecks({
-    outputRoot = process.cwd(),
-    rulesyncChecks,
-    global = false,
-    logger,
-  }: ToolCheckFromRulesyncChecksParams): Promise<CursorCheck[]> {
-    if (rulesyncChecks.length === 0) {
-      // No section to write. A stale file from an earlier generate is removed by
-      // the processor's deletion pass rather than by an empty file written here.
-      return [];
-    }
-
-    const paths = CursorCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? CURSOR_BUGBOT_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-
-    // The file is rewritten from `.rulesync/checks/` rather than merged into, so
-    // say so before hand-written instructions go away — the deletion guard
-    // protects them, but generating over them cannot.
-    const existingContent = (await readFileContentOrNull(filePath)) ?? "";
-    if (hasHandWrittenPreamble(existingContent)) {
-      logger?.warn(
-        `Cursor checks: ${filePath} holds instructions rulesync did not write, and generating ` +
-          `replaces the whole file. Run \`rulesync import --targets cursor --features checks\` ` +
-          `first to keep them.`,
-      );
-    }
-
-    const fileContent = renderCheckFile(rulesyncChecks);
-
-    return [
-      new CursorCheck({
-        outputRoot,
-        relativeDirPath: paths.relativeDirPath,
-        relativeFilePath,
-        fileContent,
-        global,
-      }),
-    ];
-  }
-
-  static async fromFile({
-    outputRoot = process.cwd(),
-    global = false,
-  }: ToolCheckFromFileParams): Promise<CursorCheck> {
-    const paths = CursorCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? CURSOR_BUGBOT_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-    return new CursorCheck({
-      outputRoot,
-      relativeDirPath: paths.relativeDirPath,
-      relativeFilePath,
-      fileContent: (await readFileContentOrNull(filePath)) ?? "",
-      global,
-    });
-  }
-
-  static forDeletion({
-    outputRoot = process.cwd(),
-    relativeDirPath,
-    relativeFilePath,
-    global = false,
-  }: ToolCheckForDeletionParams): CursorCheck {
-    return new CursorCheck({
-      outputRoot,
-      relativeDirPath,
-      relativeFilePath,
-      fileContent: "",
-      validate: false,
-      global,
-    });
-  }
-
-  validate(): ValidationResult {
-    return { success: true, error: null };
-  }
-
-  toRulesyncCheck(): RulesyncCheck {
-    const checks = this.toRulesyncChecks();
-    const first = checks[0];
-    if (!first) {
-      throw new Error(
-        `No check instructions found in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}.`,
-      );
-    }
-    return first;
-  }
-
-  override toRulesyncChecks(): RulesyncCheck[] {
-    return splitCheckFile({
-      fileContent: this.getFileContent(),
-      fallbackName: FALLBACK_CHECK_NAME,
-    });
+  protected static override getAggregatedCheckConfig(): AggregatedToolCheckConfig {
+    return {
+      displayName: "Cursor",
+      toolTarget: "cursor",
+      // The name given to a hand-written file with no marked section.
+      fallbackCheckName: "bugbot",
+      // `.cursor/BUGBOT.md` is a path only the reviewer reads, so rewriting it
+      // replaces review instructions with review instructions.
+      handWrittenPreamble: "replace",
+    };
   }
 }

--- a/src/features/checks/factorydroid-check.test.ts
+++ b/src/features/checks/factorydroid-check.test.ts
@@ -133,6 +133,10 @@ describe("FactorydroidCheck", () => {
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("keeps blocking generation"),
       );
+      // The tool's own name and target come from this adapter's config rather
+      // than from a literal in the message, so the message is read back whole.
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Factory Droid checks:"));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--targets factorydroid"));
     });
 
     it("should stay quiet when the existing file is only generated sections", async () => {

--- a/src/features/checks/factorydroid-check.ts
+++ b/src/features/checks/factorydroid-check.ts
@@ -1,31 +1,10 @@
-import { join } from "node:path";
-
 import {
   FACTORYDROID_REVIEW_GUIDELINES_DIR_NAME,
   FACTORYDROID_REVIEW_GUIDELINES_DIR_PATH,
 } from "../../constants/factorydroid-paths.js";
 import { SKILL_FILE_NAME } from "../../constants/general.js";
-import type { ValidationResult } from "../../types/ai-file.js";
-import { readFileContentOrNull } from "../../utils/file.js";
-import {
-  hasHandWrittenPreamble,
-  isOnlyGeneratedSections,
-  renderCheckFile,
-  splitCheckFile,
-} from "./aggregated-check-file.js";
-import { RulesyncCheck } from "./rulesync-check.js";
-import {
-  ToolCheck,
-  type ToolCheckForDeletionParams,
-  type ToolCheckFromFileParams,
-  type ToolCheckFromRulesyncCheckParams,
-  type ToolCheckFromRulesyncChecksParams,
-  type ToolCheckSettablePaths,
-} from "./tool-check.js";
-
-// The skill's own name: an import that finds no marked section attributes the
-// whole file to one check named after it.
-const FALLBACK_CHECK_NAME = FACTORYDROID_REVIEW_GUIDELINES_DIR_NAME;
+import { AggregatedToolCheck, type AggregatedToolCheckConfig } from "./aggregated-tool-check.js";
+import { type ToolCheckSettablePaths } from "./tool-check.js";
 
 /**
  * Drop the YAML frontmatter of a hand-authored `review-guidelines` skill before
@@ -83,6 +62,21 @@ function stripSkillFrontmatter(fileContent: string): string {
   }
 }
 
+function handWrittenWarning({ filePath }: { filePath: string }): string {
+  return (
+    `Factory Droid checks: ${filePath} holds instructions rulesync did not write, so it is ` +
+    `left as it is and no checks were generated for Factory Droid. Run ` +
+    `\`rulesync import --targets factorydroid --features checks\` to bring them into ` +
+    `\`.rulesync/checks/\` and then delete the file, so the next generate writes it back ` +
+    `from there; delete it outright if you no longer want it, or rename the directory if ` +
+    `it is an ordinary skill rather than review guidelines. Importing alone leaves this ` +
+    `file as it is, so it keeps blocking generation until it is gone. A rulesync skill ` +
+    `named \`${FACTORYDROID_REVIEW_GUIDELINES_DIR_NAME}\` is no longer generated here — ` +
+    `Factory's reviewer reads this path, so the checks feature owns it — but a directory ` +
+    `an older rulesync wrote can still be sitting there.`
+  );
+}
+
 /**
  * Checks adapter for Factory Droid's code-review guidelines
  * (`.factory/skills/review-guidelines/SKILL.md`).
@@ -91,9 +85,10 @@ function stripSkillFrontmatter(fileContent: string): string {
  * "repository-specific review guidelines" from a skill named
  * `review-guidelines` and injects them into every review run. That makes the
  * output a single aggregated file like Cursor Bugbot's and Rovo Dev's, so every
- * `.rulesync/checks/*.md` targeting Factory Droid collapses into it via
- * {@link fromRulesyncChecks}, each check written as a marked section (see
- * `aggregated-check-file.ts` for the marker convention the adapters share).
+ * `.rulesync/checks/*.md` targeting Factory Droid collapses into it via the
+ * `fromRulesyncChecks` on {@link AggregatedToolCheck}, each check written as a
+ * marked section (see `aggregated-check-file.ts` for the marker convention the
+ * three aggregated adapters share).
  *
  * The file is plain Markdown with no frontmatter, matching Factory's documented
  * example. Frontmatter would also be self-defeating here: `renderCheckFile`
@@ -111,8 +106,9 @@ function stripSkillFrontmatter(fileContent: string): string {
  * The output lives inside the same `.factory/skills/` tree the `skills` feature
  * writes, so a user-authored `review-guidelines` skill collides with it. The
  * path has one owner rather than a merge rule, and the owner is this feature:
- * {@link fromRulesyncChecks} leaves a file holding anything rulesync did not
- * write untouched, and {@link canDeleteAuxiliaryFiles} refuses to remove one.
+ * generating leaves a file holding anything rulesync did not write untouched —
+ * the `skip` policy below — and the base's `canDeleteAuxiliaryFiles` refuses to
+ * remove one.
  * Their content is somebody's own writing and rulesync cannot reconstruct it,
  * so neither direction guesses. That is stricter than Cursor Bugbot's
  * replace-and-warn, and deliberately: `.cursor/BUGBOT.md` is a path only the
@@ -122,7 +118,7 @@ function stripSkillFrontmatter(fileContent: string): string {
  *
  * @see https://docs.factory.ai/software-factory/code-review-ci
  */
-export class FactorydroidCheck extends ToolCheck {
+export class FactorydroidCheck extends AggregatedToolCheck {
   static getSettablePaths(_options: { global?: boolean } = {}): ToolCheckSettablePaths {
     return {
       relativeDirPath: FACTORYDROID_REVIEW_GUIDELINES_DIR_PATH,
@@ -130,140 +126,21 @@ export class FactorydroidCheck extends ToolCheck {
     };
   }
 
-  static isTargetedByRulesyncCheck(rulesyncCheck: RulesyncCheck): boolean {
-    return this.isTargetedByRulesyncCheckDefault({ rulesyncCheck, toolTarget: "factorydroid" });
-  }
-
-  /**
-   * Ownership guard the processor consults before it deletes anything for this
-   * tool. `review-guidelines` is an ordinary skill directory a user may have
-   * authored by hand, so dropping the last check targeting Factory Droid must
-   * not take their review instructions with it. Deletion is allowed only for a
-   * file that is nothing but generated sections.
-   */
-  static async canDeleteAuxiliaryFiles({ outputRoot }: { outputRoot: string }): Promise<boolean> {
-    const paths = FactorydroidCheck.getSettablePaths();
-    const filePath = join(
-      outputRoot,
-      paths.relativeDirPath,
-      paths.relativeFilePath ?? SKILL_FILE_NAME,
-    );
-    const fileContent = await readFileContentOrNull(filePath);
-    if (fileContent === null) {
-      return true;
-    }
-    return isOnlyGeneratedSections(fileContent);
-  }
-
-  static override fromRulesyncCheck(_params: ToolCheckFromRulesyncCheckParams): FactorydroidCheck {
-    // Sections share one file, so they are only ever built as a set.
-    throw new Error(
-      "Factory Droid checks are built from all checks at once; use fromRulesyncChecks.",
-    );
-  }
-
-  static async fromRulesyncChecks({
-    outputRoot = process.cwd(),
-    rulesyncChecks,
-    global = false,
-    logger,
-  }: ToolCheckFromRulesyncChecksParams): Promise<FactorydroidCheck[]> {
-    if (rulesyncChecks.length === 0) {
-      // No section to write. A stale file from an earlier generate is removed by
-      // the processor's deletion pass rather than by an empty file written here.
-      return [];
-    }
-
-    const paths = FactorydroidCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? SKILL_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-
-    // The file would be rewritten from `.rulesync/checks/` rather than merged
-    // into, so content rulesync did not write is left alone instead: it is a
-    // skill somebody authored at a path this feature owns, and rewriting it
-    // would drop review instructions rulesync has no way to rebuild. The
-    // deletion guard makes the same promise from the other side.
-    const existingContent = (await readFileContentOrNull(filePath)) ?? "";
-    if (hasHandWrittenPreamble(existingContent)) {
-      logger?.warn(
-        `Factory Droid checks: ${filePath} holds instructions rulesync did not write, so it is ` +
-          `left as it is and no checks were generated for Factory Droid. Run ` +
-          `\`rulesync import --targets factorydroid --features checks\` to bring them into ` +
-          `\`.rulesync/checks/\` and then delete the file, so the next generate writes it back ` +
-          `from there; delete it outright if you no longer want it, or rename the directory if ` +
-          `it is an ordinary skill rather than review guidelines. Importing alone leaves this ` +
-          `file as it is, so it keeps blocking generation until it is gone. A rulesync skill ` +
-          `named \`${FACTORYDROID_REVIEW_GUIDELINES_DIR_NAME}\` is no longer generated here — ` +
-          `Factory's reviewer reads this path, so the checks feature owns it — but a directory ` +
-          `an older rulesync wrote can still be sitting there.`,
-      );
-      return [];
-    }
-
-    const fileContent = renderCheckFile(rulesyncChecks);
-
-    return [
-      new FactorydroidCheck({
-        outputRoot,
-        relativeDirPath: paths.relativeDirPath,
-        relativeFilePath,
-        fileContent,
-        global,
-      }),
-    ];
-  }
-
-  static async fromFile({
-    outputRoot = process.cwd(),
-    global = false,
-  }: ToolCheckFromFileParams): Promise<FactorydroidCheck> {
-    const paths = FactorydroidCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? SKILL_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-    return new FactorydroidCheck({
-      outputRoot,
-      relativeDirPath: paths.relativeDirPath,
-      relativeFilePath,
-      fileContent: (await readFileContentOrNull(filePath)) ?? "",
-      global,
-    });
-  }
-
-  static forDeletion({
-    outputRoot = process.cwd(),
-    relativeDirPath,
-    relativeFilePath,
-    global = false,
-  }: ToolCheckForDeletionParams): FactorydroidCheck {
-    return new FactorydroidCheck({
-      outputRoot,
-      relativeDirPath,
-      relativeFilePath,
-      fileContent: "",
-      validate: false,
-      global,
-    });
-  }
-
-  validate(): ValidationResult {
-    return { success: true, error: null };
-  }
-
-  toRulesyncCheck(): RulesyncCheck {
-    const checks = this.toRulesyncChecks();
-    const first = checks[0];
-    if (!first) {
-      throw new Error(
-        `No check instructions found in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}.`,
-      );
-    }
-    return first;
-  }
-
-  override toRulesyncChecks(): RulesyncCheck[] {
-    return splitCheckFile({
-      fileContent: stripSkillFrontmatter(this.getFileContent()),
-      fallbackName: FALLBACK_CHECK_NAME,
-    });
+  protected static override getAggregatedCheckConfig(): AggregatedToolCheckConfig {
+    return {
+      displayName: "Factory Droid",
+      toolTarget: "factorydroid",
+      // The skill's own name: an import that finds no marked section attributes
+      // the whole file to one check named after it.
+      fallbackCheckName: FACTORYDROID_REVIEW_GUIDELINES_DIR_NAME,
+      // Stricter than Cursor Bugbot's replace-and-warn, and deliberately: a
+      // file here may be an ordinary skill written for Droid's skill loader
+      // that has nothing to do with reviews.
+      handWrittenPreamble: "skip",
+      handWrittenWarning,
+      // The only aggregated adapter that needs one: this path can also hold a
+      // hand-authored skill, and a skill carries frontmatter.
+      transformImportedContent: stripSkillFrontmatter,
+    };
   }
 }

--- a/src/features/checks/factorydroid-check.ts
+++ b/src/features/checks/factorydroid-check.ts
@@ -3,6 +3,7 @@ import {
   FACTORYDROID_REVIEW_GUIDELINES_DIR_PATH,
 } from "../../constants/factorydroid-paths.js";
 import { SKILL_FILE_NAME } from "../../constants/general.js";
+import { type ToolTarget } from "../../types/tool-targets.js";
 import { AggregatedToolCheck, type AggregatedToolCheckConfig } from "./aggregated-tool-check.js";
 import { type ToolCheckSettablePaths } from "./tool-check.js";
 
@@ -62,11 +63,19 @@ function stripSkillFrontmatter(fileContent: string): string {
   }
 }
 
-function handWrittenWarning({ filePath }: { filePath: string }): string {
+function handWrittenWarning({
+  filePath,
+  displayName,
+  toolTarget,
+}: {
+  filePath: string;
+  displayName: string;
+  toolTarget: ToolTarget;
+}): string {
   return (
-    `Factory Droid checks: ${filePath} holds instructions rulesync did not write, so it is ` +
-    `left as it is and no checks were generated for Factory Droid. Run ` +
-    `\`rulesync import --targets factorydroid --features checks\` to bring them into ` +
+    `${displayName} checks: ${filePath} holds instructions rulesync did not write, so it is ` +
+    `left as it is and no checks were generated for ${displayName}. Run ` +
+    `\`rulesync import --targets ${toolTarget} --features checks\` to bring them into ` +
     `\`.rulesync/checks/\` and then delete the file, so the next generate writes it back ` +
     `from there; delete it outright if you no longer want it, or rename the directory if ` +
     `it is an ordinary skill rather than review guidelines. Importing alone leaves this ` +

--- a/src/features/checks/rovodev-check.test.ts
+++ b/src/features/checks/rovodev-check.test.ts
@@ -106,6 +106,10 @@ describe("RovodevCheck", () => {
       });
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("rulesync did not write"));
+      // The tool's own name and target come from this adapter's config rather
+      // than from a literal in the message, so the message is read back whole.
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Rovo Dev checks:"));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--targets rovodev"));
     });
 
     it("should stay quiet when the existing file is only generated sections", async () => {

--- a/src/features/checks/rovodev-check.ts
+++ b/src/features/checks/rovodev-check.ts
@@ -1,25 +1,6 @@
-import { join } from "node:path";
-
 import { ROVODEV_DIR, ROVODEV_REVIEW_AGENT_FILE_NAME } from "../../constants/rovodev-paths.js";
-import type { ValidationResult } from "../../types/ai-file.js";
-import { readFileContentOrNull } from "../../utils/file.js";
-import {
-  hasHandWrittenPreamble,
-  isOnlyGeneratedSections,
-  renderCheckFile,
-  splitCheckFile,
-} from "./aggregated-check-file.js";
-import { RulesyncCheck } from "./rulesync-check.js";
-import {
-  ToolCheck,
-  type ToolCheckForDeletionParams,
-  type ToolCheckFromFileParams,
-  type ToolCheckFromRulesyncCheckParams,
-  type ToolCheckFromRulesyncChecksParams,
-  type ToolCheckSettablePaths,
-} from "./tool-check.js";
-
-const FALLBACK_CHECK_NAME = "review-agent";
+import { AggregatedToolCheck, type AggregatedToolCheckConfig } from "./aggregated-tool-check.js";
+import { type ToolCheckSettablePaths } from "./tool-check.js";
 
 /**
  * Checks adapter for Rovo Dev CLI's code-review custom instructions
@@ -29,9 +10,9 @@ const FALLBACK_CHECK_NAME = "review-agent";
  * `.rovodev/` folder — no frontmatter, and note the leading dot in the file
  * name. Like Cursor Bugbot it is a single aggregated file rather than a file
  * per check, so every `.rulesync/checks/*.md` targeting Rovo Dev collapses into
- * it via {@link fromRulesyncChecks}, with each check written as a marked
- * section (see `aggregated-check-file.ts` for the marker convention the two
- * adapters share).
+ * it via the `fromRulesyncChecks` on {@link AggregatedToolCheck}, with each
+ * check written as a marked section (see `aggregated-check-file.ts` for the
+ * marker convention the three aggregated adapters share).
  *
  * Rovo Dev reads the file as free prose, so a check's `severity` and `tools`
  * have no equivalent there: they are not written and do not come back on
@@ -43,7 +24,7 @@ const FALLBACK_CHECK_NAME = "review-agent";
  *
  * @see https://support.atlassian.com/rovo/docs/set-custom-instructions-for-code-reviews/
  */
-export class RovodevCheck extends ToolCheck {
+export class RovodevCheck extends AggregatedToolCheck {
   static getSettablePaths(_options: { global?: boolean } = {}): ToolCheckSettablePaths {
     // Naming the file keeps consumers that would otherwise claim the whole
     // `.rovodev/` tree — the gitignore derivation, for one — narrowed to the
@@ -51,126 +32,15 @@ export class RovodevCheck extends ToolCheck {
     return { relativeDirPath: ROVODEV_DIR, relativeFilePath: ROVODEV_REVIEW_AGENT_FILE_NAME };
   }
 
-  static isTargetedByRulesyncCheck(rulesyncCheck: RulesyncCheck): boolean {
-    return this.isTargetedByRulesyncCheckDefault({ rulesyncCheck, toolTarget: "rovodev" });
-  }
-
-  /**
-   * Ownership guard the processor consults before it deletes anything for this
-   * tool. `.review-agent.md` is a file Rovo Dev's own documentation tells users
-   * to hand-write, so anything in it that rulesync did not write is not
-   * rulesync's to remove — dropping the last check targeting Rovo Dev must not
-   * take somebody's hand-written review instructions with it.
-   */
-  static async canDeleteAuxiliaryFiles({ outputRoot }: { outputRoot: string }): Promise<boolean> {
-    const paths = RovodevCheck.getSettablePaths();
-    const filePath = join(
-      outputRoot,
-      paths.relativeDirPath,
-      paths.relativeFilePath ?? ROVODEV_REVIEW_AGENT_FILE_NAME,
-    );
-    const fileContent = await readFileContentOrNull(filePath);
-    if (fileContent === null) {
-      return true;
-    }
-    return isOnlyGeneratedSections(fileContent);
-  }
-
-  static override fromRulesyncCheck(_params: ToolCheckFromRulesyncCheckParams): RovodevCheck {
-    // Sections share one file, so they are only ever built as a set.
-    throw new Error("Rovo Dev checks are built from all checks at once; use fromRulesyncChecks.");
-  }
-
-  static async fromRulesyncChecks({
-    outputRoot = process.cwd(),
-    rulesyncChecks,
-    global = false,
-    logger,
-  }: ToolCheckFromRulesyncChecksParams): Promise<RovodevCheck[]> {
-    if (rulesyncChecks.length === 0) {
-      // No section to write. A stale file from an earlier generate is removed by
-      // the processor's deletion pass rather than by an empty file written here.
-      return [];
-    }
-
-    const paths = RovodevCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? ROVODEV_REVIEW_AGENT_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-
-    // The file is rewritten from `.rulesync/checks/` rather than merged into, so
-    // say so before hand-written instructions go away — the deletion guard
-    // protects them, but generating over them cannot.
-    const existingContent = (await readFileContentOrNull(filePath)) ?? "";
-    if (hasHandWrittenPreamble(existingContent)) {
-      logger?.warn(
-        `Rovo Dev checks: ${filePath} holds instructions rulesync did not write, and generating ` +
-          `replaces the whole file. Run \`rulesync import --targets rovodev --features checks\` ` +
-          `first to keep them.`,
-      );
-    }
-
-    return [
-      new RovodevCheck({
-        outputRoot,
-        relativeDirPath: paths.relativeDirPath,
-        relativeFilePath,
-        fileContent: renderCheckFile(rulesyncChecks),
-        global,
-      }),
-    ];
-  }
-
-  static async fromFile({
-    outputRoot = process.cwd(),
-    global = false,
-  }: ToolCheckFromFileParams): Promise<RovodevCheck> {
-    const paths = RovodevCheck.getSettablePaths({ global });
-    const relativeFilePath = paths.relativeFilePath ?? ROVODEV_REVIEW_AGENT_FILE_NAME;
-    const filePath = join(outputRoot, paths.relativeDirPath, relativeFilePath);
-    return new RovodevCheck({
-      outputRoot,
-      relativeDirPath: paths.relativeDirPath,
-      relativeFilePath,
-      fileContent: (await readFileContentOrNull(filePath)) ?? "",
-      global,
-    });
-  }
-
-  static forDeletion({
-    outputRoot = process.cwd(),
-    relativeDirPath,
-    relativeFilePath,
-    global = false,
-  }: ToolCheckForDeletionParams): RovodevCheck {
-    return new RovodevCheck({
-      outputRoot,
-      relativeDirPath,
-      relativeFilePath,
-      fileContent: "",
-      validate: false,
-      global,
-    });
-  }
-
-  validate(): ValidationResult {
-    return { success: true, error: null };
-  }
-
-  toRulesyncCheck(): RulesyncCheck {
-    const checks = this.toRulesyncChecks();
-    const first = checks[0];
-    if (!first) {
-      throw new Error(
-        `No check instructions found in ${join(this.getRelativeDirPath(), this.getRelativeFilePath())}.`,
-      );
-    }
-    return first;
-  }
-
-  override toRulesyncChecks(): RulesyncCheck[] {
-    return splitCheckFile({
-      fileContent: this.getFileContent(),
-      fallbackName: FALLBACK_CHECK_NAME,
-    });
+  protected static override getAggregatedCheckConfig(): AggregatedToolCheckConfig {
+    return {
+      displayName: "Rovo Dev",
+      toolTarget: "rovodev",
+      // The name given to a hand-written file with no marked section.
+      fallbackCheckName: "review-agent",
+      // `.review-agent.md` is a path only the reviewer reads, so rewriting it
+      // replaces review instructions with review instructions.
+      handWrittenPreamble: "replace",
+    };
   }
 }


### PR DESCRIPTION
Cursor Bugbot, Rovo Dev and Factory Droid each write one aggregated instruction file, and each carried a near-verbatim copy of the adapter around `aggregated-check-file.ts`: the same path resolution, the same deletion guard, the same `fromRulesyncChecks` / `fromFile` / `forDeletion` bodies.

This moves that skeleton into a new `AggregatedToolCheck` base and leaves each adapter with what actually differs.

## What each adapter keeps

- `getSettablePaths()` — the directory and the name of the one file it writes.
- `getAggregatedCheckConfig()` — the display name used in messages, the tool target, the fallback check name for a file with no marked section, and what generating does to a file holding instructions rulesync did not write (`replace` for Cursor and Rovo Dev, `skip` with a tool-specific warning for Factory Droid).
- Factory Droid additionally keeps `stripSkillFrontmatter`, wired in as the config's optional `transformImportedContent`, since its output path is shared with the skills feature and so can hold frontmatter.

## Notes

- The base is not declared `abstract`: its statics build the subclass with `new this(...)`, which an abstract constructor type forbids. What a subclass owes is enforced the way this codebase enforces it on statics — `getAggregatedCheckConfig()` throws "Please implement this method in the subclass." until overridden.
- No behavior change is intended; the existing per-adapter tests (Cursor, Rovo Dev, Factory Droid) pass unchanged, and a new `aggregated-tool-check.test.ts` covers the two throw paths the base adds.

Closes #2821
