### PR TITLE
refactor(fetch): fold the repeated prune mocks and the duplicated helpers

### DIFF
--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -2317,6 +2317,47 @@ describe("fetchFiles skill pruning", () => {
     mockClientInstance.getFileContent.mockResolvedValue("# Skill");
   }
 
+  /**
+   * A repository with a single skill of the given name, whose only file is
+   * SKILL.md. The tests that pin how a remote skill name is read back differ
+   * only in that name.
+   */
+  function mockSingleSkillRepository(name: string): void {
+    mockClientInstance.listDirectory.mockImplementation(
+      (_owner: string, _repo: string, path: string) => {
+        if (path === "skills") {
+          return Promise.resolve([
+            {
+              name,
+              path: `skills/${name}`,
+              type: "dir",
+              sha: "aaa",
+              size: 0,
+              download_url: null,
+            },
+          ]);
+        }
+        if (path === `skills/${name}`) {
+          return Promise.resolve([
+            {
+              name: "SKILL.md",
+              path: `skills/${name}/SKILL.md`,
+              type: "file",
+              sha: "bbb",
+              size: 100,
+              download_url: "https://example.com",
+            },
+          ]);
+        }
+        const error = new Error("Not found");
+        Object.assign(error, { statusCode: 404 });
+        return Promise.reject(error);
+      },
+    );
+
+    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+  }
+
   beforeEach(async () => {
     ({ testDir, cleanup } = await setupTestDirectory());
     vi.spyOn(process, "cwd").mockReturnValue(testDir);
@@ -2496,38 +2537,7 @@ describe("fetchFiles skill pruning", () => {
     // `skills/.\evil/SKILL.md` is written as a directory literally called
     // `.\evil`, but reads back as the skill `.`, whose directory is the whole
     // of `skills/` — so the prune would empty every skill on disk.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: ".\\evil",
-              path: "skills/.\\evil",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/.\\evil") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/.\\evil/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository(".\\evil");
     const mine = join(skillsRoot, "alpha", "SKILL.md");
     await writeFileContent(mine, "# Mine");
 
@@ -2541,38 +2551,7 @@ describe("fetchFiles skill pruning", () => {
   it("should skip a remote path whose backslash targets another skill", async () => {
     // `skills/victim\evil/` is written as its own directory, but reads back as
     // the skill `victim`, whose local directory this run never wrote.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "victim\\evil",
-              path: "skills/victim\\evil",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/victim\\evil") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/victim\\evil/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("victim\\evil");
     const victim = join(skillsRoot, "victim", "notes.md");
     await writeFileContent(victim, "# Mine");
 
@@ -2588,38 +2567,7 @@ describe("fetchFiles skill pruning", () => {
     // another spelling of `pdf`, so the fetch would write into the user's own
     // `pdf` skill while the prune, which compares names, treats it as a skill
     // this run never wrote.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "pdf::$INDEX_ALLOCATION",
-              path: "skills/pdf::$INDEX_ALLOCATION",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/pdf::$INDEX_ALLOCATION") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/pdf::$INDEX_ALLOCATION/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("pdf::$INDEX_ALLOCATION");
     const victim = join(skillsRoot, "pdf", "notes.md");
     await writeFileContent(victim, "# Mine");
 
@@ -2800,38 +2748,7 @@ describe("fetchFiles skill pruning", () => {
   it("should not prune a skill directory named like a Windows short name", async () => {
     // `REPORT~1` opens whatever long name it stands for on a volume that
     // generates short names, so it may not be the directory it reads as.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "REPORT~1",
-              path: "skills/REPORT~1",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/REPORT~1") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/REPORT~1/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("REPORT~1");
     const stale = join(skillsRoot, "REPORT~1", "reference.md");
     await writeFileContent(stale, "# Stale");
 
@@ -2848,38 +2765,7 @@ describe("fetchFiles skill pruning", () => {
     // macOS and Windows resolve `skills/PDF` to the existing `skills/pdf`, so
     // the write lands in the local skill's own directory and a prune of it
     // would judge that skill's files stale.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "PDF",
-              path: "skills/PDF",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/PDF") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/PDF/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("PDF");
     const localFile = join(skillsRoot, "pdf", "SKILL.md");
     await writeFileContent(localFile, "# Local skill");
 
@@ -2898,38 +2784,7 @@ describe("fetchFiles skill pruning", () => {
     // composed letter, exactly as a case variant would.
     const composed = "caf\u00e9";
     const decomposed = "cafe\u0301";
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: decomposed,
-              path: `skills/${decomposed}`,
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === `skills/${decomposed}`) {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: `skills/${decomposed}/SKILL.md`,
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository(decomposed);
     const localFile = join(skillsRoot, composed, "SKILL.md");
     await writeFileContent(localFile, "# Local skill");
 
@@ -2945,38 +2800,7 @@ describe("fetchFiles skill pruning", () => {
   it("should prune a skill directory whose name only contains a tilde", async () => {
     // `~2` in the middle of a name is not the short-name shape, so the guard
     // above it must not claim this directory.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "data~2parser",
-              path: "skills/data~2parser",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/data~2parser") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/data~2parser/SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("data~2parser");
     const stale = join(skillsRoot, "data~2parser", "reference.md");
     await writeFileContent(stale, "# Stale");
 
@@ -2989,38 +2813,7 @@ describe("fetchFiles skill pruning", () => {
   it("should not prune a skill directory whose name ends in a dot", async () => {
     // Windows resolves `skills/dotted.` to `skills/dotted`, so the prune would
     // empty one directory while the summary named another.
-    mockClientInstance.listDirectory.mockImplementation(
-      (_owner: string, _repo: string, path: string) => {
-        if (path === "skills") {
-          return Promise.resolve([
-            {
-              name: "dotted.",
-              path: "skills/dotted.",
-              type: "dir",
-              sha: "aaa",
-              size: 0,
-              download_url: null,
-            },
-          ]);
-        }
-        if (path === "skills/dotted.") {
-          return Promise.resolve([
-            {
-              name: "SKILL.md",
-              path: "skills/dotted./SKILL.md",
-              type: "file",
-              sha: "bbb",
-              size: 100,
-              download_url: "https://example.com",
-            },
-          ]);
-        }
-        const error = new Error("Not found");
-        Object.assign(error, { statusCode: 404 });
-        return Promise.reject(error);
-      },
-    );
-    mockClientInstance.getFileContent.mockResolvedValue("# Skill");
+    mockSingleSkillRepository("dotted.");
     const stale = join(skillsRoot, "dotted.", "reference.md");
     await writeFileContent(stale, "# Stale");
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1167,11 +1167,11 @@ async function pruneStaleSkillFiles(params: {
       // filesystem error is absorbed: anything else is a defect in the walk, and
       // one that turned into a warning would take a skipped prune with it
       // quietly. `isFileSystemError` recognizes an I/O failure by its `errno`
-      // code, so a `code` of another shape — `ERR_FS_EISDIR`, or the `UNKNOWN`
-      // libuv falls back to — is rethrown rather than warned about. That is the
-      // side to err on here: a prune silently skipped is worse than a fetch that
-      // says why it stopped. The message is stripped too, since a filesystem
-      // error carries the local path it failed on.
+      // code, so a `code` of another shape — the `UNKNOWN` libuv falls back to
+      // for a system error it cannot translate — is rethrown rather than warned
+      // about. That is the side to err on here: a prune silently skipped is
+      // worse than a fetch that says why it stopped. The message is stripped
+      // too, since a filesystem error carries the local path it failed on.
       if (!isFileSystemError(error)) {
         throw error;
       }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -48,6 +48,7 @@ import {
   createTempDirectory,
   fileExists,
   isFileNotFoundError,
+  isFileSystemError,
   removeTempDirectory,
   toPosixPath,
   writeFileContent,
@@ -289,7 +290,9 @@ type SkillPathClass =
   | { readonly kind: "skill"; readonly name: string };
 
 /** Where a skill directory sits, under the output base path and in the remote. */
-const SKILLS_DIR_PREFIX = "skills/";
+const SKILLS_DIR_NAME = "skills";
+/** The same directory as the head of a POSIX path, for prefix comparisons. */
+const SKILLS_DIR_PREFIX = `${SKILLS_DIR_NAME}/`;
 
 /**
  * The one `non-skill` verdict, shared by every caller that reaches it. It is
@@ -675,7 +678,7 @@ function formatDroppedSkillsWarning(droppedUnsafeNames: ReadonlyMap<string, stri
  */
 async function readSkillRootNames(outputBasePath: string): Promise<string[]> {
   try {
-    const entries = await readdir(join(outputBasePath, SKILLS_DIR_PREFIX), {
+    const entries = await readdir(join(outputBasePath, SKILLS_DIR_NAME), {
       withFileTypes: true,
     });
     // Directories only: a skill is a directory, and a file beside them shares
@@ -1199,15 +1202,6 @@ async function pruneStaleSkillFiles(params: {
  */
 function isSymbolicLinkLoopError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "ELOOP";
-}
-
-/**
- * Whether the error came from the filesystem rather than from the walk itself.
- * Node stamps every `fs` rejection with a `code`, so its presence is what tells
- * an I/O failure apart from a programming error raised in the same call.
- */
-function isFileSystemError(error: unknown): boolean {
-  return error instanceof Error && "code" in error && typeof error.code === "string";
 }
 
 /**

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1166,8 +1166,12 @@ async function pruneStaleSkillFiles(params: {
       // could not do rather than throwing the fetch away over it. Only a
       // filesystem error is absorbed: anything else is a defect in the walk, and
       // one that turned into a warning would take a skipped prune with it
-      // quietly. The message is stripped too, since a filesystem error carries
-      // the local path it failed on.
+      // quietly. `isFileSystemError` recognizes an I/O failure by its `errno`
+      // code, so a `code` of another shape — `ERR_FS_EISDIR`, or the `UNKNOWN`
+      // libuv falls back to — is rethrown rather than warned about. That is the
+      // side to err on here: a prune silently skipped is worse than a fetch that
+      // says why it stopped. The message is stripped too, since a filesystem
+      // error carries the local path it failed on.
       if (!isFileSystemError(error)) {
         throw error;
       }

--- a/src/utils/confusable-names.test.ts
+++ b/src/utils/confusable-names.test.ts
@@ -6,6 +6,8 @@ import { describeConfusableNames, mixedScriptsOf } from "./confusable-names.js";
 const CYRILLIC_COPY = "\u0441\u043e\u0440\u0443";
 /** "good" with both o's replaced by the Cyrillic o, U+043E. */
 const HALF_CYRILLIC_GOOD = "g\u043e\u043ed";
+/** The note both halves of a lookalike pair are given. */
+const TWIN_NOTE = "another entry differs from it only by lookalike letters";
 
 describe("mixedScriptsOf", () => {
   it.each([
@@ -103,10 +105,9 @@ describe("describeConfusableNames", () => {
     // pair is only visible by comparing the two against each other.
     const notes = describeConfusableNames(["copy", CYRILLIC_COPY]);
 
-    expect(notes.get("copy")).toBe("another entry differs from it only by lookalike letters");
+    expect(notes.get("copy")).toBe(TWIN_NOTE);
     expect(notes.get(CYRILLIC_COPY)).toBe(
-      "another entry differs from it only by lookalike letters; " +
-        "reads as Latin letters but is written in Cyrillic",
+      `${TWIN_NOTE}; reads as Latin letters but is written in Cyrillic`,
     );
   });
 
@@ -163,10 +164,9 @@ describe("describeConfusableNames", () => {
     const notes = describeConfusableNames(["good", HALF_CYRILLIC_GOOD]);
 
     expect(notes.get(HALF_CYRILLIC_GOOD)).toBe(
-      "another entry differs from it only by lookalike letters; " +
-        "mixes characters from Cyrillic and Latin",
+      `${TWIN_NOTE}; mixes characters from Cyrillic and Latin`,
     );
-    expect(notes.get("good")).toBe("another entry differs from it only by lookalike letters");
+    expect(notes.get("good")).toBe(TWIN_NOTE);
   });
 
   it("should list three scripts as a sentence rather than a chain of ands", () => {
@@ -211,52 +211,47 @@ describe("describeConfusableNames", () => {
     const armenian = "c\u0585py";
     const notes = describeConfusableNames(["copy", armenian]);
 
-    expect(notes.get("copy")).toBe("another entry differs from it only by lookalike letters");
-    expect(notes.get(armenian)).toBe(
-      "another entry differs from it only by lookalike letters; " +
-        "mixes characters from Armenian and Latin",
-    );
+    expect(notes.get("copy")).toBe(TWIN_NOTE);
+    expect(notes.get(armenian)).toBe(`${TWIN_NOTE}; mixes characters from Armenian and Latin`);
   });
 
   it("should note a twin that never leaves the Latin alphabet", () => {
-    const twin = "another entry differs from it only by lookalike letters";
     // A digit for a letter, a capital I for an l, the script g (U+0261) and the
     // dotless i (U+0131): four ways to spell a name in characters this project
     // already uses, none of which changes what the name looks like.
     expect(describeConfusableNames(["copy", "c0py"])).toEqual(
       new Map([
-        ["copy", twin],
-        ["c0py", twin],
+        ["copy", TWIN_NOTE],
+        ["c0py", TWIN_NOTE],
       ]),
     );
     expect(describeConfusableNames(["rules", "ruIes"])).toEqual(
       new Map([
-        ["rules", twin],
-        ["ruIes", twin],
+        ["rules", TWIN_NOTE],
+        ["ruIes", TWIN_NOTE],
       ]),
     );
     expect(describeConfusableNames(["git", "\u0261it"])).toEqual(
       new Map([
-        ["git", twin],
-        ["\u0261it", twin],
+        ["git", TWIN_NOTE],
+        ["\u0261it", TWIN_NOTE],
       ]),
     );
     expect(describeConfusableNames(["git", "g\u0131t"])).toEqual(
       new Map([
-        ["git", twin],
-        ["g\u0131t", twin],
+        ["git", TWIN_NOTE],
+        ["g\u0131t", TWIN_NOTE],
       ]),
     );
   });
 
   it("should note a twin the compatibility normalization would have hidden", () => {
-    const twin = "another entry differs from it only by lookalike letters";
     // U+2160 ROMAN NUMERAL ONE normalizes to a capital I, which is read as an
     // l — a pairing only visible to a fold that runs after the normalization.
     expect(describeConfusableNames(["list", "\u2160ist"])).toEqual(
       new Map([
-        ["list", twin],
-        ["\u2160ist", twin],
+        ["list", TWIN_NOTE],
+        ["\u2160ist", TWIN_NOTE],
       ]),
     );
   });
@@ -271,12 +266,7 @@ describe("describeConfusableNames", () => {
   });
 
   it("should still report a word whose every letter is drawn as a Latin one", () => {
-    // "copy" spelled in Cyrillic, written as escapes: the point of the name is
-    // that it cannot be told from the Latin word on sight, and a reviewer
-    // reading this file is owed the same warning the prompt gives.
-    const cyrillicCopy = "\u0441\u043e\u0440\u0443";
-
-    expect(describeConfusableNames([cyrillicCopy]).get(cyrillicCopy)).toBe(
+    expect(describeConfusableNames([CYRILLIC_COPY]).get(CYRILLIC_COPY)).toBe(
       "reads as Latin letters but is written in Cyrillic",
     );
   });
@@ -296,26 +286,19 @@ describe("describeConfusableNames", () => {
     // third is the one the reader has no other way to notice.
     const notes = describeConfusableNames(["copy", "copy ", "c\u043epy"]);
 
-    expect(notes.get("copy")).toBe(
-      "another entry has the same display form; " +
-        "another entry differs from it only by lookalike letters",
-    );
-    expect(notes.get("c\u043epy")).toBe(
-      "another entry differs from it only by lookalike letters; " +
-        "mixes characters from Cyrillic and Latin",
-    );
+    expect(notes.get("copy")).toBe(`another entry has the same display form; ${TWIN_NOTE}`);
+    expect(notes.get("c\u043epy")).toBe(`${TWIN_NOTE}; mixes characters from Cyrillic and Latin`);
   });
 
   it("should note a twin that only replaces the hyphen", () => {
-    const twin = "another entry differs from it only by lookalike letters";
     // Nearly every name here is kebab-case, so the separator is the one
     // character that can be swapped without touching a letter. U+2010 HYPHEN is
     // drawn exactly as the ASCII one, belongs to no script, and survives the
     // compatibility normalization untouched.
     expect(describeConfusableNames(["code-review", "code\u2010review"])).toEqual(
       new Map([
-        ["code-review", twin],
-        ["code\u2010review", twin],
+        ["code-review", TWIN_NOTE],
+        ["code\u2010review", TWIN_NOTE],
       ]),
     );
   });
@@ -328,12 +311,10 @@ describe("describeConfusableNames", () => {
   });
 
   it("should note a twin that only replaces the apostrophe", () => {
-    const twin = "another entry differs from it only by lookalike letters";
-
     expect(describeConfusableNames(["let's-go", "let\u2019s-go"])).toEqual(
       new Map([
-        ["let's-go", twin],
-        ["let\u2019s-go", twin],
+        ["let's-go", TWIN_NOTE],
+        ["let\u2019s-go", TWIN_NOTE],
       ]),
     );
   });

--- a/src/utils/confusable-names.test.ts
+++ b/src/utils/confusable-names.test.ts
@@ -2,12 +2,19 @@ import { describe, expect, it } from "vitest";
 
 import { describeConfusableNames, mixedScriptsOf } from "./confusable-names.js";
 
-/** "copy" spelled entirely in Cyrillic: U+0441 U+043E U+0440 U+0443. */
+/**
+ * "copy" spelled entirely in Cyrillic: U+0441 U+043E U+0440 U+0443. Written as
+ * escapes on purpose — the point of the name is that it cannot be told from the
+ * Latin word on sight, and a reviewer reading this file is owed the same
+ * warning the prompt gives.
+ */
 const CYRILLIC_COPY = "\u0441\u043e\u0440\u0443";
 /** "good" with both o's replaced by the Cyrillic o, U+043E. */
 const HALF_CYRILLIC_GOOD = "g\u043e\u043ed";
 /** The note both halves of a lookalike pair are given. */
 const TWIN_NOTE = "another entry differs from it only by lookalike letters";
+/** The note both halves of a pair that prints identically are given. */
+const SAME_FORM_NOTE = "another entry has the same display form";
 
 describe("mixedScriptsOf", () => {
   it.each([
@@ -77,8 +84,8 @@ describe("describeConfusableNames", () => {
   it("should note both entries that share a display form", () => {
     const notes = describeConfusableNames(["Skill", "skill"]);
 
-    expect(notes.get("Skill")).toBe("another entry has the same display form");
-    expect(notes.get("skill")).toBe("another entry has the same display form");
+    expect(notes.get("Skill")).toBe(SAME_FORM_NOTE);
+    expect(notes.get("skill")).toBe(SAME_FORM_NOTE);
   });
 
   it("should fold compatibility forms when comparing display forms", () => {
@@ -86,8 +93,8 @@ describe("describeConfusableNames", () => {
     const fullwidth = "\uff50\uff44\uff46";
     const notes = describeConfusableNames(["pdf", fullwidth]);
 
-    expect(notes.get("pdf")).toBe("another entry has the same display form");
-    expect(notes.get(fullwidth)).toBe("another entry has the same display form");
+    expect(notes.get("pdf")).toBe(SAME_FORM_NOTE);
+    expect(notes.get(fullwidth)).toBe(SAME_FORM_NOTE);
   });
 
   it("should fold invisible characters when comparing display forms", () => {
@@ -96,8 +103,8 @@ describe("describeConfusableNames", () => {
     const invisible = "pd\u200bf";
     const notes = describeConfusableNames(["pdf", invisible]);
 
-    expect(notes.get("pdf")).toBe("another entry has the same display form");
-    expect(notes.get(invisible)).toBe("another entry has the same display form");
+    expect(notes.get("pdf")).toBe(SAME_FORM_NOTE);
+    expect(notes.get(invisible)).toBe(SAME_FORM_NOTE);
   });
 
   it("should note a name spelled entirely in another script beside its twin", () => {
@@ -146,8 +153,8 @@ describe("describeConfusableNames", () => {
     const padded = "pdf  ";
     const notes = describeConfusableNames(["pdf", padded]);
 
-    expect(notes.get("pdf")).toBe("another entry has the same display form");
-    expect(notes.get(padded)).toBe("another entry has the same display form");
+    expect(notes.get("pdf")).toBe(SAME_FORM_NOTE);
+    expect(notes.get(padded)).toBe(SAME_FORM_NOTE);
   });
 
   it("should not note names that differ within a single script", () => {
@@ -194,8 +201,8 @@ describe("describeConfusableNames", () => {
     const hangulFiller = "pd\u3164f";
     const notes = describeConfusableNames(["pdf", hangulFiller]);
 
-    expect(notes.get("pdf")).toBe("another entry has the same display form");
-    expect(notes.get(hangulFiller)).toBe("another entry has the same display form");
+    expect(notes.get("pdf")).toBe(SAME_FORM_NOTE);
+    expect(notes.get(hangulFiller)).toBe(SAME_FORM_NOTE);
   });
 
   it("should not call two names of the same length twins when nothing links them", () => {
@@ -286,7 +293,7 @@ describe("describeConfusableNames", () => {
     // third is the one the reader has no other way to notice.
     const notes = describeConfusableNames(["copy", "copy ", "c\u043epy"]);
 
-    expect(notes.get("copy")).toBe(`another entry has the same display form; ${TWIN_NOTE}`);
+    expect(notes.get("copy")).toBe(`${SAME_FORM_NOTE}; ${TWIN_NOTE}`);
     expect(notes.get("c\u043epy")).toBe(`${TWIN_NOTE}; mixes characters from Cyrillic and Latin`);
   });
 

--- a/src/utils/control-characters.ts
+++ b/src/utils/control-characters.ts
@@ -1,13 +1,14 @@
 /**
  * Matches C0 controls, DEL, the C1 range (which includes the 8-bit CSI
- * introducer U+009B), the bidirectional overrides and isolates, and the Unicode
- * line and paragraph separators, and the plain LRM/RLM/ALM marks. A name or value
- * copied out of an untrusted config file, a fetched repository, or a tool's own
- * settings file must never reach the terminal with these intact: they let the
- * text forge log lines, reorder what is printed around them, or inject escape
- * sequences. LRM, RLM and the Arabic letter mark open no bidi scope of their
- * own, but they still reorder the neutral characters beside them, so they go too — a diagnostic line is not the
- * place to preserve the typography of a right-to-left name.
+ * introducer U+009B), the bidirectional overrides and isolates, the Unicode
+ * line and paragraph separators, and the plain LRM/RLM/ALM marks. A name or
+ * value copied out of an untrusted config file, a fetched repository, or a
+ * tool's own settings file must never reach the terminal with these intact:
+ * they let the text forge log lines, reorder what is printed around them, or
+ * inject escape sequences. LRM, RLM and the Arabic letter mark open no bidi
+ * scope of their own, but they still reorder the neutral characters beside
+ * them, so they go too — a diagnostic line is not the place to preserve the
+ * typography of a right-to-left name.
  */
 const CONTROL_CHARACTERS_PATTERN =
   // oxlint-disable-next-line no-control-regex


### PR DESCRIPTION
Cleanups left over from the skill-name confusability work reviewed in #2810, one of which carries a deliberate behaviour difference (below).

- `src/lib/fetch.test.ts`: the `fetchFiles skill pruning` describe inlined the same single-skill `listDirectory` mock in eight tests that differ only in the remote skill name. They now share a `mockSingleSkillRepository(name)` helper, mirroring `mockSkillRepositoryWithSkills` in the neighbouring describe.
- `src/utils/confusable-names.test.ts`: the two repeated notes are now the module-scope `TWIN_NOTE` and `SAME_FORM_NOTE`, and the local `cyrillicCopy` is gone in favour of the module-scope `CYRILLIC_COPY` (whose comment now carries the rationale for the escaped spelling).
- `src/lib/fetch.ts`: dropped the local `isFileSystemError` in favour of the one `src/utils/file.ts` already exports (it walks the `cause` chain and checks the code against the errno shape).
- `src/lib/fetch.ts`: `readSkillRootNames` handed `join` the trailing-slash `SKILLS_DIR_PREFIX`; it now takes the `SKILLS_DIR_NAME` the prefix is built from.
- `src/utils/control-characters.ts`: rewrapped the 114-column LRM/RLM/ALM comment to the ~80 the rest of the file uses.

The behaviour difference: the shared `isFileSystemError` recognizes an I/O failure by its `errno` code shape, so a `code` of another shape — the `UNKNOWN` libuv falls back to on Windows for a system error it cannot translate — is now rethrown by the prune error handler instead of being absorbed into a `Stopped partway` warning. That is the side to err on: a prune silently skipped is worse than a fetch that says why it stopped. The comment at the call site records it.

`pnpm cicheck` passes.

Closes #2816
