### PR TITLE
fix(amp): sanitize settings before importing permissions

### DIFF
--- a/src/features/permissions/amp-permissions.test.ts
+++ b/src/features/permissions/amp-permissions.test.ts
@@ -293,6 +293,21 @@ describe("AmpPermissions", () => {
       expect(config.permission.bash).toEqual({ "rm *": "deny", "git *": "allow" });
     });
 
+    it("strips prototype-pollution keys recursively while retaining valid permissions", async () => {
+      await writeFileContent(
+        join(testDir, ".amp", "settings.json"),
+        '{"constructor":{"polluted":true},"amp.permissions":[{"tool":"bash","action":"allow","metadata":{"prototype":{"polluted":true},"safe":"value"}}]}',
+      );
+
+      const instance = await AmpPermissions.fromFile({ outputRoot: testDir });
+      const settings = JSON.parse(instance.getFileContent());
+      const config = JSON.parse(instance.toRulesyncPermissions().getFileContent());
+
+      expect(Object.hasOwn(settings, "constructor")).toBe(false);
+      expect(settings["amp.permissions"][0].metadata).toEqual({ safe: "value" });
+      expect(config.permission.bash).toEqual({ "*": "allow" });
+    });
+
     it("routes delegate entries into the amp override on import (no canonical equivalent)", async () => {
       await writeFileContent(
         join(testDir, ".amp", "settings.json"),

--- a/src/features/permissions/amp-permissions.ts
+++ b/src/features/permissions/amp-permissions.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 
 import { uniq } from "es-toolkit";
-import { parse as parseJsonc, type ParseError, printParseErrorCode } from "jsonc-parser";
 
 import {
   AMP_DIR,
@@ -13,6 +12,7 @@ import type { AiFileParams, ValidationResult } from "../../types/ai-file.js";
 import type { PermissionAction, PermissionsConfig } from "../../types/permissions.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import { parseJsonc } from "../../utils/jsonc.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
@@ -106,14 +106,11 @@ function isCanonicalAmpEntry(entry: AmpPermissionEntry): boolean {
 }
 
 function parseAmpSettings(fileContent: string): Record<string, unknown> {
-  const errors: ParseError[] = [];
-  const parsed: unknown = parseJsonc(fileContent || "{}", errors, { allowTrailingComma: true });
-
-  if (errors.length > 0) {
-    const details = errors
-      .map((error) => `${printParseErrorCode(error.error)} at offset ${error.offset}`)
-      .join(", ");
-    throw new Error(`Failed to parse Amp settings: ${details}`);
+  let parsed: unknown;
+  try {
+    parsed = parseJsonc(fileContent || "{}");
+  } catch (error) {
+    throw new Error(`Failed to parse Amp settings: ${formatError(error)}`, { cause: error });
   }
 
   // `isPlainObject` (not `isRecord`) rejects class instances for


### PR DESCRIPTION
## Summary

- parse Amp settings through the shared strict JSONC sanitizer
- preserve Amp-specific parse error context and the original error cause
- prove root and nested prototype-pollution keys are removed while valid permissions still import

Fixes #2855.

## Validation

- `pnpm exec vitest run src/features/permissions/amp-permissions.test.ts` (27 passed)
- `pnpm exec oxfmt --check src/features/permissions/amp-permissions.ts src/features/permissions/amp-permissions.test.ts`
- `pnpm exec oxlint src/features/permissions/amp-permissions.ts src/features/permissions/amp-permissions.test.ts`
- `pnpm cicheck:content`
- `pnpm cicheck` reached 10,207 passing tests; its only failure is the unrelated existing `RovodevMcp` absolute-path assertion, which expects an unwrapped path while YAML folds this checkout path at the space in `github pr` (`src/features/mcp/rovodev-mcp.test.ts:1005`). The same test fails in isolation.

## Risk boundary

The change only affects reads of Amp JSON/JSONC settings. It reuses the parser already used by other adapters, retains comments and trailing commas, rejects the same malformed syntax, and removes `__proto__`, `constructor`, and `prototype` recursively before settings are inspected or re-serialized. Amp settings writes and permission merge ordering are unchanged.