### PR TITLE
ci(publish-assets): run repomix XML generation under Node via tsx

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -78,7 +78,9 @@ jobs:
         run: pnpm generate:schema
 
       - name: Generate repomix XML variants
-        run: bun scripts/generate-repomix-xml.ts
+        # Run under Node via tsx: repomix's tinypool worker pool crashes with
+        # "Terminating worker thread" when driven from Bun (see #2922).
+        run: pnpm exec tsx scripts/generate-repomix-xml.ts
 
       - name: Bundle XML files into zip
         run: zip repomix-xml.zip repomix-output-*.xml


### PR DESCRIPTION
## Summary

The `Generate repomix XML variants` step of the `Publish Assets` workflow ran `scripts/generate-repomix-xml.ts` with Bun, and repomix's tinypool worker pool crashes under Bun with `error: Terminating worker thread` at a random variant. The failure rate went from 1 of 2 attempts (v16.21.0) to 4 of 5 attempts (v16.22.0), so retrying is no longer a workable remedy.

This PR switches that single step to `pnpm exec tsx scripts/generate-repomix-xml.ts`, which runs the script under Node. The `security-scan` workflow already executes the same script this way, and this workflow already runs `pnpm generate:schema` (a tsx script) right before it after `bun install`, so the toolchain is in place. The binaries are still built with Bun.

Closes #2922

## Note for the maintainer

This PR edits a release workflow, so it was opened by the unattended run and intentionally left unmerged for a human to review and merge.

## Verification

- `pnpm cicheck` passes locally.
- The next `Publish Assets` run (next release, or a `workflow_dispatch`) exercises the changed step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e