### PR TITLE
chore: release v16.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.19.0",
+  "version": "16.20.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.19.0";
+const getVersion = () => "16.20.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## What's Changed

### Bug Fixes

- **Comments in shared JSONC files survive a regenerate.** `.vscode/settings.json`, `.vscode/mcp.json`, `.amp/settings.json`, `opencode.json(c)` and `kilo.json(c)` (with their global counterparts) are now written back as edits to the existing text rather than re-serialized from the parsed value, so comments, blank lines, and key order outside the changed spans are kept — and a `generate` that computes the same content leaves the file byte-identical. VS Code's own "MCP: Add Server" scaffold, which opens `.vscode/mcp.json` with a comment line, is no longer stripped on the next run. The whole-document writer still runs where there is nothing to preserve or edit against: an empty file, one that does not parse, a non-object root, a document using `__proto__` / `constructor` / `prototype` as a key, and an edit large enough that editing key by key would be slower than rewriting. Non-JSONC formats (YAML, TOML) are unchanged (#2854, closes #2796).
- **The all-tools `*` category reaches the command-only adapters.** deepagents-cli, Warp, and Factory Droid folded every category other than `bash` into a single "skipped" warning, so a `deny` or `ask` written under `*` never reached their command lists — Warp and Factory Droid would auto-approve the very command the config blocks. A new `shell-command-categories` helper contributes every `bash` rule plus the restricting (`deny`, `ask`) rules from `*`, never its `allow` rules, so both directions fail closed; an `allow` that an `ask` names the same pattern for is withheld, since `deny > ask > allow`. Cline had the same hole and is fixed alongside them, withholding rather than writing an `allow` that the config restricts elsewhere and naming what it withheld in its translation notice (#2828, closes #2825).
- **Permission shadowing is judged the way the tools actually match.** Command patterns are compared by glob intersection rather than by string equality, Warp and Rust-flavored regex constructs (hex, code-point, and Unicode-class escapes) are read whole, the shadow walk is bounded by pair count so a large config cannot stall it, and the reports no longer name honored asks, inert denies, or silent asks that need no attention (#2828).

### Other Changes

- The Homebrew formula was updated to v16.19.0 (#2857).

## Contributors

- @dyoshikawa

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v16.19.0...v16.20.0
