### PR TITLE
fix(rules): warn when generate deactivates Junie's import-only rule roots

### DIFF
--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -97,6 +97,55 @@ describe("RulesProcessor", () => {
       expect(result[1]).toBeInstanceOf(CopilotRule);
     });
 
+    it("should warn that generating Junie's root file deactivates existing .junie/rules/*.md", async () => {
+      // Junie reads `.junie/AGENTS.md` exclusively once it exists, so the
+      // multi-file branch (`.junie/rules/*.md`) becomes unreachable the
+      // moment `generate` writes the root file. Unlike `loadToolFiles`
+      // (import), `convertRulesyncFilesToToolFiles` never scanned for this
+      // before, so a repo that only ever runs `generate` saw no warning.
+      await writeFileContent(join(testDir, ".junie", "rules", "style.md"), "# Style");
+
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "junie" });
+      const rulesyncRules = [
+        new RulesyncRule({
+          outputRoot: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { targets: ["*"], root: true },
+          body: "Shared team instructions",
+        }),
+      ];
+
+      await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+      const warning = logger.warn.mock.calls
+        .map(([message]) => String(message))
+        .find((message) => message.includes("will no longer be read"));
+      expect(warning).toBeDefined();
+      expect(warning).toContain(join(".junie", "AGENTS.md"));
+      expect(warning).toContain(join(".junie", "rules", "style.md"));
+      expect(warning).toContain("rulesync import --targets junie");
+    });
+
+    it("should not warn about deactivated import-only roots when none exist on disk", async () => {
+      const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "junie" });
+      const rulesyncRules = [
+        new RulesyncRule({
+          outputRoot: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { targets: ["*"], root: true },
+          body: "Shared team instructions",
+        }),
+      ];
+
+      await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("will no longer be read"),
+      );
+    });
+
     it("should emit a localRoot rule to .qwen/QWEN.local.md for qwencode", async () => {
       const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "qwencode" });
 

--- a/src/features/rules/rules-processor.test.ts
+++ b/src/features/rules/rules-processor.test.ts
@@ -146,6 +146,37 @@ describe("RulesProcessor", () => {
       );
     });
 
