### PR TITLE
fix(orphan-sweep): case-fold path identity before classifying orphans

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -332,6 +332,7 @@
     "pkgjs",
     "POWERLEVEL",
     "powerline",
+    "precomposed",
     "procps",
     "projectbrief",
     "pycache",

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -210,6 +210,24 @@ describe("DirFeatureProcessor", () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
+    it("should not treat a case-only rename as an orphan", async () => {
+      const processor = new TestDirProcessor({
+        logger: createMockLogger(),
+        outputRoot: "/path/to",
+      });
+
+      // On a case-insensitive filesystem, renaming `my-skill` to `My-Skill`
+      // writes the generated directory over the existing one, so the existing
+      // path here is not actually a leftover from the old spelling.
+      const existingDirs = [createMockDir({ dirPath: "/path/to/my-skill" })];
+      const generatedDirs = [createMockDir({ dirPath: "/path/to/My-Skill" })];
+
+      const count = await processor.removeOrphanAiDirs(existingDirs, generatedDirs);
+
+      expect(count).toBe(0);
+      expect(removeDirectory).not.toHaveBeenCalled();
+    });
+
     it("should strip control characters from the deletion log", async () => {
       const logger = createMockLogger();
       const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });

--- a/src/types/dir-feature-processor.test.ts
+++ b/src/types/dir-feature-processor.test.ts
@@ -902,6 +902,44 @@ describe("DirFeatureProcessor", () => {
       );
     });
 
