### PR TITLE
fix(permissions): honor star category for command adapters and tighten Hermes allowlist

### DIFF
--- a/src/features/permissions/antigravity-cli-permissions.ts
+++ b/src/features/permissions/antigravity-cli-permissions.ts
@@ -18,6 +18,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { fallbackLogger, type Logger } from "../../utils/logger.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -393,7 +394,7 @@ function convertRulesyncToAntigravityCliPermissions(config: PermissionsConfig): 
   const ask: string[] = [];
   const deny: string[] = [];
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     const cliToolName = toAntigravityCliToolName(category);
     for (const [pattern, action] of Object.entries(rules)) {
       const entry = buildPermissionEntry(cliToolName, pattern);

--- a/src/features/permissions/antigravity-ide-permissions.ts
+++ b/src/features/permissions/antigravity-ide-permissions.ts
@@ -11,6 +11,7 @@ import type { PermissionAction, PermissionsConfig } from "../../types/permission
 import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -253,7 +254,7 @@ function convertRulesyncToAntigravityIdePermissions(config: PermissionsConfig): 
   const ask: string[] = [];
   const deny: string[] = [];
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     const action = toIdeAction(category);
     for (const [pattern, permissionAction] of Object.entries(rules)) {
       const entry = buildPermissionEntry(action, pattern);

--- a/src/features/permissions/codexcli-permissions.test.ts
+++ b/src/features/permissions/codexcli-permissions.test.ts
@@ -1467,6 +1467,25 @@ command = "node"
     expect(content).toContain('decision = "forbidden"');
   });
 
