### PR TITLE
chore: update Homebrew formula to v16.21.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.20.0"
+  version "16.21.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "0953d74a9d195c0da7e636330c97c32b463a6bcecd902e04c00dc6e77d4c6507"
+      sha256 "dd310c253d8b11a6ccb6f35ee1da16ff696b70587f76989a34ea1da2518fb3be"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "1b0f951def6bdbf4c7bc23aa34881bac0164e0437524906f1f4c60cc2b77e3d6"
+      sha256 "83ddf9c33254c6fa4782eb2cca79978977cafb78ae6c17f84adbce3555f1a858"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "2a36fc142f61a83e9ce89f401584b4384966b0c61095b46ac4a2e7e488cb5598"
+      sha256 "e0ff6c406112d30e51455da2b19d0e521babb74990bc50f70b29d0a39e70c317"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "7c23fd4230bc81de35b7f3c211e2d927dffcecbff7725f35dd5715878ea771ee"
+      sha256 "cdac2f252e25d05d3d4ccc4cf812d187e5e0d32aed83d04cee011d9d13eca0dd"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.21.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmnufPwoK73aN5Wmck9Nhx
