### PR TITLE
fix(hooks): preserve undocumented AugmentCode hook keys on regenerate

### DIFF
--- a/src/features/hooks/augmentcode-hooks.test.ts
+++ b/src/features/hooks/augmentcode-hooks.test.ts
@@ -281,6 +281,54 @@ describe("AugmentcodeHooks", () => {
       expect(parsed.hooks.PreToolUse).toBeDefined();
     });
 
+    it("should preserve undocumented AugmentCode hook event keys when regenerating", async () => {
+      await ensureDir(join(testDir, ".augment"));
+      await writeFileContent(
+        join(testDir, ".augment", "settings.json"),
+        JSON.stringify({
+          hooks: {
+            afterFileEdit: [{ hookType: "command", command: "echo edited" }],
+            stop: [{ hookType: "command", command: "echo lowercase-stop" }],
+            PreToolUse: [{ matcher: "Bash", hooks: [{ hookType: "command", command: "stale" }] }],
+          },
+        }),
+      );
+
+      const config = {
+        version: 1,
+        hooks: { preToolUse: [{ command: "echo fresh" }] },
+      };
+      const rulesyncHooks = new RulesyncHooks({
+        outputRoot: testDir,
+        relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+        relativeFilePath: "hooks.json",
+        fileContent: JSON.stringify(config),
+        validate: false,
+      });
+
+      const augmentcodeHooks = await AugmentcodeHooks.fromRulesyncHooks({
+        outputRoot: testDir,
+        rulesyncHooks,
+        validate: false,
+      });
+
+      const parsed = JSON.parse(augmentcodeHooks.getFileContent());
+      // Undocumented keys not owned by rulesync's canonical model survive verbatim.
+      expect(parsed.hooks.afterFileEdit).toEqual([{ hookType: "command", command: "echo edited" }]);
+      expect(parsed.hooks.stop).toEqual([{ hookType: "command", command: "echo lowercase-stop" }]);
+      // The native, rulesync-owned key is replaced by the freshly generated hooks.
+      expect(
+        parsed.hooks.PreToolUse.some((entry: { hooks: Array<{ command: string }> }) =>
+          entry.hooks.some((hook) => hook.command === "stale"),
+        ),
+      ).toBe(false);
+      expect(
+        parsed.hooks.PreToolUse.some((entry: { hooks: Array<{ command: string }> }) =>
+          entry.hooks.some((hook) => hook.command === "echo fresh"),
+        ),
+      ).toBe(true);
+    });
+
     it("should throw a descriptive error when existing settings.json contains invalid JSON", async () => {
       await ensureDir(join(testDir, ".augment"));
       await writeFileContent(join(testDir, ".augment", "settings.json"), "invalid json {");

--- a/src/features/hooks/augmentcode-hooks.ts
+++ b/src/features/hooks/augmentcode-hooks.ts
@@ -137,6 +137,36 @@ export class AugmentcodeHooks extends ToolHooks {
     const paths = AugmentcodeHooks.getSettablePaths({ global });
     const filePath = join(outputRoot, paths.relativeDirPath, paths.relativeFilePath);
     const existingContent = (await readFileContentOrNull(filePath)) ?? JSON.stringify({}, null, 2);
+
+    // The `hooks` key is owned wholesale by this feature (see
+    // SHARED_CONFIG_OWNERSHIP for `.augment/settings.json`), so
+    // `applySharedConfigPatch` below replaces the entire object. Auggie also
+    // recognizes several undocumented event keys beyond the ones rulesync's
+    // canonical model maps to (e.g. `afterFileEdit`, lowercase `stop`) — see
+    // https://github.com/dyoshikawa/rulesync/issues/2670. Preserve any such
+    // key that isn't one rulesync itself authors, so hand-authored entries
+    // under those keys survive regeneration instead of being silently erased.
+    // Malformed existing content is left for `applySharedConfigPatch` below to
+    // reject with its own consistent parse-error message; here it is treated
+    // as having no preservable hooks.
+    let existingHooks: Record<string, unknown> = {};
+    try {
+      const parsed: unknown = JSON.parse(existingContent);
+      const candidate =
+        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>).hooks
+          : undefined;
+      if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+        existingHooks = candidate as Record<string, unknown>;
+      }
+    } catch {
+      existingHooks = {};
+    }
+    const nativeEventKeys = new Set(Object.values(CANONICAL_TO_AUGMENTCODE_EVENT_NAMES));
+    const preservedHooks = Object.fromEntries(
+      Object.entries(existingHooks).filter(([key]) => !nativeEventKeys.has(key)),
+    );
+
     const config = rulesyncHooks.getJson();
     const augmentHooks = canonicalToToolHooks({
       config,
@@ -148,7 +178,7 @@ export class AugmentcodeHooks extends ToolHooks {
       fileKey: sharedConfigFileKey(paths),
       feature: "hooks",
       existingContent,
-      patch: { hooks: augmentHooks },
+      patch: { hooks: { ...preservedHooks, ...augmentHooks } },
       filePath,
     });
     return new AugmentcodeHooks({


### PR DESCRIPTION
## Summary

`.augment/settings.json`'s `hooks` key is owned wholesale by the hooks
feature: every `generate` run replaces the entire object with only the
events rulesync's canonical model maps to (`PreToolUse`, `PostToolUse`,
`SessionStart`, `SessionEnd`, `Stop`, `Notification`, `PromptSubmit`).

Auggie (the AugmentCode CLI) also recognizes several undocumented
alternative event keys inside that same `hooks` object — e.g.
`afterFileEdit`, `beforeShellExecution`, and a lowercase `stop` distinct
from the PascalCase `Stop` — that a user may hand-author directly into
the file. Those keys were silently erased on the next `rulesync generate`,
a data-loss bug of the same class as the previously-fixed #2420.

This PR preserves any existing `hooks` key that is not one of the
native, rulesync-owned event names before applying the patch, following
the same preserve-then-patch pattern already used for `toolPermissions`
in `augmentcode-permissions.ts`.

## Scope note

This addresses the concrete data-loss bug reported in a comment on #2670.
It does **not** close #2670: the issue's own body raises a separate,
unresolved design question (whether to add a new `augmentcode-plugin`
tool target, and whether to generalize that into a shared Agent Plugins
manifest format across multiple tools). That question is left for a
maintainer decision and is out of scope here.

## Test plan

- [x] Added a regression test reproducing the data-loss scenario: an
      existing `.augment/settings.json` with `afterFileEdit` and
      lowercase `stop` keys now survives a `fromRulesyncHooks` regenerate,
      while the native `PreToolUse` key is still replaced by freshly
      generated hooks.
- [x] `pnpm cicheck` passes.

Refs #2670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