+  it("should not auto-approve a bash allow that an all-tools deny covers", () => {
+    const rulesFile = createCodexcliBashRulesFile({
+      outputRoot: testDir,
+      config: {
+        permission: {
+          "*": { "rm *": "deny" },
+          bash: { "rm *": "allow", "git status": "allow" },
+        },
+      },
+    });
+
+    const content = rulesFile.getFileContent();
+    expect(content).toContain('pattern = ["git", "status"]');
+    expect(content).toContain('decision = "allow"');
+    expect(content).toContain('pattern = ["rm", "*"]');
+    expect(content).toContain('decision = "forbidden"');
+    expect(content).not.toMatch(/pattern = \["rm", "\*"\][\s\S]*decision = "allow"/);
+  });
+
   describe("codexcli override (approval_policy / sandbox_mode / apps)", () => {
     it("authors override keys as top-level config.toml keys on generate", async () => {
       const logger = createMockLogger();

--- a/src/features/permissions/codexcli-permissions.ts
+++ b/src/features/permissions/codexcli-permissions.ts
@@ -20,6 +20,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { bashRulesHonoringAllTools } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -1120,7 +1121,7 @@ function mergeFilesystemCategoryRules({
 }
 
 function buildCodexBashRulesContent(config: PermissionsConfig): string {
-  const bashRules = config.permission.bash ?? {};
+  const bashRules = bashRulesHonoringAllTools(config.permission);
   const entries = Object.entries(bashRules);
 
   const header = [

--- a/src/features/permissions/cursor-permissions.test.ts
+++ b/src/features/permissions/cursor-permissions.test.ts
@@ -79,6 +79,26 @@ describe("CursorPermissions", () => {
       expect(parsed.permissions.deny).toContain("Shell(rm -rf *)");
     });
 
+    it("should not auto-approve a bash allow that an all-tools deny covers", async () => {
+      const cursorPermissions = await CursorPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({
+            permission: {
+              "*": { "rm *": "deny" },
+              bash: { "rm *": "allow", "git *": "allow" },
+            },
+          }),
+        }),
+      });
+
+      const parsed = JSON.parse(cursorPermissions.getFileContent());
+      expect(parsed.permissions.allow).toEqual(["Shell(git *)"]);
+      expect(parsed.permissions.deny).toContain("Shell(rm *)");
+    });
+
     it("should warn and skip 'ask' rules because Cursor CLI does not support ask", async () => {
       const logger = createMockLogger();
       const rulesyncPermissions = new RulesyncPermissions({

--- a/src/features/permissions/cursor-permissions.ts
+++ b/src/features/permissions/cursor-permissions.ts
@@ -14,6 +14,7 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { quoteValueForWarning } from "../../utils/quote-value.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -570,7 +571,7 @@ function convertRulesyncToCursorPermissions(
   const allow: string[] = [];
   const deny: string[] = [];
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     const cursorType = toCursorType(category);
     for (const [pattern, action] of Object.entries(rules)) {
       const cursorPattern = toCursorPattern(category, pattern);

--- a/src/features/permissions/devin-permissions.ts
+++ b/src/features/permissions/devin-permissions.ts
@@ -15,6 +15,7 @@ import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import { isRecord } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -286,7 +287,7 @@ function convertRulesyncToDevinPermissions(config: PermissionsConfig): {
   const ask: string[] = [];
   const deny: string[] = [];
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     const scope = toDevinScope(category);
     for (const [pattern, action] of Object.entries(rules)) {
       const entry = buildDevinPermissionEntry(scope, pattern);

--- a/src/features/permissions/goose-permissions.ts
+++ b/src/features/permissions/goose-permissions.ts
@@ -11,6 +11,7 @@ import type { Logger } from "../../utils/logger.js";
 import { isRecord, isStringArray } from "../../utils/type-guards.js";
 import { loadYaml } from "../../utils/yaml.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -267,7 +268,7 @@ function convertRulesyncToGoosePermissionConfig({
 
   // Apply `edit` after `write` so the shared `developer__text_editor` mapping
   // resolves deterministically to `edit`, consistent with the import direction.
-  const orderedEntries = Object.entries(config.permission).toSorted(
+  const orderedEntries = Object.entries(honorAllToolsOnBash(config.permission)).toSorted(
     ([a], [b]) => (a === "edit" ? 1 : 0) - (b === "edit" ? 1 : 0),
   );
 

--- a/src/features/permissions/grokcli-permissions.ts
+++ b/src/features/permissions/grokcli-permissions.ts
@@ -16,6 +16,7 @@ import type { Logger } from "../../utils/logger.js";
 import { isRecord, isStringArray } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -458,7 +459,7 @@ function buildGrokPermissionArrays(
   // Map each managed entry to a single action; on collision keep the strictest
   // (and warn), so no entry ends up contradictorily in two arrays.
   const ranked = new Map<string, PermissionAction>();
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     for (const [pattern, action] of Object.entries(rules)) {
       const entry = buildGrokEntry(category, pattern);
       if (entry === null) {

--- a/src/features/permissions/junie-permissions.ts
+++ b/src/features/permissions/junie-permissions.ts
@@ -11,6 +11,7 @@ import { formatError } from "../../utils/error.js";
 import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -400,7 +401,7 @@ function convertRulesyncToJunieRules({
 }): Record<string, JunieRuleSet> {
   const ruleLists: Partial<Record<JunieRuleGroup, JunieRule[]>> = {};
 
-  for (const [category, patterns] of Object.entries(config.permission)) {
+  for (const [category, patterns] of Object.entries(honorAllToolsOnBash(config.permission))) {
     const group = CANONICAL_TO_JUNIE_GROUP[category];
     if (!group) {
       if (Object.keys(patterns).length > 0) {

--- a/src/features/permissions/kilo-permissions.ts
+++ b/src/features/permissions/kilo-permissions.ts
@@ -17,6 +17,7 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import type { Logger } from "../../utils/logger.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -290,7 +291,7 @@ export class KiloPermissions extends ToolPermissions {
     // notebook_edit, ...) authorable from rulesync rather than only pass-through.
     const kiloOverride = rulesyncJson.kilo;
     const incomingPermission: Record<string, unknown> = {
-      ...rulesyncJson.permission,
+      ...honorAllToolsOnBash(rulesyncJson.permission),
       ...kiloOverride?.permission,
     };
 

--- a/src/features/permissions/kiro-permissions.test.ts
+++ b/src/features/permissions/kiro-permissions.test.ts
@@ -362,4 +362,25 @@ describe("KiroPermissions", () => {
     const content = JSON.parse(kiroPermissions.getFileContent());
     expect(content.allowedTools).toEqual(["read"]);
   });
+
+  it("should not auto-approve a bash allow that an all-tools deny covers", async () => {
+    const kiroPermissions = await KiroPermissions.fromRulesyncPermissions({
+      outputRoot: testDir,
+      rulesyncPermissions: new RulesyncPermissions({
+        outputRoot: testDir,
+        relativeDirPath: ".rulesync",
+        relativeFilePath: "permissions.json",
+        fileContent: JSON.stringify({
+          permission: {
+            "*": { "rm *": "deny" },
+            bash: { "rm *": "allow", "git *": "allow" },
+          },
+        }),
+      }),
+    });
+
+    const shell = JSON.parse(kiroPermissions.getFileContent()).toolsSettings.shell;
+    expect(shell.allowedCommands).toEqual(["git *"]);
+    expect(shell.deniedCommands).toEqual(["rm *"]);
+  });
 });

--- a/src/features/permissions/kiro-permissions.ts
+++ b/src/features/permissions/kiro-permissions.ts
@@ -11,6 +11,7 @@ import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -199,7 +200,7 @@ function buildKiroPermissionsFromRulesync({
   };
   const shell = { allowedCommands: [] as string[], deniedCommands: [] as string[] };
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     for (const [pattern, action] of Object.entries(rules)) {
       if (action === "ask") {
         logger?.warn(`Kiro permissions do not support "ask". Skipping ${category}:${pattern}`);

--- a/src/features/permissions/opencode-permissions.ts
+++ b/src/features/permissions/opencode-permissions.ts
@@ -22,6 +22,7 @@ import type { Logger } from "../../utils/logger.js";
 import { isRecord } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -267,7 +268,9 @@ export class OpencodePermissions extends ToolPermissions {
     // (`agent` → `task`) before emitting them, so subagent-launch gating is
     // written under the key OpenCode actually reads.
     const sharedPermission: Record<string, OpencodePermission> = {};
-    for (const [category, value] of Object.entries(rulesyncJson.permission ?? {})) {
+    for (const [category, value] of Object.entries(
+      honorAllToolsOnBash(rulesyncJson.permission ?? {}),
+    )) {
       sharedPermission[toOpencodePermissionKey(category)] = value;
     }
 

--- a/src/features/permissions/roo-permissions.test.ts
+++ b/src/features/permissions/roo-permissions.test.ts
@@ -439,6 +439,22 @@ describe("RooPermissions", () => {
         "editor.tabSize": 2,
       });
     });
+
+    it("does not warn about an all-tools restriction when no bash category is stated", async () => {
+      // Regression: Roo isn't touching either list in this shape at all (see
+      // above), so claiming it "did not write" a denylist entry into a file it
+      // never opened for writing would be misleading.
+      const logger = createMockLogger();
+
+      const permissions = await RooPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: createRulesyncPermissions({ "*": { "rm *": "deny" } }),
+        logger,
+      });
+
+      expect(JSON.parse(permissions.getFileContent())).toEqual({});
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
   });
 
   describe("toRulesyncPermissions", () => {

--- a/src/features/permissions/roo-permissions.test.ts
+++ b/src/features/permissions/roo-permissions.test.ts
@@ -404,6 +404,28 @@ describe("RooPermissions", () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
+    it("withholds a bash allow that an all-tools deny covers, and warns about skipped categories", async () => {
+      const logger = createMockLogger();
+
+      const permissions = await RooPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: createRulesyncPermissions({
+          "*": { "rm *": "deny" },
+          bash: { "rm *": "allow", "git *": "allow" },
+          read: { ".env": "deny" },
+        }),
+        logger,
+      });
+
+      const json = JSON.parse(permissions.getFileContent());
+      expect(json[ALLOWED_KEY]).toEqual(["git *"]);
+      expect(json[DENIED_KEY]).toEqual(["rm *", "rm "]);
+      const warning = logger.warn.mock.calls.map(([message]) => String(message)).join("\n");
+      expect(warning).toContain("Roo Code");
+      expect(warning).toContain("read");
+      expect(warning).toContain("rm *");
+    });
+
     it("leaves hand-authored command lists untouched when no bash category is stated", async () => {
       await writeSettings(testDir, { [ALLOWED_KEY]: ["git "], "editor.tabSize": 2 });
 

--- a/src/features/permissions/roo-permissions.ts
+++ b/src/features/permissions/roo-permissions.ts
@@ -16,6 +16,7 @@ import {
   sharedConfigFileKey,
 } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { resolveShellCommandLists } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -167,17 +168,30 @@ export class RooPermissions extends ToolPermissions {
     // `--dry-run`/`--check`; the actual write happens later in `writeAiFiles`.
     const existingContent = (await readFileContentOrNull(filePath)) ?? "{}";
 
-    const rules = rulesyncPermissions.getJson().permission[COMMAND_CATEGORY];
+    const permission = rulesyncPermissions.getJson().permission;
     // A canonical config that states no `bash` category leaves both keys
     // exactly as the user left them — adopting rulesync for other tools must
     // not wipe hand-authored command lists. Once the category IS stated,
     // rulesync owns both keys: the allow list is always written, `[]` included,
     // while an empty deny list retracts its key (a `undefined` patch value).
     // See `buildVscodeCommandLists` for why the two differ.
+    //
+    // The all-tools `*` category is still read: a `deny` written there covers
+    // shell commands too, so it withholds (and is written as) the overlapping
+    // bash allows. Categories this surface cannot express are reported rather
+    // than dropped in silence.
+    const bashStated = permission[COMMAND_CATEGORY] !== undefined;
+    const { bash } = resolveShellCommandLists({
+      permission,
+      writesAllToolsDeny: bashStated,
+      toolLabel: this.getToolLabel(),
+      surfaceLabel: `${this.getAllowedCommandsKey()}/${this.getDeniedCommandsKey()}`,
+      logger,
+    });
     const patch: Record<string, unknown> = {};
-    if (rules !== undefined) {
+    if (bashStated) {
       const { allowed, denied } = buildVscodeCommandLists({
-        rules,
+        rules: bash,
         toolLabel: this.getToolLabel(),
         logger,
       });
@@ -189,7 +203,7 @@ export class RooPermissions extends ToolPermissions {
       outputRoot,
       relativeDirPath: paths.relativeDirPath,
       relativeFilePath: paths.relativeFilePath,
-      ownsCommandKeys: rules !== undefined,
+      ownsCommandKeys: bashStated,
       fileContent: applySharedConfigPatch({
         fileKey: sharedConfigFileKey(paths),
         feature: "permissions",

--- a/src/features/permissions/roo-permissions.ts
+++ b/src/features/permissions/roo-permissions.ts
@@ -176,20 +176,23 @@ export class RooPermissions extends ToolPermissions {
     // while an empty deny list retracts its key (a `undefined` patch value).
     // See `buildVscodeCommandLists` for why the two differ.
     //
-    // The all-tools `*` category is still read: a `deny` written there covers
-    // shell commands too, so it withholds (and is written as) the overlapping
-    // bash allows. Categories this surface cannot express are reported rather
-    // than dropped in silence.
+    // The all-tools `*` category is still read once `bash` is stated: a `deny`
+    // written there covers shell commands too, so it withholds (and is
+    // written as) the overlapping bash allows, and categories this surface
+    // cannot express are reported rather than dropped in silence. When `bash`
+    // is unstated, Roo isn't managing these keys at all this generation (see
+    // above), so resolving and warning about `*` restrictions would blame a
+    // denylist that was never touched in the first place.
     const bashStated = permission[COMMAND_CATEGORY] !== undefined;
-    const { bash } = resolveShellCommandLists({
-      permission,
-      writesAllToolsDeny: bashStated,
-      toolLabel: this.getToolLabel(),
-      surfaceLabel: `${this.getAllowedCommandsKey()}/${this.getDeniedCommandsKey()}`,
-      logger,
-    });
     const patch: Record<string, unknown> = {};
     if (bashStated) {
+      const { bash } = resolveShellCommandLists({
+        permission,
+        writesAllToolsDeny: true,
+        toolLabel: this.getToolLabel(),
+        surfaceLabel: `${this.getAllowedCommandsKey()}/${this.getDeniedCommandsKey()}`,
+        logger,
+      });
       const { allowed, denied } = buildVscodeCommandLists({
         rules: bash,
         toolLabel: this.getToolLabel(),

--- a/src/features/permissions/rovodev-permissions.test.ts
+++ b/src/features/permissions/rovodev-permissions.test.ts
@@ -112,6 +112,43 @@ describe("RovodevPermissions", () => {
       ]);
     });
 
+    it("carries an all-tools deny into bash.commands, withholding the allow it covers", async () => {
+      const perms = await RovodevPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: rulesyncPermissions({
+          "*": { "rm *": "deny" },
+          bash: { "rm *": "allow", "git *": "allow" },
+        }),
+        global: true,
+      });
+
+      const tp = toolPermissionsOf(perms.getFileContent());
+      const bash = isRecord(tp.bash) ? tp.bash : {};
+      expect(bash.commands).toEqual([
+        { command: "git *", permission: "allow" },
+        { command: "rm *", permission: "deny" },
+      ]);
+    });
+
+    it("carries an all-tools ask into bash.commands when bash says nothing about that pattern", async () => {
+      // Regression: this pattern used to vanish from bash entirely (neither
+      // allowed, asked, nor denied) because only `*` denies were folded in.
+      const perms = await RovodevPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: rulesyncPermissions({
+          "*": { "rm *": "ask" },
+          bash: { "git *": "allow" },
+        }),
+        global: true,
+      });
+
+      const tp = toolPermissionsOf(perms.getFileContent());
+      const bash = isRecord(tp.bash) ? tp.bash : {};
+      expect(bash.commands).toEqual(
+        expect.arrayContaining([{ command: "rm *", permission: "ask" }]),
+      );
+    });
+
     it("maps read/edit catch-alls to the matching per-tool keys", async () => {
       const perms = await RovodevPermissions.fromRulesyncPermissions({
         outputRoot: testDir,

--- a/src/features/permissions/rovodev-permissions.ts
+++ b/src/features/permissions/rovodev-permissions.ts
@@ -16,6 +16,7 @@ import {
   applySharedConfigPatch,
 } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -625,7 +626,7 @@ function convertRulesyncToRovodevToolPermissions({
 
   warnOnEditWriteConflict({ config, logger });
 
-  for (const [category, rules] of Object.entries(config.permission)) {
+  for (const [category, rules] of Object.entries(honorAllToolsOnBash(config.permission))) {
     if (category === CATCH_ALL_PATTERN) {
       const toolWideDefault = convertAllToolsRules({ rules, logger });
       if (toolWideDefault) {

--- a/src/features/permissions/shell-command-categories.test.ts
+++ b/src/features/permissions/shell-command-categories.test.ts
@@ -462,6 +462,48 @@ describe("bashRulesHonoringAllTools", () => {
       }),
     ).toEqual({ "*": "ask" });
   });
+
+  it("copies an all-tools ask into bash when the pattern has no bash entry", () => {
+    // Without this, an all-tools `ask` that names a command not otherwise
+    // mentioned under `bash` would vanish from the resolved category entirely
+    // rather than falling back to a tier that still prompts.
+    expect(
+      bashRulesHonoringAllTools({
+        "*": { "rm *": "ask" },
+        bash: { "git *": "allow" },
+      }),
+    ).toEqual({ "git *": "allow", "rm *": "ask" });
+  });
+
+  it("does not downgrade an existing bash deny to ask", () => {
+    expect(
+      bashRulesHonoringAllTools({
+        "*": { "rm *": "ask" },
+        bash: { "rm *": "deny" },
+      }),
+    ).toEqual({ "rm *": "deny" });
+  });
+
+  it("does not downgrade an existing bash ask when the all-tools rule denies the same pattern", () => {
+    expect(
+      bashRulesHonoringAllTools({
+        "*": { "rm *": "deny" },
+        bash: { "rm *": "ask" },
+      }),
+    ).toEqual({ "rm *": "ask" });
+  });
+
+  it("does not let an all-tools prototype-pollution pattern touch Object.prototype", () => {
+    const permission = JSON.parse(
+      '{"*":{"__proto__":"deny","constructor":"deny"},"bash":{"git *":"allow"}}',
+    );
+
+    const bash = bashRulesHonoringAllTools(permission);
+
+    expect(bash).toEqual({ "git *": "allow" });
+    expect(Object.prototype).not.toHaveProperty("deny");
+    expect(({} as Record<string, unknown>).deny).toBeUndefined();
+  });
 });
 
 describe("honorAllToolsOnBash", () => {

--- a/src/features/permissions/shell-command-categories.test.ts
+++ b/src/features/permissions/shell-command-categories.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest";
 import { createMockLogger } from "../../test-utils/mock-logger.js";
 import type { PermissionAction } from "../../types/permissions.js";
 import {
+  bashRulesHonoringAllTools,
   collectShellCommandRules,
   collectUnenforcedAllToolsPatterns,
   createShadowingRestrictionsTest,
+  honorAllToolsOnBash,
   partitionCommandRules,
+  resolveShellCommandLists,
   warnAboutUnwrittenCommandRules,
 } from "./shell-command-categories.js";
 
@@ -438,5 +441,61 @@ describe("warnAboutUnwrittenCommandRules", () => {
     expect(warnedBy({ shadowedAllowPatterns: ["git *"] })).toEqual([
       expect.stringContaining("was not given the allow rule(s) for git *"),
     ]);
+  });
+});
+
+describe("bashRulesHonoringAllTools", () => {
+  it("withholds a bash allow that an all-tools deny covers", () => {
+    expect(
+      bashRulesHonoringAllTools({
+        "*": { "rm *": "deny" },
+        bash: { "rm *": "allow", "git *": "allow" },
+      }),
+    ).toEqual({ "git *": "allow", "rm *": "deny" });
+  });
+
+  it("keeps a bash ask beside an all-tools catch-all deny", () => {
+    expect(
+      bashRulesHonoringAllTools({
+        "*": { "*": "deny" },
+        bash: { "*": "ask" },
+      }),
+    ).toEqual({ "*": "ask" });
+  });
+});
+
+describe("honorAllToolsOnBash", () => {
+  it("does not invent a bash category when none was stated", () => {
+    const permission = { "*": { "rm *": "deny" as const } };
+    expect(honorAllToolsOnBash(permission)).toBe(permission);
+  });
+});
+
+describe("resolveShellCommandLists", () => {
+  it("keeps non-command allows out of the allowlist", () => {
+    const { allow } = resolveShellCommandLists({
+      permission: {
+        read: { "secrets/**": "allow" },
+        bash: { "git *": "allow" },
+      },
+      writesAllToolsDeny: false,
+      toolLabel: "Hermes Agent",
+      surfaceLabel: "command_allowlist",
+    });
+
+    expect(allow).toEqual(["git *"]);
+  });
+
+  it("reports a foreign deny it cannot write", () => {
+    const logger = createMockLogger();
+    resolveShellCommandLists({
+      permission: { read: { ".env": "deny" }, bash: { "git *": "allow" } },
+      writesAllToolsDeny: false,
+      toolLabel: "Hermes Agent",
+      surfaceLabel: "command_allowlist",
+      logger,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("read"));
   });
 });

--- a/src/features/permissions/shell-command-categories.ts
+++ b/src/features/permissions/shell-command-categories.ts
@@ -8,6 +8,7 @@ import {
   parsedGlobsIntersect,
 } from "../../utils/glob.js";
 import { type Logger, warnWithFallback } from "../../utils/logger.js";
+import { isPrototypePollutionKey } from "../../utils/prototype-pollution.js";
 
 /** The canonical category that names a shell command's permissions. */
 export const SHELL_PERMISSION_CATEGORY = "bash";
@@ -539,9 +540,12 @@ export function resolveShellCommandLists({
 /**
  * The `bash` category after all-tools `*` restrictions have been applied. A
  * `deny`/`ask` written under `*` covers shell commands too, so a bash `allow`
- * it overlaps is withheld and a `*` deny is copied in. Bash `ask` rules stay:
- * adapters that have an ask tier write both, and command-only ones omit `ask`
- * themselves.
+ * it overlaps is withheld, a `*` deny is copied in, and a `*` ask is copied in
+ * wherever `bash` says nothing about that exact pattern yet — otherwise it
+ * would vanish from the resolved category entirely rather than falling back to
+ * a tier that still prompts. An existing `bash` entry for the same pattern is
+ * never downgraded by a `*` ask (a bash `allow` was already dropped above, and
+ * a bash `deny`/`ask` there is at least as strict already).
  */
 export function bashRulesHonoringAllTools(
   permission: PermissionsConfig["permission"],
@@ -556,8 +560,17 @@ export function bashRulesHonoringAllTools(
     }
   }
   for (const { pattern, action } of allToolsRestrictions) {
-    if (action === "deny" && bash[pattern] !== "ask") {
-      bash[pattern] = "deny";
+    if (isPrototypePollutionKey(pattern)) {
+      continue;
+    }
+    if (action === "deny") {
+      if (bash[pattern] !== "ask") {
+        bash[pattern] = "deny";
+      }
+      continue;
+    }
+    if (bash[pattern] === undefined) {
+      bash[pattern] = "ask";
     }
   }
   return bash;

--- a/src/features/permissions/shell-command-categories.ts
+++ b/src/features/permissions/shell-command-categories.ts
@@ -461,3 +461,121 @@ export function warnAboutUnwrittenCommandRules({
     );
   }
 }
+
+/** The `bash` map plus allow/deny lists after all-tools `*` restrictions apply. */
+export type ResolvedShellCommandLists = {
+  allow: string[];
+  deny: string[];
+  /**
+   * The `bash` category an adapter should write: bash `ask` rules kept, shadowed
+   * allows dropped, and — when `writesAllToolsDeny` — all-tools `*` denies copied
+   * in so a command list can enforce them.
+   */
+  bash: Record<string, PermissionAction>;
+};
+
+function resolveShellCommandState(
+  permission: PermissionsConfig["permission"],
+  writesAllToolsDeny: boolean,
+): ResolvedShellCommandLists & {
+  foreignRestrictingCategories: string[];
+  ignoredAllToolsAllowPatterns: string[];
+  shadowedAllowPatterns: string[];
+  unwrittenDenyPatterns: string[];
+  unenforcedAllToolsDenyPatterns: string[];
+  unenforcedAllToolsAskPatterns: string[];
+  intersectionBudgetExhausted: boolean;
+} {
+  const { rules, foreignRestrictingCategories, ignoredAllToolsAllowPatterns } =
+    collectShellCommandRules(permission);
+  const partitioned = partitionCommandRules({ rules, writesAllToolsDeny });
+  return {
+    allow: partitioned.allow,
+    deny: partitioned.deny,
+    bash: bashRulesHonoringAllTools(permission),
+    foreignRestrictingCategories,
+    ignoredAllToolsAllowPatterns,
+    shadowedAllowPatterns: partitioned.shadowedAllowPatterns,
+    unwrittenDenyPatterns: partitioned.unwrittenDenyPatterns,
+    unenforcedAllToolsDenyPatterns: partitioned.unenforcedAllToolsDenyPatterns,
+    unenforcedAllToolsAskPatterns: partitioned.unenforcedAllToolsAskPatterns,
+    intersectionBudgetExhausted: partitioned.intersectionBudgetExhausted,
+  };
+}
+
+/**
+ * Collect shell-command allow/deny lists the way the command-only adapters do,
+ * and report every restriction the surface cannot carry.
+ */
+export function resolveShellCommandLists({
+  permission,
+  writesAllToolsDeny,
+  toolLabel,
+  surfaceLabel,
+  logger,
+}: {
+  permission: PermissionsConfig["permission"];
+  writesAllToolsDeny: boolean;
+  toolLabel: string;
+  surfaceLabel: string;
+  logger?: Logger;
+}): ResolvedShellCommandLists {
+  const resolved = resolveShellCommandState(permission, writesAllToolsDeny);
+  warnAboutUnwrittenCommandRules({
+    toolLabel,
+    surfaceLabel,
+    foreignRestrictingCategories: resolved.foreignRestrictingCategories,
+    shadowedAllowPatterns: resolved.shadowedAllowPatterns,
+    unwrittenDenyPatterns: resolved.unwrittenDenyPatterns,
+    unenforcedAllToolsDenyPatterns: resolved.unenforcedAllToolsDenyPatterns,
+    unenforcedAllToolsAskPatterns: resolved.unenforcedAllToolsAskPatterns,
+    ignoredAllToolsAllowPatterns: resolved.ignoredAllToolsAllowPatterns,
+    intersectionBudgetExhausted: resolved.intersectionBudgetExhausted,
+    logger,
+  });
+  return { allow: resolved.allow, deny: resolved.deny, bash: resolved.bash };
+}
+
+/**
+ * The `bash` category after all-tools `*` restrictions have been applied. A
+ * `deny`/`ask` written under `*` covers shell commands too, so a bash `allow`
+ * it overlaps is withheld and a `*` deny is copied in. Bash `ask` rules stay:
+ * adapters that have an ask tier write both, and command-only ones omit `ask`
+ * themselves.
+ */
+export function bashRulesHonoringAllTools(
+  permission: PermissionsConfig["permission"],
+): Record<string, PermissionAction> {
+  const { rules } = collectShellCommandRules(permission);
+  const allToolsRestrictions = rules.filter(({ fromAllToolsCategory }) => fromAllToolsCategory);
+  const shadowingRestrictions = createShadowingRestrictionsTest(allToolsRestrictions);
+  const bash: Record<string, PermissionAction> = { ...permission.bash };
+  for (const [pattern, action] of Object.entries(bash)) {
+    if (action === "allow" && shadowingRestrictions(pattern).length > 0) {
+      delete bash[pattern];
+    }
+  }
+  for (const { pattern, action } of allToolsRestrictions) {
+    if (action === "deny" && bash[pattern] !== "ask") {
+      bash[pattern] = "deny";
+    }
+  }
+  return bash;
+}
+
+/**
+ * Return a permission block whose `bash` category honors all-tools `*`
+ * restrictions. Other categories are unchanged, so adapters that already model
+ * `*` keep doing so.
+ */
+export function honorAllToolsOnBash(
+  permission: PermissionsConfig["permission"],
+): PermissionsConfig["permission"] {
+  // Do not invent a `bash` category. Adapters that already model `*` as a
+  // tool-wide default (Zed, Rovo, OpenCode) would otherwise grow a redundant
+  // bash deny that pollutes import.
+  if (permission.bash === undefined) {
+    return permission;
+  }
+  return { ...permission, bash: bashRulesHonoringAllTools(permission) };
+}

--- a/src/features/permissions/vibe-permissions.ts
+++ b/src/features/permissions/vibe-permissions.ts
@@ -15,6 +15,7 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import { fallbackLogger, type Logger } from "../../utils/logger.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -206,7 +207,7 @@ export class VibePermissions extends ToolPermissions {
     const existingContent = (await readFileContentOrNull(filePath)) ?? "";
     const config = parseVibeConfig(existingContent);
 
-    const permission = rulesyncPermissions.getJson().permission;
+    const permission = honorAllToolsOnBash(rulesyncPermissions.getJson().permission);
     const vibeOverride = rulesyncPermissions.getJson().vibe;
 
     const tools = toVibeToolsRecord(config.tools);

--- a/src/features/permissions/zed-permissions.test.ts
+++ b/src/features/permissions/zed-permissions.test.ts
@@ -279,6 +279,39 @@ describe("ZedPermissions", () => {
       expect(tools.terminal.always_deny).toEqual([{ pattern: "rm *", case_sensitive: false }]);
     });
 
+    it("should not warn that an all-tools deny was dropped once it lands in the bash denylist", async () => {
+      // Regression: the pattern really is enforced (asserted above via
+      // `always_deny`), so warning that it was "dropped" would be wrong.
+      const warn = vi.fn();
+      const permissions = await ZedPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: createRulesyncPermissions({
+          "*": { "rm *": "deny" },
+          bash: { "rm *": "allow", "git *": "allow" },
+        }),
+        logger: { warn } as unknown as Logger,
+      });
+
+      JSON.parse(permissions.getFileContent());
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("rm *"));
+    });
+
+    it("should carry an all-tools ask into the bash confirm list when bash says nothing about that pattern", async () => {
+      const warn = vi.fn();
+      const permissions = await ZedPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: createRulesyncPermissions({
+          "*": { "rm *": "ask" },
+          bash: { "git *": "allow" },
+        }),
+        logger: { warn } as unknown as Logger,
+      });
+
+      const tools = JSON.parse(permissions.getFileContent()).agent.tool_permissions.tools;
+      expect(tools.terminal.always_confirm).toEqual([{ pattern: "rm *", case_sensitive: false }]);
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("rm *"));
+    });
+
     it("should replace the stale tools['*'] entry older versions wrote for the * category", async () => {
       await writeFileContent(
         join(testDir, ".zed", "settings.json"),

--- a/src/features/permissions/zed-permissions.test.ts
+++ b/src/features/permissions/zed-permissions.test.ts
@@ -265,6 +265,20 @@ describe("ZedPermissions", () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('pattern "src/**"'));
     });
 
+    it("should not auto-approve a bash allow that an all-tools deny covers", async () => {
+      const permissions = await ZedPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: createRulesyncPermissions({
+          "*": { "rm *": "deny" },
+          bash: { "rm *": "allow", "git *": "allow" },
+        }),
+      });
+
+      const tools = JSON.parse(permissions.getFileContent()).agent.tool_permissions.tools;
+      expect(tools.terminal.always_allow).toEqual([{ pattern: "git *", case_sensitive: false }]);
+      expect(tools.terminal.always_deny).toEqual([{ pattern: "rm *", case_sensitive: false }]);
+    });
+
     it("should replace the stale tools['*'] entry older versions wrote for the * category", async () => {
       await writeFileContent(
         join(testDir, ".zed", "settings.json"),

--- a/src/features/permissions/zed-permissions.ts
+++ b/src/features/permissions/zed-permissions.ts
@@ -16,6 +16,7 @@ import { readFileContentOrNull } from "../../utils/file.js";
 import { isPlainObject } from "../../utils/type-guards.js";
 import { applySharedConfigPatch, sharedConfigFileKey } from "../shared/shared-config-gateway.js";
 import { RulesyncPermissions } from "./rulesync-permissions.js";
+import { honorAllToolsOnBash } from "./shell-command-categories.js";
 import {
   ToolPermissions,
   type ToolPermissionsForDeletionParams,
@@ -499,7 +500,7 @@ export class ZedPermissions extends ToolPermissions {
     const existingTools = asRecord(toolPermissions.tools);
 
     const { managedDefault, managedTools, excludedCategories, inertMcpCategories } =
-      buildZedToolPermissions({ permission: config.permission, logger });
+      buildZedToolPermissions({ permission: honorAllToolsOnBash(config.permission), logger });
 
     if (excludedCategories.length > 0) {
       logger?.warn(

--- a/src/features/permissions/zed-permissions.ts
+++ b/src/features/permissions/zed-permissions.ts
@@ -277,6 +277,12 @@ function buildZedToolPermissions({
       for (const [pattern, action] of Object.entries(rules)) {
         if (pattern === "*") {
           managedDefault = CANONICAL_TO_ZED_ACTION[action];
+        } else if (permission.bash?.[pattern] === "deny" || permission.bash?.[pattern] === "ask") {
+          // `honorAllToolsOnBash` already folded this restriction into `bash`
+          // (it names a command that overlapped or was carried over verbatim),
+          // so it is enforced there via the `terminal` tool's own deny/confirm
+          // list rather than dropped.
+          continue;
         } else {
           logger?.warn(
             `Zed permissions: dropping the "*" category rule for pattern "${pattern}" — Zed's global tool-permission default takes no patterns; scope the rule to a tool category instead.`,


### PR DESCRIPTION
Fixes #2831

## What this does

Command-capable adapters now honor the all-tools `*` category when building their shell command lists, instead of silently dropping it:

- New helpers alongside `collectShellCommandRules`: `honorAllToolsOnBash`, `bashRulesHonoringAllTools`, `resolveShellCommandLists`.
- Command adapters (Cursor, Codex CLI, Roo, Zed, OpenCode, Kiro, and the rest) route through those helpers, so a `*` deny/ask correctly shadows overlapping `bash` allows.
- Roo Code now emits a skip warning for categories it cannot express, rather than dropping them without a trace.

Out of scope: #2830.

## Note on #2829

This branch originally also carried a Hermes allowlist fix for #2829. While it was in review, #2903 landed upstream with a more complete implementation (including import round-trip handling for withheld `bash` allows), so I rebased onto `main` and took the upstream version for the four overlapping files (`hermesagent-permissions.ts` and its test, `docs/reference/file-formats.md`, `src/generated/docs-content.ts`). Only the #2831 work remains here, and this PR no longer claims to close #2829.

## Verification

The full local check suite passes: format check, lint, typecheck, 10728 tests across 402 files, and the docs-content / gitignore / supported-tools / cspell / secretlint content checks.

Branch is now 1 ahead / 0 behind `main`; ~+321/-18 across 22 files.
