### PR TITLE
fix(watch): sanitize control characters in trigger-path log output

### DIFF
--- a/src/lib/watch.test.ts
+++ b/src/lib/watch.test.ts
@@ -379,6 +379,23 @@ describe("formatTriggerPaths", () => {
       }),
     ).toBe(`${join(".rulesync", "rules", "a.md")}, ${join(".rulesync", "rules", "b.md")}`);
   });
+
+  it("strips control characters from a relative trigger path", () => {
+    expect(
+      formatTriggerPaths({
+        triggers: [join(baseDir, ".rulesync", "rules", "a\u001b[31m.md")],
+        inputRoots: [baseDir],
+      }),
+    ).toBe(join(".rulesync", "rules", "a[31m.md"));
+  });
+
+  it("strips control characters from a trigger displayed absolute", () => {
+    const outside = join("/", "sibling", "b\u001b[31m.md");
+
+    expect(formatTriggerPaths({ triggers: [outside], inputRoots: [baseDir] })).toBe(
+      join("/", "sibling", "b[31m.md"),
+    );
+  });
 });
 
 describe("watchTargets", () => {

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -2,6 +2,7 @@ import { existsSync, type FSWatcher, watch as fsWatch, statSync } from "node:fs"
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 
 import { RULESYNC_LOCAL_CONFIG_RELATIVE_FILE_PATH } from "../constants/rulesync-paths.js";
+import { stripControlCharacters } from "../utils/control-characters.js";
 
 /**
  * Trailing debounce window applied to file-system events before a regeneration
@@ -423,6 +424,11 @@ export function buildConfigFilePaths({ configFilePath }: { configFilePath: strin
  * path a caller passes explicitly — is displayed absolute, which is what
  * users expect from the "configuration file changed" message. Long bursts
  * are truncated so a `git checkout` does not flood the terminal.
+ *
+ * Trigger paths come from filesystem watch events, so a repository whose
+ * working tree holds a maliciously named file could embed control characters
+ * (e.g. ANSI escapes or bidirectional overrides) in what becomes a single
+ * terminal line; each displayed path is sanitized before joining.
  */
 export function formatTriggerPaths({
   triggers,
@@ -450,10 +456,10 @@ export function formatTriggerPaths({
         continue;
       }
 
-      return rel;
+      return stripControlCharacters(rel);
     }
 
-    return trigger;
+    return stripControlCharacters(trigger);
   });
 
   const remaining = triggers.length - displayed.length;


### PR DESCRIPTION
## Summary

`formatTriggerPaths()` renders filesystem watch-event paths directly into the `Change detected: ...` log line without sanitizing them. A file whose name (or a path segment above it) contains control characters — ANSI escapes, bidirectional overrides, etc. — created in the watched tree would let those characters reach the terminal verbatim, letting a malicious repo forge or manipulate what the log line displays.

This fixes the remaining gap from #2753. The other half of that issue's claim — that `formatError()` in `src/utils/error.ts` doesn't sanitize — is already resolved on `main` by prior commits `8b76df953` and `7c39a9520`; both the `ZodError` and generic-`Error` code paths there already run through `stripControlCharacters`/`stripControlCharactersKeepingLineFeeds`. This PR narrows scope to just the still-real `formatTriggerPaths` gap.

## Changes

- `src/lib/watch.ts`: `formatTriggerPaths()` now strips control characters from every displayed path (both the relative and the outside-every-root/absolute fallback) before joining, consistent with how the codebase already sanitizes untrusted strings elsewhere (`WarningCollection`, `formatError`, `commands-processor.ts`).
- `src/lib/watch.test.ts`: two new tests covering control-character stripping for both the relative-path and absolute-path display branches.

## Verification

Full local check suite passes: format check, lint, typecheck, 10752 tests across 402 files, and the docs-content / gitignore / supported-tools / cspell / secretlint content checks.

Closes #2753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e