### PR TITLE
refactor(logging): give the strip-then-quote idiom one home

### DIFF
--- a/src/features/skills/claudecode-skill.ts
+++ b/src/features/skills/claudecode-skill.ts
@@ -9,7 +9,7 @@ import {
 import { SKILL_FILE_NAME } from "../../constants/general.js";
 import { RULESYNC_SKILLS_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths.js";
 import { ValidationResult } from "../../types/ai-dir.js";
-import { stripControlCharacters } from "../../utils/control-characters.js";
+import { quoteForLog } from "../../utils/control-characters.js";
 import { formatError } from "../../utils/error.js";
 import {
   directoryExists,
@@ -159,9 +159,7 @@ async function checkNestedSkillsRoot({
     // Named rather than quoted when it is the project root, whose relative path is
     // the empty string and would otherwise be reported as a pair of quotes.
     const resolvedDescription =
-      realRelativeDirPath === ""
-        ? "the project root"
-        : JSON.stringify(stripControlCharacters(realRelativeDirPath));
+      realRelativeDirPath === "" ? "the project root" : quoteForLog(realRelativeDirPath);
     return {
       reason: `it resolves to ${resolvedDescription}, which is not a ${CLAUDECODE_SKILLS_DIR_POSIX_PATH} directory.`,
     };
@@ -169,7 +167,7 @@ async function checkNestedSkillsRoot({
   const excludedSegment = excludedNestedScanSegment(aboveTailSegments);
   if (excludedSegment !== undefined) {
     return {
-      reason: `it resolves inside ${JSON.stringify(stripControlCharacters(excludedSegment))}, which the nested scan excludes.`,
+      reason: `it resolves inside ${quoteForLog(excludedSegment)}, which the nested scan excludes.`,
     };
   }
   // The gitignore filter needs no such second pass, though it too runs on the
@@ -533,7 +531,7 @@ export class ClaudecodeSkill extends ToolSkill {
       });
       if ("reason" in check) {
         logger?.warn(
-          `Skipping the nested Claude Code skills directory ${JSON.stringify(stripControlCharacters(scannedDirPath))}: ` +
+          `Skipping the nested Claude Code skills directory ${quoteForLog(scannedDirPath)}: ` +
             `${check.reason} Its skills are not imported.`,
         );
         continue;

--- a/src/features/skills/skills-processor.ts
+++ b/src/features/skills/skills-processor.ts
@@ -18,7 +18,7 @@ import {
 } from "../../types/feature-processor.js";
 import { skillsProcessorToolTargetTuple } from "../../types/tool-target-tuples.js";
 import { ToolTarget } from "../../types/tool-targets.js";
-import { stripControlCharacters } from "../../utils/control-characters.js";
+import { quoteForLog, stripControlCharacters } from "../../utils/control-characters.js";
 import { formatError } from "../../utils/error.js";
 import {
   assertWritablePathInsideRoot,
@@ -681,7 +681,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
             // that outlives the rulesync skill it came from. The name is quoted
             // and stripped because whoever wrote the repository chose it.
             this.logger.warn(
-              `Skipping skill ${JSON.stringify(stripControlCharacters(dirName))} for ` +
+              `Skipping skill ${quoteForLog(dirName)} for ` +
                 `'${this.toolTarget}': ${dirWriteBlockReason}`,
             );
             return null;
@@ -943,7 +943,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
                 throw error;
               }
               this.logger.warn(
-                `Skipping ${JSON.stringify(stripControlCharacters(sourcePath))}: ` +
+                `Skipping ${quoteForLog(sourcePath)}: ` +
                   // The error names the same path, so it is stripped too.
                   stripControlCharacters(formatError(error)),
               );
@@ -993,7 +993,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
                 throw error;
               }
               this.logger.warn(
-                `Skipping ${JSON.stringify(stripControlCharacters(sourcePath))}: ` +
+                `Skipping ${quoteForLog(sourcePath)}: ` +
                   // The error names the same path, so it is stripped too.
                   stripControlCharacters(formatError(error)),
               );
@@ -1049,7 +1049,7 @@ export class SkillsProcessor extends DirFeatureProcessor {
       // quoted string means.
       warnOnceWithFallback(
         this.logger,
-        `Skipping ${JSON.stringify(stripControlCharacters(join(dirPath, name)))}: a ${consequence}`,
+        `Skipping ${quoteForLog(join(dirPath, name))}: a ${consequence}`,
       );
       return false;
     });

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -43,6 +43,7 @@ import type { ToolTarget } from "../types/tool-targets.js";
 import { describeConfusableNames, readingFormOf } from "../utils/confusable-names.js";
 import {
   hasDeceptiveHiddenCharacters,
+  quoteForLog,
   stripControlCharacters,
   stripHiddenCharacters,
 } from "../utils/control-characters.js";
@@ -97,7 +98,7 @@ function validateFileSize(relativePath: string, size: number): void {
       // The path comes from the remote repository, and this message is read in
       // a terminal, so it is quoted and stripped like every other remote path
       // this command prints.
-      `File ${JSON.stringify(stripControlCharacters(relativePath))} exceeds maximum size limit (${(size / 1024 / 1024).toFixed(2)}MB > ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
+      `File ${quoteForLog(relativePath)} exceeds maximum size limit (${(size / 1024 / 1024).toFixed(2)}MB > ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
     );
   }
 }
@@ -431,7 +432,7 @@ function validateRemoteRelativePath(relativePath: string): void {
   const segments = relativePath.split("/");
   if (segments.some((segment) => segment === "." || segment === "..")) {
     throw new Error(
-      `Unsafe path in the remote repository: ${JSON.stringify(stripControlCharacters(relativePath))}. A fetched path ` +
+      `Unsafe path in the remote repository: ${quoteForLog(relativePath)}. A fetched path ` +
         `must be a plain POSIX path, without "." and ".." segments.`,
     );
   }
@@ -474,10 +475,7 @@ function dropAmbiguousRemotePaths(params: {
     // longer distinguishable from one it dropped.
     incompleteRemoteDirs.add(posix.dirname(toPosixPath(file.remotePath)));
     logger.warn(
-      // `JSON.stringify` escapes the C0 controls and nothing else, so the path
-      // is stripped as well before it is quoted: the C1 range and the bidi
-      // overrides would otherwise reach the terminal intact.
-      `Skipping ${JSON.stringify(stripControlCharacters(file.remotePath))}: its path contains a ` +
+      `Skipping ${quoteForLog(file.remotePath)}: its path contains a ` +
         `backslash or a colon, which names one file on some systems and a directory, or part of ` +
         `another file, on others.`,
     );
@@ -694,7 +692,7 @@ function formatConfusableSkillsWarning(params: {
   }
   const described = [...notes]
     .toSorted(([a], [b]) => (a < b ? -1 : 1))
-    .map(([name, note]) => `${JSON.stringify(stripControlCharacters(name))} (${note})`);
+    .map(([name, note]) => `${quoteForLog(name)} (${note})`);
   return (
     `Some fetched skill names may not be told apart on sight from what they appear to be \u2014 ` +
     `from another name the source repository publishes, which this run may not have fetched, ` +
@@ -1048,7 +1046,7 @@ async function pruneDirectory(params: {
     // enough that a fetched tree stays well inside it, since the remote walk
     // fails outright rather than truncating when it runs past its own.
     logger.warn(
-      `Not pruning below ${JSON.stringify(stripControlCharacters(relativeDirPath))}: it is ` +
+      `Not pruning below ${quoteForLog(relativeDirPath)}: it is ` +
         `more than ${MAX_RECURSION_DEPTH} directories deep.`,
     );
     return "kept";
@@ -1061,7 +1059,7 @@ async function pruneDirectory(params: {
   // directory swapped for a link between the two reads.
   if (await isSymbolicLink(dirPath)) {
     logger.warn(
-      `Not pruning ${JSON.stringify(stripControlCharacters(relativeDirPath))}: it is a ` +
+      `Not pruning ${quoteForLog(relativeDirPath)}: it is a ` +
         `symbolic link, and its target is outside what this fetch may delete from. Remove ` +
         `unwanted files by hand.`,
     );
@@ -1096,9 +1094,7 @@ async function pruneDirectory(params: {
       }
       await rm(entryPath, { force: true });
       deleted.push({ relativePath: entryRelativePath, status: "deleted" });
-      logger.debug(
-        `Deleted stale skill entry: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
-      );
+      logger.debug(`Deleted stale skill entry: ${quoteForLog(entryRelativePath)}`);
       continue;
     }
 
@@ -1136,9 +1132,7 @@ async function pruneDirectory(params: {
         throw error;
       }
       deleted.push({ relativePath: `${entryRelativePath}/`, status: "deleted" });
-      logger.debug(
-        `Removed stale skill directory: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
-      );
+      logger.debug(`Removed stale skill directory: ${quoteForLog(entryRelativePath)}`);
       continue;
     }
 
@@ -1158,9 +1152,7 @@ async function pruneDirectory(params: {
 
     await rm(entryPath, { force: true });
     deleted.push({ relativePath: entryRelativePath, status: "deleted" });
-    logger.debug(
-      `Deleted stale skill file: ${JSON.stringify(stripControlCharacters(entryRelativePath))}`,
-    );
+    logger.debug(`Deleted stale skill file: ${quoteForLog(entryRelativePath)}`);
   }
 
   return survivors > 0 ? "kept" : "emptied";
@@ -1273,7 +1265,7 @@ async function pruneStaleSkillFiles(params: {
     // from one upstream dropped — so nothing here is judged stale.
     if (remoteDir === undefined) {
       logger.warn(
-        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: the remote ` +
+        `Not pruning ${quoteForLog(skillDir)}: the remote ` +
           `directory it was fetched from could not be worked out, so there is nothing to judge ` +
           `the local files against. Remove unwanted files by hand.`,
       );
@@ -1282,7 +1274,7 @@ async function pruneStaleSkillFiles(params: {
 
     if (hasPathAtOrUnder(incompleteRemoteDirs, remoteDir)) {
       logger.warn(
-        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: the remote listing ` +
+        `Not pruning ${quoteForLog(skillDir)}: the remote listing ` +
           `for it came back incomplete, so a stale local file cannot be told apart from one the ` +
           `listing left out. Remove unwanted files by hand.`,
       );
@@ -1307,7 +1299,7 @@ async function pruneStaleSkillFiles(params: {
     // file the fetch wrote there is matched by identity rather than by name.
     if (hasWindowsFoldableSkillName(skillDir)) {
       logger.warn(
-        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: its name is one ` +
+        `Not pruning ${quoteForLog(skillDir)}: its name is one ` +
           `some systems resolve to a different directory, so it may not be the directory this ` +
           `name reads as. Remove unwanted files by hand.`,
       );
@@ -1339,8 +1331,8 @@ async function pruneStaleSkillFiles(params: {
     );
     if (variant !== undefined) {
       logger.warn(
-        `Not pruning ${JSON.stringify(stripControlCharacters(skillDir))}: ` +
-          `${JSON.stringify(`${SKILLS_DIR_PREFIX}${stripControlCharacters(variant)}`)} is also ` +
+        `Not pruning ${quoteForLog(skillDir)}: ` +
+          `${quoteForLog(`${SKILLS_DIR_PREFIX}${variant}`)} is also ` +
           `there and differs only in ways some filesystems ignore, so this name may not be the ` +
           `directory it reads as. Remove unwanted files by hand.`,
       );
@@ -1380,7 +1372,7 @@ async function pruneStaleSkillFiles(params: {
       // "Stopped partway", not "did not prune": entries deleted before the
       // failure are already recorded, and the summary lists them.
       logger.warn(
-        `Stopped partway through pruning ${JSON.stringify(stripControlCharacters(skillDir))}. ` +
+        `Stopped partway through pruning ${quoteForLog(skillDir)}. ` +
           `${stripControlCharacters(formatError(error))}`,
       );
     }
@@ -1587,9 +1579,9 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
   // Resolve ref to use
   const ref = resolvedRef ?? (await client.getDefaultBranch(parsed.owner, parsed.repo));
   // A default branch name is chosen by the remote repository, and git allows
-  // characters in it that reorder a terminal line, so it is stripped and quoted
+  // characters in it that reorder a terminal line, so it is quoted for the log
   // like every other remote-controlled string this command prints.
-  logger.debug(`Using ref: ${JSON.stringify(stripControlCharacters(ref))}`);
+  logger.debug(`Using ref: ${quoteForLog(ref)}`);
 
   // If target is a tool format, use conversion flow
   if (isToolTarget(target)) {
@@ -1670,9 +1662,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
       const exists = await fileExists(localPath);
 
       if (exists && conflictStrategy === "skip") {
-        logger.debug(
-          `Skipping existing file: ${JSON.stringify(stripControlCharacters(relativePath))}`,
-        );
+        logger.debug(`Skipping existing file: ${quoteForLog(relativePath)}`);
         return { relativePath, status: "skipped" as const };
       }
 
@@ -1685,7 +1675,7 @@ export async function fetchFiles(params: FetchParams): Promise<FetchSummary> {
       }
 
       const status = exists ? ("overwritten" as const) : ("created" as const);
-      logger.debug(`Wrote: ${JSON.stringify(stripControlCharacters(relativePath))} (${status})`);
+      logger.debug(`Wrote: ${quoteForLog(relativePath)} (${status})`);
       return { relativePath, status };
     }),
   );
@@ -1777,7 +1767,7 @@ async function collectFeatureFiles(params: {
           } catch (error) {
             // Only skip 404 errors (file not found), re-throw other errors
             if (isNotFoundError(error)) {
-              logger.debug(`File not found: ${JSON.stringify(stripControlCharacters(fullPath))}`);
+              logger.debug(`File not found: ${quoteForLog(fullPath)}`);
             } else {
               throw error;
             }
@@ -1817,7 +1807,7 @@ async function collectFeatureFiles(params: {
         // Check for 404 errors (feature not found)
         if (isNotFoundError(error)) {
           // Feature directory/file not found, skip silently
-          logger.debug(`Feature not found: ${JSON.stringify(stripControlCharacters(fullPath))}`);
+          logger.debug(`Feature not found: ${quoteForLog(fullPath)}`);
           return collected;
         }
         throw error;
@@ -1931,9 +1921,7 @@ async function fetchAndConvertToolFiles(params: {
           client.getFileContent(parsed.owner, parsed.repo, remotePath, ref),
         );
         await writeFileContent(localPath, content);
-        logger.debug(
-          `Fetched to temp: ${JSON.stringify(stripControlCharacters(toolRelativePath))}`,
-        );
+        logger.debug(`Fetched to temp: ${quoteForLog(toolRelativePath)}`);
       }),
     );
 

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -14,7 +14,7 @@ import {
   GitHubReleaseSchema,
   GitHubRepoInfoSchema,
 } from "../types/fetch.js";
-import { stripControlCharacters } from "../utils/control-characters.js";
+import { quoteForLog, stripControlCharacters } from "../utils/control-characters.js";
 import { formatError } from "../utils/error.js";
 import type { Logger } from "../utils/logger.js";
 
@@ -141,9 +141,7 @@ export class GitHubClient {
 
       // API returns single object for files, array for directories
       if (!Array.isArray(data)) {
-        throw new GitHubClientError(
-          `Path ${JSON.stringify(stripControlCharacters(path))} is not a directory`,
-        );
+        throw new GitHubClientError(`Path ${quoteForLog(path)} is not a directory`);
       }
 
       const entries: GitHubFileEntry[] = [];
@@ -259,7 +257,7 @@ export class GitHubClient {
         throw new GitHubClientError(
           // `path` names a file in the remote repository, so it is stripped
           // and quoted before it reaches a terminal.
-          `File ${JSON.stringify(stripControlCharacters(path))} exceeds maximum size limit of ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+          `File ${quoteForLog(path)} exceeds maximum size limit of ${MAX_FILE_SIZE / 1024 / 1024}MB`,
         );
       }
 

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -5,7 +5,7 @@ import {
   companionFileContentsEquivalent,
   fileContentsEquivalent,
 } from "../utils/content-equivalence.js";
-import { stripControlCharacters } from "../utils/control-characters.js";
+import { quoteForLog, stripControlCharacters } from "../utils/control-characters.js";
 import { formatError } from "../utils/error.js";
 import {
   addTrailingNewline,
@@ -285,7 +285,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     // A set, so two candidates that report the same directory delete it once
     // and are counted once.
     const orphanPaths = new Set<string>();
-    const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
+    const quotedOutputRoot = quoteForLog(this.outputRoot);
 
     for (const aiDir of existingDirs) {
       // Read once, and check and delete that one value: `getDirPath()` is a
@@ -297,8 +297,8 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       // came off disk, and while the strip rules out forging a whole line, an
       // unquoted path like `Deleted directory: /home/you/important` still reads
       // as one. The root is quoted with it so one line reads consistently.
-      const quotedDirPath = JSON.stringify(stripControlCharacters(dirPath));
-      const quotedRoot = JSON.stringify(stripControlCharacters(root));
+      const quotedDirPath = quoteForLog(dirPath);
+      const quotedRoot = quoteForLog(root);
 
       // Reported before anything about the directory's position, because a root
       // that is not in the directory this run writes to makes that position
@@ -322,7 +322,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
         if (verdict === "equal") {
           this.logger.debug(
             `Skipping orphan sweep for ` +
-              `${JSON.stringify(stripControlCharacters(aiDir.getDirName()))}: ` +
+              `${quoteForLog(aiDir.getDirName())}: ` +
               `${quotedDirPath} is a shared root, not a directory of its own`,
           );
         } else {
@@ -429,7 +429,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     }
 
     const orphanPaths = new Set<string>();
-    const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
+    const quotedOutputRoot = quoteForLog(this.outputRoot);
 
     for (const aiDir of generatedDirs) {
       // Read once and act on that one value, as the sweeps around this one do:
@@ -437,8 +437,8 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       // answer differently from the one the checks below ruled on.
       const dirPath = aiDir.getDirPath();
       const { verdict, root } = locateInOwnRoot({ aiDir, dirPath, outputRoot: this.outputRoot });
-      const quotedDirPath = JSON.stringify(stripControlCharacters(dirPath));
-      const quotedRoot = JSON.stringify(stripControlCharacters(root));
+      const quotedDirPath = quoteForLog(dirPath);
+      const quotedRoot = quoteForLog(root);
 
       // Asked before anything else, in the order the directory sweep asks it: a
       // root that is not in the directory this run writes to makes every
@@ -462,7 +462,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
         if (verdict === "equal") {
           this.logger.debug(
             `Skipping orphan sweep for ` +
-              `${JSON.stringify(stripControlCharacters(aiDir.getDirName()))}: ` +
+              `${quoteForLog(aiDir.getDirName())}: ` +
               `${quotedDirPath} is a shared root, not a directory of its own`,
           );
         } else {
@@ -541,7 +541,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
           // what this sweep exists to remove. Refusing it is the safe half of
           // the guess; saying so is what lets the other half be corrected.
           this.logger.warn(
-            `Refusing to delete ${JSON.stringify(stripControlCharacters(filePath))}: this run ` +
+            `Refusing to delete ${quoteForLog(filePath)}: this run ` +
               `wrote a file whose path differs from it only in case, which on a case-insensitive ` +
               `filesystem is the very file it wrote`,
           );
@@ -571,7 +571,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     kind: "directory" | "file";
   }): Promise<number> {
     for (const targetPath of paths) {
-      const loggedPath = JSON.stringify(stripControlCharacters(targetPath));
+      const loggedPath = quoteForLog(targetPath);
       if (this.dryRun) {
         this.logger.info(`[DRY RUN] Would delete ${kind}: ${loggedPath}`);
       } else {
@@ -639,7 +639,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     // A set, for the same reason the directory sweep uses one: two candidates
     // that report the same file delete it once and are counted once.
     const orphanPaths = new Set<string>();
-    const quotedOutputRoot = JSON.stringify(stripControlCharacters(this.outputRoot));
+    const quotedOutputRoot = quoteForLog(this.outputRoot);
 
     for (const aiDir of existingFlatFiles) {
       // Read once and delete that one value, as in the directory sweep: both
@@ -648,7 +648,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       const filePath = aiDir.getFlatFilePath();
       if (filePath === undefined) {
         this.logger.warn(
-          `Refusing to sweep ${JSON.stringify(stripControlCharacters(aiDir.getDirName()))}: it ` +
+          `Refusing to sweep ${quoteForLog(aiDir.getDirName())}: it ` +
             `owns a directory of its own, or names no file directly under the root it was found in`,
         );
         continue;
@@ -658,8 +658,8 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       const { verdict, root } = locateInOwnRoot({ aiDir, dirPath, outputRoot: this.outputRoot });
       // Quoted for the same reason the directory sweep quotes: the last segment
       // of the path is a name that came off disk.
-      const quotedFilePath = JSON.stringify(stripControlCharacters(filePath));
-      const quotedRoot = JSON.stringify(stripControlCharacters(root));
+      const quotedFilePath = quoteForLog(filePath);
+      const quotedRoot = quoteForLog(root);
 
       if (verdict === "root-outside") {
         this.logger.warn(

--- a/src/utils/control-characters.test.ts
+++ b/src/utils/control-characters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasDeceptiveHiddenCharacters,
+  quoteForLog,
   stripControlCharacters,
   stripControlCharactersKeepingLineFeeds,
   stripHiddenCharacters,
@@ -27,6 +28,33 @@ describe("stripControlCharacters", () => {
 
   it("should strip the plain right-to-left marks, which reorder the neutrals beside them", () => {
     expect(stripControlCharacters("a\u200fb\u200ec")).toBe("abc");
+  });
+});
+
+describe("quoteForLog", () => {
+  it("should JSON-quote printable text so a reader can see where the name ends", () => {
+    expect(quoteForLog("skill-a")).toBe(`"skill-a"`);
+  });
+
+  it("should quote the empty string as a pair of quotes", () => {
+    expect(quoteForLog("")).toBe(`""`);
+  });
+
+  it("should escape the quotes and backslashes that would blur the edge of the quoting", () => {
+    expect(quoteForLog(`a"b\\c`)).toBe(`"a\\"b\\\\c"`);
+  });
+
+  it("should remove a newline rather than spell it out as an escape", () => {
+    expect(quoteForLog("key\n[warn] forged")).toBe(`"key[warn] forged"`);
+  });
+
+  it("should remove the C1 range and the bidi overrides, which JSON quoting alone would pass through", () => {
+    expect(JSON.stringify("a\u009bb\u202ec")).toBe(`"a\u009bb\u202ec"`);
+    expect(quoteForLog("a\u009bb\u202ec")).toBe(`"abc"`);
+  });
+
+  it("should remove the C0 controls and DEL as well", () => {
+    expect(quoteForLog("a\u0000b\u001bc\u007fd")).toBe(`"abcd"`);
   });
 });
 

--- a/src/utils/control-characters.ts
+++ b/src/utils/control-characters.ts
@@ -23,6 +23,27 @@ export function stripControlCharacters(text: string): string {
 }
 
 /**
+ * Strips the control characters from `text` and then JSON-quotes it, which is
+ * the form a remote-derived name — a fetched path, a directory name read off
+ * the disk, a branch name chosen by a remote repository — takes in a log line.
+ *
+ * The two steps do different jobs, and neither is enough on its own. The
+ * quoting delimits the untrusted text, so a reader can tell where the name
+ * ends and the diagnostic resumes, and it escapes the quotes and backslashes
+ * that would blur that edge. But `JSON.stringify` escapes the C0 controls and
+ * nothing else: the C1 range, the 8-bit CSI introducer among it, and the bidi
+ * overrides pass through it intact, and any one of them reaches the terminal
+ * with its power to forge a line or reorder one. The strip is what takes those
+ * out. It runs first so that the quoting sees only printable text and the line
+ * carries no escaped control characters the reader has to decode — what could
+ * do harm is gone rather than spelled out — and so that the rationale for the
+ * order lives here, once, rather than at every call site.
+ */
+export function quoteForLog(text: string): string {
+  return JSON.stringify(stripControlCharacters(text));
+}
+
+/**
  * Removes every control character from `text` except the line feed, so a
  * message written to be read over several lines still is.
  *

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -20,7 +20,7 @@ import { kebabCase } from "es-toolkit";
 import { globbySync, isGitIgnoredSync } from "globby";
 
 import { mapWithConcurrency } from "./concurrency.js";
-import { stripControlCharacters } from "./control-characters.js";
+import { quoteForLog, stripControlCharacters } from "./control-characters.js";
 import { formatError } from "./error.js";
 import { isEnvTest } from "./vitest.js";
 
@@ -234,17 +234,13 @@ export function checkPathTraversal({
   // Check for .. segments in the path (even if they don't escape the directory)
   const segments = relativePath.split(/[/\\]/);
   if (segments.includes("..")) {
-    throw new Error(
-      `Path traversal detected: ${JSON.stringify(stripControlCharacters(relativePath))}`,
-    );
+    throw new Error(`Path traversal detected: ${quoteForLog(relativePath)}`);
   }
 
   const resolved = resolve(intendedRootDir, relativePath);
   const rel = relative(intendedRootDir, resolved);
   if (rel.startsWith("..") || resolve(resolved) !== resolved) {
-    throw new Error(
-      `Path traversal detected: ${JSON.stringify(stripControlCharacters(relativePath))}`,
-    );
+    throw new Error(`Path traversal detected: ${quoteForLog(relativePath)}`);
   }
 }
 


### PR DESCRIPTION
Closes #2842

## Summary

`JSON.stringify(stripControlCharacters(x))` is how a remote-derived name reaches a log line, and it was spelled out at 45 call sites across `src/`, with the reason the strip has to run first living in a comment at one of them. This PR exports `quoteForLog(text)` from `src/utils/control-characters.ts`, carries the ordering rationale in its doc comment, and routes every call site through it.

Pure refactor: no log message wording or behaviour changes. The one variant that quoted a prefixed name, `JSON.stringify(\`${SKILLS_DIR_PREFIX}${stripControlCharacters(variant)}\`)` in `fetch.ts`, now reads `quoteForLog(\`${SKILLS_DIR_PREFIX}${variant}\`)`; the prefix is a constant with no control characters, so the output is identical. The `quoted*` locals in `dir-feature-processor.ts` are kept and now call the helper.

## Changes

- `src/utils/control-characters.ts`: add `quoteForLog` with a doc comment explaining why the strip runs before the JSON quoting (`JSON.stringify` escapes quotes, backslashes and the C0 controls but passes the C1 range and the bidi overrides through intact).
- `src/utils/control-characters.test.ts`: unit tests for `quoteForLog` (printable text quoted, empty string becomes `""`, quotes and backslashes escaped, newline removed rather than escaped, C0/DEL/C1/bidi removed).
- Call sites replaced, per file:
  - `src/lib/fetch.ts`: 21 (20 direct plus the prefixed variant); the call-site rationale comment is dropped now that the helper carries it.
  - `src/types/dir-feature-processor.ts`: 14
  - `src/features/skills/skills-processor.ts`: 4
  - `src/features/skills/claudecode-skill.ts`: 3 (its `stripControlCharacters` import is now unused and removed)
  - `src/lib/github-client.ts`: 2
  - `src/utils/file.ts`: 2
- Files that still strip without quoting (error messages, summary lines) keep their `stripControlCharacters` import.

## Test plan

- [x] `grep -rn "JSON.stringify(stripControlCharacters" src` matches only the helper's own body.
- [x] `pnpm vitest run src/utils/control-characters.test.ts` passes (69 tests).
- [x] `pnpm cicheck` passes: format, oxlint, typecheck, 10377 tests across 398 files, docs/gitignore/tables sync, cspell, secretlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmnufPwoK73aN5Wmck9Nhx
