### PR TITLE
fix: scan every glob-discovered path from a literal root

### DIFF
--- a/src/features/checks/checks-processor.test.ts
+++ b/src/features/checks/checks-processor.test.ts
@@ -143,6 +143,36 @@ Look for issues.
     expect(toolFiles[0]?.getRelativeFilePath()).toBe("literal.md");
   });
 
+  // `*` is not a legal filename character on Windows.
+  it.skipIf(process.platform === "win32")(
+    "should not reach a sibling project when the output root ends in a wildcard",
+    async () => {
+      // Matching too much is the dangerous direction here: every path this
+      // returns goes on the `--delete` orphan list, so a root read as a pattern
+      // would put another project's files there.
+      const literalRoot = join(testDir, "project*x");
+      await writeFileContent(
+        join(literalRoot, AMP_CHECKS_PROJECT_DIR, "mine.md"),
+        "---\nname: mine\ndescription: Mine\n---\n\nContent",
+      );
+      await writeFileContent(
+        join(testDir, "projectOTHERx", AMP_CHECKS_PROJECT_DIR, "theirs.md"),
+        "---\nname: theirs\ndescription: Theirs\n---\n\nContent",
+      );
+
+      const processor = new ChecksProcessor({
+        outputRoot: literalRoot,
+        inputRoots: [join(literalRoot, RULESYNC_RELATIVE_DIR_PATH)],
+        toolTarget: "amp",
+        logger,
+      });
+
+      const toolFiles = await processor.loadToolFiles({ forDeletion: true });
+
+      expect(toolFiles.map((file) => file.getRelativeFilePath())).toEqual(["mine.md"]);
+    },
+  );
+
   // Windows needs elevated rights to create symlinks, so this one is POSIX-only.
   it.skipIf(process.platform === "win32")(
     "should not load symlinked checks for deletion",

--- a/src/features/commands/augmentcode-command.ts
+++ b/src/features/commands/augmentcode-command.ts
@@ -205,7 +205,7 @@ export class AugmentcodeCommand extends ToolCommand {
     logger?: Logger;
   } = {}): Promise<AugmentcodeCommand[]> {
     const rootDir = join(outputRoot, AUGMENTCODE_AGENTS_COMMANDS_DIR_PATH);
-    const filePaths = await findFilesByGlobs(join(rootDir, "**", "*.md"));
+    const filePaths = await findFilesByGlobs("**/*.md", { cwd: rootDir });
 
     const commands = await Promise.all(
       filePaths.map(async (filePath) => {

--- a/src/features/commands/command-skill-ownership.ts
+++ b/src/features/commands/command-skill-ownership.ts
@@ -35,7 +35,9 @@ export async function rulesyncCommandSlugExists({
   dirName: string;
 }): Promise<boolean> {
   const perRootPaths = await Promise.all(
-    inputRoots.map((root) => findFilesByGlobs(join(root, COMMANDS_FEATURE_SUBDIR, "**", "*.md"))),
+    inputRoots.map((root) =>
+      findFilesByGlobs("**/*.md", { cwd: join(root, COMMANDS_FEATURE_SUBDIR) }),
+    ),
   );
 
   return perRootPaths.flat().some((filePath) => commandSlug(basename(filePath)) === dirName);

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -834,9 +834,9 @@ describe("CommandsProcessor", () => {
 
       const result = await processor.loadRulesyncFiles();
 
-      expect(mockFindFilesByGlobs).toHaveBeenCalledWith(
-        join(testDir, RULESYNC_COMMANDS_RELATIVE_DIR_PATH, "**", "*.md"),
-      );
+      expect(mockFindFilesByGlobs).toHaveBeenCalledWith("**/*.md", {
+        cwd: join(testDir, RULESYNC_COMMANDS_RELATIVE_DIR_PATH),
+      });
       expect(RulesyncCommand.fromFile).toHaveBeenCalledTimes(2);
       expect(RulesyncCommand.fromFile).toHaveBeenCalledWith({
         outputRoot: testDir,
@@ -1362,6 +1362,43 @@ describe("CommandsProcessor", () => {
         mockFindFilesByGlobs.mockReset();
       }
     });
+
+    // `*` is not a legal filename character on Windows.
+    it.skipIf(process.platform === "win32")(
+      "should not reach a sibling project when the output root ends in a wildcard",
+      async () => {
+        // Matching too much is the dangerous direction here: every path this
+        // returns goes on the `--delete` orphan list, so a root read as a
+        // pattern would put another project's files there.
+        const literalRoot = join(testDir, "project*x");
+        await writeFileContent(
+          join(literalRoot, ".claude", "commands", "mine.md"),
+          "---\ndescription: Mine\n---\n\nContent",
+        );
+        await writeFileContent(
+          join(testDir, "projectOTHERx", ".claude", "commands", "theirs.md"),
+          "---\ndescription: Theirs\n---\n\nContent",
+        );
+
+        const literalProcessor = new CommandsProcessor({
+          logger,
+          outputRoot: literalRoot,
+          toolTarget: "claudecode",
+        });
+
+        const actualFile =
+          await vi.importActual<typeof import("../../utils/file.js")>("../../utils/file.js");
+        mockFindFilesByGlobs.mockImplementation(actualFile.findFilesByGlobs);
+
+        try {
+          const toolFiles = await literalProcessor.loadToolFiles({ forDeletion: true });
+
+          expect(toolFiles.map((file) => file.getRelativeFilePath())).toEqual(["mine.md"]);
+        } finally {
+          mockFindFilesByGlobs.mockReset();
+        }
+      },
+    );
 
     it("should return files with correct paths for deletion", async () => {
       processor = new CommandsProcessor({ logger, outputRoot: testDir, toolTarget: "claudecode" });

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -799,7 +799,7 @@ export class CommandsProcessor extends FeatureProcessor {
     // symlink no longer resolves must not glob to nothing and read as "every
     // command was deleted".
     const rulesyncCommandPaths = (await directoryExistsStrict(basePath))
-      ? await findFilesByGlobs(join(basePath, "**", "*.md"))
+      ? await findFilesByGlobs("**/*.md", { cwd: basePath })
       : [];
 
     return await Promise.all(

--- a/src/features/rules/agentsmd-rule.test.ts
+++ b/src/features/rules/agentsmd-rule.test.ts
@@ -323,8 +323,9 @@ describe("AgentsMdRule", () => {
         await writeFileContent(join(testDir, relativePath), "# rule");
       }
 
-      const patterns = AgentsMdRule.getNestedFilePatterns({ outputRoot: testDir });
+      const patterns = AgentsMdRule.getNestedFilePatterns();
       const matched = await findFilesByGlobs(patterns.include, {
+        cwd: testDir,
         type: "file",
         followSymbolicLinks: false,
         ignore: patterns.ignore,
@@ -345,8 +346,9 @@ describe("AgentsMdRule", () => {
       await symlink(join(outsideDir, "secret.md"), join(testDir, "docs", "AGENTS.md"));
       await symlink(outsideDir, join(testDir, "linked"));
 
-      const patterns = AgentsMdRule.getNestedFilePatterns({ outputRoot: testDir });
+      const patterns = AgentsMdRule.getNestedFilePatterns();
       const matched = await findFilesByGlobs(patterns.include, {
+        cwd: testDir,
         type: "file",
         followSymbolicLinks: false,
         ignore: patterns.ignore,
@@ -410,8 +412,9 @@ describe("AgentsMdRule", () => {
         await writeFileContent(join(testDir, relativePath), "# rule");
       }
 
-      const patterns = AgentsMdRule.getNestedFilePatterns({ outputRoot: testDir });
+      const patterns = AgentsMdRule.getNestedFilePatterns();
       const matched = await findFilesByGlobs(patterns.include, {
+        cwd: testDir,
         type: "file",
         followSymbolicLinks: false,
         ignore: patterns.ignore,

--- a/src/features/rules/agentsmd-rule.ts
+++ b/src/features/rules/agentsmd-rule.ts
@@ -71,8 +71,8 @@ export class AgentsMdRule extends ToolRule {
    *
    * @see https://agents.md/
    */
-  static getNestedFilePatterns({ outputRoot }: { outputRoot: string }): ToolRuleNestedFilePatterns {
-    return this.buildNestedFilePatterns({ outputRoot, fileName: AGENTSMD_RULE_FILE_NAME });
+  static getNestedFilePatterns(): ToolRuleNestedFilePatterns {
+    return this.buildNestedFilePatterns({ fileName: AGENTSMD_RULE_FILE_NAME });
   }
 
   /**

--- a/src/features/rules/kiro-rule.test.ts
+++ b/src/features/rules/kiro-rule.test.ts
@@ -663,9 +663,9 @@ describe("KiroRule", () => {
     });
 
     it("should exclude the workspace-root AGENTS.md from the nested scan", () => {
-      const patterns = KiroRule.getNestedFilePatterns({ outputRoot: testDir });
-      expect(patterns.include).toEqual([`${testDir}/**/AGENTS.md`]);
-      expect(patterns.ignore).toContain(`${testDir}/AGENTS.md`);
+      const patterns = KiroRule.getNestedFilePatterns();
+      expect(patterns.include).toEqual(["**/AGENTS.md"]);
+      expect(patterns.ignore).toContain("AGENTS.md");
     });
   });
 

--- a/src/features/rules/kiro-rule.ts
+++ b/src/features/rules/kiro-rule.ts
@@ -367,16 +367,15 @@ export class KiroRule extends ToolRule {
    * never wrote.
    * @see https://kiro.dev/docs/steering/
    */
-  static getNestedFilePatterns({ outputRoot }: { outputRoot: string }): ToolRuleNestedFilePatterns {
-    const root = toPosixPath(outputRoot);
+  static getNestedFilePatterns(): ToolRuleNestedFilePatterns {
     return {
-      include: [`${root}/**/${KIRO_NESTED_STEERING_FILE_NAME}`],
+      include: [`**/${KIRO_NESTED_STEERING_FILE_NAME}`],
       ignore: [
         // The workspace-root file is another target's root rule, not a nested one.
-        `${root}/${KIRO_NESTED_STEERING_FILE_NAME}`,
-        `${root}/**/.*/**`,
-        ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `${root}/**/${dir}/**`),
-        ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${root}/${dir}/**`),
+        KIRO_NESTED_STEERING_FILE_NAME,
+        "**/.*/**",
+        ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `**/${dir}/**`),
+        ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${dir}/**`),
       ],
     };
   }

--- a/src/features/rules/qwencode-rule.ts
+++ b/src/features/rules/qwencode-rule.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, posix } from "node:path";
 
 import { z } from "zod/mini";
 
@@ -6,7 +6,7 @@ import { QWENCODE_DIR, QWENCODE_RULE_FILE_NAME } from "../../constants/qwencode-
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-file.js";
 import { formatError } from "../../utils/error.js";
-import { readFileContent } from "../../utils/file.js";
+import { readFileContent, toPosixPath } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
@@ -355,13 +355,7 @@ export class QwencodeRule extends ToolRule {
    * The personal local context file lives under `.qwen/`, not at the project
    * root where the settable root path points, so override the deletion glob.
    */
-  static getLocalRootFileGlob({
-    outputRoot,
-    fileName,
-  }: {
-    outputRoot: string;
-    fileName: string;
-  }): string {
-    return join(outputRoot, QWENCODE_DIR, fileName);
+  static getLocalRootFileGlob({ fileName }: { fileName: string }): string {
+    return posix.join(toPosixPath(QWENCODE_DIR), fileName);
   }
 }

--- a/src/features/rules/reasonix-rule.test.ts
+++ b/src/features/rules/reasonix-rule.test.ts
@@ -171,11 +171,11 @@ describe("ReasonixRule", () => {
     });
 
     it("should exclude the root file and dependency dirs from the nested scan patterns", () => {
-      const patterns = ReasonixRule.getNestedFilePatterns({ outputRoot: "/proj" });
-      expect(patterns.include).toEqual(["/proj/**/REASONIX.md"]);
-      expect(patterns.ignore).toContain("/proj/REASONIX.md");
-      expect(patterns.ignore).toContain("/proj/**/node_modules/**");
-      expect(patterns.ignore).toContain("/proj/vendor/**");
+      const patterns = ReasonixRule.getNestedFilePatterns();
+      expect(patterns.include).toEqual(["**/REASONIX.md"]);
+      expect(patterns.ignore).toContain("REASONIX.md");
+      expect(patterns.ignore).toContain("**/node_modules/**");
+      expect(patterns.ignore).toContain("vendor/**");
     });
   });
 

--- a/src/features/rules/reasonix-rule.ts
+++ b/src/features/rules/reasonix-rule.ts
@@ -70,8 +70,8 @@ export class ReasonixRule extends ToolRule {
    * (same exclusions, import-only, project scope).
    * @see https://github.com/esengine/DeepSeek-Reasonix/blob/v1.18.0/docs/SESSION_MEMORY_RETRIEVAL.md
    */
-  static getNestedFilePatterns({ outputRoot }: { outputRoot: string }): ToolRuleNestedFilePatterns {
-    return this.buildNestedFilePatterns({ outputRoot, fileName: REASONIX_RULE_FILE_NAME });
+  static getNestedFilePatterns(): ToolRuleNestedFilePatterns {
+    return this.buildNestedFilePatterns({ fileName: REASONIX_RULE_FILE_NAME });
   }
 
   /**

--- a/src/features/rules/roo-rule.test.ts
+++ b/src/features/rules/roo-rule.test.ts
@@ -8,7 +8,7 @@ import {
   RULESYNC_RULES_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { ensureDir, toPosixPath, writeFileContent } from "../../utils/file.js";
+import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { RooRule } from "./roo-rule.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 
@@ -689,8 +689,8 @@ describe("RooRule", () => {
     });
 
     it("enumerates mode directories for import only", () => {
-      const patterns = RooRule.getNestedFilePatterns({ outputRoot: testDir });
-      expect(patterns.include).toEqual([`${toPosixPath(testDir)}/.roo/rules-*/**/*.md`]);
+      const patterns = RooRule.getNestedFilePatterns();
+      expect(patterns.include).toEqual([".roo/rules-*/**/*.md"]);
     });
   });
 });

--- a/src/features/rules/roo-rule.ts
+++ b/src/features/rules/roo-rule.ts
@@ -196,10 +196,9 @@ export class RooRule extends ToolRule {
    * generic directory is the only one the deletion sweep enumerates, because a
    * `rules-*` glob would also match mode rules a user wrote by hand.
    */
-  static getNestedFilePatterns({ outputRoot }: { outputRoot: string }): ToolRuleNestedFilePatterns {
-    const root = toPosixPath(outputRoot);
+  static getNestedFilePatterns(): ToolRuleNestedFilePatterns {
     return {
-      include: [`${root}/${toPosixPath(ROO_DIR)}/rules-*/**/*.md`],
+      include: [`${toPosixPath(ROO_DIR)}/rules-*/**/*.md`],
       ignore: [],
     };
   }
@@ -243,13 +242,7 @@ export class RooRule extends ToolRule {
    * Glob for the `separate-local-file` deletion; Roo reads `AGENTS.local.md`
    * at the project root, not under `.roo/` (mirrors rovodev).
    */
-  static getLocalRootFileGlob({
-    outputRoot,
-    fileName,
-  }: {
-    outputRoot: string;
-    fileName: string;
-  }): string {
-    return join(outputRoot, fileName);
+  static getLocalRootFileGlob({ fileName }: { fileName: string }): string {
+    return fileName;
   }
 }

--- a/src/features/rules/rovodev-rule.test.ts
+++ b/src/features/rules/rovodev-rule.test.ts
@@ -523,20 +523,22 @@ describe("RovodevRule", () => {
     });
 
     it("getMirrorDeletionGlobs points primary at .rovodev/AGENTS.md and mirror at ./AGENTS.md", () => {
-      const globs = RovodevRule.getRootMirror().getMirrorDeletionGlobs({ outputRoot: testDir });
+      const globs = RovodevRule.getRootMirror().getMirrorDeletionGlobs();
 
+      // Root-relative: the processor passes the project root as `cwd`, so a root
+      // directory named `project(a)` is scanned as the directory it is.
       expect(globs).toEqual({
-        primaryGlob: join(testDir, ".rovodev", "AGENTS.md"),
-        mirrorGlob: join(testDir, "AGENTS.md"),
+        primaryGlob: ".rovodev/AGENTS.md",
+        mirrorGlob: "AGENTS.md",
       });
     });
   });
 
   describe("getLocalRootFileGlob", () => {
     it("points the separate-local-file glob at the project root, not under .rovodev/", () => {
-      expect(
-        RovodevRule.getLocalRootFileGlob({ outputRoot: testDir, fileName: "AGENTS.local.md" }),
-      ).toBe(join(testDir, "AGENTS.local.md"));
+      expect(RovodevRule.getLocalRootFileGlob({ fileName: "AGENTS.local.md" })).toBe(
+        "AGENTS.local.md",
+      );
     });
   });
 });

--- a/src/features/rules/rovodev-rule.ts
+++ b/src/features/rules/rovodev-rule.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, posix } from "node:path";
 
 import {
   ROVODEV_DIR,
@@ -7,7 +7,7 @@ import {
 } from "../../constants/rovodev-paths.js";
 import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { AiFileParams, ValidationResult } from "../../types/ai-file.js";
-import { readFileContent } from "../../utils/file.js";
+import { readFileContent, toPosixPath } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import {
   ToolRule,
@@ -327,7 +327,7 @@ export class RovodevRule extends ToolRule {
       rootRule: ToolRule;
       content: string;
     }): RovodevRule[];
-    getMirrorDeletionGlobs(params: { outputRoot: string }): {
+    getMirrorDeletionGlobs(): {
       primaryGlob: string;
       mirrorGlob: string;
     };
@@ -358,21 +358,15 @@ export class RovodevRule extends ToolRule {
       },
       // The `./AGENTS.md` mirror (`mirrorGlob`) is deleted only when the primary
       // `.rovodev/AGENTS.md` (`primaryGlob`) still exists.
-      getMirrorDeletionGlobs: ({ outputRoot }) => ({
-        primaryGlob: join(outputRoot, ROVODEV_DIR, ROVODEV_RULE_FILE_NAME),
-        mirrorGlob: join(outputRoot, ROVODEV_RULE_FILE_NAME),
+      getMirrorDeletionGlobs: () => ({
+        primaryGlob: posix.join(toPosixPath(ROVODEV_DIR), ROVODEV_RULE_FILE_NAME),
+        mirrorGlob: ROVODEV_RULE_FILE_NAME,
       }),
     };
   }
 
   /** Glob for the `separate-local-file` deletion; rovodev writes it at project root, not under `.rovodev/`. */
-  static getLocalRootFileGlob({
-    outputRoot,
-    fileName,
-  }: {
-    outputRoot: string;
-    fileName: string;
-  }): string {
-    return join(outputRoot, fileName);
+  static getLocalRootFileGlob({ fileName }: { fileName: string }): string {
+    return fileName;
   }
 }

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -4152,4 +4152,110 @@ targets: ["*"]
       ).toBeUndefined();
     });
   });
+  describe("output roots that hold glob metacharacters", () => {
+    // Every scan below spells the project root into `findFilesByGlobs`'s `cwd`
+    // rather than into the pattern. Spelled into the pattern, `project(glob)` is
+    // a picomatch group and matches nothing at all -- and an empty scan is not a
+    // visible failure: on the input side it reads as "every rule was deleted",
+    // so `--delete` removes generated files it can no longer regenerate and the
+    // run still reports success.
+
+    it("should load rulesync rules from a root that holds glob metacharacters", async () => {
+      const literalRoot = join(testDir, "project(glob)");
+      await writeFileContent(
+        join(literalRoot, RULESYNC_RULES_RELATIVE_DIR_PATH, "overview.md"),
+        '---\nroot: true\ntargets: ["*"]\n---\n\nRoot rule',
+      );
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: literalRoot,
+        inputRoots: [join(literalRoot, RULESYNC_RELATIVE_DIR_PATH)],
+        toolTarget: "claudecode",
+      });
+
+      const rulesyncFiles = await processor.loadRulesyncFiles();
+
+      expect(rulesyncFiles.map((file) => file.getRelativeFilePath())).toEqual(["overview.md"]);
+    });
+
+    it("should load root and non-root tool files for deletion from such a root", async () => {
+      const literalRoot = join(testDir, "project{a,b}");
+      await writeFileContent(join(literalRoot, "CLAUDE.md"), "# Root");
+      await writeFileContent(join(literalRoot, ".claude", "rules", "detail.md"), "# Detail");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: literalRoot,
+        toolTarget: "claudecode",
+      });
+
+      const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
+
+      expect(filesToDelete.map((file) => file.getRelativeFilePath()).toSorted()).toEqual([
+        "CLAUDE.md",
+        "detail.md",
+      ]);
+    });
+
+    it("should find the local root file from such a root", async () => {
+      // `getLocalRootFileGlob` overrides where this one is looked for, so it
+      // takes a different path through the processor than the root file above.
+      const literalRoot = join(testDir, "project(glob)");
+      await writeFileContent(join(literalRoot, ".rovodev", "AGENTS.md"), "# Root");
+      await writeFileContent(join(literalRoot, "AGENTS.local.md"), "# Local root");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: literalRoot,
+        toolTarget: "rovodev",
+      });
+
+      const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
+
+      expect(filesToDelete.map((file) => file.getRelativeFilePath())).toContain("AGENTS.local.md");
+    });
+
+    it("should find nested subproject files from such a root", async () => {
+      const literalRoot = join(testDir, "project(glob)");
+      await writeFileContent(join(literalRoot, "AGENTS.md"), "# Root");
+      await writeFileContent(join(literalRoot, "packages", "api", "AGENTS.md"), "# Nested");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: literalRoot,
+        toolTarget: "agentsmd",
+      });
+
+      const toolFiles = await processor.loadToolFiles();
+
+      expect(toolFiles.map((file) => file.getRelativeDirPath())).toContain(join("packages", "api"));
+    });
+
+    // `*` is not a legal filename character on Windows.
+    it.skipIf(process.platform === "win32")(
+      "should not sweep a sibling project when the root ends in a wildcard",
+      async () => {
+        // The false-positive side. For an orphan sweep this is the worse
+        // direction of the two: a root read as a pattern puts another
+        // project's files on the deletion list.
+        const literalRoot = join(testDir, "project*x");
+        await writeFileContent(join(literalRoot, "CLAUDE.md"), "# Mine");
+        await writeFileContent(
+          join(testDir, "projectOTHERx", ".claude", "rules", "theirs.md"),
+          "# Theirs",
+        );
+
+        const processor = new RulesProcessor({
+          logger,
+          outputRoot: literalRoot,
+          toolTarget: "claudecode",
+        });
+
+        const filesToDelete = await processor.loadToolFiles({ forDeletion: true });
+
+        expect(filesToDelete.map((file) => file.getRelativeFilePath())).toEqual(["CLAUDE.md"]);
+      },
+    );
+  });
 });

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -4236,9 +4236,12 @@ targets: ["*"]
     it.skipIf(process.platform === "win32")(
       "should not sweep a sibling project when the root ends in a wildcard",
       async () => {
-        // The false-positive side. For an orphan sweep this is the worse
-        // direction of the two: a root read as a pattern puts another
-        // project's files on the deletion list.
+        // The false-positive side: a root read as a pattern reaches into the
+        // sibling `projectOTHERx`. Here the stray path does not survive as far
+        // as the deletion list -- `checkPathTraversal` rejects it and the whole
+        // scan is discarded -- so the visible damage is that the sweep silently
+        // finds nothing, not that it deletes a stranger's file. Either way the
+        // root must be a directory, not a pattern.
         const literalRoot = join(testDir, "project*x");
         await writeFileContent(join(literalRoot, "CLAUDE.md"), "# Mine");
         await writeFileContent(

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative, sep } from "node:path";
+import { basename, dirname, join, posix, relative, sep } from "node:path";
 
 import { encode } from "@toon-format/toon";
 import { z } from "zod/mini";
@@ -266,7 +266,8 @@ type ToolRuleFactory = {
         rootRule: ToolRule;
         content: string;
       }): ToolRule[];
-      getMirrorDeletionGlobs(params: { outputRoot: string }): {
+      /** Both globs relative to the project root, which the processor passes as `cwd`. */
+      getMirrorDeletionGlobs(): {
         primaryGlob: string;
         mirrorGlob: string;
       };
@@ -274,9 +275,10 @@ type ToolRuleFactory = {
     /**
      * Override where the `separate-local-file` glob points when the tool writes
      * its local file outside its root dir. Used for both import and deletion.
+     * Relative to the project root, which the processor passes as `cwd`.
      * See {@link RovodevRule.getLocalRootFileGlob}.
      */
-    getLocalRootFileGlob?(params: { outputRoot: string; fileName: string }): string;
+    getLocalRootFileGlob?(params: { fileName: string }): string;
     /**
      * Extra fixed-path files this tool manages beyond the root and non-root
      * rules (e.g. Pi's `APPEND_SYSTEM.md` system-prompt file). The RulesProcessor
@@ -292,7 +294,7 @@ type ToolRuleFactory = {
      * so enumerating them for `--delete` would sweep away work rulesync never
      * wrote. See {@link AgentsMdRule.getNestedFilePatterns}.
      */
-    getNestedFilePatterns?(params: { outputRoot: string }): ToolRuleNestedFilePatterns;
+    getNestedFilePatterns?(): ToolRuleNestedFilePatterns;
   };
   meta: {
     /** File extension for the rule file */
@@ -989,15 +991,29 @@ const findFilesWithFallback = async (
   primaryFilePaths: string[],
   alternativeRoots: Array<{ relativeDirPath: string; relativeFilePath: string }> | undefined,
   buildAltGlob: (alt: { relativeDirPath: string; relativeFilePath: string }) => string,
+  outputRoot: string,
 ): Promise<string[]> => {
   if (primaryFilePaths.length > 0) {
     return primaryFilePaths;
   }
   if (alternativeRoots) {
-    return await findFilesByGlobs(alternativeRoots.map(buildAltGlob));
+    return await findFilesByGlobs(alternativeRoots.map(buildAltGlob), { cwd: outputRoot });
   }
   return [];
 };
+
+/**
+ * A project-root-relative glob for a file a tool keeps at a fixed path, joined
+ * with `/` because a glob is always posix-separated.
+ *
+ * Relative because the root goes to `findFilesByGlobs` as `cwd` rather than into
+ * the pattern: a project directory named `project(a)` or `project{a,b}` would
+ * otherwise be read as a glob and match nothing at all — and on a `--delete`
+ * sweep an empty result reads as "every source was removed", so rulesync would
+ * delete generated files it can no longer regenerate and report success.
+ */
+const rootRelativeGlob = (...segments: Array<string | undefined>): string =>
+  posix.join(...segments.filter((segment) => segment !== undefined).map(toPosixPath));
 
 export class RulesProcessor extends FeatureProcessor {
   private readonly toolTarget: RulesProcessorToolTarget;
@@ -1690,8 +1706,8 @@ As this project's AI coding tool, you must follow the additional conventions bel
     ]);
 
     const [discoveredFiles, discoveredCuratedFiles] = await Promise.all([
-      rulesDirExists ? findFilesByGlobs(join(rulesyncOutputRoot, "**", "*.md")) : [],
-      curatedDirExists ? findFilesByGlobs(join(curatedOutputRoot, "**", "*.md")) : [],
+      rulesDirExists ? findFilesByGlobs("**/*.md", { cwd: rulesyncOutputRoot }) : [],
+      curatedDirExists ? findFilesByGlobs("**/*.md", { cwd: curatedOutputRoot }) : [],
     ]);
 
     const files = [...new Set([...discoveredFiles, ...discoveredCuratedFiles])];
@@ -2015,11 +2031,11 @@ As this project's AI coding tool, you must follow the additional conventions bel
        */
       const primaryRootFilePaths = settablePaths.root
         ? await findFilesByGlobs(
-            join(
-              this.outputRoot,
+            rootRelativeGlob(
               settablePaths.root.relativeDirPath ?? ".",
               settablePaths.root.relativeFilePath,
             ),
+            { cwd: this.outputRoot },
           )
         : [];
 
@@ -2031,7 +2047,8 @@ As this project's AI coding tool, you must follow the additional conventions bel
         const uniqueRootFilePaths = await findFilesWithFallback(
           primaryRootFilePaths,
           settablePaths.alternativeRoots,
-          (alt) => join(this.outputRoot, alt.relativeDirPath, alt.relativeFilePath),
+          (alt) => rootRelativeGlob(alt.relativeDirPath, alt.relativeFilePath),
+          this.outputRoot,
         );
 
         if (forDeletion) {
@@ -2057,19 +2074,21 @@ As this project's AI coding tool, you must follow the additional conventions bel
 
         const filePaths = await (async () => {
           if (factory.class.getLocalRootFileGlob) {
-            return await findFilesByGlobs(
-              factory.class.getLocalRootFileGlob({ outputRoot: this.outputRoot, fileName }),
-            );
+            return await findFilesByGlobs(factory.class.getLocalRootFileGlob({ fileName }), {
+              cwd: this.outputRoot,
+            });
           }
           if (!settablePaths.root) {
             return [];
           }
           return await findFilesWithFallback(
             await findFilesByGlobs(
-              join(this.outputRoot, settablePaths.root.relativeDirPath ?? ".", fileName),
+              rootRelativeGlob(settablePaths.root.relativeDirPath ?? ".", fileName),
+              { cwd: this.outputRoot },
             ),
             settablePaths.alternativeRoots,
-            (alt) => join(this.outputRoot, alt.relativeDirPath, fileName),
+            (alt) => rootRelativeGlob(alt.relativeDirPath, fileName),
+            this.outputRoot,
           );
         })();
 
@@ -2103,14 +2122,12 @@ As this project's AI coding tool, you must follow the additional conventions bel
         if (!forDeletion || this.global || !rootMirror) {
           return [];
         }
-        const { primaryGlob, mirrorGlob } = rootMirror.getMirrorDeletionGlobs({
-          outputRoot: this.outputRoot,
-        });
-        const primaryPaths = await findFilesByGlobs(primaryGlob);
+        const { primaryGlob, mirrorGlob } = rootMirror.getMirrorDeletionGlobs();
+        const primaryPaths = await findFilesByGlobs(primaryGlob, { cwd: this.outputRoot });
         if (primaryPaths.length === 0) {
           return [];
         }
-        const mirrorPaths = await findFilesByGlobs(mirrorGlob);
+        const mirrorPaths = await findFilesByGlobs(mirrorGlob, { cwd: this.outputRoot });
         return buildDeletionRulesFromPaths(mirrorPaths);
       })();
 
@@ -2123,9 +2140,8 @@ As this project's AI coding tool, you must follow the additional conventions bel
         }
 
         const filePaths = await findFilesByGlobs(
-          extraFiles.map((file) =>
-            join(this.outputRoot, file.relativeDirPath, file.relativeFilePath),
-          ),
+          extraFiles.map((file) => rootRelativeGlob(file.relativeDirPath, file.relativeFilePath)),
+          { cwd: this.outputRoot },
         );
         if (filePaths.length === 0) {
           return [];
@@ -2158,9 +2174,7 @@ As this project's AI coding tool, you must follow the additional conventions bel
       const nestedToolRules = await (async () => {
         // Never in global mode: the output root is the home directory there, and
         // walking all of it looking for subprojects is both wrong and expensive.
-        const patterns = this.global
-          ? undefined
-          : factory.class.getNestedFilePatterns?.({ outputRoot: this.outputRoot });
+        const patterns = this.global ? undefined : factory.class.getNestedFilePatterns?.();
         if (forDeletion || !patterns || patterns.include.length === 0) {
           return [];
         }
@@ -2171,6 +2185,7 @@ As this project's AI coding tool, you must follow the additional conventions bel
         // version-controlled `.rulesync/rules/`. Not following them also keeps a
         // pair of directory symlinks from exploding the traversal.
         const matchedPaths = await findFilesByGlobs(patterns.include, {
+          cwd: this.outputRoot,
           type: "file",
           followSymbolicLinks: false,
           ignore: patterns.ignore,
@@ -2235,12 +2250,11 @@ As this project's AI coding tool, you must follow the additional conventions bel
         const skippedPaths: string[] = [];
         for (const importOnlyRoot of importOnlyRoots) {
           const matchedPaths = await findFilesByGlobs(
-            join(
-              this.outputRoot,
+            rootRelativeGlob(
               importOnlyRoot.relativeDirPath,
               importOnlyRoot.relativeFilePath ?? `*.${factory.meta.extension}`,
             ),
-            { type: "file" },
+            { cwd: this.outputRoot, type: "file" },
           );
           if (importOnlyRoot.onlyWhenRootAbsent === true && rootFilePath !== undefined) {
             skippedPaths.push(...matchedPaths);
@@ -2275,9 +2289,9 @@ As this project's AI coding tool, you must follow the additional conventions bel
         }
 
         const nonRootOutputRoot = join(this.outputRoot, settablePaths.nonRoot.relativeDirPath);
-        const nonRootFilePaths = await findFilesByGlobs(
-          join(nonRootOutputRoot, "**", `*.${factory.meta.extension}`),
-        );
+        const nonRootFilePaths = await findFilesByGlobs(`**/*.${factory.meta.extension}`, {
+          cwd: nonRootOutputRoot,
+        });
 
         if (forDeletion) {
           return buildDeletionRulesFromPaths(nonRootFilePaths, {

--- a/src/features/rules/tool-rule.ts
+++ b/src/features/rules/tool-rule.ts
@@ -61,6 +61,11 @@ export type ToolRuleExtraFixedFile = {
  * optional static `getNestedFilePatterns` hook and consumed by the
  * RulesProcessor on import.
  *
+ * Both sides are relative to the project root, which the processor passes as
+ * `findFilesByGlobs`'s `cwd`. Embedding the root in the pattern instead would
+ * read a project directory named `project(a)` or `project{a,b}` as a glob and
+ * silently match nothing.
+ *
  * `ignore` is separate from `include` rather than expressed as `!` patterns
  * because globby rewrites a negative pattern containing no glob metacharacter as
  * cwd-relative, which makes an absolute one silently match nothing.
@@ -277,21 +282,18 @@ export abstract class ToolRule extends ToolFile {
    * `--delete` would sweep away work rulesync never wrote.
    */
   protected static buildNestedFilePatterns({
-    outputRoot,
     fileName,
   }: {
-    outputRoot: string;
     fileName: string;
   }): ToolRuleNestedFilePatterns {
-    const root = toPosixPath(outputRoot);
     return {
-      include: [`${root}/**/${fileName}`],
+      include: [`**/${fileName}`],
       ignore: [
         // Enumerated separately as the root rule.
-        `${root}/${fileName}`,
-        `${root}/**/.*/**`,
-        ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `${root}/**/${dir}/**`),
-        ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${root}/${dir}/**`),
+        fileName,
+        "**/.*/**",
+        ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `**/${dir}/**`),
+        ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${dir}/**`),
       ],
     };
   }

--- a/src/features/rules/vibe-rule.test.ts
+++ b/src/features/rules/vibe-rule.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
-import { toPosixPath, writeFileContent } from "../../utils/file.js";
+import { writeFileContent } from "../../utils/file.js";
 import { RulesyncRule } from "./rulesync-rule.js";
 import { VibeRule } from "./vibe-rule.js";
 
@@ -156,11 +156,13 @@ describe("VibeRule", () => {
   });
 
   it("should exclude the root file and vendored trees from the nested scan", () => {
-    const patterns = VibeRule.getNestedFilePatterns({ outputRoot: testDir });
+    const patterns = VibeRule.getNestedFilePatterns();
 
-    expect(patterns.include).toEqual([`${toPosixPath(testDir)}/**/AGENTS.md`]);
-    expect(patterns.ignore).toContain(`${toPosixPath(testDir)}/AGENTS.md`);
-    expect(patterns.ignore).toContain(`${toPosixPath(testDir)}/**/node_modules/**`);
+    // Root-relative: the project root travels as `findFilesByGlobs`'s `cwd`, so
+    // a root whose name holds a glob metacharacter is read as the directory it is.
+    expect(patterns.include).toEqual(["**/AGENTS.md"]);
+    expect(patterns.ignore).toContain("AGENTS.md");
+    expect(patterns.ignore).toContain("**/node_modules/**");
   });
 
   it("should treat only the project and global root paths as root on deletion", () => {

--- a/src/features/rules/vibe-rule.ts
+++ b/src/features/rules/vibe-rule.ts
@@ -61,8 +61,8 @@ export class VibeRule extends ToolRule {
    * literally the same files.
    * @see https://github.com/mistralai/mistral-vibe/blob/main/vibe/core/config/harness_files/_harness_manager.py
    */
-  static getNestedFilePatterns({ outputRoot }: { outputRoot: string }): ToolRuleNestedFilePatterns {
-    return this.buildNestedFilePatterns({ outputRoot, fileName: AGENTSMD_RULE_FILE_NAME });
+  static getNestedFilePatterns(): ToolRuleNestedFilePatterns {
+    return this.buildNestedFilePatterns({ fileName: AGENTSMD_RULE_FILE_NAME });
   }
 
   /**

--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -465,19 +465,21 @@ export class ClaudecodeSkill extends ToolSkill {
     if (global) {
       return [];
     }
-    const root = toPosixPath(outputRoot);
-    const dirPaths = await findFilesByGlobs(
-      [`${root}/*/**/${toPosixPath(CLAUDECODE_SKILLS_DIR_PATH)}`],
-      {
-        type: "dir",
-        followSymbolicLinks: false,
-        ignore: [
-          `${root}/**/.*/**/${toPosixPath(CLAUDECODE_SKILLS_DIR_PATH)}`,
-          ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `${root}/**/${dir}/**`),
-          ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${root}/${dir}/**`),
-        ],
-      },
-    );
+    // Patterns are relative and the root travels as `cwd`: spelled into the
+    // pattern instead, a project directory named `project(a)` or `project{a,b}`
+    // would be read as a glob and match nothing, and `project*x` would reach
+    // into sibling projects.
+    const skillsDirPath = toPosixPath(CLAUDECODE_SKILLS_DIR_PATH);
+    const dirPaths = await findFilesByGlobs([`*/**/${skillsDirPath}`], {
+      cwd: outputRoot,
+      type: "dir",
+      followSymbolicLinks: false,
+      ignore: [
+        `**/.*/**/${skillsDirPath}`,
+        ...NESTED_SCAN_EXCLUDED_DIRS_ANY_DEPTH.map((dir) => `**/${dir}/**`),
+        ...NESTED_SCAN_EXCLUDED_ROOT_DIRS.map((dir) => `${dir}/**`),
+      ],
+    });
     // Honor the project's .gitignore like the nested AGENTS.md scan does: a
     // gitignored scratch checkout's skills are somebody else's project and
     // must not be pulled into the shared `.rulesync/skills/` namespace.

--- a/src/features/subagents/subagents-processor.test.ts
+++ b/src/features/subagents/subagents-processor.test.ts
@@ -738,6 +738,35 @@ Body from inputRoots[0]`;
       expect(toolFiles[0]?.getRelativeFilePath()).toBe("literal.md");
     });
 
+    // `*` is not a legal filename character on Windows.
+    it.skipIf(process.platform === "win32")(
+      "should not reach a sibling project when the output root ends in a wildcard",
+      async () => {
+        // Matching too much is the dangerous direction here: every path this
+        // returns goes on the `--delete` orphan list, so a root read as a
+        // pattern would put another project's files there.
+        const literalRoot = join(testDir, "project*x");
+        await writeFileContent(
+          join(literalRoot, ".claude", "agents", "mine.md"),
+          "---\nname: mine\ndescription: Mine\n---\n\nContent",
+        );
+        await writeFileContent(
+          join(testDir, "projectOTHERx", ".claude", "agents", "theirs.md"),
+          "---\nname: theirs\ndescription: Theirs\n---\n\nContent",
+        );
+
+        const processor = new SubagentsProcessor({
+          logger: createMockLogger(),
+          outputRoot: literalRoot,
+          toolTarget: "claudecode",
+        });
+
+        const toolFiles = await processor.loadToolFiles({ forDeletion: true });
+
+        expect(toolFiles.map((file) => file.getRelativeFilePath())).toEqual(["mine.md"]);
+      },
+    );
+
     it("should delegate to loadClaudecodeSubagents for claudecode target", async () => {
       const processor = new SubagentsProcessor({
         logger: createMockLogger(),

--- a/src/features/subagents/subagents-processor.ts
+++ b/src/features/subagents/subagents-processor.ts
@@ -121,7 +121,14 @@ type ToolSubagentFactory = {
     supportsSimulated: boolean;
     /** Whether the tool supports global (user-level) subagents */
     supportsGlobal: boolean;
-    /** File pattern for import (e.g., "*.md", "*.json") */
+    /**
+     * File pattern for import (e.g., "*.md", "*.json").
+     *
+     * A glob, not a filesystem path, so multi-segment patterns are spelled with
+     * `/` literally rather than joined with `node:path`'s `join`: on Windows
+     * `join` would separate the segments with a backslash, which only works by
+     * accident because `findFilesByGlobs` rewrites backslashes.
+     */
     filePattern: string;
   };
 };
@@ -332,7 +339,7 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
         supportsSimulated: false,
         // dcode discovers user-level subagents in `~/.deepagents/<agent_name>/agents/`.
         supportsGlobal: true,
-        filePattern: join("*", "AGENTS.md"),
+        filePattern: "*/AGENTS.md",
       },
     },
   ],
@@ -349,7 +356,7 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
         supportsProject: true,
         supportsSimulated: false,
         supportsGlobal: true,
-        filePattern: join("*", "AGENT.md"),
+        filePattern: "*/AGENT.md",
       },
     },
   ],
@@ -480,7 +487,7 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
         supportsProject: true,
         supportsSimulated: false,
         supportsGlobal: true,
-        filePattern: join("**", "*.md"),
+        filePattern: "**/*.md",
       },
     },
   ],
@@ -523,7 +530,7 @@ export const toolSubagentFactories = new Map<SubagentsProcessorToolTarget, ToolS
         supportsProject: true,
         supportsSimulated: false,
         supportsGlobal: true,
-        filePattern: join("*", "SKILL.md"),
+        filePattern: "*/SKILL.md",
       },
     },
   ],


### PR DESCRIPTION
Completes the literal-root glob fix started in #2811.

## Problem

The rules, commands and skills scans still embedded the project root directly into their glob patterns. A project directory whose name holds a glob metacharacter is then read as a pattern rather than as the directory it is:

| Directory name | Embedded in the pattern | Passed as `cwd` |
| --- | --- | --- |
| `project(glob)` | 0 files (missed) | 1 |
| `project{a,b}` | 0 files (missed) | 1 |
| `project*x` | 1, plus sibling directories | 1 |

The input side is the data-loss route: with `proj(x)/.rulesync/rules/a.md` present, `loadRulesyncFiles()` returned `[]`, which reads as "every rule was deleted" — so `generate --delete` removed generated files it could no longer regenerate, and the run still reported success.

## Changes

- `rules-processor.ts`: every scan now passes the root as `findFilesByGlobs`'s `cwd` with a root-relative pattern — the `.rulesync/rules` and `.curated` input paths, the root and local-root files, the root-mirror deletion globs, the extra fixed files, the nested subproject scan, the import-only roots and the non-root tree.
- `getNestedFilePatterns()`, `getLocalRootFileGlob()` and `getMirrorDeletionGlobs()` return root-relative globs and no longer take `outputRoot`, so a tool cannot reintroduce the bug by spelling the root into its own pattern.
- The same conversion for `commands-processor.ts`, `command-skill-ownership.ts`, `augmentcode-command.ts` and the nested `.claude/skills/` scan in `claudecode-skill.ts` (whose `ignore` array embedded the root too).

## Tests

Five new `rules-processor` cases, all verified to fail on the previous code: the `.rulesync/rules` input path, root plus non-root deletion, the local-root override, the nested subproject scan, and a `project*x` root that must not sweep a `projectOTHERx` sibling.

The sibling-directory case is also added to the subagents, checks and commands processors, covering the false-positive side that the original tests left out — for an orphan sweep, matching too much is the more dangerous direction.

Closes #2870
Related: #2811