### PR TITLE
fix(commands): resolve case-insensitive collisions across command import sources

### DIFF
--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -157,6 +157,7 @@ vi.mocked(OpenCodeCommand).forDeletion = vi.fn().mockImplementation((params) => 
   isDeletable: () => true,
   getRelativeFilePath: () => params.relativeFilePath,
 }));
+vi.mocked(OpenCodeCommand).loadAdditionalImportFiles = vi.fn().mockResolvedValue([]);
 
 // Set up static methods after mocking
 vi.mocked(RooCommand).fromFile = vi.fn();
@@ -1551,6 +1552,89 @@ describe("CommandsProcessor secondary import roots", () => {
 
     expect(loaded.map((file) => file.getRelativeFilePath())).toEqual([join("git", "commit.md")]);
     expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Duplicate augmentcode"));
+  });
+
+  it("drops a shared-root copy that differs only in case and says which spelling won", async () => {
+    // Written back into one `.rulesync/commands/` tree, `commit.md` and
+    // `Commit.md` are a single file on macOS and Windows, so an exact-match
+    // check would let the shared-root copy overwrite the tool's own one.
+    const mockLogger = createMockLogger();
+    const actualFile =
+      await vi.importActual<typeof import("../../utils/file.js")>("../../utils/file.js");
+    vi.mocked(findFilesByGlobs).mockImplementation(actualFile.findFilesByGlobs);
+    await ensureDir(join(testDir, ".augment", "commands"));
+    await ensureDir(join(testDir, ".agents", "commands"));
+    const body = ["---", "description: Commit", "---", "", "Commit it.", ""].join("\n");
+    await writeFileContent(join(testDir, ".augment", "commands", "commit.md"), body);
+    await writeFileContent(join(testDir, ".agents", "commands", "Commit.md"), body);
+
+    const processor = new CommandsProcessor({
+      outputRoot: testDir,
+      toolTarget: "augmentcode",
+      logger: mockLogger,
+    });
+    const loaded = await processor.loadToolFiles();
+
+    expect(loaded.map((file) => file.getRelativeFilePath())).toEqual(["commit.md"]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Case-insensitive augmentcode command collision: "commit\.md" and "Commit\.md" .* Keeping "commit\.md" from the higher-precedence .*\.augment.*commands .* ignoring "Commit\.md"/,
+      ),
+    );
+  });
+
+  it("drops a shared-root copy whose basename differs only in case from a nested command", async () => {
+    // The flattened twin of `git/commit.md` is matched by basename; the match
+    // must fold case the same way the exact path match does.
+    const mockLogger = createMockLogger();
+    const actualFile =
+      await vi.importActual<typeof import("../../utils/file.js")>("../../utils/file.js");
+    vi.mocked(findFilesByGlobs).mockImplementation(actualFile.findFilesByGlobs);
+    await ensureDir(join(testDir, ".augment", "commands", "git"));
+    await ensureDir(join(testDir, ".agents", "commands"));
+    const body = ["---", "description: Commit", "---", "", "Commit it.", ""].join("\n");
+    await writeFileContent(join(testDir, ".augment", "commands", "git", "commit.md"), body);
+    await writeFileContent(join(testDir, ".agents", "commands", "COMMIT.md"), body);
+
+    const processor = new CommandsProcessor({
+      outputRoot: testDir,
+      toolTarget: "augmentcode",
+      logger: mockLogger,
+    });
+    const loaded = await processor.loadToolFiles();
+
+    expect(loaded.map((file) => file.getRelativeFilePath())).toEqual([join("git", "commit.md")]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Case-insensitive augmentcode command collision"),
+    );
+  });
+
+  it("reports a case-only collision inside the secondary source as same-source", async () => {
+    // OpenCode's inline `command` block can hold `Commit` and `commit` as two
+    // JSON keys; only the first can survive the write-back. JSON parsing
+    // itself is covered by opencode-command.test.ts, so this test mocks
+    // `loadAdditionalImportFiles` directly to isolate the dedupe logic below.
+    const mockLogger = createMockLogger();
+    vi.mocked(OpenCodeCommand).loadAdditionalImportFiles = vi
+      .fn()
+      .mockResolvedValue([
+        { getRelativeFilePath: () => "Commit.md" },
+        { getRelativeFilePath: () => "commit.md" },
+      ]);
+
+    const processor = new CommandsProcessor({
+      outputRoot: testDir,
+      toolTarget: "opencode",
+      logger: mockLogger,
+    });
+    const loaded = await processor.loadToolFiles();
+
+    expect(loaded.map((file) => file.getRelativeFilePath())).toEqual(["Commit.md"]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Case-insensitive opencode command collision: "Commit\.md" and "commit\.md" .* Keeping "Commit\.md" from earlier in the same source/,
+      ),
+    );
   });
 
   it("keeps a nested command from the shared root that only shares a basename", async () => {

--- a/src/features/commands/commands-processor.test.ts
+++ b/src/features/commands/commands-processor.test.ts
@@ -1615,12 +1615,10 @@ describe("CommandsProcessor secondary import roots", () => {
     // itself is covered by opencode-command.test.ts, so this test mocks
     // `loadAdditionalImportFiles` directly to isolate the dedupe logic below.
     const mockLogger = createMockLogger();
-    vi.mocked(OpenCodeCommand).loadAdditionalImportFiles = vi
-      .fn()
-      .mockResolvedValue([
-        { getRelativeFilePath: () => "Commit.md" },
-        { getRelativeFilePath: () => "commit.md" },
-      ]);
+    vi.mocked(OpenCodeCommand.loadAdditionalImportFiles).mockResolvedValueOnce([
+      { getRelativeFilePath: () => "Commit.md" } as unknown as OpenCodeCommand,
+      { getRelativeFilePath: () => "commit.md" } as unknown as OpenCodeCommand,
+    ]);
 
     const processor = new CommandsProcessor({
       outputRoot: testDir,
@@ -1634,6 +1632,39 @@ describe("CommandsProcessor secondary import roots", () => {
       expect.stringMatching(
         /Case-insensitive opencode command collision: "Commit\.md" and "commit\.md" .* Keeping "Commit\.md" from earlier in the same source/,
       ),
+    );
+  });
+
+  it("keeps a flat shared-root command that does not collide with anything", async () => {
+    // A flat command's own relative path already equals its basename, so
+    // checking a basename-matching tool's secondary candidates against both
+    // must not treat that command as colliding with itself.
+    const mockLogger = createMockLogger();
+    const actualFile =
+      await vi.importActual<typeof import("../../utils/file.js")>("../../utils/file.js");
+    vi.mocked(findFilesByGlobs).mockImplementation(actualFile.findFilesByGlobs);
+    await writeFileContent(
+      join(testDir, ".augment", "commands", "other.md"),
+      ["---", "description: Other", "---", "", "Other command.", ""].join("\n"),
+    );
+    await writeFileContent(
+      join(testDir, ".agents", "commands", "unique.md"),
+      ["---", "description: Unique", "---", "", "Unique command.", ""].join("\n"),
+    );
+
+    const processor = new CommandsProcessor({
+      outputRoot: testDir,
+      toolTarget: "augmentcode",
+      logger: mockLogger,
+    });
+    const loaded = await processor.loadToolFiles();
+
+    expect(loaded.map((file) => file.getRelativeFilePath()).toSorted()).toEqual([
+      "other.md",
+      "unique.md",
+    ]);
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("augmentcode command"),
     );
   });
 

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -22,6 +22,7 @@ import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
 import { commandsProcessorToolTargetTuple } from "../../types/tool-target-tuples.js";
 import type { ToolTarget } from "../../types/tool-targets.js";
+import { stripControlCharacters } from "../../utils/control-characters.js";
 import { formatError } from "../../utils/error.js";
 import {
   checkPathTraversal,
@@ -958,7 +959,11 @@ export class CommandsProcessor extends FeatureProcessor {
       });
       for (const command of additionalCommands) {
         const key = command.getRelativeFilePath();
-        const collision = keysOf(command, true)
+        // A flat command's own key already equals its basename, so
+        // `keysOf(command, true)` would otherwise yield the same candidate
+        // twice; claiming it once and then checking the second copy against
+        // the claim it just made would report a collision with itself.
+        const collision = [...new Set(keysOf(command, true))]
           .map((candidate) => {
             const claimed = claimedKeys.claim({ identity: candidate, source: secondarySource });
             return claimed === null ? undefined : { candidate, claimed };
@@ -968,18 +973,18 @@ export class CommandsProcessor extends FeatureProcessor {
           const { candidate, claimed } = collision;
           if (claimed.spelling === candidate) {
             this.logger.warn(
-              `Duplicate ${this.toolTarget} command "${key}" from ${secondarySource}; ` +
-                `keeping the one already loaded.`,
+              `Duplicate ${this.toolTarget} command "${stripControlCharacters(key)}" from ` +
+                `${secondarySource}; keeping the one already loaded.`,
             );
           } else {
             // The dropped copy is not the one the user would search for by
             // name, and on a case-sensitive filesystem — where the two really
             // are separate commands — this is the only sign one was dropped.
             this.logger.warn(
-              `Case-insensitive ${this.toolTarget} command collision: "${claimed.spelling}" and ` +
-                `"${candidate}" resolve to the same command file. Keeping "${claimed.spelling}" ` +
+              `Case-insensitive ${this.toolTarget} command collision: "${stripControlCharacters(claimed.spelling)}" and ` +
+                `"${stripControlCharacters(candidate)}" resolve to the same command file. Keeping "${stripControlCharacters(claimed.spelling)}" ` +
                 `from ${claimed.source === secondarySource ? "earlier in the same source" : `the higher-precedence ${claimed.source}`} ` +
-                `and ignoring "${key}" from ${secondarySource}, which is not imported.`,
+                `and ignoring "${stripControlCharacters(key)}" from ${secondarySource}, which is not imported.`,
             );
           }
           continue;

--- a/src/features/commands/commands-processor.ts
+++ b/src/features/commands/commands-processor.ts
@@ -12,7 +12,11 @@ import {
   RULESYNC_COMMANDS_RELATIVE_DIR_PATH,
 } from "../../constants/rulesync-paths.js";
 import { AiFile } from "../../types/ai-file.js";
-import { FeatureProcessor, mergeByCaseInsensitiveIdentity } from "../../types/feature-processor.js";
+import {
+  ClaimedIdentities,
+  FeatureProcessor,
+  mergeByCaseInsensitiveIdentity,
+} from "../../types/feature-processor.js";
 import type { FlattenedCommandNaming } from "../../types/features.js";
 import { RulesyncFile } from "../../types/rulesync-file.js";
 import { ToolFile } from "../../types/tool-file.js";
@@ -933,7 +937,20 @@ export class CommandsProcessor extends FeatureProcessor {
         }
         return [key, basename(key)];
       };
-      const seen = new Set(toolCommands.flatMap((command) => keysOf(command)));
+      // Keys are compared case-insensitively: every command is written back
+      // into the one `.rulesync/commands/` tree, where `commit.md` and
+      // `Commit.md` are a single file on macOS and Windows, so a secondary
+      // copy that differs only in case would overwrite the primary one instead
+      // of yielding to it. The primary root's own keys are registered first so
+      // it keeps precedence.
+      const claimedKeys = new ClaimedIdentities();
+      const primarySource = paths.relativeDirPath;
+      const secondarySource = "a secondary source";
+      for (const command of toolCommands) {
+        for (const candidate of keysOf(command)) {
+          claimedKeys.claim({ identity: candidate, source: primarySource });
+        }
+      }
       const additionalCommands = await factory.class.loadAdditionalImportFiles({
         outputRoot: this.outputRoot,
         global: this.global,
@@ -941,15 +958,34 @@ export class CommandsProcessor extends FeatureProcessor {
       });
       for (const command of additionalCommands) {
         const key = command.getRelativeFilePath();
-        if (keysOf(command, true).some((candidate) => seen.has(candidate))) {
-          this.logger.warn(
-            `Duplicate ${this.toolTarget} command "${key}" from a secondary source; ` +
-              `keeping the one already loaded.`,
-          );
+        const collision = keysOf(command, true)
+          .map((candidate) => {
+            const claimed = claimedKeys.claim({ identity: candidate, source: secondarySource });
+            return claimed === null ? undefined : { candidate, claimed };
+          })
+          .find((hit) => hit !== undefined);
+        if (collision) {
+          const { candidate, claimed } = collision;
+          if (claimed.spelling === candidate) {
+            this.logger.warn(
+              `Duplicate ${this.toolTarget} command "${key}" from ${secondarySource}; ` +
+                `keeping the one already loaded.`,
+            );
+          } else {
+            // The dropped copy is not the one the user would search for by
+            // name, and on a case-sensitive filesystem — where the two really
+            // are separate commands — this is the only sign one was dropped.
+            this.logger.warn(
+              `Case-insensitive ${this.toolTarget} command collision: "${claimed.spelling}" and ` +
+                `"${candidate}" resolve to the same command file. Keeping "${claimed.spelling}" ` +
+                `from ${claimed.source === secondarySource ? "earlier in the same source" : `the higher-precedence ${claimed.source}`} ` +
+                `and ignoring "${key}" from ${secondarySource}, which is not imported.`,
+            );
+          }
           continue;
         }
         for (const candidate of keysOf(command)) {
-          seen.add(candidate);
+          claimedKeys.claim({ identity: candidate, source: secondarySource });
         }
         toolCommands.push(command);
       }


### PR DESCRIPTION
## Summary

`CommandsProcessor.loadToolFiles()` de-duplicated commands from a secondary import source (OpenCode's inline `command` block, or a shared root matched by basename) with an exact-match `Set<string>`, so two spellings that differ only in case (e.g. `commit.md` / `Commit.md`) both passed as distinct commands. Written back into the single `.rulesync/commands/` tree, those spellings collide on case-insensitive filesystems (macOS, Windows), so the copy written last silently overwrote the other instead of the source precedence being honored, with no warning.

This is the same class of bug as #2733, fixed for skills and subagents in PR #2738.

## Fix

Reuse `ClaimedIdentities` from `src/types/feature-processor.ts` for the secondary-source merge, exactly as suggested in the issue:

- The primary tool root's own commands claim their keys first, so they keep precedence.
- Each secondary-source candidate key (including the basename-matched flattened twin, where applicable) is claimed through the shared case-folding helper instead of a plain `Set`.
- A collision now distinguishes a same-source duplicate ("keeping the one already loaded") from a cross-source, case-insensitive collision (names which spelling won and which source it came from).
- The existing basename-matching logic (`matchAdditionalImportsByBasename`) is preserved as-is.

## Tests

Added three regression tests to `commands-processor.test.ts`:
- A shared-root copy that differs only in case from the primary tool's own command is dropped, and the warning names which spelling won.
- A shared-root copy whose basename differs only in case from a nested command is dropped via the basename-match path.
- OpenCode's inline `command` block reports a same-source, case-only collision (`Commit` / `commit`) distinctly from a cross-source one.

## Test plan

- [x] `pnpm cicheck` (format, lint, typecheck, full test suite, docs/gitignore/supported-tools drift checks, cspell, secretlint)

Closes #2741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e