+    it("should not warn about deactivated import-only roots in Junie's global mode, since global settable paths have none", async () => {
+      // Junie's global scope writes a single `~/.junie/AGENTS.md` root file
+      // and has no multi-file `importOnlyRoots` branch at all (see
+      // `JunieRule.getSettablePaths({ global: true })`), so this generate run
+      // must never warn here even though the exact same on-disk files that
+      // trigger the warning in project mode are present.
+      await writeFileContent(join(testDir, ".junie", "rules", "style.md"), "# Style");
+
+      const processor = new RulesProcessor({
+        logger,
+        outputRoot: testDir,
+        toolTarget: "junie",
+        global: true,
+      });
+      const rulesyncRules = [
+        new RulesyncRule({
+          outputRoot: testDir,
+          relativeDirPath: RULESYNC_RULES_RELATIVE_DIR_PATH,
+          relativeFilePath: "root.md",
+          frontmatter: { targets: ["*"], root: true },
+          body: "Shared team instructions",
+        }),
+      ];
+
+      await processor.convertRulesyncFilesToToolFiles(rulesyncRules);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("will no longer be read"),
+      );
+    });
+
     it("should emit a localRoot rule to .qwen/QWEN.local.md for qwencode", async () => {
       const processor = new RulesProcessor({ logger, outputRoot: testDir, toolTarget: "qwencode" });
 

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1137,6 +1137,7 @@ export class RulesProcessor extends FeatureProcessor {
 
     const outputFiles = [...toolRules, ...extraFiles];
     this.warnForOutputPathCollisions({ outputFiles, convertedRules });
+    await this.warnForDeactivatedImportOnlyRoots({ toolRules, factory });
     return outputFiles;
   }
 
@@ -1530,6 +1531,72 @@ export class RulesProcessor extends FeatureProcessor {
       }
       seen.set(key, file);
     }
+  }
+
+  /**
+   * Warn when this generate run is about to write a root rule file that will
+   * make the tool stop reading paths it currently reads instead — Junie's
+   * `.junie/rules/*.md` and `.junie/playbook.md` become unreachable the
+   * moment `.junie/AGENTS.md` exists, since Junie reads the root file
+   * exclusively once it is present. `importOnlyRoots` with
+   * `onlyWhenRootAbsent` already models exactly this shape for import; this
+   * reuses the same declaration so the
+   * `generate` path — which never calls `loadToolFiles` and so never reached
+   * the existing import-side warning — surfaces it too. Without this, a repo
+   * that only ever runs `generate` never sees any warning: the deactivated
+   * files stay on disk, untouched and not gitignored, silently unread.
+   */
+  private async warnForDeactivatedImportOnlyRoots({
+    toolRules,
+    factory,
+  }: {
+    toolRules: ToolRule[];
+    factory: ToolRuleFactory;
+  }): Promise<void> {
+    const rootRule = toolRules.find((rule) => rule.isRoot());
+    if (!rootRule) {
+      return;
+    }
+
+    const settablePaths = factory.class.getSettablePaths({ global: this.global });
+    const importOnlyRoots =
+      "importOnlyRoots" in settablePaths ? settablePaths.importOnlyRoots : undefined;
+    if (!importOnlyRoots || importOnlyRoots.length === 0) {
+      return;
+    }
+
+    const existingPaths: string[] = [];
+    for (const importOnlyRoot of importOnlyRoots) {
+      if (importOnlyRoot.onlyWhenRootAbsent !== true) {
+        continue;
+      }
+      const matchedPaths = await findFilesByGlobs(
+        rootRelativeGlob(
+          importOnlyRoot.relativeDirPath,
+          importOnlyRoot.relativeFilePath ?? `*.${factory.meta.extension}`,
+        ),
+        { cwd: this.outputRoot, type: "file" },
+      );
+      existingPaths.push(...matchedPaths);
+    }
+
+    if (existingPaths.length === 0) {
+      return;
+    }
+
+    const rootFilePath = join(
+      this.outputRoot,
+      rootRule.getRelativeDirPath(),
+      rootRule.getRelativeFilePath(),
+    );
+    const names = existingPaths.map((filePath) =>
+      stripControlCharacters(relative(this.outputRoot, filePath)),
+    );
+    const listedNames = names.slice(0, MAX_LISTED_SKIPPED_IMPORT_ONLY_PATHS);
+    const remainingCount = names.length - listedNames.length;
+    this.logger.warn(
+      `Writing ${stripControlCharacters(relative(this.outputRoot, rootFilePath))} for ${this.toolTarget} means ${listedNames.join(", ")}${remainingCount > 0 ? ` and ${remainingCount} more` : ""} will no longer be read. Run \`rulesync import --targets ${this.toolTarget}\` first to carry that content into ${RULESYNC_RULES_RELATIVE_DIR_PATH}, or delete ${listedNames.length === 1 ? "it" : "them"} once you have checked the content is already in the root file.`,
+    );
   }
 
   /**

--- a/src/features/rules/rules-processor.ts
+++ b/src/features/rules/rules-processor.ts
@@ -1584,8 +1584,7 @@ export class RulesProcessor extends FeatureProcessor {
       return;
     }
 
-    const rootFilePath = join(
-      this.outputRoot,
+    const rootFileRelativePath = join(
       rootRule.getRelativeDirPath(),
       rootRule.getRelativeFilePath(),
     );
@@ -1595,7 +1594,7 @@ export class RulesProcessor extends FeatureProcessor {
     const listedNames = names.slice(0, MAX_LISTED_SKIPPED_IMPORT_ONLY_PATHS);
     const remainingCount = names.length - listedNames.length;
     this.logger.warn(
-      `Writing ${stripControlCharacters(relative(this.outputRoot, rootFilePath))} for ${this.toolTarget} means ${listedNames.join(", ")}${remainingCount > 0 ? ` and ${remainingCount} more` : ""} will no longer be read. Run \`rulesync import --targets ${this.toolTarget}\` first to carry that content into ${RULESYNC_RULES_RELATIVE_DIR_PATH}, or delete ${listedNames.length === 1 ? "it" : "them"} once you have checked the content is already in the root file.`,
+      `Writing ${stripControlCharacters(rootFileRelativePath)} for ${this.toolTarget} means ${listedNames.join(", ")}${remainingCount > 0 ? ` and ${remainingCount} more` : ""} will no longer be read. Run \`rulesync import --targets ${this.toolTarget}\` first to carry that content into ${RULESYNC_RULES_RELATIVE_DIR_PATH}, or delete ${listedNames.length === 1 ? "it" : "them"} once you have checked the content is already in the root file.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- `rulesync generate --targets junie` writes `.junie/AGENTS.md`. Junie reads that file exclusively once it exists, so the multi-file branch (`.junie/rules/*.md`, `.junie/playbook.md`) becomes unreachable with no warning and no visible change.
- The import side already handles this: `RulesProcessor.loadToolFiles()` checks `importOnlyRoots` with `onlyWhenRootAbsent` and warns when those paths exist alongside a root file. `generate` calls `convertRulesyncFilesToToolFiles()`, which never reached that check, so a repo that only ever runs `generate` never saw the warning.
- Added `warnForDeactivatedImportOnlyRoots()`, reusing the same `importOnlyRoots` declaration used on import, and call it from `convertRulesyncFilesToToolFiles()` whenever a root rule is about to be written. It warns once per generate run, naming the paths that will stop being read and pointing at `rulesync import --targets <tool>` as the way to carry the content over first.

## Testing

- `pnpm cicheck`
- Added two tests: one confirming the warning fires and names the deactivated `.junie/rules/*.md` file, and one confirming no warning fires when no import-only paths exist on disk.

Closes #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e