### PR TITLE
fix(hooks): resolve native event names with own-property lookups

### DIFF
--- a/src/features/hooks/antigravity-hooks.ts
+++ b/src/features/hooks/antigravity-hooks.ts
@@ -14,6 +14,7 @@ import {
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import type { ToolHooksConverterConfig } from "./tool-hooks-converter.js";
@@ -75,7 +76,7 @@ function flattenAntigravityHooks(parsed: unknown): Record<string, unknown> {
     if (isPrototypePollutionKey(event) || !Array.isArray(entries)) {
       return;
     }
-    const existing = Object.hasOwn(flat, event) ? flat[event] : undefined;
+    const existing = lookupOwn({ record: flat, key: event });
     flat[event] = existing ? [...existing, ...entries] : [...entries];
   };
   for (const [key, value] of Object.entries(parsed)) {

--- a/src/features/hooks/copilot-hooks.test.ts
+++ b/src/features/hooks/copilot-hooks.test.ts
@@ -918,6 +918,35 @@ describe("CopilotHooks", () => {
       expect(entry.command).toBe("run.sh");
       expect(entry.customKey).toBeUndefined();
     });
+
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const copilotHooks = new CopilotHooks({
+        outputRoot: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilot-hooks.json",
+        // JSON.parse yields an own enumerable `toString` key, unlike an object
+        // literal whose `toString` the lookup map would inherit from
+        // Object.prototype.
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [{ type: "command", bash: "echo start" }],
+            toString: [{ type: "command", bash: "echo crafted" }],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = copilotHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(Object.keys(json.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (json as { copilot?: { hooks?: Record<string, unknown[]> } }).copilot
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "echo crafted" });
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/hooks/copilot-hooks.test.ts
+++ b/src/features/hooks/copilot-hooks.test.ts
@@ -466,6 +466,40 @@ describe("CopilotHooks", () => {
       expect(parsed.hooks.errorOccurred[0].command).toBe("error-handler.sh");
     });
 
+    it("should write an override event named toString as a plain string key (#2757)", async () => {
+      // The override block is only loosely validated, so an event named after an
+      // Object.prototype member reaches the generate-side reverse lookup
+      // exactly as it reaches the import side.
+      const config = {
+        version: 1,
+        hooks: {
+          sessionStart: [{ type: "command", command: "shared.sh" }],
+        },
+        copilot: {
+          hooks: {
+            toString: [{ type: "command", command: "crafted.sh" }],
+          },
+        },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const copilotHooks = await CopilotHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(copilotHooks.getFileContent());
+      expect(Object.keys(parsed.hooks).toSorted()).toEqual(["sessionStart", "toString"]);
+      expect(parsed.hooks["toString"][0].command).toBe("crafted.sh");
+    });
+
     it("should produce standalone file without merging existing content", async () => {
       const config = {
         version: 1,

--- a/src/features/hooks/copilot-hooks.ts
+++ b/src/features/hooks/copilot-hooks.ts
@@ -84,7 +84,8 @@ function canonicalToCopilotHooks(config: HooksConfig): Record<string, CopilotHoo
   };
   const copilot: Record<string, CopilotHookEntry[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const copilotEventName = CANONICAL_TO_COPILOT_EVENT_NAMES[eventName] ?? eventName;
+    const copilotEventName =
+      lookupOwn({ record: CANONICAL_TO_COPILOT_EVENT_NAMES, key: eventName }) ?? eventName;
     const entries: CopilotHookEntry[] = [];
     for (const def of definitions) {
       const hookType = def.type ?? "command";

--- a/src/features/hooks/copilot-hooks.ts
+++ b/src/features/hooks/copilot-hooks.ts
@@ -20,6 +20,7 @@ import {
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
@@ -178,7 +179,9 @@ function copilotHooksToCanonical(copilotHooks: unknown, logger?: Logger): HooksC
 
   const canonical: HooksConfig["hooks"] = {};
   for (const [copilotEventName, hookEntries] of Object.entries(copilotHooks)) {
-    const eventName = COPILOT_TO_CANONICAL_EVENT_NAMES[copilotEventName] ?? copilotEventName;
+    const eventName =
+      lookupOwn({ record: COPILOT_TO_CANONICAL_EVENT_NAMES, key: copilotEventName }) ??
+      copilotEventName;
     if (!Array.isArray(hookEntries)) continue;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of hookEntries) {

--- a/src/features/hooks/copilotcli-hooks.test.ts
+++ b/src/features/hooks/copilotcli-hooks.test.ts
@@ -621,6 +621,35 @@ describe("CopilotcliHooks", () => {
       const json = hooks.toRulesyncHooks().getJson();
       expect(json.hooks.sessionStart?.[0]?.command).toBe("echo no-type");
     });
+
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const hooks = new CopilotcliHooks({
+        outputRoot: testDir,
+        relativeDirPath: join(".github", "hooks"),
+        relativeFilePath: "copilotcli-hooks.json",
+        // JSON.parse yields an own enumerable `toString` key, unlike an object
+        // literal whose `toString` the lookup map would inherit from
+        // Object.prototype.
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [{ type: "command", bash: "echo start" }],
+            toString: [{ type: "command", bash: "echo crafted" }],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = hooks.toRulesyncHooks().getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(Object.keys(json.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (json as { copilotcli?: { hooks?: Record<string, unknown[]> } })
+        .copilotcli?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "echo crafted" });
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/hooks/copilotcli-hooks.ts
+++ b/src/features/hooks/copilotcli-hooks.ts
@@ -273,7 +273,8 @@ function canonicalToCopilotCliHooks(
   };
   const out: Record<string, CopilotCliHookEntry[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const copilotEventName = CANONICAL_TO_COPILOTCLI_EVENT_NAMES[eventName] ?? eventName;
+    const copilotEventName =
+      lookupOwn({ record: CANONICAL_TO_COPILOTCLI_EVENT_NAMES, key: eventName }) ?? eventName;
     const entries = buildCopilotCliEntriesForEvent({
       eventName,
       definitions,

--- a/src/features/hooks/copilotcli-hooks.ts
+++ b/src/features/hooks/copilotcli-hooks.ts
@@ -20,6 +20,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { compact } from "../../utils/object.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
@@ -338,7 +339,9 @@ function copilotCliHooksToCanonical(rawHooks: unknown, logger?: Logger): HooksCo
 
   const canonical: HooksConfig["hooks"] = {};
   for (const [copilotEventName, hookEntries] of Object.entries(rawHooks)) {
-    const eventName = COPILOTCLI_TO_CANONICAL_EVENT_NAMES[copilotEventName] ?? copilotEventName;
+    const eventName =
+      lookupOwn({ record: COPILOTCLI_TO_CANONICAL_EVENT_NAMES, key: copilotEventName }) ??
+      copilotEventName;
     if (!Array.isArray(hookEntries)) continue;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of hookEntries) {

--- a/src/features/hooks/cursor-hooks.test.ts
+++ b/src/features/hooks/cursor-hooks.test.ts
@@ -173,6 +173,35 @@ describe("CursorHooks", () => {
       expect(json.hooks.afterFileEdit).toHaveLength(1);
       expect(json.version).toBe(1);
     });
+
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const cursorHooks = new CursorHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".cursor",
+        relativeFilePath: "hooks.json",
+        // JSON.parse yields an own enumerable `toString` key, unlike an object
+        // literal whose `toString` the lookup map would inherit from
+        // Object.prototype.
+        fileContent: JSON.stringify({
+          version: 1,
+          hooks: {
+            sessionStart: [{ type: "command", command: "echo start" }],
+            toString: [{ type: "command", command: "echo crafted" }],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = cursorHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(Object.keys(json.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (json as { cursor?: { hooks?: Record<string, unknown[]> } }).cursor
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "echo crafted" });
+    });
   });
 
   describe("round-trip", () => {

--- a/src/features/hooks/cursor-hooks.ts
+++ b/src/features/hooks/cursor-hooks.ts
@@ -91,7 +91,8 @@ export class CursorHooks extends ToolHooks {
     // types are skipped (the HooksProcessor warns about them).
     const cursorSupportedTypes = new Set(["command", "prompt"]);
     for (const [eventName, defs] of Object.entries(mergedHooks)) {
-      const cursorEventName = CANONICAL_TO_CURSOR_EVENT_NAMES[eventName] ?? eventName;
+      const cursorEventName =
+        lookupOwn({ record: CANONICAL_TO_CURSOR_EVENT_NAMES, key: eventName }) ?? eventName;
       const mappedDefs = defs
         .filter((def) => cursorSupportedTypes.has(def.type ?? "command"))
         .map((def) => ({

--- a/src/features/hooks/cursor-hooks.ts
+++ b/src/features/hooks/cursor-hooks.ts
@@ -10,6 +10,7 @@ import {
   CANONICAL_TO_CURSOR_EVENT_NAMES,
 } from "../../types/hooks.js";
 import { readFileContent } from "../../utils/file.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
@@ -134,7 +135,9 @@ export class CursorHooks extends ToolHooks {
     // (see CANONICAL_TO_CURSOR_EVENT_NAMES in types/hooks.ts).
     const canonicalHooks: HooksConfig["hooks"] = {};
     for (const [cursorEventName, defs] of Object.entries(cursorHooks)) {
-      const eventName = CURSOR_TO_CANONICAL_EVENT_NAMES[cursorEventName] ?? cursorEventName;
+      const eventName =
+        lookupOwn({ record: CURSOR_TO_CANONICAL_EVENT_NAMES, key: cursorEventName }) ??
+        cursorEventName;
       canonicalHooks[eventName] = defs;
     }
     const version = parsed.version ?? 1;

--- a/src/features/hooks/deepagents-hooks.test.ts
+++ b/src/features/hooks/deepagents-hooks.test.ts
@@ -393,6 +393,32 @@ describe("DeepagentsHooks", () => {
       expect(rulesyncHooks.getJson().hooks).toEqual({});
     });
 
+    it("should drop a v2 event named toString instead of keying by Object.prototype.toString (#2757)", () => {
+      const hooks = new DeepagentsHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".deepagents",
+        relativeFilePath: "hooks.json",
+        // JSON.parse yields an own enumerable `toString` key, unlike an object
+        // literal whose `toString` the lookup map would inherit from
+        // Object.prototype.
+        fileContent: JSON.stringify({
+          hooks: {
+            SessionStart: [{ hooks: [{ type: "command", command: "echo start" }] }],
+            toString: [{ hooks: [{ type: "command", command: "echo crafted" }] }],
+          },
+        }),
+      });
+
+      const canonical = hooks.toRulesyncHooks().getJson();
+
+      expect(canonical.hooks.sessionStart).toEqual([{ type: "command", command: "echo start" }]);
+      // deepagents only imports events it maps, so the unmapped name is dropped
+      // like any other unknown event rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      expect(Object.keys(canonical.hooks)).toEqual(["sessionStart"]);
+      expect((canonical as { deepagents?: unknown }).deepagents).toBeUndefined();
+    });
+
     it("should import the pre-v2 flat list format", () => {
       const hooks = new DeepagentsHooks({
         outputRoot: testDir,
@@ -415,6 +441,26 @@ describe("DeepagentsHooks", () => {
       ]);
       expect(canonical.hooks.sessionEnd).toEqual([{ type: "command", command: "echo multi" }]);
       expect(canonical.hooks.stop).toEqual([{ type: "command", command: "pnpm test --runInBand" }]);
+    });
+
+    it("should drop a legacy event named toString instead of keying by Object.prototype.toString (#2757)", () => {
+      const hooks = new DeepagentsHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".deepagents",
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify({
+          hooks: [{ command: ["bash", "-c", "echo start"], events: ["session.start", "toString"] }],
+        }),
+      });
+
+      const canonical = hooks.toRulesyncHooks().getJson();
+
+      expect(canonical.hooks.sessionStart).toEqual([{ type: "command", command: "echo start" }]);
+      // The legacy event list is filtered the same way as the v2 record: an
+      // unmapped name is dropped, never resolved through the lookup map's
+      // prototype.
+      expect(Object.keys(canonical.hooks)).toEqual(["sessionStart"]);
+      expect((canonical as { deepagents?: unknown }).deepagents).toBeUndefined();
     });
 
     it("should import the legacy context.offload event as canonical contextOffload", () => {

--- a/src/features/hooks/deepagents-hooks.ts
+++ b/src/features/hooks/deepagents-hooks.ts
@@ -11,6 +11,7 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
@@ -115,7 +116,10 @@ function deepagentsToCanonicalHooks(hooks: DeepagentsHooksFile["hooks"]): HooksC
   const canonical: HooksConfig["hooks"] = {};
 
   for (const [deepagentsEvent, groups] of Object.entries(hooks)) {
-    const canonicalEvent = DEEPAGENTS_TO_CANONICAL_EVENT_NAMES[deepagentsEvent];
+    const canonicalEvent = lookupOwn({
+      record: DEEPAGENTS_TO_CANONICAL_EVENT_NAMES,
+      key: deepagentsEvent,
+    });
     if (!canonicalEvent || !Array.isArray(groups)) continue;
 
     for (const group of groups) {
@@ -162,7 +166,7 @@ function deepagentsLegacyToCanonicalHooks(entries: unknown[]): HooksConfig["hook
     for (const legacyEvent of events) {
       const canonicalEvent =
         typeof legacyEvent === "string"
-          ? DEEPAGENTS_LEGACY_TO_CANONICAL_EVENT_NAMES[legacyEvent]
+          ? lookupOwn({ record: DEEPAGENTS_LEGACY_TO_CANONICAL_EVENT_NAMES, key: legacyEvent })
           : undefined;
       if (!canonicalEvent) continue;
 

--- a/src/features/hooks/deepagents-hooks.ts
+++ b/src/features/hooks/deepagents-hooks.ts
@@ -72,7 +72,10 @@ function canonicalToDeepagentsHooks(config: HooksConfig): DeepagentsHooksFile["h
   for (const [canonicalEvent, definitions] of Object.entries(effectiveHooks)) {
     if (!supported.has(canonicalEvent)) continue;
 
-    const deepagentsEvent = CANONICAL_TO_DEEPAGENTS_EVENT_NAMES[canonicalEvent];
+    const deepagentsEvent = lookupOwn({
+      record: CANONICAL_TO_DEEPAGENTS_EVENT_NAMES,
+      key: canonicalEvent,
+    });
     if (!deepagentsEvent) continue;
 
     for (const def of definitions) {

--- a/src/features/hooks/hermesagent-hooks.test.ts
+++ b/src/features/hooks/hermesagent-hooks.test.ts
@@ -599,6 +599,27 @@ hooks:
       });
     });
 
+    it("carries an event named toString through as a plain string key (#2757)", () => {
+      // `toString` is not a prototype-pollution key, so it reaches the event
+      // name lookup; the lookup must not resolve Object.prototype.toString.
+      const hooks = new HermesagentHooks({
+        outputRoot: ".",
+        fileContent: `hooks:
+  pre_tool_call:
+    - command: guard.sh
+  toString:
+    - command: crafted.sh
+`,
+      });
+
+      const json = hooks.toRulesyncHooks().getJson();
+      expect(json.hooks.preToolUse).toEqual([{ type: "command", command: "guard.sh" }]);
+      expect(Object.keys(json.hooks)).toEqual(["preToolUse"]);
+      const overrideHooks = json.hermesagent?.hooks ?? {};
+      expect(Object.keys(overrideHooks)).toEqual(["toString"]);
+      expect(overrideHooks["toString"]).toEqual([{ type: "command", command: "crafted.sh" }]);
+    });
+
     it("imports both fail_closed spellings back into canonical failClosed (#2414)", () => {
       const hooks = new HermesagentHooks({
         outputRoot: ".",

--- a/src/features/hooks/hermesagent-hooks.ts
+++ b/src/features/hooks/hermesagent-hooks.ts
@@ -204,7 +204,10 @@ function canonicalToHermesHooks({
     if (!HERMESAGENT_CANONICAL_EVENTS.has(canonicalEvent)) {
       continue;
     }
-    const nativeEvent = CANONICAL_TO_HERMESAGENT_EVENT_NAMES[canonicalEvent];
+    const nativeEvent = lookupOwn({
+      record: CANONICAL_TO_HERMESAGENT_EVENT_NAMES,
+      key: canonicalEvent,
+    });
     if (nativeEvent) {
       setHermesHookEntries({
         result,
@@ -220,7 +223,10 @@ function canonicalToHermesHooks({
     if (!HERMESAGENT_CANONICAL_EVENTS.has(canonicalEvent)) {
       continue;
     }
-    const nativeEvent = CANONICAL_TO_HERMESAGENT_EVENT_NAMES[canonicalEvent];
+    const nativeEvent = lookupOwn({
+      record: CANONICAL_TO_HERMESAGENT_EVENT_NAMES,
+      key: canonicalEvent,
+    });
     if (nativeEvent) {
       setHermesHookEntries({
         result,

--- a/src/features/hooks/hermesagent-hooks.ts
+++ b/src/features/hooks/hermesagent-hooks.ts
@@ -23,6 +23,7 @@ import {
   getHermesagentSharedConfigWritePaths,
 } from "../../utils/hermesagent.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { PROTOTYPE_POLLUTION_KEYS } from "../../utils/prototype-pollution.js";
 import { isPlainObject, isRecord } from "../../utils/type-guards.js";
 import {
@@ -327,7 +328,8 @@ function hermesHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
     if (!isHermesHookEventEntry(nativeEvent, entries)) {
       continue;
     }
-    const rulesyncEvent = HERMESAGENT_TO_CANONICAL_EVENT_NAMES[nativeEvent] ?? nativeEvent;
+    const rulesyncEvent =
+      lookupOwn({ record: HERMESAGENT_TO_CANONICAL_EVENT_NAMES, key: nativeEvent }) ?? nativeEvent;
 
     const defs = entries
       .map((raw) => hermesEntryToDefinition({ nativeEvent, raw }))

--- a/src/features/hooks/kimi-code-hooks.test.ts
+++ b/src/features/hooks/kimi-code-hooks.test.ts
@@ -183,6 +183,33 @@ describe("KimiCodeHooks", () => {
       expect(config["kimi-code"].hooks.SessionHeartbeat).toHaveLength(1);
     });
 
+    it("carries an event named toString through as a plain string key (#2757)", () => {
+      const hooks = new KimiCodeHooks({
+        outputRoot: testDir,
+        fileContent: [
+          "[[hooks]]",
+          'event = "SessionStart"',
+          'command = "./start.sh"',
+          "",
+          "[[hooks]]",
+          'event = "toString"',
+          'command = "./crafted.sh"',
+          "",
+        ].join("\n"),
+        validate: false,
+      });
+
+      const config = JSON.parse(hooks.toRulesyncHooks().getFileContent());
+      expect(config.hooks.sessionStart).toEqual([{ type: "command", command: "./start.sh" }]);
+      expect(Object.keys(config.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      expect(Object.keys(config["kimi-code"].hooks)).toEqual(["toString"]);
+      expect(config["kimi-code"].hooks["toString"]).toEqual([
+        { type: "command", command: "./crafted.sh" },
+      ]);
+    });
+
     it("preserves a matcher on the matcher-less events, unlike generate", () => {
       const hooks = new KimiCodeHooks({
         outputRoot: testDir,

--- a/src/features/hooks/kimi-code-hooks.ts
+++ b/src/features/hooks/kimi-code-hooks.ts
@@ -23,6 +23,7 @@ import {
   getKimiCodeRulesyncOutputRoot,
 } from "../../utils/kimi-code.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import {
   applySharedConfigPatch,
   parseSharedConfig,
@@ -192,14 +193,17 @@ function kimiCodeHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
     if (typeof entry.event !== "string" || typeof entry.command !== "string") {
       continue;
     }
-    const event = KIMI_CODE_TO_CANONICAL_EVENT_NAMES[entry.event] ?? entry.event;
+    const event =
+      lookupOwn({ record: KIMI_CODE_TO_CANONICAL_EVENT_NAMES, key: entry.event }) ?? entry.event;
     const definition: HookDefinition = {
       type: "command",
       command: stripTrustedDirectoryWrapper(entry.command),
       ...(typeof entry.matcher === "string" && { matcher: entry.matcher }),
       ...(typeof entry.timeout === "number" && { timeout: entry.timeout }),
     };
-    (result[event] ??= []).push(definition);
+    const list = lookupOwn({ record: result, key: event }) ?? [];
+    list.push(definition);
+    result[event] = list;
   }
   return result;
 }

--- a/src/features/hooks/kimi-code-hooks.ts
+++ b/src/features/hooks/kimi-code-hooks.ts
@@ -149,7 +149,8 @@ function canonicalToKimiCodeHooks({
   for (const [event, definitions] of Object.entries(
     buildEffectiveHooks(config, toolOverrideHooks),
   )) {
-    const nativeEvent = CANONICAL_TO_KIMI_CODE_EVENT_NAMES[event] ?? event;
+    const nativeEvent =
+      lookupOwn({ record: CANONICAL_TO_KIMI_CODE_EVENT_NAMES, key: event }) ?? event;
     if (!nativeEvents.has(nativeEvent)) {
       logger?.warn(`Kimi Code hooks: skipping unsupported event "${event}".`);
       continue;

--- a/src/features/hooks/kiro-hooks.test.ts
+++ b/src/features/hooks/kiro-hooks.test.ts
@@ -470,6 +470,32 @@ describe("KiroHooks", () => {
         ?.hooks;
       expect(overrideHooks?.someUnknownEvent?.[0]).toMatchObject({ command: "echo unknown" });
     });
+
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const kiroHooks = new KiroHooks(
+        createMockAiFileParams({
+          // JSON.parse yields an own enumerable `toString` key, unlike an
+          // object literal whose `toString` the lookup map would inherit from
+          // Object.prototype.
+          fileContent: JSON.stringify({
+            hooks: {
+              agentSpawn: [{ command: "echo start" }],
+              toString: [{ command: "echo crafted" }],
+            },
+          }),
+        }),
+      );
+
+      const parsed = kiroHooks.toRulesyncHooks().getJson();
+      expect(parsed.hooks.sessionStart?.[0]).toMatchObject({ command: "echo start" });
+      expect(Object.keys(parsed.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (parsed as { kiro?: { hooks?: Record<string, unknown[]> } }).kiro
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "echo crafted" });
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/hooks/kiro-hooks.ts
+++ b/src/features/hooks/kiro-hooks.ts
@@ -113,7 +113,8 @@ function canonicalToKiroHooks({
   };
   const kiro: Record<string, unknown[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const kiroEventName = CANONICAL_TO_KIRO_EVENT_NAMES[eventName] ?? eventName;
+    const kiroEventName =
+      lookupOwn({ record: CANONICAL_TO_KIRO_EVENT_NAMES, key: eventName }) ?? eventName;
     const entries = buildKiroEntriesForEvent(definitions);
     if (entries.length > 0) {
       if (kiro[kiroEventName]) {

--- a/src/features/hooks/kiro-hooks.ts
+++ b/src/features/hooks/kiro-hooks.ts
@@ -16,6 +16,7 @@ import {
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
@@ -154,7 +155,8 @@ function kiroHooksToCanonical(kiroHooks: unknown): HooksConfig["hooks"] {
   }
   const canonical: HooksConfig["hooks"] = {};
   for (const [kiroEventName, entries] of Object.entries(kiroHooks)) {
-    const eventName = KIRO_TO_CANONICAL_EVENT_NAMES[kiroEventName] ?? kiroEventName;
+    const eventName =
+      lookupOwn({ record: KIRO_TO_CANONICAL_EVENT_NAMES, key: kiroEventName }) ?? kiroEventName;
     if (!Array.isArray(entries)) continue;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of entries) {

--- a/src/features/hooks/kiro-ide-hooks.test.ts
+++ b/src/features/hooks/kiro-ide-hooks.test.ts
@@ -314,4 +314,39 @@ describe("KiroIdeHooks", () => {
     // generate run does not fail on it.
     expect(HooksConfigSchema.safeParse(canonical).success).toBe(true);
   });
+
+  it("carries a trigger named toString through as a plain string key (#2757)", () => {
+    // `toString` is not a prototype-pollution key, so it reaches the event
+    // name lookup; the lookup must not resolve Object.prototype.toString.
+    const hooks = new KiroIdeHooks({
+      outputRoot: testDir,
+      relativeDirPath: join(".kiro", "hooks"),
+      relativeFilePath: "rulesync.json",
+      fileContent: JSON.stringify({
+        version: "v1",
+        hooks: [
+          {
+            name: "lint",
+            trigger: "PreToolUse",
+            action: { type: "command", command: "echo lint" },
+            enabled: true,
+          },
+          {
+            name: "crafted",
+            trigger: "toString",
+            action: { type: "command", command: "echo crafted" },
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    const canonical = JSON.parse(hooks.toRulesyncHooks().getFileContent());
+    expect(canonical.hooks.preToolUse[0].command).toBe("echo lint");
+    expect(Object.keys(canonical.hooks)).toEqual(["preToolUse"]);
+    // The unmapped trigger must fall through verbatim rather than resolving to
+    // Object.prototype.toString and landing under its stringified source.
+    expect(Object.keys(canonical.kiro.hooks)).toEqual(["toString"]);
+    expect(canonical.kiro.hooks["toString"][0].command).toBe("echo crafted");
+  });
 });

--- a/src/features/hooks/kiro-ide-hooks.ts
+++ b/src/features/hooks/kiro-ide-hooks.ts
@@ -14,6 +14,7 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
@@ -158,7 +159,8 @@ function kiroIdeHooksToCanonical(entries: KiroIdeHookEntry[]): HooksConfig["hook
   const canonical: HooksConfig["hooks"] = {};
   for (const entry of entries) {
     if (entry.trigger === undefined || entry.action === undefined) continue;
-    const eventName = KIRO_IDE_TO_CANONICAL_EVENT_NAMES[entry.trigger] ?? entry.trigger;
+    const eventName =
+      lookupOwn({ record: KIRO_IDE_TO_CANONICAL_EVENT_NAMES, key: entry.trigger }) ?? entry.trigger;
     // A crafted `trigger` (e.g. "__proto__") would otherwise make the
     // `canonical[eventName] ??= []` bracket access resolve to a prototype member
     // and throw; skip prototype-pollution keys defensively.
@@ -186,7 +188,9 @@ function kiroIdeHooksToCanonical(entries: KiroIdeHookEntry[]): HooksConfig["hook
     // it would add noise to every imported hook definition.
     if (entry.enabled === false) def.enabled = false;
 
-    (canonical[eventName] ??= []).push(def);
+    const list = lookupOwn({ record: canonical, key: eventName }) ?? [];
+    list.push(def);
+    canonical[eventName] = list;
   }
   return canonical;
 }

--- a/src/features/hooks/kiro-ide-hooks.ts
+++ b/src/features/hooks/kiro-ide-hooks.ts
@@ -147,8 +147,8 @@ function canonicalToKiroIdeHooks(config: HooksConfig): KiroIdeHookEntry[] {
     // emitted verbatim, which would write a trigger this format does not
     // define. Anything else still passes through unchanged.
     const trigger =
-      CANONICAL_TO_KIRO_IDE_EVENT_NAMES[eventName] ??
-      KIRO_LEGACY_TO_KIRO_IDE_TRIGGER_NAMES[eventName] ??
+      lookupOwn({ record: CANONICAL_TO_KIRO_IDE_EVENT_NAMES, key: eventName }) ??
+      lookupOwn({ record: KIRO_LEGACY_TO_KIRO_IDE_TRIGGER_NAMES, key: eventName }) ??
       eventName;
     entries.push(...buildKiroIdeEntriesForEvent(trigger, definitions));
   }

--- a/src/features/hooks/qwencode-hooks.test.ts
+++ b/src/features/hooks/qwencode-hooks.test.ts
@@ -539,6 +539,32 @@ describe("QwencodeHooks", () => {
       expect(parsed.hooks.sessionDelete[0].matcher).toBeUndefined();
     });
 
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const qwencodeHooks = new QwencodeHooks(
+        createMockAiFileParams({
+          // JSON.parse yields an own enumerable `toString` key, unlike an
+          // object literal whose `toString` the lookup map would inherit from
+          // Object.prototype.
+          fileContent: JSON.stringify({
+            hooks: {
+              SessionStart: [{ hooks: [{ type: "command", command: "echo start" }] }],
+              toString: [{ hooks: [{ type: "command", command: "echo crafted" }] }],
+            },
+          }),
+        }),
+      );
+
+      const json = qwencodeHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.sessionStart?.[0]?.command).toBe("echo start");
+      expect(Object.keys(json.hooks)).toEqual(["sessionStart"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (json as { qwencode?: { hooks?: Record<string, unknown[]> } }).qwencode
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "echo crafted" });
+    });
+
     it("should round-trip Qwen Code PascalCase back to canonical", () => {
       const qwencodeHooks = new QwencodeHooks(
         createMockAiFileParams({

--- a/src/features/hooks/qwencode-hooks.ts
+++ b/src/features/hooks/qwencode-hooks.ts
@@ -15,6 +15,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { compact } from "../../utils/object.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
@@ -245,7 +246,9 @@ function qwencodeHooksToCanonical(qwencodeHooks: unknown): HooksConfig["hooks"] 
   }
   const canonical: HooksConfig["hooks"] = {};
   for (const [qwencodeEventName, matcherEntries] of Object.entries(qwencodeHooks)) {
-    const eventName = QWENCODE_TO_CANONICAL_EVENT_NAMES[qwencodeEventName] ?? qwencodeEventName;
+    const eventName =
+      lookupOwn({ record: QWENCODE_TO_CANONICAL_EVENT_NAMES, key: qwencodeEventName }) ??
+      qwencodeEventName;
     if (!Array.isArray(matcherEntries)) continue;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of matcherEntries) {

--- a/src/features/hooks/qwencode-hooks.ts
+++ b/src/features/hooks/qwencode-hooks.ts
@@ -95,7 +95,8 @@ function canonicalToQwencodeHooks(config: HooksConfig, logger?: Logger): Record<
   const qwencodeSupportedTypes = new Set(["command", "prompt", "http", "function"]);
   const qwencode: Record<string, unknown[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const qwencodeEventName = CANONICAL_TO_QWENCODE_EVENT_NAMES[eventName] ?? eventName;
+    const qwencodeEventName =
+      lookupOwn({ record: CANONICAL_TO_QWENCODE_EVENT_NAMES, key: eventName }) ?? eventName;
     const byMatcher = new Map<string, HooksConfig["hooks"][string]>();
     for (const def of definitions) {
       if (!qwencodeSupportedTypes.has(def.type ?? "command")) continue;

--- a/src/features/hooks/reasonix-hooks.test.ts
+++ b/src/features/hooks/reasonix-hooks.test.ts
@@ -382,6 +382,34 @@ describe("ReasonixHooks", () => {
       expect(json.hooks.stop?.[0]?.command).toBe("audit.sh");
     });
 
+    it("should carry an event named toString through as a plain string key (#2757)", () => {
+      const reasonixHooks = new ReasonixHooks({
+        outputRoot: testDir,
+        relativeDirPath: ".reasonix",
+        relativeFilePath: "settings.json",
+        // JSON.parse yields an own enumerable `toString` key, unlike an object
+        // literal whose `toString` the lookup map would inherit from
+        // Object.prototype.
+        fileContent: JSON.stringify({
+          hooks: {
+            Stop: [{ command: "audit.sh" }],
+            toString: [{ command: "crafted.sh" }],
+          },
+        }),
+        validate: false,
+      });
+
+      const json = reasonixHooks.toRulesyncHooks().getJson();
+      expect(json.hooks.stop?.[0]?.command).toBe("audit.sh");
+      expect(Object.keys(json.hooks)).toEqual(["stop"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (json as { reasonix?: { hooks?: Record<string, unknown[]> } }).reasonix
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "crafted.sh" });
+    });
+
     it("should handle an empty or missing hooks key", () => {
       const reasonixHooks = new ReasonixHooks({
         outputRoot: testDir,

--- a/src/features/hooks/reasonix-hooks.ts
+++ b/src/features/hooks/reasonix-hooks.ts
@@ -71,7 +71,8 @@ function canonicalToReasonixHooks({
     if (!SUPPORTED_REASONIX_EVENTS.has(event)) {
       continue;
     }
-    const reasonixEvent = CANONICAL_TO_REASONIX_EVENT_NAMES[event] ?? event;
+    const reasonixEvent =
+      lookupOwn({ record: CANONICAL_TO_REASONIX_EVENT_NAMES, key: event }) ?? event;
     const isMatcherEvent = REASONIX_MATCHER_EVENTS.has(reasonixEvent);
     const entries: ReasonixHookEntry[] = [];
     for (const def of defs) {
@@ -104,7 +105,10 @@ function canonicalToReasonixHooks({
       entries.push(entry);
     }
     if (entries.length > 0) {
-      result[reasonixEvent] = [...(result[reasonixEvent] ?? []), ...entries];
+      result[reasonixEvent] = [
+        ...(lookupOwn({ record: result, key: reasonixEvent }) ?? []),
+        ...entries,
+      ];
     }
   }
   return result;

--- a/src/features/hooks/reasonix-hooks.ts
+++ b/src/features/hooks/reasonix-hooks.ts
@@ -12,6 +12,7 @@ import {
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
 import {
@@ -122,7 +123,8 @@ function reasonixHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
     if (!Array.isArray(rawEntries)) {
       continue;
     }
-    const canonicalEvent = REASONIX_TO_CANONICAL_EVENT_NAMES[reasonixEvent] ?? reasonixEvent;
+    const canonicalEvent =
+      lookupOwn({ record: REASONIX_TO_CANONICAL_EVENT_NAMES, key: reasonixEvent }) ?? reasonixEvent;
     const defs: HookDefinition[] = [];
     for (const rawEntry of rawEntries) {
       if (rawEntry === null || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
@@ -145,7 +147,10 @@ function reasonixHooksToCanonical(hooks: unknown): HooksConfig["hooks"] {
       defs.push(def);
     }
     if (defs.length > 0) {
-      canonical[canonicalEvent] = [...(canonical[canonicalEvent] ?? []), ...defs];
+      canonical[canonicalEvent] = [
+        ...(lookupOwn({ record: canonical, key: canonicalEvent }) ?? []),
+        ...defs,
+      ];
     }
   }
   return canonical;

--- a/src/features/hooks/tool-hooks-converter.test.ts
+++ b/src/features/hooks/tool-hooks-converter.test.ts
@@ -594,3 +594,26 @@ describe("ClaudecodeHooks.toRulesyncHooks", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 });
+
+describe("toolHooksToCanonical with an event named after an Object.prototype member (#2757)", () => {
+  it("carries a toString event through as a plain string key", () => {
+    const logger = createMockLogger();
+    // JSON.parse yields an own enumerable `toString` key, unlike an object
+    // literal whose `toString` the lookup map would inherit from
+    // Object.prototype.
+    const hooks: unknown = JSON.parse(
+      JSON.stringify({
+        PreToolUse: [{ hooks: [{ type: "command", command: "./guard.sh" }] }],
+        toString: [{ hooks: [{ type: "command", command: "./crafted.sh" }] }],
+      }),
+    );
+
+    const canonical = toolHooksToCanonical({ hooks, converterConfig: BASE_CONFIG, logger });
+
+    expect(canonical.preToolUse).toEqual([{ type: "command", command: "./guard.sh" }]);
+    // The unmapped name must fall through verbatim rather than resolving to
+    // Object.prototype.toString and landing under its stringified source.
+    expect(Object.keys(canonical)).toEqual(["preToolUse", "toString"]);
+    expect(canonical["toString"]).toEqual([{ type: "command", command: "./crafted.sh" }]);
+  });
+});

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -801,7 +801,8 @@ export function canonicalToToolHooks({
   const warn = warnOnce(logger);
   const result: Record<string, unknown[]> = {};
   for (const [eventName, definitions] of Object.entries(effectiveHooks)) {
-    const toolEventName = converterConfig.canonicalToToolEventNames[eventName] ?? eventName;
+    const toolEventName =
+      lookupOwn({ record: converterConfig.canonicalToToolEventNames, key: eventName }) ?? eventName;
     const byMatcher = groupDefinitionsByMatcher({ definitions, converterConfig });
     const entries: unknown[] = [];
     const isNoMatcherEvent = converterConfig.noMatcherEvents?.has(eventName) ?? false;

--- a/src/features/hooks/tool-hooks-converter.ts
+++ b/src/features/hooks/tool-hooks-converter.ts
@@ -12,6 +12,7 @@ import {
 } from "../../types/hooks.js";
 import type { Logger } from "../../utils/logger.js";
 import { compact } from "../../utils/object.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { quoteValueForWarning } from "../../utils/quote-value.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 
@@ -1336,7 +1337,9 @@ export function toolHooksToCanonical({
   const warn = warnOnce(logger);
   const canonical: HooksConfig["hooks"] = {};
   for (const [toolEventName, matcherEntries] of Object.entries(hooks)) {
-    const eventName = converterConfig.toolToCanonicalEventNames[toolEventName] ?? toolEventName;
+    const eventName =
+      lookupOwn({ record: converterConfig.toolToCanonicalEventNames, key: toolEventName }) ??
+      toolEventName;
     if (!Array.isArray(matcherEntries)) continue;
     const defs: HooksConfig["hooks"][string] = [];
     for (const rawEntry of matcherEntries) {

--- a/src/features/hooks/vibe-hooks.test.ts
+++ b/src/features/hooks/vibe-hooks.test.ts
@@ -281,6 +281,35 @@ describe("VibeHooks", () => {
       expect(Object.keys(parsed.hooks)).toEqual(["preToolUse"]);
       expect(parsed.vibe).toBeUndefined();
     });
+
+    it("should carry an event type named toString through as a plain string key (#2757)", () => {
+      // `toString` is not a prototype-pollution key, so it reaches the event
+      // name lookup; the lookup must not resolve Object.prototype.toString.
+      const fileContent = smolToml.stringify({
+        hooks: [
+          { name: "ok", type: "pre_tool", match: "bash", command: "./guard" },
+          { name: "crafted", type: "toString", command: "./crafted" },
+        ],
+      });
+
+      const vibeHooks = new VibeHooks(
+        createMockAiFileParams({
+          relativeDirPath: ".vibe",
+          relativeFilePath: "hooks.toml",
+          fileContent,
+        }),
+      );
+
+      const parsed = vibeHooks.toRulesyncHooks().getJson();
+      expect(parsed.hooks.preToolUse?.[0]).toMatchObject({ command: "./guard", matcher: "bash" });
+      expect(Object.keys(parsed.hooks)).toEqual(["preToolUse"]);
+      // The unmapped name must fall through verbatim rather than resolving to
+      // Object.prototype.toString and landing under its stringified source.
+      const overrideHooks = (parsed as { vibe?: { hooks?: Record<string, unknown[]> } }).vibe
+        ?.hooks;
+      expect(Object.keys(overrideHooks ?? {})).toEqual(["toString"]);
+      expect(overrideHooks?.["toString"]?.[0]).toMatchObject({ command: "./crafted" });
+    });
   });
 
   describe("fromFile", () => {

--- a/src/features/hooks/vibe-hooks.ts
+++ b/src/features/hooks/vibe-hooks.ts
@@ -12,6 +12,7 @@ import {
 } from "../../types/hooks.js";
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
+import { lookupOwn } from "../../utils/own-lookup.js";
 import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import type { RulesyncHooks } from "./rulesync-hooks.js";
 import { buildImportedHooksConfig } from "./tool-hooks-converter.js";
@@ -129,14 +130,16 @@ function vibeEntryToCanonicalDef(
   if (vibeEvent === undefined) {
     return null;
   }
-  // A crafted `type` (e.g. "__proto__") would otherwise make the bracket lookup
-  // below resolve to a prototype member instead of falling back to the raw name,
-  // keying the canonical record by that member. Skip such names, as
-  // `kiroIdeHooksToCanonical` does.
+  // The lookup below is own-property-only, so a crafted `type` such as
+  // "toString" falls back to the raw name instead of a prototype member. The
+  // raw name is still written as a key of the canonical record, so a
+  // prototype-pollution key is skipped outright, as `kiroIdeHooksToCanonical`
+  // does.
   if (isPrototypePollutionKey(vibeEvent)) {
     return null;
   }
-  const canonicalEvent = VIBE_TO_CANONICAL_EVENT_NAMES[vibeEvent] ?? vibeEvent;
+  const canonicalEvent =
+    lookupOwn({ record: VIBE_TO_CANONICAL_EVENT_NAMES, key: vibeEvent }) ?? vibeEvent;
   const def: HookDefinition = { type: "command" };
   if (typeof entry.command === "string") {
     def.command = entry.command;
@@ -177,7 +180,7 @@ function vibeHooksToCanonical(parsed: unknown): HooksConfig["hooks"] {
     if (result === null) {
       continue;
     }
-    const list = canonical[result.canonicalEvent] ?? [];
+    const list = lookupOwn({ record: canonical, key: result.canonicalEvent }) ?? [];
     list.push(result.def);
     canonical[result.canonicalEvent] = list;
   }

--- a/src/features/hooks/vibe-hooks.ts
+++ b/src/features/hooks/vibe-hooks.ts
@@ -76,7 +76,7 @@ function canonicalToVibeHooks(
     if (!SUPPORTED_VIBE_EVENTS.has(event)) {
       continue;
     }
-    const vibeEvent = CANONICAL_TO_VIBE_EVENT_NAMES[event] ?? event;
+    const vibeEvent = lookupOwn({ record: CANONICAL_TO_VIBE_EVENT_NAMES, key: event }) ?? event;
     let index = 0;
     for (const def of defs) {
       const hookType = def.type ?? "command";

--- a/src/utils/own-lookup.test.ts
+++ b/src/utils/own-lookup.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { lookupOwn } from "./own-lookup.js";
+
+describe("lookupOwn", () => {
+  const record: Record<string, string> = { PreToolUse: "preToolUse" };
+
+  it("returns the value of an own key", () => {
+    expect(lookupOwn({ record, key: "PreToolUse" })).toBe("preToolUse");
+  });
+
+  it("returns undefined for a key the record does not define", () => {
+    expect(lookupOwn({ record, key: "Unknown" })).toBeUndefined();
+  });
+
+  it.each(["toString", "valueOf", "hasOwnProperty", "constructor", "__proto__"])(
+    "does not resolve the inherited member %s",
+    (key) => {
+      expect(lookupOwn({ record, key })).toBeUndefined();
+    },
+  );
+});

--- a/src/utils/own-lookup.ts
+++ b/src/utils/own-lookup.ts
@@ -1,0 +1,19 @@
+/**
+ * Read a key from a plain string map without walking its prototype chain.
+ *
+ * A bracket read on an object literal resolves inherited members too, so a
+ * user-supplied key such as `toString` or `constructor` "succeeds" with an
+ * `Object.prototype` function instead of falling through to the caller's
+ * `?? fallback`. Hook adapters translate native event names this way from
+ * `Object.entries()` over a config file, so route the read through here to keep
+ * the fallback honest: only a key the map itself defines yields a value.
+ */
+export function lookupOwn<V>({
+  record,
+  key,
+}: {
+  record: Readonly<Record<string, V>>;
+  key: string;
+}): V | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
+}


### PR DESCRIPTION
## Summary

Hook adapters translated a native event name back to the canonical one with `X_TO_CANONICAL_EVENT_NAMES[name] ?? name`. The map is a plain object, so the bracket read walks its prototype chain: a config file whose event key is an `Object.prototype` member (`toString`, `valueOf`, `constructor`, `__proto__`, ...) resolved to an inherited function or object instead of falling through to the `??` fallback, and the imported hook was then filed under a stringified prototype member such as `function toString() { [native code] }`. The existing `isPrototypePollutionKey` guards only cover the assignment-sink set (`__proto__`, `constructor`, `prototype`), so `toString` and friends still slipped through.

- Add `lookupOwn({ record, key })` in `src/utils/own-lookup.ts`, an own-property-only read that keeps the `?? fallback` honest.
- Route every event-name reverse lookup through it: the shared `toolHooksToCanonical` converter (Claude Code, Goose, Devin, Augment Code, Antigravity, Codex CLI, Factory Droid, ...) plus the per-adapter sites in Copilot, Copilot CLI, Cursor, Deep Agents (v2 record and legacy `events` array), Hermes Agent, Kimi Code, Kiro, Kiro IDE, Qwen Code, Reasonix, and Vibe.
- Keep the `isPrototypePollutionKey` guards where they also protect an assignment sink, and reword the comments so they no longer claim to make the read safe.
- Add a regression test per adapter with a `toString` event name, and unit tests for the helper.

Closes #2757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
