### PR TITLE
fix(fetch): quote the name a prune warning names

### DIFF
--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,4 +1,4 @@
-import { link, lstat, symlink } from "node:fs/promises";
+import { chmod, link, lstat, symlink } from "node:fs/promises";
 import { join, posix } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -2812,12 +2812,46 @@ describe("fetchFiles skill pruning", () => {
     mockSingleSkillRepository(forged);
     await writeFileContent(join(skillsRoot, forged, "reference.md"), "# Stale");
 
-    await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
+    const summary = await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
 
+    expect(summary.deleted).toBe(0);
+    expect(await fileExists(join(skillsRoot, forged, "reference.md"))).toBe(true);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`Not pruning ${JSON.stringify(`skills/${forged}`)}:`),
     );
   });
+
+  // Root ignores the permission bits the failure is staged with, and Windows
+  // does not have them.
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "should quote the name when a prune stops partway through",
+    async () => {
+      // The name is a sentence about what was deleted, which is the very thing
+      // this warning reports, and the error text follows it. Quoted, the
+      // sentence is plainly part of the name.
+      const forged = "docs. Everything was deleted";
+      mockSingleSkillRepository(forged);
+      // The stale file sits in a directory the prune may read but not delete
+      // from, so the walk reaches it and the removal fails. The skill root
+      // itself stays writable, since the fetch writes into it before pruning.
+      const staleDir = join(skillsRoot, forged, "reference");
+      await writeFileContent(join(staleDir, "stale.md"), "# Stale");
+      await chmod(staleDir, 0o500);
+
+      try {
+        const summary = await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
+
+        expect(summary.deleted).toBe(0);
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Stopped partway through pruning ${JSON.stringify(`skills/${forged}`)}.`,
+          ),
+        );
+      } finally {
+        await chmod(staleDir, 0o700);
+      }
+    },
+  );
 
   it("should not prune a skill directory a local one differs from only in case", async () => {
     // macOS and Windows resolve `skills/PDF` to the existing `skills/pdf`, so
@@ -2832,7 +2866,9 @@ describe("fetchFiles skill pruning", () => {
     expect(summary.deleted).toBe(0);
     expect(await fileExists(localFile)).toBe(true);
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining("differs only in ways some filesystems ignore"),
+      // The sibling this one is confused with is a name from the same place, so
+      // it is quoted like any other.
+      expect.stringContaining(`${JSON.stringify("skills/pdf")} is also there and differs only`),
     );
   });
 

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,7 +1,7 @@
 import { chmod, link, lstat, symlink } from "node:fs/promises";
 import { join, posix } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import { createMockLogger } from "../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../test-utils/test-directories.js";
@@ -2817,7 +2817,9 @@ describe("fetchFiles skill pruning", () => {
     expect(summary.deleted).toBe(0);
     expect(await fileExists(join(skillsRoot, forged, "reference.md"))).toBe(true);
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining(`Not pruning ${JSON.stringify(`skills/${forged}`)}:`),
+      expect.stringContaining(
+        `Not pruning ${JSON.stringify(`skills/${forged}`)}: its name is one some systems resolve`,
+      ),
     );
   });
 
@@ -2837,19 +2839,21 @@ describe("fetchFiles skill pruning", () => {
       const staleDir = join(skillsRoot, forged, "reference");
       await writeFileContent(join(staleDir, "stale.md"), "# Stale");
       await chmod(staleDir, 0o500);
-
-      try {
-        const summary = await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
-
-        expect(summary.deleted).toBe(0);
-        expect(logger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(
-            `Stopped partway through pruning ${JSON.stringify(`skills/${forged}`)}.`,
-          ),
-        );
-      } finally {
+      // Registered with the runner rather than left to a `finally`, so the mode
+      // is put back even if this test is cut short before its body ends.
+      onTestFinished(async () => {
         await chmod(staleDir, 0o700);
-      }
+      });
+
+      const summary = await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
+
+      expect(summary.deleted).toBe(0);
+      expect(await fileExists(join(staleDir, "stale.md"))).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Stopped partway through pruning ${JSON.stringify(`skills/${forged}`)}.`,
+        ),
+      );
     },
   );
 

--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -2803,6 +2803,22 @@ describe("fetchFiles skill pruning", () => {
     );
   });
 
