### PR TITLE
refactor(mcp): centralize raw server lookup

### DIFF
--- a/src/features/mcp/codexcli-mcp.ts
+++ b/src/features/mcp/codexcli-mcp.ts
@@ -559,10 +559,9 @@ export class CodexcliMcp extends ToolMcp {
     }
 
     const strippedMcpServers = rulesyncMcp.getMcpServers();
-    const rawMcpServers = rulesyncMcp.getJson().mcpServers;
     const mcpServersWithCodexFields = Object.fromEntries(
       Object.entries(strippedMcpServers).map(([serverName, serverConfig]) => {
-        const rawServer = isRecord(rawMcpServers) ? rawMcpServers[serverName] : undefined;
+        const rawServer = rulesyncMcp.getRawMcpServer(serverName);
         return [
           serverName,
           {

--- a/src/features/mcp/musecode-mcp.ts
+++ b/src/features/mcp/musecode-mcp.ts
@@ -318,10 +318,9 @@ export class MusecodeMcp extends ToolMcp {
     // `musecodeMode` is stripped by `getMcpServers()` so it cannot leak into
     // other tools' configs, so read it back off the unfiltered source JSON —
     // the same re-merge codex does for `envVars`.
-    const rawMcpServers = rulesyncMcp.getJson().mcpServers;
     const mcpServers = Object.fromEntries(
       Object.entries(rulesyncMcp.getMcpServers()).map(([serverName, serverConfig]) => {
-        const rawServer = isRecord(rawMcpServers) ? rawMcpServers[serverName] : undefined;
+        const rawServer = rulesyncMcp.getRawMcpServer(serverName);
         const mode = asMusecodeMode(isRecord(rawServer) ? rawServer.musecodeMode : undefined);
         return [serverName, { ...serverConfig, ...(mode !== undefined && { musecodeMode: mode }) }];
       }),

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -717,17 +717,10 @@ export class RovodevMcp extends ToolMcp {
     // pass — it must not reach the other targets — so the unfiltered source is
     // read back here to recover it for the target that owns it, the way codex
     // recovers `envVars` and musecode recovers `musecodeMode`.
-    const rawMcpServers = rulesyncMcp.getJson().mcpServers;
     const mcpServers = Object.fromEntries(
       Object.entries(rulesyncMcp.getMcpServers())
         .map(([name, server]) => {
-          // `Object.hasOwn` before the lookup, matching `lookupTransport` and
-          // the `fromFile` disabled overlay: a name must never resolve up the
-          // prototype chain, however hard that is to reach from here.
-          const rawServer =
-            isRecord(rawMcpServers) && Object.hasOwn(rawMcpServers, name)
-              ? rawMcpServers[name]
-              : undefined;
+          const rawServer = rulesyncMcp.getRawMcpServer(name);
           const record: Record<string, unknown> = {
             ...(server as Record<string, unknown>),
             // Both spellings are accepted in `.rulesync/mcp.json`: the

--- a/src/features/mcp/rulesync-mcp.test.ts
+++ b/src/features/mcp/rulesync-mcp.test.ts
@@ -1452,6 +1452,55 @@ describe("RulesyncMcp", () => {
     });
   });
 
+  describe("getRawMcpServer", () => {
+    it("returns an own server from the unfiltered source", () => {
+      const rulesyncMcp = makeInstance({
+        mcpServers: {
+          pal: { command: "uvx", envVars: ["OPENAI_API_KEY"] },
+        },
+      });
+
+      expect(rulesyncMcp.getRawMcpServer("pal")).toEqual({
+        command: "uvx",
+        envVars: ["OPENAI_API_KEY"],
+      });
+    });
+
+    it("does not resolve a server from the prototype chain", () => {
+      const rulesyncMcp = makeInstance({ mcpServers: {} });
+      Object.setPrototypeOf(rulesyncMcp.getJson().mcpServers, {
+        inherited: { command: "evil" },
+      });
+
+      expect(rulesyncMcp.getRawMcpServer("inherited")).toBeUndefined();
+    });
+
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects the prototype-pollution key %s even when it is an own property",
+      (name) => {
+        const rulesyncMcp = makeInstance({ mcpServers: {} });
+        Object.defineProperty(rulesyncMcp.getJson().mcpServers, name, {
+          configurable: true,
+          enumerable: true,
+          value: { command: "evil" },
+        });
+
+        expect(rulesyncMcp.getRawMcpServer(name)).toBeUndefined();
+      },
+    );
+
+    it("returns undefined when the raw mcpServers value is not a record", () => {
+      const rulesyncMcp = new RulesyncMcp({
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "mcp.json",
+        fileContent: '{"mcpServers":[]}',
+        validate: false,
+      });
+
+      expect(rulesyncMcp.getRawMcpServer("pal")).toBeUndefined();
+    });
+  });
+
   describe("integration and edge cases", () => {
     it("should handle large JSON structures", () => {
       const largeJsonData = {

--- a/src/features/mcp/rulesync-mcp.ts
+++ b/src/features/mcp/rulesync-mcp.ts
@@ -579,6 +579,19 @@ export class RulesyncMcp extends RulesyncFile {
     throw new RulesyncSourceNotFoundError(`No ${recommendedPath} found.`);
   }
 
+  /**
+   * Return one server exactly as authored, before `getMcpServers()` strips
+   * rulesync- and tool-specific fields. Keep this lookup here so every target
+   * that re-merges one of those fields shares the same own-property and
+   * prototype-pollution guards.
+   */
+  getRawMcpServer(name: string): unknown {
+    if (isPrototypePollutionKey(name)) return undefined;
+
+    const mcpServers = isRecord(this.json) ? this.json.mcpServers : undefined;
+    return isRecord(mcpServers) && Object.hasOwn(mcpServers, name) ? mcpServers[name] : undefined;
+  }
+
   getMcpServers(): McpServers {
     // Tolerate missing/empty mcpServers (e.g., a RulesyncMcp constructed
     // from `{}` with validation disabled). Callers that previously read


### PR DESCRIPTION
## Summary

- add a guarded RulesyncMcp.getRawMcpServer accessor for unfiltered source entries
- use the shared accessor in the Codex CLI, Muse Code, and Rovo Dev adapters
- cover own-property, prototype-pollution, and malformed-map handling directly

Closes #2794

## Validation

- pnpm cicheck (10,243 passed; 3 skipped)