### PR TITLE
Release v16.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.21.0",
+  "version": "16.22.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.21.0";
+const getVersion = () => "16.22.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release v16.22.0.

- Bump CLI version in src/cli/program.ts
- Bump package.json version

Release notes: see the draft GitHub release v16.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
