### PR TITLE
fix(prompt): count East Asian Ambiguous characters as two columns

### DIFF
--- a/src/lib/skill-prompt.test.ts
+++ b/src/lib/skill-prompt.test.ts
@@ -1,4 +1,4 @@
-// cspell:ignore lette revievv -- a lookalike fixture and a label cut mid-word on purpose
+// cspell:ignore lett revievv -- a lookalike fixture and a label cut mid-word on purpose
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { displayWidthOf } from "../utils/display-width.js";
@@ -122,7 +122,7 @@ describe("promptSkillSelection", () => {
             // the tail of the second is cut: the marker and the first reason
             // are the ones a cut never reaches.
             name:
-              "[!] another entry differs from it only by lookalike letters; mi\u2026 " +
+              "[!] another entry differs from it only by lookalike letters; \u2026 " +
               `\u2014 ${lookalike}`,
             value: lookalike,
             checked: false,
@@ -148,7 +148,7 @@ describe("promptSkillSelection", () => {
     // names.
     expect(checkboxMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        choices: [{ name: `pdf${"o".repeat(68)}\u2026`, value: long, checked: false }],
+        choices: [{ name: `pdf${"o".repeat(67)}\u2026`, value: long, checked: false }],
       }),
     );
   });
@@ -170,7 +170,7 @@ describe("promptSkillSelection", () => {
       expect.objectContaining({
         choices: [
           {
-            name: `[!] carries more whitespace than the row shows \u2014 pdf${" ".repeat(19)}\u2026`,
+            name: `[!] carries more whitespace than the row shows \u2014 pdf${" ".repeat(17)}\u2026`,
             value: padded,
             checked: false,
           },
@@ -221,6 +221,35 @@ describe("promptSkillSelection", () => {
     expect(choices[0]?.value).toBe(wide);
   });
 
+  it("should measure a label at the width a wide-ambiguous terminal draws it", async () => {
+    checkboxMock.mockResolvedValue([]);
+    // 60 box-drawing characters and `● pdf-tools` pass the hidden-character
+    // check, are 71 columns under a Latin font — inside the budget — and are
+    // 132 columns in a terminal set to draw the East Asian Ambiguous class
+    // wide, which is a common setting in CJK locales. The prompt's own renderer
+    // counts them at one column each too, so the terminal is what breaks the
+    // row: 38 of them in front of the four-column prefix put the break exactly
+    // before `●`, and `● pdf-tools` lands at the left margin of a line that
+    // carries no pointer and no checkbox.
+    const ambiguous = `${"─".repeat(60)}● pdf-tools`;
+
+    await promptSkillSelection({
+      availableSkills: [ambiguous],
+      preselectedSkills: [],
+      localSkillNames: [],
+    });
+
+    const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{
+      name: string;
+      value: string;
+    }>;
+    // To the column: 35 box-drawing characters and the ellipsis are 72 columns
+    // at two apiece, and `● pdf-tools` is what the cut takes away.
+    expect(choices[0]?.name).toBe(`${"─".repeat(35)}…`);
+    expect(displayWidthOf(choices[0]?.name ?? "")).toBe(72);
+    expect(choices[0]?.value).toBe(ambiguous);
+  });
+
   it("should number labels that two different names are shortened into", async () => {
     checkboxMock.mockResolvedValue([]);
     // Neither name is confusable in itself: they are only indistinguishable
@@ -237,7 +266,7 @@ describe("promptSkillSelection", () => {
 
     // The number leads the row, so it is not left sitting past the untrusted
     // half of the label, and the name is cut to leave room for it.
-    const shortened = "a".repeat(67);
+    const shortened = "a".repeat(66);
     expect(checkboxMock).toHaveBeenCalledWith(
       expect.objectContaining({
         choices: [
@@ -341,11 +370,11 @@ describe("promptSkillSelection", () => {
       value: string;
     }>;
     expect(choices[0]?.name).toBe(
-      "(1) [!] another entry differs from it only by lookalike letters \u2014 review",
+      "(1) [!] another entry differs from it only by lookalike lett\u2026 \u2014 review",
     );
     // One column longer than the row above it, so its reasons are cut by one.
     expect(choices[1]?.name).toBe(
-      "(2) [!] another entry differs from it only by lookalike lette\u2026 \u2014 revievv",
+      "(2) [!] another entry differs from it only by lookalike let\u2026 \u2014 revievv",
     );
     expect(choices[1]?.value).toBe("revievv");
   });
@@ -473,7 +502,7 @@ describe("promptSkillSelection", () => {
     // subtracted the wrong prefix would fail here instead of passing by being
     // shorter than it had to be.
     expect(choices[0]?.name).toBe(
-      `[!] carries more whitespace than th\u2026 \u2014 pdf${" ".repeat(12)}\u2026`,
+      `[!] carries more whitespace than \u2026 \u2014 pdf${" ".repeat(11)}\u2026`,
     );
     expect(displayWidthOf(choices[0]?.name ?? "")).toBe(55);
     expect(choices[0]?.value).toBe(padded);
@@ -492,7 +521,7 @@ describe("promptSkillSelection", () => {
       localSkillNames: [],
     });
 
-    const shortened = "a".repeat(50);
+    const shortened = "a".repeat(49);
     expect(checkboxMock).toHaveBeenCalledWith(
       expect.objectContaining({
         choices: [
@@ -517,7 +546,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(68)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(67)}\u2026`);
   });
 
   it("should treat a width of zero as a terminal that did not answer", async () => {
@@ -536,7 +565,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(68)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(67)}\u2026`);
   });
 
   it("should budget against CLI_WIDTH when the terminal reports zero columns", async () => {
@@ -556,7 +585,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(51)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(50)}\u2026`);
     expect(displayWidthOf(choices[0]?.name ?? "")).toBe(55);
   });
 
@@ -580,7 +609,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(68)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(67)}\u2026`);
   });
 
   it("should leave CLI_WIDTH unread while the terminal reports a width", async () => {
@@ -599,7 +628,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(68)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(67)}\u2026`);
   });
 
   it("should keep a name readable in a terminal too narrow for any label", async () => {
@@ -617,7 +646,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`pdf${"o".repeat(12)}\u2026`);
+    expect(choices[0]?.name).toBe(`pdf${"o".repeat(11)}\u2026`);
   });
 
   it("should keep a noted label inside a terminal too narrow to seat it", async () => {
@@ -626,6 +655,9 @@ describe("promptSkillSelection", () => {
     // not fit beside a whole name in it. The name gives way rather than the
     // label running past the row: a label wider than the row wraps onto a line
     // the prompt draws no checkbox on, which is the row a padded name wants.
+    // With the separator and the ellipsis at two columns apiece, the number,
+    // the marker and the separator leave the name and the note a mark of the
+    // cut each and nothing more.
     setTerminalWidth(19);
     const latin = `pdf${"x".repeat(40)}`;
     const cyrillic = `pdf${"x".repeat(39)}\u0445`;
@@ -640,7 +672,7 @@ describe("promptSkillSelection", () => {
       name: string;
       value: string;
     }>;
-    expect(choices[0]?.name).toBe("(1) [!] \u2026 \u2014 pdf\u2026");
+    expect(choices[0]?.name).toBe("(1) [!] \u2026 \u2014 \u2026");
     expect(displayWidthOf(choices[0]?.name ?? "")).toBe(16);
     expect(displayWidthOf(choices[1]?.name ?? "")).toBe(16);
     // The row is unreadable at that width, and the value behind it is not: what
@@ -671,7 +703,7 @@ describe("promptSkillSelection", () => {
     // To the column, like its siblings: a bound would be met by counting a
     // joiner at two columns, or at five, as readily as at the one the renderer
     // spends on it.
-    expect(choices[0]?.name).toBe(`${"\u0627\u200c".repeat(35)}\u0627\u2026`);
+    expect(choices[0]?.name).toBe(`${"\u0627\u200c".repeat(35)}\u2026`);
     expect(displayWidthOf(choices[0]?.name ?? "")).toBe(72);
     expect(choices[0]?.value).toBe(joined);
   });
@@ -690,7 +722,7 @@ describe("promptSkillSelection", () => {
     });
 
     const choices = checkboxMock.mock.calls.at(-1)?.[0].choices as Array<{ name: string }>;
-    expect(choices[0]?.name).toBe(`${"\u0627\u200c".repeat(27)}\u2026`);
+    expect(choices[0]?.name).toBe(`${"\u0627\u200c".repeat(26)}\u0627\u2026`);
     expect(displayWidthOf(choices[0]?.name ?? "")).toBe(55);
   });
 

--- a/src/lib/skill-prompt.ts
+++ b/src/lib/skill-prompt.ts
@@ -62,9 +62,11 @@ const MAX_SKILL_LABEL_WIDTH = 72;
  * `( )` where it does not — the Linux console, and the older Windows console
  * outside Terminal — and the fallback box alone is three columns, for five in
  * all. The Unicode spelling comes to four at its widest: of the three glyphs
- * only `◯` is East Asian Ambiguous, which this project counts at one column and
- * a terminal set to draw the ambiguous characters wide draws at two, while the
- * pointer `❯` and the checked box `◉` are Neutral and stay at one either way.
+ * only `◯` is East Asian Ambiguous, which a terminal set to draw the ambiguous
+ * characters wide draws at two columns — and which `displayWidthOf` counts at
+ * two for the same reason, so the four is what measuring the prefix with it
+ * would give — while the pointer `❯` and the checked box `◉` are Neutral and
+ * stay at one either way.
  *
  * Five, then, because a budget two columns short is a row that wraps, and two
  * columns spent on a prefix that turned out to be narrower is two characters of
@@ -170,7 +172,12 @@ function skillLabelBudget(): number {
 /** Marks the label as carrying the tool's own warning rather than a name. */
 const NOTE_MARKER = "[!] ";
 
-/** Separates the note from the name; an em dash appears in no directory name. */
+/**
+ * Separates the note from the name; an em dash appears in no directory name.
+ * Measured with `displayWidthOf` wherever it is budgeted for rather than taken
+ * as three columns: the dash is East Asian Ambiguous, and a terminal that draws
+ * the class wide draws it at two.
+ */
 const NOTE_SEPARATOR = " \u2014 ";
 
 /**

--- a/src/lib/skill-prompt.ts
+++ b/src/lib/skill-prompt.ts
@@ -198,11 +198,12 @@ const NOTE_SEPARATOR = " \u2014 ";
  *
  * The name is given `MIN_SHORTENED_NAME_WIDTH` columns however long the note
  * is, but never more than the row has left after the marker, the separator and
- * the one column a cut note is still drawn in. That is what shares out a
- * terminal too narrow to seat both, and the composed label is cut to the budget
- * on the way out, so what is returned is the width it was budgeted or less
- * however the pieces fall — a wider label wraps onto a line the prompt draws no
- * marker on, which is the row this module exists to keep a name from painting.
+ * the `ELLIPSIS_WIDTH` columns a cut note is still drawn in. That is what
+ * shares out a terminal too narrow to seat both, and the composed label is cut
+ * to the budget on the way out, so what is returned is the width it was
+ * budgeted or less however the pieces fall — a wider label wraps onto a line
+ * the prompt draws no marker on, which is the row this module exists to keep a
+ * name from painting.
  */
 function formatSkillChoiceLabel(params: {
   name: string;
@@ -228,10 +229,12 @@ function formatSkillChoiceLabel(params: {
   // Cut as a whole once the pieces are laid out: each is kept to what it was
   // given, but a budget too small for the marker, the separator and a mark of
   // the cut on either side is one none of them can give any more back to. This
-  // is the cut that holds the bound, at any budget of a column or more — the
-  // numbered rows, whose budget is this one less the number in front of them,
-  // included. The clamp above it decides which piece gives way rather than
-  // whether one does: the name yields and the marker and the separator do not.
+  // is the cut that holds the bound, at any budget of `ELLIPSIS_WIDTH` columns
+  // or more — a narrower one is drawn as the mark of the cut alone, which is
+  // the narrowest a cut row can be — the numbered rows, whose budget is this
+  // one less the number in front of them, included. The clamp above it decides
+  // which piece gives way rather than whether one does: the name yields and
+  // the marker and the separator do not.
   return shortenToWidth({
     text: `${NOTE_MARKER}${shownNote}${NOTE_SEPARATOR}${shownName}`,
     budget,

--- a/src/utils/display-width.test.ts
+++ b/src/utils/display-width.test.ts
@@ -1,9 +1,11 @@
 import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 import {
   AMBIGUOUS_CHARACTERS_PATTERN,
+  COMBINING_MARK_PATTERN,
   ELLIPSIS_WIDTH,
   displayWidthOf,
   shortenToWidth,
@@ -190,32 +192,44 @@ describe("shortenToWidth", () => {
 });
 
 // The table is held to the property it was written from rather than trusted:
-// `get-east-asian-width` is loaded through the prompt renderer this module
-// mirrors, `@inquirer/checkbox`, which depends on it by way of `@inquirer/core`
-// and `fast-string-width`. That is the copy whose Unicode version the renderer
-// measures with, and the one the table has to agree with. It is not a
-// dependency of this package and is not imported statically for that reason;
-// the static-import rule is for the code that ships, and a test resolving a
-// transitive package through the one that owns it is what `createRequire` is
-// for. A failure to resolve fails the test rather than skipping it, because a
-// renderer that stopped depending on the package is a change worth noticing.
+// `get-east-asian-width` is the copy the prompt renderer measures with, and it
+// is found the way the renderer finds it, one dependency at a time —
+// `@inquirer/checkbox` depends on `@inquirer/core`, which depends on
+// `fast-string-width`, which depends on `get-east-asian-width` — so that the
+// test checks the renderer's own copy rather than whichever one the package
+// manager happened to hoist beside it. Each step resolves the package's main
+// entry rather than its `package.json`, which `fast-string-width` does not
+// expose. A failure to resolve fails the test rather than skipping it, because
+// a renderer that stopped depending on the package is a change worth noticing.
+//
+// The package is not a dependency of this one and a static import cannot reach
+// it from `src`, so `createRequire` does the resolving and a dynamic import does
+// the loading: the package is ESM only, and `require` of an ESM module is not
+// something every Node this package supports can do. This is the one place the
+// static-import rule gives way, and it gives way in a test.
 const FIRST_SURROGATE = 0xd800;
 const LAST_SURROGATE = 0xdfff;
 const LAST_CODE_POINT = 0x10ffff;
-const COMBINING_MARK_PATTERN = /[\p{Mn}\p{Me}]/u;
 
 function formatCodePoint(codePoint: number): string {
   return `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
 }
 
+async function loadRendererEastAsianWidth(): Promise<{
+  eastAsianWidthType: (codePoint: number) => string;
+}> {
+  const checkboxRequire = createRequire(
+    createRequire(import.meta.url).resolve("@inquirer/checkbox/package.json"),
+  );
+  const core = checkboxRequire.resolve("@inquirer/core");
+  const fastStringWidth = createRequire(core).resolve("fast-string-width");
+  const getEastAsianWidth = createRequire(fastStringWidth).resolve("get-east-asian-width");
+  return await import(pathToFileURL(getEastAsianWidth).href);
+}
+
 describe("AMBIGUOUS_CHARACTERS_PATTERN", () => {
-  it("should hold every East Asian Ambiguous code point of the renderer's Unicode, marks aside, and nothing else", () => {
-    const rendererRequire = createRequire(
-      createRequire(import.meta.url).resolve("@inquirer/checkbox/package.json"),
-    );
-    const { eastAsianWidthType } = rendererRequire("get-east-asian-width") as {
-      eastAsianWidthType: (codePoint: number) => string;
-    };
+  it("should hold every East Asian Ambiguous code point of the renderer's Unicode, marks aside, and nothing else", async () => {
+    const { eastAsianWidthType } = await loadRendererEastAsianWidth();
 
     const missingFromTable: string[] = [];
     const extraInTable: string[] = [];

--- a/src/utils/display-width.test.ts
+++ b/src/utils/display-width.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { displayWidthOf, shortenToWidth } from "./display-width.js";
+import { ELLIPSIS_WIDTH, displayWidthOf, shortenToWidth } from "./display-width.js";
 
 describe("displayWidthOf", () => {
   it.each([
@@ -60,6 +60,42 @@ describe("displayWidthOf", () => {
     expect(displayWidthOf(character)).toBe(2);
   });
 
+  // The East Asian Ambiguous class is drawn at one column under a Latin font
+  // and at two in a terminal set to draw it wide, which is a common setting in
+  // CJK locales. Counted at two: overstating a width shortens a label that did
+  // not need it, while understating one lets the terminal break the row onto a
+  // continuation line that carries no pointer and no checkbox.
+  it.each([
+    ["a box-drawing character", "─"],
+    ["a black circle", "●"],
+    ["a Greek letter", "α"],
+    ["an accented letter from the Latin-1 supplement", "é"],
+    ["an em dash", "—"],
+    ["the ellipsis", "…"],
+  ])(
+    "should count %s at the two columns a wide-ambiguous terminal draws",
+    (_description, character) => {
+      expect(displayWidthOf(character)).toBe(2);
+    },
+  );
+
+  // The Neutral class is drawn at one column whatever the terminal is set to,
+  // so it stays at one: these are the glyphs the prompt's own prefix is drawn
+  // with, and they are not what an attacker can pad a name with.
+  it.each([
+    ["the fisheye, the checked box of the prompt", "◉"],
+    ["the heavy right-pointing angle, the prompt's pointer", "❯"],
+  ])("should count %s at one column", (_description, character) => {
+    expect(displayWidthOf(character)).toBe(1);
+  });
+
+  it("should not hand a name a budget it fills with box-drawing characters", () => {
+    // 60 box-drawing characters and `● pdf-tools`: 71 columns under a Latin
+    // font, inside a 72-column budget, and 132 where the ambiguous class is
+    // drawn wide, which wraps `● pdf-tools` onto a row of its own.
+    expect(displayWidthOf(`${"─".repeat(60)}● pdf-tools`)).toBe(132);
+  });
+
   // The joiners draw as nothing and are counted as something, because the
   // renderer counts them and they are the only invisible characters a name that
   // reaches the prompt is allowed to carry.
@@ -82,16 +118,16 @@ describe("shortenToWidth", () => {
   });
 
   it("should keep the ellipsis inside the budget", () => {
-    expect(shortenToWidth({ text: "abcdef", budget: 4 })).toBe("abc…");
+    expect(shortenToWidth({ text: "abcdef", budget: 5 })).toBe("abc…");
   });
 
   it("should count wide characters as the two columns they occupy", () => {
-    // Four ideographs are eight columns; a budget of five leaves room for two
-    // of them plus the ellipsis.
-    const result = shortenToWidth({ text: "設定設定", budget: 5 });
+    // Four ideographs are eight columns; a budget of six leaves room for two
+    // of them plus the two-column ellipsis.
+    const result = shortenToWidth({ text: "設定設定", budget: 6 });
 
     expect(result).toBe("設定…");
-    expect(displayWidthOf(result)).toBeLessThanOrEqual(5);
+    expect(displayWidthOf(result)).toBeLessThanOrEqual(6);
   });
 
   it("should not split a wide character across the budget", () => {
@@ -111,5 +147,15 @@ describe("shortenToWidth", () => {
 
   it("should still mark the cut when nothing fits", () => {
     expect(shortenToWidth({ text: "abc", budget: 0 })).toBe("…");
+  });
+
+  it("should pay for the ellipsis at the two columns it is measured at", () => {
+    // The ellipsis is East Asian Ambiguous itself, so a cut string keeps one
+    // character fewer than a one-column mark would have let it keep.
+    expect(ELLIPSIS_WIDTH).toBe(2);
+    const result = shortenToWidth({ text: "abcdef", budget: 4 });
+
+    expect(result).toBe("ab…");
+    expect(displayWidthOf(result)).toBe(4);
   });
 });

--- a/src/utils/display-width.test.ts
+++ b/src/utils/display-width.test.ts
@@ -1,6 +1,13 @@
+import { createRequire } from "node:module";
+
 import { describe, expect, it } from "vitest";
 
-import { ELLIPSIS_WIDTH, displayWidthOf, shortenToWidth } from "./display-width.js";
+import {
+  AMBIGUOUS_CHARACTERS_PATTERN,
+  ELLIPSIS_WIDTH,
+  displayWidthOf,
+  shortenToWidth,
+} from "./display-width.js";
 
 describe("displayWidthOf", () => {
   it.each([
@@ -157,5 +164,55 @@ describe("shortenToWidth", () => {
 
     expect(result).toBe("ab…");
     expect(displayWidthOf(result)).toBe(4);
+  });
+});
+
+// The table is held to the property it was written from rather than trusted:
+// `get-east-asian-width` is loaded through the prompt renderer this module
+// mirrors, `@inquirer/checkbox`, which depends on it by way of `@inquirer/core`
+// and `fast-string-width`. That is the copy whose Unicode version the renderer
+// measures with, and the one the table has to agree with. It is not a
+// dependency of this package and is not imported statically for that reason;
+// the static-import rule is for the code that ships, and a test resolving a
+// transitive package through the one that owns it is what `createRequire` is
+// for. A failure to resolve fails the test rather than skipping it, because a
+// renderer that stopped depending on the package is a change worth noticing.
+const FIRST_SURROGATE = 0xd800;
+const LAST_SURROGATE = 0xdfff;
+const LAST_CODE_POINT = 0x10ffff;
+const COMBINING_MARK_PATTERN = /[\p{Mn}\p{Me}]/u;
+
+function formatCodePoint(codePoint: number): string {
+  return `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+describe("AMBIGUOUS_CHARACTERS_PATTERN", () => {
+  it("should hold every East Asian Ambiguous code point of the renderer's Unicode, marks aside, and nothing else", () => {
+    const rendererRequire = createRequire(
+      createRequire(import.meta.url).resolve("@inquirer/checkbox/package.json"),
+    );
+    const { eastAsianWidthType } = rendererRequire("get-east-asian-width") as {
+      eastAsianWidthType: (codePoint: number) => string;
+    };
+
+    const missingFromTable: string[] = [];
+    const extraInTable: string[] = [];
+    for (let codePoint = 0; codePoint <= LAST_CODE_POINT; codePoint++) {
+      if (codePoint >= FIRST_SURROGATE && codePoint <= LAST_SURROGATE) {
+        continue;
+      }
+      const character = String.fromCodePoint(codePoint);
+      const inTable = AMBIGUOUS_CHARACTERS_PATTERN.test(character);
+      const ambiguous = eastAsianWidthType(codePoint) === "ambiguous";
+      if (ambiguous && !inTable && !COMBINING_MARK_PATTERN.test(character)) {
+        missingFromTable.push(formatCodePoint(codePoint));
+      }
+      if (inTable && !ambiguous) {
+        extraInTable.push(formatCodePoint(codePoint));
+      }
+    }
+
+    expect(missingFromTable, "ambiguous in the property but not in the table").toEqual([]);
+    expect(extraInTable, "in the table but not ambiguous in the property").toEqual([]);
   });
 });

--- a/src/utils/display-width.test.ts
+++ b/src/utils/display-width.test.ts
@@ -117,6 +117,28 @@ describe("displayWidthOf", () => {
     // 39 Arabic letters and 38 non-joiners: drawn in 39 columns, wrapped as 77.
     expect(displayWidthOf(`${"\u0627\u200c".repeat(38)}\u0627`)).toBe(77);
   });
+
+  // A lone surrogate reaches a string through a JSON escape and is written to
+  // stdout as U+FFFD, which is East Asian Ambiguous: it is measured as the
+  // replacement character the terminal is shown rather than as a column of
+  // nothing in particular.
+  it.each([
+    ["a lone high surrogate", "\ud800"],
+    ["a lone low surrogate", "\udfff"],
+    ["the replacement character it is written as", "\ufffd"],
+  ])("should count %s at the two columns the replacement character draws", (_description, text) => {
+    expect(displayWidthOf(text)).toBe(2);
+  });
+
+  it("should not hand a name a budget it fills with lone surrogates", () => {
+    // 72 lone surrogates measured as themselves fit a 72-column budget and
+    // are drawn as 72 replacement characters in 144; 36 of them fill it.
+    expect(displayWidthOf("\ud800".repeat(36))).toBe(72);
+    expect(displayWidthOf("\ud800".repeat(72))).toBe(144);
+    expect(shortenToWidth({ text: "\ud800".repeat(72), budget: 72 })).toBe(
+      `${"\ud800".repeat(35)}…`,
+    );
+  });
 });
 
 describe("shortenToWidth", () => {

--- a/src/utils/display-width.test.ts
+++ b/src/utils/display-width.test.ts
@@ -195,12 +195,13 @@ describe("shortenToWidth", () => {
 // `get-east-asian-width` is the copy the prompt renderer measures with, and it
 // is found the way the renderer finds it, one dependency at a time —
 // `@inquirer/checkbox` depends on `@inquirer/core`, which depends on
-// `fast-string-width`, which depends on `get-east-asian-width` — so that the
-// test checks the renderer's own copy rather than whichever one the package
-// manager happened to hoist beside it. Each step resolves the package's main
-// entry rather than its `package.json`, which `fast-string-width` does not
-// expose. A failure to resolve fails the test rather than skipping it, because
-// a renderer that stopped depending on the package is a change worth noticing.
+// `fast-wrap-ansi`, which depends on `fast-string-width`, which depends on
+// `get-east-asian-width` — so that the test checks the renderer's own copy
+// rather than whichever one the package manager happened to hoist beside it.
+// Each step resolves the package's main entry rather than its `package.json`,
+// which `fast-wrap-ansi` and `fast-string-width` do not expose. A failure to
+// resolve fails the test rather than skipping it, because a renderer that
+// stopped depending on the package is a change worth noticing.
 //
 // The package is not a dependency of this one and a static import cannot reach
 // it from `src`, so `createRequire` does the resolving and a dynamic import does
@@ -222,7 +223,8 @@ async function loadRendererEastAsianWidth(): Promise<{
     createRequire(import.meta.url).resolve("@inquirer/checkbox/package.json"),
   );
   const core = checkboxRequire.resolve("@inquirer/core");
-  const fastStringWidth = createRequire(core).resolve("fast-string-width");
+  const fastWrapAnsi = createRequire(core).resolve("fast-wrap-ansi");
+  const fastStringWidth = createRequire(fastWrapAnsi).resolve("fast-string-width");
   const getEastAsianWidth = createRequire(fastStringWidth).resolve("get-east-asian-width");
   return await import(pathToFileURL(getEastAsianWidth).href);
 }

--- a/src/utils/display-width.ts
+++ b/src/utils/display-width.ts
@@ -20,8 +20,8 @@
  * why an emoji built from a chain of joiners is counted per component: two
  * columns each rather than the two the whole chain draws.
  *
- * Ambiguous-width characters are counted as one column, which is what a
- * terminal running a Latin font does.
+ * The East Asian Ambiguous class is counted at two columns as well, by the
+ * table below this one rather than by these ranges; the reason is given there.
  *
  * Two of the ranges are here for a narrower reason: a name the skill prompt can
  * offer may not be counted narrower here than the prompt's own renderer counts
@@ -59,6 +59,54 @@
  */
 const WIDE_CHARACTERS_PATTERN =
   /\p{Emoji_Presentation}|\p{Emoji_Modifier_Base}|[\u2329\u232a\u2630-\u2637\u268a-\u268f\u4dc0-\u4dff]|[\u1100-\u11ff\u2e80-\u303e\u3041-\u33ff\u3400-\u4dbf\u4e00-\u9fff\ua000-\ua4cf\ua960-\ua97f\uac00-\ud7a3\ud7b0-\ud7fb\uf900-\ufaff\ufe10-\ufe19\ufe30-\ufe6f\uff00-\uff60\uffe0-\uffe6]|[\u{16fe0}-\u{16ff6}]|[\u{17000}-\u{18dff}]|[\u{1aff0}-\u{1b2ff}]|[\u{1f000}-\u{1faff}]|[\u{20000}-\u{3fffd}]/u;
+
+/**
+ * The East Asian Ambiguous class of UAX #11: the characters a terminal draws
+ * one column wide under a Latin font and two columns wide where it is set to
+ * draw the ambiguous class wide, which is a common setting in CJK locales. The
+ * box-drawing characters, the geometric shapes, the Greek and Cyrillic
+ * alphabets, and the accented letters of the Latin-1 supplement are all here.
+ *
+ * Counted at two columns, which is the wider of the two answers, because the
+ * two ways of being wrong are not the same size. Overstating a width shortens
+ * a label that did not need it: a name carrying a Greek letter or an accented
+ * letter is cut a little earlier on a Latin terminal than it had to be.
+ * Understating one lets a forged row wrap: a name of sixty box-drawing
+ * characters and `● pdf-tools` measures 71 columns at one column apiece,
+ * inside the prompt's budget, and draws at 132 in a terminal that draws the
+ * class wide, so the terminal breaks the row itself and puts `● pdf-tools` at
+ * the left margin of a continuation line that carries no pointer and no
+ * checkbox.
+ *
+ * The prompt's own renderer, `fast-string-width`, counts the class at one
+ * column and never sees the wrap coming either; the terminal is what breaks
+ * the row, and only the budget can keep the row short enough not to be broken.
+ *
+ * One width model rather than two — a wide one for bounding an untrusted name
+ * and a narrow one for laying out the tool's own text — because the second
+ * model would buy a column or two of alignment in the tool's own output at the
+ * price of two measurements that have to be kept from being confused for each
+ * other. Where this is used to lay out text of the tool's own, the cost of the
+ * single model is a line cut a little earlier than it needed to be.
+ *
+ * The ranges are the `East_Asian_Width=A` property of Unicode 17.0, taken from
+ * the table `get-east-asian-width` 1.6.0 carries and merged where two are
+ * adjacent; the package itself is not imported, for the reason the comment
+ * above gives for not carrying the full table. Three stretches of the property
+ * are left out because they never reach this pattern: the combining diacritical
+ * marks of U+0300–U+036F and the variation selectors of U+FE00–U+FE0F and
+ * U+E0100–U+E01EF are marks by category and are counted by the mark rule
+ * before the width of a character is looked up. Leaving them out is also what
+ * keeps the class from holding a combining character, which
+ * `no-misleading-character-class` is there to catch. The private use areas are
+ * in it, as the property says they are: a name is free to carry them and a
+ * terminal is free to draw them wide.
+ *
+ * Escapes rather than the characters themselves, for the reason given above.
+ */
+// cspell:ignore ffffd -- the last code point of the first private use plane
+const AMBIGUOUS_CHARACTERS_PATTERN =
+  /[\u00a1\u00a4\u00a7-\u00a8\u00aa\u00ad-\u00ae\u00b0-\u00b4\u00b6-\u00ba\u00bc-\u00bf\u00c6\u00d0\u00d7-\u00d8\u00de-\u00e1\u00e6\u00e8-\u00ea\u00ec-\u00ed\u00f0\u00f2-\u00f3\u00f7-\u00fa\u00fc\u00fe\u0101\u0111\u0113\u011b\u0126-\u0127\u012b\u0131-\u0133\u0138\u013f-\u0142\u0144\u0148-\u014b\u014d\u0152-\u0153\u0166-\u0167\u016b\u01ce\u01d0\u01d2\u01d4\u01d6\u01d8\u01da\u01dc\u0251\u0261\u02c4\u02c7\u02c9-\u02cb\u02cd\u02d0\u02d8-\u02db\u02dd\u02df\u0391-\u03a1\u03a3-\u03a9\u03b1-\u03c1\u03c3-\u03c9\u0401\u0410-\u044f\u0451\u2010\u2013-\u2016\u2018-\u2019\u201c-\u201d\u2020-\u2022\u2024-\u2027\u2030\u2032-\u2033\u2035\u203b\u203e\u2074\u207f\u2081-\u2084\u20ac\u2103\u2105\u2109\u2113\u2116\u2121-\u2122\u2126\u212b\u2153-\u2154\u215b-\u215e\u2160-\u216b\u2170-\u2179\u2189\u2190-\u2199\u21b8-\u21b9\u21d2\u21d4\u21e7\u2200\u2202-\u2203\u2207-\u2208\u220b\u220f\u2211\u2215\u221a\u221d-\u2220\u2223\u2225\u2227-\u222c\u222e\u2234-\u2237\u223c-\u223d\u2248\u224c\u2252\u2260-\u2261\u2264-\u2267\u226a-\u226b\u226e-\u226f\u2282-\u2283\u2286-\u2287\u2295\u2299\u22a5\u22bf\u2312\u2460-\u24e9\u24eb-\u254b\u2550-\u2573\u2580-\u258f\u2592-\u2595\u25a0-\u25a1\u25a3-\u25a9\u25b2-\u25b3\u25b6-\u25b7\u25bc-\u25bd\u25c0-\u25c1\u25c6-\u25c8\u25cb\u25ce-\u25d1\u25e2-\u25e5\u25ef\u2605-\u2606\u2609\u260e-\u260f\u261c\u261e\u2640\u2642\u2660-\u2661\u2663-\u2665\u2667-\u266a\u266c-\u266d\u266f\u269e-\u269f\u26bf\u26c6-\u26cd\u26cf-\u26d3\u26d5-\u26e1\u26e3\u26e8-\u26e9\u26eb-\u26f1\u26f4\u26f6-\u26f9\u26fb-\u26fc\u26fe-\u26ff\u273d\u2776-\u277f\u2b56-\u2b59\u3248-\u324f\ue000-\uf8ff\ufffd\u{1f100}-\u{1f10a}\u{1f110}-\u{1f12d}\u{1f130}-\u{1f169}\u{1f170}-\u{1f18d}\u{1f18f}-\u{1f190}\u{1f19b}-\u{1f1ac}\u{f0000}-\u{ffffd}\u{100000}-\u{10fffd}]/u;
 
 /**
  * U+FE0F VARIATION SELECTOR-16, which takes no width of its own but asks the
@@ -139,7 +187,9 @@ function widthInContext(params: { character: string; precedingMarks: number }): 
   if (ZERO_WIDTH_CHARACTERS_PATTERN.test(character)) {
     return 0;
   }
-  return WIDE_CHARACTERS_PATTERN.test(character) ? 2 : 1;
+  return WIDE_CHARACTERS_PATTERN.test(character) || AMBIGUOUS_CHARACTERS_PATTERN.test(character)
+    ? 2
+    : 1;
 }
 
 /**
@@ -163,8 +213,11 @@ export function displayWidthOf(text: string): number {
 const SHORTENING_ELLIPSIS = "\u2026";
 
 /**
- * The one column a cut string is drawn in at the very least: what is left when
- * the budget has room for the mark of the cut and nothing before it.
+ * The columns a cut string is drawn in at the very least: what is left when
+ * the budget has room for the mark of the cut and nothing before it. Two, since
+ * the ellipsis is itself East Asian Ambiguous and is measured the way every
+ * other such character is, so that a shortened label is not wider than it was
+ * measured to be on the terminal the measurement is for.
  *
  * Exported because a caller composing several shortened pieces into one line
  * has to leave room for it to decide which of them gives way, and the width of
@@ -172,7 +225,7 @@ const SHORTENING_ELLIPSIS = "\u2026";
  * at the other end. Leaving room for it is not what bounds the line: cutting
  * the composed line is.
  */
-export const ELLIPSIS_WIDTH = 1;
+export const ELLIPSIS_WIDTH = displayWidthOf(SHORTENING_ELLIPSIS);
 
 /**
  * Cut `text` down to at most `budget` columns, marking the cut with an ellipsis.

--- a/src/utils/display-width.ts
+++ b/src/utils/display-width.ts
@@ -10,18 +10,20 @@
  * not emoji at all are named beside it: the angle brackets, the trigrams and
  * digrams, and the hexagrams of U+4DC0–U+4DFF.
  *
- * The ranges are the standard ones rather than a lookup of the full property
- * table, which Unicode revises with every release and which is not worth
- * carrying for the one thing it is used for here — deciding when a label is
- * long enough to wrap. Where a range is coarse it is coarse in the safe
- * direction: the whole of U+1F000–U+1FAFF is counted as wide, which overstates
- * the few narrow symbols in it, because overstating a width shortens a label
- * that did not need it while understating one lets a label wrap. That is also
- * why an emoji built from a chain of joiners is counted per component: two
- * columns each rather than the two the whole chain draws.
+ * The ranges are the standard blocks rather than the full `East_Asian_Width`
+ * property, because the wide characters sit in blocks and a block is coarse in
+ * the safe direction: the whole of U+1F000–U+1FAFF is counted as wide, which
+ * overstates the few narrow symbols in it, because overstating a width shortens
+ * a label that did not need it while understating one lets a label wrap. That
+ * is also why an emoji built from a chain of joiners is counted per component:
+ * two columns each rather than the two the whole chain draws.
  *
  * The East Asian Ambiguous class is counted at two columns as well, by the
- * table below this one rather than by these ranges; the reason is given there.
+ * table below this one rather than by these ranges, and that table is the
+ * whole of its property: the class is scattered among the Neutral characters
+ * rather than gathered in blocks, so a block list over it would either miss
+ * members or take in characters that are not wide anywhere. The reason for
+ * counting it, and how the table is kept in step with Unicode, is given there.
  *
  * Two of the ranges are here for a narrower reason: a name the skill prompt can
  * offer may not be counted narrower here than the prompt's own renderer counts
@@ -91,21 +93,34 @@ const WIDE_CHARACTERS_PATTERN =
  *
  * The ranges are the `East_Asian_Width=A` property of Unicode 17.0, taken from
  * the table `get-east-asian-width` 1.6.0 carries and merged where two are
- * adjacent; the package itself is not imported, for the reason the comment
- * above gives for not carrying the full table. Three stretches of the property
- * are left out because they never reach this pattern: the combining diacritical
- * marks of U+0300–U+036F and the variation selectors of U+FE00–U+FE0F and
- * U+E0100–U+E01EF are marks by category and are counted by the mark rule
- * before the width of a character is looked up. Leaving them out is also what
- * keeps the class from holding a combining character, which
- * `no-misleading-character-class` is there to catch. The private use areas are
- * in it, as the property says they are: a name is free to carry them and a
- * terminal is free to draw them wide.
+ * adjacent. The table is written out here rather than read from the package so
+ * that the one lookup adds no dependency of its own, and the drift test in
+ * `display-width.test.ts` is what keeps it honest: it loads the package through
+ * the prompt renderer that already depends on it, walks every code point, and
+ * fails when this table and the property disagree in either direction. When
+ * the renderer's copy moves to a newer Unicode, that test is what fails, and
+ * the table is regenerated from the new property — its ranges, marks aside,
+ * merged where adjacent and written as escapes — with the version named here.
+ *
+ * Three stretches of the property are left out because they never reach this
+ * pattern: the combining diacritical marks of U+0300–U+036F and the variation
+ * selectors of U+FE00–U+FE0F and U+E0100–U+E01EF are marks by category and are
+ * counted by the mark rule before the width of a character is looked up.
+ * Leaving them out is also what keeps the class from holding a combining
+ * character, which `no-misleading-character-class` is there to catch, and they
+ * are the one exception the drift test allows. U+00AD SOFT HYPHEN never reaches
+ * this pattern either — it is a format character, and the zero-width rule
+ * counts it at nothing first — but it is kept, as the property has it, so that
+ * the test holds the table to the property exactly rather than to a list of
+ * exceptions. The private use areas are in it, as the property says they are: a
+ * name is free to carry them and a terminal is free to draw them wide.
  *
  * Escapes rather than the characters themselves, for the reason given above.
+ * Exported for the drift test alone; the width of a string is asked for
+ * through `displayWidthOf`.
  */
 // cspell:ignore ffffd -- the last code point of the first private use plane
-const AMBIGUOUS_CHARACTERS_PATTERN =
+export const AMBIGUOUS_CHARACTERS_PATTERN =
   /[\u00a1\u00a4\u00a7-\u00a8\u00aa\u00ad-\u00ae\u00b0-\u00b4\u00b6-\u00ba\u00bc-\u00bf\u00c6\u00d0\u00d7-\u00d8\u00de-\u00e1\u00e6\u00e8-\u00ea\u00ec-\u00ed\u00f0\u00f2-\u00f3\u00f7-\u00fa\u00fc\u00fe\u0101\u0111\u0113\u011b\u0126-\u0127\u012b\u0131-\u0133\u0138\u013f-\u0142\u0144\u0148-\u014b\u014d\u0152-\u0153\u0166-\u0167\u016b\u01ce\u01d0\u01d2\u01d4\u01d6\u01d8\u01da\u01dc\u0251\u0261\u02c4\u02c7\u02c9-\u02cb\u02cd\u02d0\u02d8-\u02db\u02dd\u02df\u0391-\u03a1\u03a3-\u03a9\u03b1-\u03c1\u03c3-\u03c9\u0401\u0410-\u044f\u0451\u2010\u2013-\u2016\u2018-\u2019\u201c-\u201d\u2020-\u2022\u2024-\u2027\u2030\u2032-\u2033\u2035\u203b\u203e\u2074\u207f\u2081-\u2084\u20ac\u2103\u2105\u2109\u2113\u2116\u2121-\u2122\u2126\u212b\u2153-\u2154\u215b-\u215e\u2160-\u216b\u2170-\u2179\u2189\u2190-\u2199\u21b8-\u21b9\u21d2\u21d4\u21e7\u2200\u2202-\u2203\u2207-\u2208\u220b\u220f\u2211\u2215\u221a\u221d-\u2220\u2223\u2225\u2227-\u222c\u222e\u2234-\u2237\u223c-\u223d\u2248\u224c\u2252\u2260-\u2261\u2264-\u2267\u226a-\u226b\u226e-\u226f\u2282-\u2283\u2286-\u2287\u2295\u2299\u22a5\u22bf\u2312\u2460-\u24e9\u24eb-\u254b\u2550-\u2573\u2580-\u258f\u2592-\u2595\u25a0-\u25a1\u25a3-\u25a9\u25b2-\u25b3\u25b6-\u25b7\u25bc-\u25bd\u25c0-\u25c1\u25c6-\u25c8\u25cb\u25ce-\u25d1\u25e2-\u25e5\u25ef\u2605-\u2606\u2609\u260e-\u260f\u261c\u261e\u2640\u2642\u2660-\u2661\u2663-\u2665\u2667-\u266a\u266c-\u266d\u266f\u269e-\u269f\u26bf\u26c6-\u26cd\u26cf-\u26d3\u26d5-\u26e1\u26e3\u26e8-\u26e9\u26eb-\u26f1\u26f4\u26f6-\u26f9\u26fb-\u26fc\u26fe-\u26ff\u273d\u2776-\u277f\u2b56-\u2b59\u3248-\u324f\ue000-\uf8ff\ufffd\u{1f100}-\u{1f10a}\u{1f110}-\u{1f12d}\u{1f130}-\u{1f169}\u{1f170}-\u{1f18d}\u{1f18f}-\u{1f190}\u{1f19b}-\u{1f1ac}\u{f0000}-\u{ffffd}\u{100000}-\u{10fffd}]/u;
 
 /**

--- a/src/utils/display-width.ts
+++ b/src/utils/display-width.ts
@@ -185,11 +185,28 @@ function isCombiningMark(character: string): boolean {
 }
 
 /**
+ * A lone surrogate, which is no character at all: a string can carry one — a
+ * `"\ud800"` escape in JSON is enough — and the encoder that writes stdout
+ * replaces it with U+FFFD on the way out, so the replacement character is what
+ * the terminal draws and what has to be measured. U+FFFD is East Asian
+ * Ambiguous, so the difference is a column apiece: 72 of them measured as
+ * themselves fit a 72-column budget and are drawn in 144.
+ */
+const LONE_SURROGATE_PATTERN = /\p{Cs}/u;
+
+/** What the stdout encoder writes in place of a lone surrogate. */
+const REPLACEMENT_CHARACTER = "\ufffd";
+
+/**
  * The width of one character, given how many marks already sit on the character
  * before it.
  */
 function widthInContext(params: { character: string; precedingMarks: number }): number {
-  const { character, precedingMarks } = params;
+  const { precedingMarks } = params;
+  // Measured as what is drawn rather than as what is in the string.
+  const character = LONE_SURROGATE_PATTERN.test(params.character)
+    ? REPLACEMENT_CHARACTER
+    : params.character;
   if (character === EMOJI_PRESENTATION_SELECTOR) {
     return 1;
   }

--- a/src/utils/display-width.ts
+++ b/src/utils/display-width.ts
@@ -132,8 +132,13 @@ export const AMBIGUOUS_CHARACTERS_PATTERN =
  */
 const EMOJI_PRESENTATION_SELECTOR = "\ufe0f";
 
-/** Combining marks are drawn on top of the character before them, not beside it. */
-const COMBINING_MARK_PATTERN = /[\p{Mn}\p{Me}]/u;
+/**
+ * Combining marks are drawn on top of the character before them, not beside it.
+ *
+ * Exported for the drift test on the ambiguous table, which has to leave out
+ * exactly the characters this rule catches first.
+ */
+export const COMBINING_MARK_PATTERN = /[\p{Mn}\p{Me}]/u;
 
 /** The characters that take no width at all, marks aside. */
 const ZERO_WIDTH_CHARACTERS_PATTERN = /[\p{Cf}\p{Default_Ignorable_Code_Point}]/u;


### PR DESCRIPTION
Closes #2845

## Summary

`displayWidthOf` counted the UAX #11 East Asian Ambiguous class at one column, which is what a Latin terminal draws, while a terminal set to draw the class wide (a common setting in CJK locales) draws it at two. The prompt's own renderer, `fast-string-width`, counts the class at one as well, so neither the label budget nor the renderer saw the extra columns: a skill directory named `"─".repeat(60) + "● pdf-tools"` passed `hasDeceptiveHiddenCharacters`, measured 71 columns, fit the 72-column budget, and was hard-wrapped by the terminal at 132 columns, leaving `● pdf-tools` at the left margin of a continuation line that carries no pointer and no checkbox. This is the forged-row primitive #2813 closed for the other width mismatches, reached through a terminal setting.

The Ambiguous class is now counted at two columns, the single-wide-model option the issue weighs as the smaller change. Overstating a width shortens a label that did not need it; understating one lets a forged row wrap.

## Changes

- `src/utils/display-width.ts`: add `AMBIGUOUS_CHARACTERS_PATTERN`, a hand-written escaped range table of the `East_Asian_Width=A` property of Unicode 17.0, derived from the table `get-east-asian-width` 1.6.0 carries (the package is not imported and no dependency is added). Adjacent ranges are merged; the combining stretches of the property (U+0300–U+036F, U+FE00–U+FE0F, U+E0100–U+E01EF) are left out because the mark rule counts them before a width is looked up, which also keeps `no-misleading-character-class` quiet. `widthInContext` returns two for the class. `ELLIPSIS_WIDTH` is derived from `displayWidthOf(SHORTENING_ELLIPSIS)` and becomes two, since the ellipsis is itself Ambiguous. The module comment that stated the one-column rule now explains the asymmetry.
- `src/lib/skill-prompt.ts`: comments only. `NOTE_SEPARATOR` (an em dash, also Ambiguous) and `NOTE_MARKER` were already measured through `displayWidthOf`, so they follow automatically; the `CHOICE_PREFIX_WIDTH` and `NOTE_SEPARATOR` comments no longer restate the one-column rule.
- `src/utils/display-width.test.ts`: U+2500, U+25CF, U+03B1, U+00E9, the em dash and the ellipsis at two columns; the Neutral U+25C9 and U+276F still at one; the 132-column measurement of the issue's name; `ELLIPSIS_WIDTH` at two and the cut it costs.
- `src/lib/skill-prompt.test.ts`: reproduction with the issue's name asserting the label is cut to 35 box-drawing characters plus the ellipsis (72 columns); the pinned label expectations move by the extra column of the separator and of the ellipsis (e.g. `pdf` + 67 `o` rather than 68 at the 80-column fallback). Every new value was checked against the budget arithmetic by hand.

Not changed: `src/features/permissions/vibe-permissions.ts` still uses `shortenToWidth` for the tool's own log text and shortens slightly earlier where an entry carries an Ambiguous character; harmless, and its tests pass unchanged. No `docs/**` page describes the width rule, so no documentation change.

The cost is that names carrying Greek, Cyrillic or accented Latin-1 letters are cut a little earlier on Latin terminals (about 36 such characters fill the 72-column budget in the worst case).

## Test plan

- [x] `pnpm cicheck` passes: 398 test files, 10369 tests, oxfmt/oxlint/typecheck clean, cspell 0 issues, secretlint clean
- [x] `src/utils/display-width.test.ts`: Ambiguous characters at two columns, Neutral at one, the issue's name at 132 columns, `ELLIPSIS_WIDTH === 2`
- [x] `src/lib/skill-prompt.test.ts`: the issue's name is offered as `"─".repeat(35) + "…"`, 72 columns wide
- [x] Range table diffed against the output of `eastAsianWidthType` from `get-east-asian-width` 1.6.0 over every code point (identical apart from the three combining stretches deliberately left out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmnufPwoK73aN5Wmck9Nhx
