### PR TITLE
fix(skills): stop rejecting packaging metadata shapes tools tolerate

### DIFF
--- a/src/features/skills/deepagents-skill.test.ts
+++ b/src/features/skills/deepagents-skill.test.ts
@@ -99,6 +99,39 @@ Do the thing.`;
       expect(skill.getFrontmatter().name).toBe("My Skill");
       expect(skill.getFrontmatter().description).toBe("A useful skill.");
     });
+
+    it("should import the packaging metadata in the shapes YAML actually produces", async () => {
+      const skillDir = join(testDir, ".deepagents", "skills", "packaged-skill");
+      // dcode never hard-fails on these fields: it coerces with `str()`,
+      // truncates an overlong `compatibility`, and drops non-dict `metadata`
+      // with a warning, so none of them may fail the import of a SKILL.md it
+      // happily loads.
+      const skillContent = `---
+name: packaged-skill
+description: A skill shared through a catalog
+license: MIT
+compatibility:
+  - deepagents
+  - claude-code
+metadata: platform-team
+---
+
+Packaged body`;
+      await writeFileContent(join(skillDir, SKILL_FILE_NAME), skillContent);
+
+      const skill = await DeepagentsSkill.fromDir({
+        outputRoot: testDir,
+        dirName: "packaged-skill",
+        global: false,
+      });
+
+      const section = skill.toRulesyncSkill().getFrontmatter().deepagents;
+      expect(section).toEqual({
+        license: "MIT",
+        compatibility: ["deepagents", "claude-code"],
+        metadata: "platform-team",
+      });
+    });
   });
 
   describe("fromRulesyncSkill", () => {

--- a/src/features/skills/deepagents-skill.ts
+++ b/src/features/skills/deepagents-skill.ts
@@ -28,14 +28,17 @@ const DeepagentsSkillFrontmatterSchema = z.looseObject({
   // still accepted here for tolerant parsing of hand-written files, but on emit
   // rulesync always writes the space-delimited string form.
   "allowed-tools": z.optional(z.union([z.string(), z.array(z.string())])),
-  // Agent Skills spec fields read by dcode's `_parse_skill_metadata`.
-  // https://agentskills.io/specification
-  license: z.optional(z.string()),
-  // The Agent Skills spec defines `compatibility` as a free-form string
-  // (1–500 chars), which is what dcode actually reads; an object form is also
-  // tolerated for backward compatibility (matches the `agentsskills` adapter).
-  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-  metadata: z.optional(z.looseObject({})),
+  // dcode's `_parse_skill_metadata` reads `license`, `compatibility`, and
+  // `metadata` (see langchain-ai/deepagents
+  // libs/deepagents/deepagents/middleware/skills.py), but it never hard-fails
+  // on an unexpected shape: values are coerced with `str()`, an overlong
+  // `compatibility` is truncated with a logged warning, and non-dict
+  // `metadata` is replaced with `{}` and a logged warning via
+  // `_validate_metadata`. Left untyped so rulesync never aborts on a value
+  // the underlying tool itself tolerates.
+  license: z.optional(z.unknown()),
+  compatibility: z.optional(z.unknown()),
+  metadata: z.optional(z.unknown()),
 });
 
 export type DeepagentsSkillFrontmatter = z.infer<typeof DeepagentsSkillFrontmatterSchema>;

--- a/src/features/skills/kilo-skill.test.ts
+++ b/src/features/skills/kilo-skill.test.ts
@@ -386,5 +386,17 @@ It can be multiline.`;
       const result = KiloSkillFrontmatterSchema.safeParse(validFrontmatter);
       expect(result.success).toBe(true);
     });
+
+    it("should accept packaging metadata shapes a typed schema would reject", () => {
+      const result = KiloSkillFrontmatterSchema.safeParse({
+        name: "Test Skill",
+        description: "Test description",
+        license: 2024,
+        compatibility: ["kilo", "claude-code"],
+        metadata: "platform-team",
+      });
+
+      expect(result.success).toBe(true);
+    });
   });
 });

