### PR TITLE
refactor(mcp): extract existing pointer classifier

### DIFF
--- a/src/features/mcp/rovodev-mcp.test.ts
+++ b/src/features/mcp/rovodev-mcp.test.ts
@@ -10,7 +10,7 @@ import {
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, toPosixPath, writeFileContent } from "../../utils/file.js";
-import { RovodevMcp } from "./rovodev-mcp.js";
+import { classifyExistingPointer, RovodevMcp } from "./rovodev-mcp.js";
 import { RulesyncMcp } from "./rulesync-mcp.js";
 
 describe("RovodevMcp", () => {
@@ -36,6 +36,18 @@ describe("RovodevMcp", () => {
   afterEach(async () => {
     await cleanup();
     vi.restoreAllMocks();
+  });
+
+  describe("classifyExistingPointer", () => {
+    it.each([
+      ["an unset pointer", undefined, false, "unset"],
+      ["the generated project file", ".rovodev/mcp.json", false, "already-generated"],
+      ["Atlassian's documented default", "~/.rovodev/mcp_config.json", true, "documented-default"],
+      ["an environment-variable spelling", "$HOME/.rovodev/mcp.json", true, "env-var-spelling"],
+      ["a user-chosen project file", "custom/mcp.json", false, "unrelated"],
+    ] as const)("classifies %s", (_label, existing, global, kind) => {
+      expect(classifyExistingPointer({ existing, global, outputRoot: testDir })).toEqual({ kind });
+    });
   });
 
   describe("getSettablePaths", () => {
@@ -1042,7 +1054,7 @@ describe("RovodevMcp", () => {
       expect(message).toContain("defines legacy");
       // This user already has a value, so the message has to end on the change
       // to make rather than on rulesync leaving their value alone.
-      expect(message).toContain('change mcp.mcpConfigPath to "~/.rovodev/mcp.json"');
+      expect(message).toMatch(/change mcp\.mcpConfigPath to "~\/\.rovodev\/mcp\.json"\.$/);
       expect(message).not.toContain("will not overwrite");
     });
 

--- a/src/features/mcp/rovodev-mcp.ts
+++ b/src/features/mcp/rovodev-mcp.ts
@@ -354,6 +354,50 @@ function envVarMcpFileSpellings({ fileName }: { fileName: string }): string[] {
   return [`$HOME/${tail}`, `\${HOME}/${tail}`];
 }
 
+export type ExistingPointerClassification =
+  | { kind: "unset" }
+  | { kind: "already-generated" }
+  | { kind: "documented-default" }
+  | { kind: "env-var-spelling" }
+  | { kind: "unrelated" };
+
+/**
+ * Classify the existing `mcpConfigPath` without deciding how to report it.
+ * Keep the known-file checks in this order: the generated file is valid in
+ * either scope, while the documented default and environment-variable
+ * spellings are global-only alternatives that need their own warnings.
+ */
+export function classifyExistingPointer({
+  existing,
+  global,
+  outputRoot,
+}: {
+  existing: unknown;
+  global: boolean;
+  outputRoot: string;
+}): ExistingPointerClassification {
+  if (existing === undefined) return { kind: "unset" };
+
+  const normalized =
+    typeof existing === "string" ? normalizeMcpConfigPathValue(existing) : undefined;
+  const namesFile = (fileName: string): boolean =>
+    normalized !== undefined &&
+    mcpFileSpellings({ fileName, global, outputRoot }).includes(normalized);
+
+  if (namesFile(ROVODEV_MCP_FILE_NAME)) return { kind: "already-generated" };
+  if (global && namesFile(ROVODEV_ALTERNATE_MCP_FILE_NAME)) {
+    return { kind: "documented-default" };
+  }
+  if (
+    global &&
+    normalized !== undefined &&
+    envVarMcpFileSpellings({ fileName: ROVODEV_MCP_FILE_NAME }).includes(normalized)
+  ) {
+    return { kind: "env-var-spelling" };
+  }
+  return { kind: "unrelated" };
+}
+
 /**
  * Point `mcp.mcpConfigPath` at the `mcp.json` rulesync writes for this scope,
  * and report whether the block gained a value it did not already carry.
@@ -511,17 +555,11 @@ async function applyMcpConfigPointer({
   logger?: Logger;
 }): Promise<boolean> {
   const { pointer, configLabel, mcpLabel } = pointerLabels(global);
-
   const existing = existingMcp.mcpConfigPath;
-  const normalizedExisting =
-    typeof existing === "string" ? normalizeMcpConfigPathValue(existing) : undefined;
-  const namesFile = (fileName: string): boolean =>
-    normalizedExisting !== undefined &&
-    mcpFileSpellings({ fileName, global, outputRoot }).includes(normalizedExisting);
-  const pointsAtGeneratedFile = namesFile(ROVODEV_MCP_FILE_NAME);
+  const classification = classifyExistingPointer({ existing, global, outputRoot });
 
   if (!hasLiveServers) {
-    if (pointsAtGeneratedFile) {
+    if (classification.kind === "already-generated") {
       logger?.warn(
         `Rovo Dev MCP: mcp.mcpConfigPath in ${configLabel} points at ${mcpLabel}, which now has ` +
           `no enabled server. Rovo Dev reads MCP servers from that file and nowhere else, so ` +
@@ -533,60 +571,48 @@ async function applyMcpConfigPointer({
     return false;
   }
 
-  if (existing === undefined) {
-    const displaced = global ? await describeDisplacedGlobalServers({ outputRoot }) : null;
-    if (displaced !== null) {
+  switch (classification.kind) {
+    case "unset": {
+      const displaced = global ? await describeDisplacedGlobalServers({ outputRoot }) : null;
+      if (displaced !== null) {
+        logger?.warn(
+          `Rovo Dev MCP: leaving mcp.mcpConfigPath unset in ${configLabel}, because ${displaced}. ` +
+            `Atlassian documents that path and ${mcpLabel} as two different defaults for the ` +
+            `setting, and mcpConfigPath names one config rather than merging, so pointing it at ` +
+            `${mcpLabel} would stop those servers being read on every project. Move the ones you ` +
+            `want to keep into .rulesync/mcp.jsonc — or none at all, if it turns out to hold ` +
+            `nothing you need — then set mcp.mcpConfigPath to "${pointer}" yourself, which ` +
+            `rulesync will not overwrite.`,
+        );
+        return false;
+      }
+
+      existingMcp.mcpConfigPath = pointer;
+      announcePointer({ global, logger });
+      return true;
+    }
+    case "already-generated":
+      return false;
+    case "documented-default":
+      await warnAtDocumentedDefault({ existing, outputRoot, logger });
+      return false;
+    case "env-var-spelling":
       logger?.warn(
-        `Rovo Dev MCP: leaving mcp.mcpConfigPath unset in ${configLabel}, because ${displaced}. ` +
-          `Atlassian documents that path and ${mcpLabel} as two different defaults for the ` +
-          `setting, and mcpConfigPath names one config rather than merging, so pointing it at ` +
-          `${mcpLabel} would stop those servers being read on every project. Move the ones you ` +
-          `want to keep into .rulesync/mcp.jsonc — or none at all, if it turns out to hold ` +
-          `nothing you need — then set mcp.mcpConfigPath to "${pointer}" yourself, which ` +
-          `rulesync will not overwrite.`,
+        `Rovo Dev MCP: mcp.mcpConfigPath in ${configLabel} is ${quoteValueForWarning(existing)}. That ` +
+          `names ${mcpLabel} only if Rovo Dev expands environment variables in this setting, ` +
+          `which Atlassian does not document — if it does not, the path resolves literally and ` +
+          `Rovo Dev reads no MCP servers at all. Write "${pointer}" instead, the form its own ` +
+          `documented default uses.`,
       );
       return false;
-    }
-
-    existingMcp.mcpConfigPath = pointer;
-    announcePointer({ global, logger });
-    return true;
+    case "unrelated":
+      logger?.warn(
+        `Rovo Dev MCP: leaving mcp.mcpConfigPath as ${quoteValueForWarning(existing)} in ${configLabel}. ` +
+          `Rovo Dev reads MCP servers from that path, so the generated ${mcpLabel} is unused until ` +
+          `it is set to "${pointer}".`,
+      );
+      return false;
   }
-  if (pointsAtGeneratedFile) {
-    return false;
-  }
-
-  // Quite possibly Rovo Dev's own writing rather than a destination the user
-  // chose, so it gets a message that says what to do rather than the generic
-  // "you aimed this somewhere else".
-  if (global && namesFile(ROVODEV_ALTERNATE_MCP_FILE_NAME)) {
-    await warnAtDocumentedDefault({ existing, outputRoot, logger });
-    return false;
-  }
-
-  // Aimed at the right file under a spelling that only works if Rovo Dev
-  // expands environment variables, which nothing documents that it does.
-  if (
-    global &&
-    normalizedExisting !== undefined &&
-    envVarMcpFileSpellings({ fileName: ROVODEV_MCP_FILE_NAME }).includes(normalizedExisting)
-  ) {
-    logger?.warn(
-      `Rovo Dev MCP: mcp.mcpConfigPath in ${configLabel} is ${quoteValueForWarning(existing)}. That ` +
-        `names ${mcpLabel} only if Rovo Dev expands environment variables in this setting, ` +
-        `which Atlassian does not document — if it does not, the path resolves literally and ` +
-        `Rovo Dev reads no MCP servers at all. Write "${pointer}" instead, the form its own ` +
-        `documented default uses.`,
-    );
-    return false;
-  }
-
-  logger?.warn(
-    `Rovo Dev MCP: leaving mcp.mcpConfigPath as ${quoteValueForWarning(existing)} in ${configLabel}. ` +
-      `Rovo Dev reads MCP servers from that path, so the generated ${mcpLabel} is unused until ` +
-      `it is set to "${pointer}".`,
-  );
-  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

- extract the five existing mcpConfigPath states into a pure classifyExistingPointer function
- replace the branching in applyMcpConfigPointer with an exhaustive switch while preserving all outcomes and messages
- cover every classifier state directly and pin the documented-default remedy to the end of its warning

Closes #2795

## Validation

- pnpm cicheck (10,263 passed; 3 skipped)
- pnpm exec vitest run src/features/mcp/rovodev-mcp.test.ts (72 passed)