+    it("should treat the composed and decomposed spelling of an accented name as the same file", async () => {
+      // Most Linux filesystems store whichever byte sequence they were given
+      // and never normalize it, so a source that writes the decomposed form
+      // (`e` + a combining acute accent) reads back a name that never exactly
+      // matches the composed form (`\u00e9`) rulesync generated -- even though
+      // macOS resolves both to a single file, which is exactly what
+      // `caseFoldIdentity`'s NFC pass folds them onto here too.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: testDir });
+      const dirPath = join(testDir, "demo");
+      // "e" (U+0065) plus a combining acute accent (U+0301): the decomposed spelling.
+      const decomposedName = "cafe\u0301.md";
+      await writeFiles(dirPath, [decomposedName]);
+
+      const count = await processor.removeOrphanFilesInAiDirs({
+        generatedDirs: [
+          createMockDirWithFiles({
+            dirPath,
+            mainFileBody: "body",
+            otherFiles: [
+              {
+                // The same name spelled with the precomposed "\u00e9" (U+00E9).
+                relativeFilePathToDirPath: "caf\u00e9.md",
+                fileBuffer: Buffer.from("content"),
+              } as unknown as AiDirFile,
+            ],
+          }),
+        ],
+        isClaimed: () => false,
+      });
+
+      expect(count).toBe(0);
+      expect(removeFile).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("differs from it only in case"),
+      );
+    });
+
     it("should report a candidate that owns no tree and is not a shared root either", async () => {
       // A `getDirPath()` override out of agreement with `ownsDirTree()`. The
       // directory sweep reports that shape rather than passing it over, and so
@@ -1055,6 +1093,32 @@ describe("DirFeatureProcessor", () => {
 
       expect(count).toBe(1);
       expect(removeFile).toHaveBeenCalledExactlyOnceWith(join(root, "stale.md"));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("differs from it only in case"),
+      );
+    });
+
+    it("should treat the composed and decomposed spelling of an accented name as the same file", async () => {
+      // Most Linux filesystems store whichever byte sequence they were given
+      // and never normalize it, so a source that writes the decomposed form
+      // (`e` + a combining acute accent) reads back a name that never exactly
+      // matches the composed form rulesync generated -- even though macOS
+      // resolves both to a single file, which is exactly what
+      // `caseFoldIdentity`'s NFC pass folds them onto here too.
+      const logger = createMockLogger();
+      const processor = new TestDirProcessor({ logger, outputRoot: "/path/to" });
+
+      const count = await processor.removeOrphanFlatFiles({
+        existingFlatFiles: [
+          // "e" (U+0065) plus a combining acute accent (U+0301): the decomposed spelling.
+          createMockFlatDir({ root, fileName: "cafe\u0301.md" }),
+        ],
+        // The same name spelled with the precomposed "\u00e9" (U+00E9).
+        generatedDirs: [createMockFlatDir({ root, fileName: "caf\u00e9.md" })],
+      });
+
+      expect(count).toBe(0);
+      expect(removeFile).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("differs from it only in case"),
       );

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -28,6 +28,7 @@ import { type Logger, warnOnceWithFallback } from "../utils/logger.js";
 import type { WriteResult } from "../utils/result.js";
 import { hasIncompleteCarriedFiles } from "../utils/warned-once.js";
 import { AiDir, AiDirFile } from "./ai-dir.js";
+import { caseFoldIdentity } from "./feature-processor.js";
 import { RulesyncSourceConsumer } from "./rulesync-source-consumer.js";
 import { ToolTarget } from "./tool-targets.js";
 
@@ -281,7 +282,11 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
    * This only deletes directories that are no longer in the rulesync source, not directories that will be overwritten.
    */
   async removeOrphanAiDirs(existingDirs: AiDir[], generatedDirs: AiDir[]): Promise<number> {
-    const generatedPaths = new Set(generatedDirs.map((d) => d.getDirPath()));
+    // Case-folded for the same reason as `removeOrphanAiFiles`: on a
+    // case-insensitive filesystem, renaming a directory only by case still
+    // writes into the existing directory, and comparing paths exactly would
+    // otherwise classify it as an orphan and delete what was just generated.
+    const generatedPaths = new Set(generatedDirs.map((d) => caseFoldIdentity(d.getDirPath())));
     // A set, so two candidates that report the same directory delete it once
     // and are counted once.
     const orphanPaths = new Set<string>();
@@ -351,7 +356,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
         continue;
       }
 
-      if (!generatedPaths.has(dirPath)) {
+      if (!generatedPaths.has(caseFoldIdentity(dirPath))) {
         orphanPaths.add(dirPath);
       }
     }

--- a/src/types/dir-feature-processor.ts
+++ b/src/types/dir-feature-processor.ts
@@ -515,7 +515,9 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       // renamed from `Ref.md` to `ref.md` is written through the directory
       // entry that is still spelled `Ref.md`, and the name read back would
       // otherwise match nothing this run wrote and be swept as an orphan.
-      const generatedNamesFolded = new Set([...generatedNames].map((name) => name.toLowerCase()));
+      const generatedNamesFolded = new Set(
+        [...generatedNames].map((name) => caseFoldIdentity(name)),
+      );
 
       // A subdirectory this run cannot read is refused the same way as the
       // rest, not thrown: every file has been written by now, and a sweep is
@@ -539,7 +541,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
           continue;
         }
         const filePath = join(dirPath, existingName);
-        if (generatedNamesFolded.has(posixName.toLowerCase())) {
+        if (generatedNamesFolded.has(caseFoldIdentity(posixName))) {
           // Reported rather than skipped in silence, as the flat-file sweep
           // reports it: on a case-sensitive filesystem the two names really are
           // two files, and the one this run did not write is stale — exactly
@@ -639,7 +641,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
     // enumeration reads back never matches the path this run wrote and the
     // file the run just produced would be swept as an orphan.
     const generatedPathsFolded = new Set(
-      [...generatedPaths].map((generatedPath) => generatedPath.toLowerCase()),
+      [...generatedPaths].map((generatedPath) => caseFoldIdentity(generatedPath)),
     );
     // A set, for the same reason the directory sweep uses one: two candidates
     // that report the same file delete it once and are counted once.
@@ -703,7 +705,7 @@ export abstract class DirFeatureProcessor extends RulesyncSourceConsumer {
       if (generatedPaths.has(filePath)) {
         continue;
       }
-      if (generatedPathsFolded.has(filePath.toLowerCase())) {
+      if (generatedPathsFolded.has(caseFoldIdentity(filePath))) {
         this.logger.warn(
           `Refusing to delete ${quotedFilePath}: this run wrote a file whose path differs from ` +
             `it only in case, which on a case-insensitive filesystem is the very file it wrote`,

--- a/src/types/feature-processor.test.ts
+++ b/src/types/feature-processor.test.ts
@@ -145,6 +145,21 @@ describe("FeatureProcessor", () => {
       expect(removeFile).not.toHaveBeenCalled();
     });
 
+    it("should not treat a case-only rename as an orphan", async () => {
+      const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
+
+      // On a case-insensitive filesystem, renaming `my-skill.md` to
+      // `My-Skill.md` writes the generated file over the existing one, so the
+      // existing path here is not actually a leftover from the old spelling.
+      const existingFiles = [createMockFile("/path/to/my-skill.md")];
+      const generatedFiles = [createMockFile("/path/to/My-Skill.md")];
+
+      const count = await processor.removeOrphanAiFiles(existingFiles, generatedFiles);
+
+      expect(count).toBe(0);
+      expect(removeFile).not.toHaveBeenCalled();
+    });
+
     it("should remove all files when generated is empty", async () => {
       const processor = new TestProcessor({ logger: createMockLogger(), outputRoot: testDir });
 

--- a/src/types/feature-processor.ts
+++ b/src/types/feature-processor.ts
@@ -155,8 +155,15 @@ export abstract class FeatureProcessor extends RulesyncSourceConsumer {
    * This only deletes files that are no longer in the rulesync source, not files that will be overwritten.
    */
   async removeOrphanAiFiles(existingFiles: AiFile[], generatedFiles: AiFile[]): Promise<number> {
-    const generatedPaths = new Set(generatedFiles.map((f) => f.getFilePath()));
-    const orphanFiles = existingFiles.filter((f) => !generatedPaths.has(f.getFilePath()));
+    // Case-folded so a rename that only changes case (e.g. `my-skill.md` ->
+    // `My-Skill.md`) is not treated as deleting one file and creating another:
+    // on a case-insensitive filesystem the write already landed on the
+    // existing path, and comparing exactly would classify it as an orphan and
+    // delete the file that was just (re)written.
+    const generatedPaths = new Set(generatedFiles.map((f) => caseFoldIdentity(f.getFilePath())));
+    const orphanFiles = existingFiles.filter(
+      (f) => !generatedPaths.has(caseFoldIdentity(f.getFilePath())),
+    );
 
     for (const aiFile of orphanFiles) {
       const filePath = aiFile.getFilePath();


### PR DESCRIPTION
## Summary

`FeatureProcessor.removeOrphanAiFiles()` and `DirFeatureProcessor.removeOrphanAiDirs()` compared existing vs. generated paths with an exact-string `Set` lookup. On a case-insensitive filesystem (macOS, Windows), renaming a rule/skill by case only (e.g. `my-skill` -> `My-Skill`) writes the generated output over the existing on-disk entry, but the exact-match comparison did not recognize the two spellings as the same identity — so the sweep classified the pre-existing spelling as an orphan and deleted the file/directory that `generate` had just (re)written.

## Fix

Both sweeps now compare `caseFoldIdentity()` of the paths instead of the raw strings, matching the case-folding + Unicode normalization already used for cross-root de-duplication in `feature-processor.ts` (added in #2738). This is a comparison-only change — the paths that are actually deleted are still the original, un-folded spellings.

## Testing

- Added a case-only-rename regression test to both `removeOrphanAiFiles` (`feature-processor.test.ts`) and `removeOrphanAiDirs` (`dir-feature-processor.test.ts`).
- `pnpm cicheck` passes in full.

Closes #2740

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