--- a/src/features/skills/kilo-skill.ts
+++ b/src/features/skills/kilo-skill.ts
@@ -20,13 +20,16 @@ import {
 export const KiloSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
-  // Kilo's official SKILL.md frontmatter: `name`, `description`, `license`,
-  // `compatibility`, and `metadata`. https://kilo.ai/docs/customize/skills
-  license: z.optional(z.string()),
-  // `compatibility` is a free-form string per the Agent Skills spec; the
-  // object form is kept for back-compat with existing rulesync skill files.
-  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-  metadata: z.optional(z.looseObject({})),
+  // Kilo Code documents `name`, `description`, `license`, `compatibility`,
+  // and `metadata` (https://kilo.ai/docs/customize/skills), but its SKILL.md
+  // parser is forked from OpenCode's engine, whose `Frontmatter` schema
+  // (`packages/core/src/skill.ts` in Kilo-Org/kilocode) does not model
+  // `license`, `compatibility`, or `metadata` at all, so it cannot reject any
+  // shape rulesync writes for them. Left untyped so rulesync never aborts on
+  // a value the underlying tool itself tolerates.
+  license: z.optional(z.unknown()),
+  compatibility: z.optional(z.unknown()),
+  metadata: z.optional(z.unknown()),
   // `allowed-tools` is NOT recognized by Kilo; it is retained for backward
   // compatibility with existing rulesync skill files.
   "allowed-tools": z.optional(z.array(z.string())),

--- a/src/features/skills/kiro-skill.test.ts
+++ b/src/features/skills/kiro-skill.test.ts
@@ -90,6 +90,25 @@ describe("KiroSkill", () => {
       expect(kiroSkill.getBody()).toBe("Test body");
     });
 
+    it("should emit name and description before the kiro section's own keys", () => {
+      const rulesyncSkill = new RulesyncSkill({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_SKILLS_RELATIVE_DIR_PATH,
+        dirName: "field-order",
+        frontmatter: {
+          name: "field-order",
+          description: "The kiro section must not push name/description to the end",
+          kiro: {
+            compatibility: "Requires jq",
+          },
+        },
+        body: "Body",
+      });
+
+      const frontmatter = KiroSkill.fromRulesyncSkill({ rulesyncSkill }).getFrontmatter();
+      expect(Object.keys(frontmatter).slice(0, 2)).toEqual(["name", "description"]);
+    });
+
     it("should fall back to the root-level license/compatibility/metadata when the kiro section omits them", () => {
       const rulesyncSkill = new RulesyncSkill({
         outputRoot: testDir,

--- a/src/features/skills/kiro-skill.ts
+++ b/src/features/skills/kiro-skill.ts
@@ -176,12 +176,11 @@ export class KiroSkill extends ToolSkill {
       section: kiroSection,
     });
 
+    const { name: _sectionName, description: _sectionDescription, ...section } = kiroSection ?? {};
     const kiroFrontmatter: KiroSkillFrontmatter = {
-      // The section is written first so the canonical `name`/`description`
-      // still own their keys.
-      ...kiroSection,
       name: rulesyncFrontmatter.name,
       description: rulesyncFrontmatter.description,
+      ...section,
       ...(license !== undefined && { license }),
       ...(compatibility !== undefined && { compatibility }),
       ...(metadata !== undefined && { metadata }),

--- a/src/features/skills/opencode-skill.test.ts
+++ b/src/features/skills/opencode-skill.test.ts
@@ -498,6 +498,18 @@ Body content.`;
       const result = OpenCodeSkillFrontmatterSchema.safeParse(validFrontmatter);
       expect(result.success).toBe(true);
     });
+
+    it("should accept packaging metadata shapes a typed schema would reject", () => {
+      const result = OpenCodeSkillFrontmatterSchema.safeParse({
+        name: "Test Skill",
+        description: "Test description",
+        license: 2024,
+        compatibility: ["opencode", "claude-code"],
+        metadata: "platform-team",
+      });
+
+      expect(result.success).toBe(true);
+    });
   });
   describe("getConfiguredImportRoots", () => {
     it("returns the skills.paths entries opencode.json configures", async () => {

--- a/src/features/skills/opencode-skill.ts
+++ b/src/features/skills/opencode-skill.ts
@@ -27,16 +27,15 @@ import {
 export const OpenCodeSkillFrontmatterSchema = z.looseObject({
   name: z.string(),
   description: z.string(),
-  // OpenCode's SKILL.md parser recognizes exactly five frontmatter fields:
-  // `name`, `description`, `license`, `compatibility`, and `metadata`.
-  // See https://opencode.ai/docs/skills.md
-  license: z.optional(z.string()),
-  // OpenCode documents `compatibility` as a free-form string (e.g.
-  // `compatibility: opencode`, see https://opencode.ai/docs/skills/ ). The
-  // object form is also tolerated for backward compatibility with skills that
-  // model it as a per-tool version-constraint map.
-  compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-  metadata: z.optional(z.looseObject({})),
+  // OpenCode's docs mention `name`, `description`, `license`, `compatibility`,
+  // and `metadata` (https://opencode.ai/docs/skills/), but the actual
+  // `Frontmatter` schema it parses SKILL.md with (`packages/core/src/skill.ts`
+  // in sst/opencode) does not define `license`, `compatibility`, or
+  // `metadata` at all, so it never validates or rejects them. Left untyped so
+  // rulesync never aborts on a value the underlying tool itself tolerates.
+  license: z.optional(z.unknown()),
+  compatibility: z.optional(z.unknown()),
+  metadata: z.optional(z.unknown()),
   // `allowed-tools` is NOT recognized by OpenCode (it is an Anthropic-spec
   // field that OpenCode silently ignores). It is kept as an optional
   // passthrough purely for lossless round-trip with the rulesync frontmatter.

--- a/src/features/skills/rulesync-skill.ts
+++ b/src/features/skills/rulesync-skill.ts
@@ -130,11 +130,14 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   opencode: z.optional(
     z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
-      license: z.optional(z.string()),
-      // OpenCode documents `compatibility` as a free-form string; the object
-      // form stays accepted for back-compat. See https://opencode.ai/docs/skills/
-      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-      metadata: z.optional(z.looseObject({})),
+      // OpenCode's actual `Frontmatter` schema (`packages/core/src/skill.ts`
+      // in sst/opencode) does not define `license`, `compatibility`, or
+      // `metadata` at all, so it never validates or rejects them. Left
+      // untyped so rulesync never aborts on a value the tool itself
+      // tolerates. See https://opencode.ai/docs/skills/
+      license: z.optional(z.unknown()),
+      compatibility: z.optional(z.unknown()),
+      metadata: z.optional(z.unknown()),
     }),
   ),
   kilo: z.optional(
@@ -142,11 +145,14 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
       // `allowed-tools` is not part of Kilo's official SKILL.md frontmatter; it is
       // retained for backward compatibility with existing rulesync skill files.
       "allowed-tools": z.optional(z.array(z.string())),
-      license: z.optional(z.string()),
-      // `compatibility` is a free-form string per the Agent Skills spec; the
-      // object form is kept for back-compat with existing rulesync skill files.
-      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-      metadata: z.optional(z.looseObject({})),
+      // Kilo Code's SKILL.md parser is forked from OpenCode's engine, whose
+      // schema does not model `license`, `compatibility`, or `metadata` at
+      // all, so it cannot reject any shape rulesync writes for them. Left
+      // untyped so rulesync never aborts on a value the tool itself
+      // tolerates.
+      license: z.optional(z.unknown()),
+      compatibility: z.optional(z.unknown()),
+      metadata: z.optional(z.unknown()),
     }),
   ),
   kiro: z.optional(
@@ -162,11 +168,15 @@ const RulesyncSkillFrontmatterSchemaInternal = z.looseObject({
   deepagents: z.optional(
     z.looseObject({
       "allowed-tools": z.optional(z.array(z.string())),
-      license: z.optional(z.string()),
-      // The Agent Skills spec defines `compatibility` as a free-form string
-      // (1–500 chars); an object form is also tolerated for back-compat.
-      compatibility: z.optional(z.union([z.string(), z.looseObject({})])),
-      metadata: z.optional(z.looseObject({})),
+      // dcode's `_parse_skill_metadata` never hard-fails on an unexpected
+      // shape for `license`, `compatibility`, or `metadata`: values are
+      // coerced with `str()`, an overlong `compatibility` is truncated with a
+      // logged warning, and non-dict `metadata` is replaced with `{}` and a
+      // logged warning. Left untyped so rulesync never aborts on a value the
+      // tool itself tolerates.
+      license: z.optional(z.unknown()),
+      compatibility: z.optional(z.unknown()),
+      metadata: z.optional(z.unknown()),
     }),
   ),
   copilot: z.optional(
@@ -403,15 +413,15 @@ export type RulesyncSkillFrontmatterInput = {
   };
   opencode?: {
     "allowed-tools"?: string[];
-    license?: string;
-    compatibility?: string | Record<string, unknown>;
-    metadata?: Record<string, unknown>;
+    license?: unknown;
+    compatibility?: unknown;
+    metadata?: unknown;
   };
   kilo?: {
     "allowed-tools"?: string[];
-    license?: string;
-    compatibility?: string | Record<string, unknown>;
-    metadata?: Record<string, unknown>;
+    license?: unknown;
+    compatibility?: unknown;
+    metadata?: unknown;
   };
   kiro?: {
     license?: string;
@@ -420,9 +430,9 @@ export type RulesyncSkillFrontmatterInput = {
   };
   deepagents?: {
     "allowed-tools"?: string[];
-    license?: string;
-    compatibility?: string | Record<string, unknown>;
-    metadata?: Record<string, unknown>;
+    license?: unknown;
+    compatibility?: unknown;
+    metadata?: unknown;
   };
   copilot?: {
     license?: string;


### PR DESCRIPTION
## Summary

PR #2748 fixed Factory Droid's packaging frontmatter fields (`license`, `compatibility`, `metadata`, `version`) by declaring them `z.optional(z.unknown())`, because Factory Droid documents these fields without pinning a type and never validates them: a strictly-typed optional field turns an otherwise-tolerated value into a hard Zod parse failure that aborts the entire `import`/`generate` run for that file.

The same three fields (`license`, `compatibility`, `metadata`) were still declared strictly for six other skill targets. This PR researches each target's own documentation and, where accessible, its actual implementation, and applies the same fix only where the evidence supports it.

## Per-target research and decisions

**Loosened to `z.optional(z.unknown())`** (in both `{tool}-skill.ts` and the matching `rulesync-skill.ts` section):

- **Kilo Code** — docs list `license`/`compatibility`/`metadata` (https://kilo.ai/docs/customize/skills), but Kilo's SKILL.md parser is forked from OpenCode's engine, and its actual `Frontmatter` schema (`packages/core/src/skill.ts` in `Kilo-Org/kilocode`, confirmed via source inspection) does not model these fields at all, so it cannot reject any shape rulesync writes.
- **OpenCode** — docs list the same three fields (https://opencode.ai/docs/skills/), but the actual `Frontmatter` schema it parses SKILL.md with (`packages/core/src/skill.ts` in `sst/opencode`, confirmed via source inspection) omits them entirely.
- **DeepAgents** — dcode's `_parse_skill_metadata` (`libs/deepagents/deepagents/middleware/skills.py` in `langchain-ai/deepagents`, read directly) never hard-fails on an unexpected shape: values are coerced with `str()`, an overlong `compatibility` is truncated with a logged warning, and non-dict `metadata` is replaced with `{}` and a logged warning.

**Left strictly typed (no change)**:

- **Kiro** (https://kiro.dev/docs/skills/) and **Rovo Dev** (https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/) are both closed-source, and both docs explicitly defer to the Agent Skills spec for these fields. The spec (https://agentskills.io/specification) itself pins `compatibility` to a free-form string of 1-500 characters and `metadata` to a string-to-string map — contrary to the issue's premise that "the specs behind them do not define a type either," the spec does define types for these two fields. With no implementation access and no evidence of runtime leniency, these stay strict.
- **agentsskills** is the reference implementation of the Agent Skills spec itself. It already handles nonconforming input via its own warn-and-continue `collectAgentSkillViolations` mechanism rather than via Zod strictness, so it needs no change here.

## Deferred: blanket warn-and-passthrough policy

The issue's second question — whether *any* declared-field validation failure should degrade to a warning plus passthrough as a general policy, rather than deciding field-by-field — is intentionally **not** addressed in this PR. That's a separate, larger design decision for the maintainer, mirroring how PR #2748 deferred its own second gap to issue #2749.

## Also fixed: Kiro frontmatter key order

`KiroSkill.fromRulesyncSkill` spread the `kiro` section before `name`/`description`, so a `kiro` section with any of its own keys pushed `name`/`description` to the end of the emitted frontmatter — unlike every sibling adapter (e.g. `FactorydroidSkill.fromRulesyncSkill`), which always emits `name`/`description` first. Fixed by destructuring `name`/`description` out of the section before building the frontmatter object, matching the established pattern.

## Test plan

- [x] Added a schema round-trip test to `kilo-skill.test.ts` and `opencode-skill.test.ts` proving a previously-rejected shape (numeric `license`, array `compatibility`, scalar `metadata`) now parses.
- [x] Added a `fromDir` test to `deepagents-skill.test.ts` proving the same previously-rejected shapes now import successfully.
- [x] Added a new test to `kiro-skill.test.ts` asserting `name`/`description` are always the first two emitted frontmatter keys, even when the `kiro` section defines other keys.
- [x] `pnpm cicheck` passes (402 test files, 10754 tests; format, lint, typecheck, docs sync, gitignore, supported-tools tables, cspell, secretlint all clean).

Closes #2750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
