### PR TITLE
chore: update Homebrew formula to v16.22.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.21.0"
+  version "16.22.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "dd310c253d8b11a6ccb6f35ee1da16ff696b70587f76989a34ea1da2518fb3be"
+      sha256 "1efd1a8b6eb7b5706865c3cc34992f8faaa8688782f3680b71983c8e6cbfee3a"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "83ddf9c33254c6fa4782eb2cca79978977cafb78ae6c17f84adbce3555f1a858"
+      sha256 "70d69816ef2e2dbc9ce6e87618d9ac5a227972b157975767ad348d92bb700459"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "e0ff6c406112d30e51455da2b19d0e521babb74990bc50f70b29d0a39e70c317"
+      sha256 "2f219433782a1c66f3990787258f2bbbc4fff0b53a14d23cf0bee8f8c780b263"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "cdac2f252e25d05d3d4ccc4cf812d187e5e0d32aed83d04cee011d9d13eca0dd"
+      sha256 "0ca4b8134e4e054ed94c05f6f6ce21cfa4c0af574427fb241ca33a1750ece37e"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.22.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e