+  it("should quote the name it names in a prune warning", async () => {
+    // The name is a sentence of the remote's choosing, and it ends in a dot, so
+    // it reaches the warning through the guard above. Quoted, the sentence is
+    // plainly part of the name; spliced in bare it would read as the start of
+    // the warning itself.
+    const forged = "docs. Nothing was skipped.";
+    mockSingleSkillRepository(forged);
+    await writeFileContent(join(skillsRoot, forged, "reference.md"), "# Stale");
+
+    await fetchFiles({ logger, source: "owner/repo", outputRoot: testDir });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`Not pruning ${JSON.stringify(`skills/${forged}`)}:`),
+    );
+  });
+
   it("should not prune a skill directory a local one differs from only in case", async () => {
     // macOS and Windows resolve `skills/PDF` to the existing `skills/pdf`, so
     // the write lands in the local skill's own directory and a prune of it

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -854,8 +854,8 @@ async function pruneDirectory(params: {
     // enough that a fetched tree stays well inside it, since the remote walk
     // fails outright rather than truncating when it runs past its own.
     logger.warn(
-      `Not pruning below ${stripControlCharacters(relativeDirPath)}: it is more than ` +
-        `${MAX_RECURSION_DEPTH} directories deep.`,
+      `Not pruning below ${JSON.stringify(stripControlCharacters(relativeDirPath))}: it is ` +
+        `more than ${MAX_RECURSION_DEPTH} directories deep.`,
     );
     return "kept";
   }
@@ -867,8 +867,9 @@ async function pruneDirectory(params: {
   // directory swapped for a link between the two reads.
   if (await isSymbolicLink(dirPath)) {
     logger.warn(
-      `Not pruning ${stripControlCharacters(relativeDirPath)}: it is a symbolic link, and its ` +
-        `target is outside what this fetch may delete from. Remove unwanted files by hand.`,
+      `Not pruning ${JSON.stringify(stripControlCharacters(relativeDirPath))}: it is a ` +
+        `symbolic link, and its target is outside what this fetch may delete from. Remove ` +
+        `unwanted files by hand.`,
     );
     return "kept";
   }
@@ -1072,18 +1073,18 @@ async function pruneStaleSkillFiles(params: {
     // from one upstream dropped — so nothing here is judged stale.
     if (remoteDir === undefined) {
       logger.warn(
-        `Not pruning ${stripControlCharacters(skillDir)}: the remote directory it was fetched ` +
-          `from could not be worked out, so there is nothing to judge the local files against. ` +
-          `Remove unwanted files by hand.`,
+        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: the remote ` +
+          `directory it was fetched from could not be worked out, so there is nothing to judge ` +
+          `the local files against. Remove unwanted files by hand.`,
       );
       continue;
     }
 
     if (hasPathAtOrUnder(incompleteRemoteDirs, remoteDir)) {
       logger.warn(
-        `Not pruning ${stripControlCharacters(skillDir)}: the remote listing for it came back ` +
-          `incomplete, so a stale local file cannot be told apart from one the listing left out. ` +
-          `Remove unwanted files by hand.`,
+        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: the remote listing ` +
+          `for it came back incomplete, so a stale local file cannot be told apart from one the ` +
+          `listing left out. Remove unwanted files by hand.`,
       );
       continue;
     }
@@ -1106,9 +1107,9 @@ async function pruneStaleSkillFiles(params: {
     // file the fetch wrote there is matched by identity rather than by name.
     if (/[.\s]$/.test(skillDir) || /~\d+(?:\.[^.]*)?$/.test(skillDir)) {
       logger.warn(
-        `Not pruning ${stripControlCharacters(skillDir)}: its name is one some systems resolve ` +
-          `to a different directory, so it may not be the directory this name reads as. Remove ` +
-          `unwanted files by hand.`,
+        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: its name is one ` +
+          `some systems resolve to a different directory, so it may not be the directory this ` +
+          `name reads as. Remove unwanted files by hand.`,
       );
       continue;
     }
@@ -1138,10 +1139,10 @@ async function pruneStaleSkillFiles(params: {
     );
     if (variant !== undefined) {
       logger.warn(
-        `Not pruning ${stripControlCharacters(skillDir)}: ${SKILLS_DIR_PREFIX}` +
-          `${stripControlCharacters(variant)} is also there and differs only in ways some ` +
-          `filesystems ignore, so this name may not be the directory it reads as. Remove ` +
-          `unwanted files by hand.`,
+        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: ` +
+          `${JSON.stringify(`${SKILLS_DIR_PREFIX}${stripControlCharacters(variant)}`)} is also ` +
+          `there and differs only in ways some filesystems ignore, so this name may not be the ` +
+          `directory it reads as. Remove unwanted files by hand.`,
       );
       continue;
     }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1894,6 +1894,12 @@ export function formatFetchSummary(summary: FetchSummary): string {
     // fetched one it never went through the checks on a remote path. An escape
     // sequence in it could rewrite or erase the lines around it, and the lines
     // around it are the record of what this command deleted.
+    // Not quoted, unlike the same paths in the log lines: this is a listing of
+    // one path per line rather than a sentence a name could prefix, and quoting
+    // every row would put a pair of marks on names that are almost always
+    // ordinary. The cost is that a name ending in something shaped like the
+    // status column can be misread as one — within its own row only, since the
+    // strip above leaves it nothing to end the line with.
     lines.push(`  ${icon} ${stripControlCharacters(file.relativePath)} ${statusText}`);
   }
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -902,7 +902,9 @@ async function pruneDirectory(params: {
       }
       await rm(entryPath, { force: true });
       deleted.push({ relativePath: entryRelativePath, status: "deleted" });
-      logger.debug(`Deleted stale skill entry: ${stripControlCharacters(entryRelativePath)}`);
+      logger.debug(
+        `Deleted stale skill entry: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
+      );
       continue;
     }
 
@@ -940,7 +942,9 @@ async function pruneDirectory(params: {
         throw error;
       }
       deleted.push({ relativePath: `${entryRelativePath}/`, status: "deleted" });
-      logger.debug(`Removed stale skill directory: ${stripControlCharacters(entryRelativePath)}`);
+      logger.debug(
+        `Removed stale skill directory: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
+      );
       continue;
     }
 
@@ -960,7 +964,9 @@ async function pruneDirectory(params: {
 
     await rm(entryPath, { force: true });
     deleted.push({ relativePath: entryRelativePath, status: "deleted" });
-    logger.debug(`Deleted stale skill file: ${stripControlCharacters(entryRelativePath)}`);
+    logger.debug(
+      `Deleted stale skill file: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
+    );
   }
 
   return survivors > 0 ? "kept" : "emptied";
@@ -1180,7 +1186,7 @@ async function pruneStaleSkillFiles(params: {
       // "Stopped partway", not "did not prune": entries deleted before the
       // failure are already recorded, and the summary lists them.
       logger.warn(
-        `Stopped partway through pruning ${stripControlCharacters(skillDir)}. ` +
+        `Stopped partway through pruning ${JSON.stringify(stripControlCharacters(skillDir))}. ` +
           `${stripControlCharacters(formatError(error))}`,
       );
     }
@@ -1338,9 +1344,9 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
   // Resolve ref to use
   const ref = resolvedRef ?? (await client.getDefaultBranch(parsed.owner, parsed.repo));
   // A default branch name is chosen by the remote repository, and git allows
-  // characters in it that reorder a terminal line, so it is stripped like every
-  // other remote-controlled string this command prints.
-  logger.debug(`Using ref: ${stripControlCharacters(ref)}`);
+  // characters in it that reorder a terminal line, so it is stripped and quoted
+  // like every other remote-controlled string this command prints.
+  logger.debug(`Using ref: ${JSON.stringify(stripControlCharacters(ref))}`);
 
   // If target is a tool format, use conversion flow
   if (isToolTarget(target)) {
@@ -1410,7 +1416,9 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
       const exists = await fileExists(localPath);
 
       if (exists && conflictStrategy === "skip") {
-        logger.debug(`Skipping existing file: ${stripControlCharacters(relativePath)}`);
+        logger.debug(
+          `Skipping existing file: ${JSON.stringify(stripControlCharacters(relativePath))}`,
+        );
         return { relativePath, status: "skipped" as const };
       }
 
@@ -1420,7 +1428,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
       await writeFileContent(localPath, content);
 
       const status = exists ? ("overwritten" as const) : ("created" as const);
-      logger.debug(`Wrote: ${stripControlCharacters(relativePath)} (${status})`);
+      logger.debug(`Wrote: ${JSON.stringify(stripControlCharacters(relativePath))} (${status})`);
       return { relativePath, status };
     }),
   );
@@ -1512,7 +1520,7 @@ async function collectFeatureFiles(params: {
           } catch (error) {
             // Only skip 404 errors (file not found), re-throw other errors
             if (isNotFoundError(error)) {
-              logger.debug(`File not found: ${stripControlCharacters(fullPath)}`);
+              logger.debug(`File not found: ${JSON.stringify(stripControlCharacters(fullPath))}`);
             } else {
               throw error;
             }
@@ -1552,7 +1560,7 @@ async function collectFeatureFiles(params: {
         // Check for 404 errors (feature not found)
         if (isNotFoundError(error)) {
           // Feature directory/file not found, skip silently
-          logger.debug(`Feature not found: ${stripControlCharacters(fullPath)}`);
+          logger.debug(`Feature not found: ${JSON.stringify(stripControlCharacters(fullPath))}`);
           return collected;
         }
         throw error;


### PR DESCRIPTION
## Summary

The prune warnings in `src/lib/fetch.ts` stripped control characters out of the skill directory name but spliced it into the sentence bare, while the convention elsewhere is to print a remote-derived name as `JSON.stringify(stripControlCharacters(name))`. A directory named `docs. Nothing was skipped.` therefore rendered as

```
Not pruning skills/docs. Nothing was skipped.: its name is one some systems resolve to ...
```

prefixing the real warning with a sentence of the remote's choosing.

The impact was limited — control characters are already stripped, so no newline could be injected and the line itself could not be forged — but the convention should hold everywhere a remote name is printed, so this applies it to every such line in `fetch.ts` rather than only the six the issue names.

## Changes

- `src/lib/fetch.ts`: quote the name in all six `Not pruning` warnings, in the `Stopped partway through pruning` warning of the same loop (where the name is followed by an error message, so a name could fabricate a first filesystem error), and in the eight `logger.debug` lines that print a remote-derived path.
- `src/lib/fetch.test.ts`: pin the quoting with a skill named `docs. Nothing was skipped.`, which reaches the warning through the trailing-dot guard; pin the sibling path quoted in the case-variant warning; and pin the partway failure, staged with a directory the prune may read but not delete from (skipped on Windows and as root, which ignore the permission bits).

Closes #2814
