### PR TITLE
fix(shared-config): bound the sanitizer walk against YAML alias bombs and cycles

### DIFF
--- a/src/features/shared/shared-config-gateway.test.ts
+++ b/src/features/shared/shared-config-gateway.test.ts
@@ -14,6 +14,9 @@ import {
   CLAUDE_SETTINGS_SHARED_FILE_KEY,
   HERMES_CONFIG_SHARED_FILE_KEY,
   isReadDenyEntry,
+  MAX_SHARED_CONFIG_DEPTH,
+  MAX_SHARED_CONFIG_STRING_CHARS,
+  MAX_SHARED_CONFIG_VALUES,
   mergeSharedConfigDeep,
   mergeSharedConfigShallow,
   parseSharedConfig,
@@ -23,6 +26,22 @@ import {
   stringifySharedConfig,
   TAKT_CONFIG_SHARED_FILE_KEY,
 } from "./shared-config-gateway.js";
+
+/**
+ * A YAML document whose `metadata` key holds `levels` nested anchors, each an
+ * array of `width` aliases to the previous one: `width ** levels` values once
+ * every alias is expanded, from a file of a few hundred bytes.
+ */
+function aliasChain(levels: number, width: number): string {
+  const names = "abcdefghijklmnopqrstuvwxyz";
+  const lines = ["metadata:"];
+  for (let i = 0; i < levels; i += 1) {
+    const items = Array.from({ length: width }, () => (i === 0 ? "x" : `*${names[i - 1]}`));
+    lines.push(`  ${names[i]}: &${names[i]} [${items.join(", ")}]`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
 
 /** The whole-document fallback warnings `logger` received, in order. */
 const wholeRewriteWarnings = (logger: ReturnType<typeof createMockLogger>): string[] =>
@@ -116,6 +135,68 @@ plugins:
       },
     });
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("refuses a YAML alias bomb instead of expanding it", () => {
+    expect(() =>
+      parseSharedConfig({
+        format: "yaml",
+        fileContent: aliasChain(6, 10),
+        filePath: ".rovodev/config.yml",
+      }),
+    ).toThrow(
+      new RegExp(
+        `^Failed to parse shared config at \\.rovodev/config\\.yml: .*Shared config expands to more than ${MAX_SHARED_CONFIG_VALUES} values`,
+      ),
+    );
+  });
+
+  it("refuses a self-referencing YAML anchor instead of overflowing the stack", () => {
+    expect(() =>
+      parseSharedConfig({ format: "yaml", fileContent: "a: &a\n  keep: 1\n  self: *a\n" }),
+    ).toThrow(/circular YAML alias/);
+    expect(() =>
+      parseSharedConfig({ format: "yaml", fileContent: "items: &a\n  - 1\n  - *a\n" }),
+    ).toThrow(/circular YAML alias/);
+  });
+
+  it("refuses a long string aliased past the character budget", () => {
+    const chunk = "x".repeat(50_000);
+    const lines = [`s: &s "${chunk}"`, "many:"];
+    for (let i = 0; i < 100; i += 1) {
+      lines.push("  - *s");
+    }
+    expect(() => parseSharedConfig({ format: "yaml", fileContent: lines.join("\n") })).toThrow(
+      `Shared config's string values expand to more than ${MAX_SHARED_CONFIG_STRING_CHARS} characters`,
+    );
+  });
+
+  it("refuses a document nested past the depth cap", () => {
+    // Each alias wraps the previous one, so the document stays tiny per
+    // level while nesting one container deeper each time.
+    const lines = ["a0: &a0 [x]"];
+    for (let i = 1; i <= MAX_SHARED_CONFIG_DEPTH + 1; i += 1) {
+      lines.push(`a${i}: &a${i} [*a${i - 1}]`);
+    }
+    expect(() => parseSharedConfig({ format: "yaml", fileContent: lines.join("\n") })).toThrow(
+      `Shared config nests more than ${MAX_SHARED_CONFIG_DEPTH} levels deep`,
+    );
+  });
+
+  it("keeps a shared YAML reference that is not a cycle", () => {
+    const config = parseSharedConfig({
+      format: "yaml",
+      fileContent: "shared: &s\n  k: v\nfirst: *s\nsecond: *s\n",
+    });
+    expect(config).toEqual({ shared: { k: "v" }, first: { k: "v" }, second: { k: "v" } });
+    expect(config.first).not.toBe(config.second);
+  });
+
+  it("charges the value under a dropped pollution key so it cannot hide an alias bomb", () => {
+    const bomb = aliasChain(6, 10).replace("metadata:", "__proto__:");
+    expect(() => parseSharedConfig({ format: "yaml", fileContent: bomb })).toThrow(
+      `Shared config expands to more than ${MAX_SHARED_CONFIG_VALUES} values`,
+    );
   });
 
   it("keeps the rest of a JSONC file that states a root-level pollution key", () => {

--- a/src/features/shared/shared-config-gateway.ts
+++ b/src/features/shared/shared-config-gateway.ts
@@ -25,6 +25,7 @@ import {
 } from "../../constants/takt-paths.js";
 import type { ClaudeSettingsJson } from "../../types/claude-settings.js";
 import type { Feature } from "../../types/features.js";
+import { type BoundedWalk, createBoundedWalk } from "../../utils/bounded-walk.js";
 import { quoteForLog, stripControlCharacters } from "../../utils/control-characters.js";
 import { formatError } from "../../utils/error.js";
 import { type Logger, warnOnceWithFallback } from "../../utils/logger.js";
@@ -82,6 +83,33 @@ export type SharedConfigInvalidRootPolicy = "coerce-empty" | "error";
 export type SharedConfigJsoncParseErrorsPolicy = "tolerate" | "error";
 
 /**
+ * Upper bound on the number of values a shared config document may expand
+ * to once every YAML alias is written out. Real config files hold a few
+ * hundred values at most; even a large MCP server catalog stays orders of
+ * magnitude below the limit.
+ */
+export const MAX_SHARED_CONFIG_VALUES = 100_000;
+
+/**
+ * Upper bound on the total character count of the string leaves and keys a
+ * shared config document may expand to. The value budget bounds how many
+ * values are visited, but one long string aliased thousands of times fits
+ * that budget while the duplicated output balloons; charging every visited
+ * string's length separately bounds the output regardless of alias count.
+ */
+export const MAX_SHARED_CONFIG_STRING_CHARS = 4_000_000;
+
+/**
+ * Upper bound on how many containers deep a shared config document may nest.
+ * A chain of aliases that each wrap the previous one is deep rather than
+ * wide, so it overflows the call stack long before either budget above
+ * trips; capping depth well below that point keeps the failure a clear error.
+ * The same bounds apply to JSON, JSONC and TOML files, which have no aliases
+ * to amplify them but share the walk.
+ */
+export const MAX_SHARED_CONFIG_DEPTH = 64;
+
+/**
  * Rebuild a parsed document without its prototype-pollution keys.
  *
  * Every object is rebuilt, not just the ones that are already plain: a literal
@@ -110,98 +138,44 @@ export type SharedConfigJsoncParseErrorsPolicy = "tolerate" | "error";
  * ancestor outright, each with a clear error instead of a hang or a crash.
  */
 function sanitizeSharedConfigValue(value: unknown): unknown {
-  return sanitizeSharedConfigValueBounded(value, {
-    ancestors: new WeakSet(),
-    valuesRemaining: MAX_SHARED_CONFIG_VALUES,
-    stringCharsRemaining: MAX_SHARED_CONFIG_STRING_CHARS,
-    depth: 0,
-  });
+  return sanitizeSharedConfigValueBounded(
+    value,
+    createBoundedWalk({
+      subject: "Shared config",
+      limits: {
+        maxValues: MAX_SHARED_CONFIG_VALUES,
+        maxStringChars: MAX_SHARED_CONFIG_STRING_CHARS,
+        maxDepth: MAX_SHARED_CONFIG_DEPTH,
+      },
+    }),
+  );
 }
 
 /**
- * Upper bound on the number of values a shared config document may expand
- * to once every YAML alias is written out. Real config files hold a few
- * hundred values at most; even a large MCP server catalog stays orders of
- * magnitude below the limit.
+ * Refuse a container that is already on the descent path. Unlike the
+ * frontmatter cleaner, which drops such a cycle and keeps the rest of the
+ * document, a shared config file is refused outright: silently dropping part
+ * of a user's settings file would let a later write-back persist the loss.
  */
-export const MAX_SHARED_CONFIG_VALUES = 100_000;
-
-/**
- * Upper bound on the total character count of the string leaves and keys a
- * shared config document may expand to. The value budget bounds how many
- * values are visited, but one long string aliased thousands of times fits
- * that budget while the duplicated output balloons; charging every visited
- * string's length separately bounds the output regardless of alias count.
- */
-export const MAX_SHARED_CONFIG_STRING_CHARS = 4_000_000;
-
-/**
- * Upper bound on how many containers deep a shared config document may nest.
- * A chain of aliases that each wrap the previous one is deep rather than
- * wide, so it overflows the call stack long before either budget above
- * trips; capping depth well below that point keeps the failure a clear error.
- */
-export const MAX_SHARED_CONFIG_DEPTH = 64;
-
-const ALIAS_HINT = "(a chain of YAML aliases may be amplifying the document)";
-
-type SanitizeWalk = {
-  /**
-   * Containers on the current descent path. A reference back to one of them
-   * (a YAML anchor that aliases its own ancestor) is a cycle no output format
-   * can represent, so it is refused rather than walked until the stack
-   * overflows.
-   */
-  ancestors: WeakSet<object>;
-  valuesRemaining: number;
-  stringCharsRemaining: number;
-  depth: number;
-};
-
-function chargeSharedConfigChars(walk: SanitizeWalk, chars: number): void {
-  walk.stringCharsRemaining -= chars;
-  if (walk.stringCharsRemaining < 0) {
-    throw new Error(
-      `Shared config's string values expand to more than ${MAX_SHARED_CONFIG_STRING_CHARS} characters; refusing to process it ${ALIAS_HINT}`,
-    );
-  }
-}
-
-function enterSharedConfigContainer(walk: SanitizeWalk, container: object): void {
-  if (walk.ancestors.has(container)) {
+function enterSharedConfigContainer(walk: BoundedWalk, container: object): void {
+  if (walk.isAncestor(container)) {
     throw new Error(
       "Shared config contains a value that refers back to itself (a circular YAML alias); refusing to process it",
     );
   }
-  walk.depth += 1;
-  if (walk.depth > MAX_SHARED_CONFIG_DEPTH) {
-    throw new Error(
-      `Shared config nests more than ${MAX_SHARED_CONFIG_DEPTH} levels deep; refusing to process it ${ALIAS_HINT}`,
-    );
-  }
-  walk.ancestors.add(container);
+  walk.enter(container);
 }
 
-function leaveSharedConfigContainer(walk: SanitizeWalk, container: object): void {
-  walk.ancestors.delete(container);
-  walk.depth -= 1;
-}
-
-function sanitizeSharedConfigValueBounded(value: unknown, walk: SanitizeWalk): unknown {
-  walk.valuesRemaining -= 1;
-  if (walk.valuesRemaining < 0) {
-    throw new Error(
-      `Shared config expands to more than ${MAX_SHARED_CONFIG_VALUES} values; refusing to process it ${ALIAS_HINT}`,
-    );
-  }
+function sanitizeSharedConfigValueBounded(value: unknown, walk: BoundedWalk): unknown {
   if (typeof value === "string") {
-    chargeSharedConfigChars(walk, value.length);
+    walk.chargeValue(value.length);
     return value;
   }
+  walk.chargeValue();
   if (Array.isArray(value)) {
     enterSharedConfigContainer(walk, value);
     const items = value.map((item) => sanitizeSharedConfigValueBounded(item, walk));
-    leaveSharedConfigContainer(walk, value);
+    walk.leave(value);
     return items;
   }
   if (value === null || typeof value !== "object" || value instanceof Date) {
@@ -213,12 +187,12 @@ function sanitizeSharedConfigValueBounded(value: unknown, walk: SanitizeWalk): u
     // A mapping key can itself be an alias, so it is charged like a string
     // leaf; the value under a dropped pollution key is still walked so the
     // key cannot hide an unbudgeted alias chain.
-    chargeSharedConfigChars(walk, key.length);
+    walk.chargeChars(key.length);
     const sanitized = sanitizeSharedConfigValueBounded(nested, walk);
     if (isPrototypePollutionKey(key)) continue;
     result[key] = sanitized;
   }
-  leaveSharedConfigContainer(walk, value);
+  walk.leave(value);
   return result;
 }
 

--- a/src/features/shared/shared-config-gateway.ts
+++ b/src/features/shared/shared-config-gateway.ts
@@ -96,19 +96,129 @@ export type SharedConfigJsoncParseErrorsPolicy = "tolerate" | "error";
  *
  * Dates are the one object the YAML and TOML parsers produce that is not a
  * mapping, so they are passed through rather than flattened into `{}`.
+ *
+ * The rebuild is bounded, because a YAML alias makes one parsed container
+ * reachable from many keys and every alias is copied out independently (the
+ * writers dump with `noRefs: true`, so memoizing here would only move the
+ * blowup into serialization). A small "alias bomb" of nested anchors would
+ * otherwise cost exponential time and memory, and a self-referencing anchor
+ * would recurse until the stack overflowed — both reachable from a config
+ * file committed to a cloned repository. The walk therefore charges every
+ * value against {@link MAX_SHARED_CONFIG_VALUES}, every string and key
+ * against {@link MAX_SHARED_CONFIG_STRING_CHARS}, caps nesting at
+ * {@link MAX_SHARED_CONFIG_DEPTH}, and refuses a reference back to an
+ * ancestor outright, each with a clear error instead of a hang or a crash.
  */
 function sanitizeSharedConfigValue(value: unknown): unknown {
+  return sanitizeSharedConfigValueBounded(value, {
+    ancestors: new WeakSet(),
+    valuesRemaining: MAX_SHARED_CONFIG_VALUES,
+    stringCharsRemaining: MAX_SHARED_CONFIG_STRING_CHARS,
+    depth: 0,
+  });
+}
+
+/**
+ * Upper bound on the number of values a shared config document may expand
+ * to once every YAML alias is written out. Real config files hold a few
+ * hundred values at most; even a large MCP server catalog stays orders of
+ * magnitude below the limit.
+ */
+export const MAX_SHARED_CONFIG_VALUES = 100_000;
+
+/**
+ * Upper bound on the total character count of the string leaves and keys a
+ * shared config document may expand to. The value budget bounds how many
+ * values are visited, but one long string aliased thousands of times fits
+ * that budget while the duplicated output balloons; charging every visited
+ * string's length separately bounds the output regardless of alias count.
+ */
+export const MAX_SHARED_CONFIG_STRING_CHARS = 4_000_000;
+
+/**
+ * Upper bound on how many containers deep a shared config document may nest.
+ * A chain of aliases that each wrap the previous one is deep rather than
+ * wide, so it overflows the call stack long before either budget above
+ * trips; capping depth well below that point keeps the failure a clear error.
+ */
+export const MAX_SHARED_CONFIG_DEPTH = 64;
+
+const ALIAS_HINT = "(a chain of YAML aliases may be amplifying the document)";
+
+type SanitizeWalk = {
+  /**
+   * Containers on the current descent path. A reference back to one of them
+   * (a YAML anchor that aliases its own ancestor) is a cycle no output format
+   * can represent, so it is refused rather than walked until the stack
+   * overflows.
+   */
+  ancestors: WeakSet<object>;
+  valuesRemaining: number;
+  stringCharsRemaining: number;
+  depth: number;
+};
+
+function chargeSharedConfigChars(walk: SanitizeWalk, chars: number): void {
+  walk.stringCharsRemaining -= chars;
+  if (walk.stringCharsRemaining < 0) {
+    throw new Error(
+      `Shared config's string values expand to more than ${MAX_SHARED_CONFIG_STRING_CHARS} characters; refusing to process it ${ALIAS_HINT}`,
+    );
+  }
+}
+
+function enterSharedConfigContainer(walk: SanitizeWalk, container: object): void {
+  if (walk.ancestors.has(container)) {
+    throw new Error(
+      "Shared config contains a value that refers back to itself (a circular YAML alias); refusing to process it",
+    );
+  }
+  walk.depth += 1;
+  if (walk.depth > MAX_SHARED_CONFIG_DEPTH) {
+    throw new Error(
+      `Shared config nests more than ${MAX_SHARED_CONFIG_DEPTH} levels deep; refusing to process it ${ALIAS_HINT}`,
+    );
+  }
+  walk.ancestors.add(container);
+}
+
+function leaveSharedConfigContainer(walk: SanitizeWalk, container: object): void {
+  walk.ancestors.delete(container);
+  walk.depth -= 1;
+}
+
+function sanitizeSharedConfigValueBounded(value: unknown, walk: SanitizeWalk): unknown {
+  walk.valuesRemaining -= 1;
+  if (walk.valuesRemaining < 0) {
+    throw new Error(
+      `Shared config expands to more than ${MAX_SHARED_CONFIG_VALUES} values; refusing to process it ${ALIAS_HINT}`,
+    );
+  }
+  if (typeof value === "string") {
+    chargeSharedConfigChars(walk, value.length);
+    return value;
+  }
   if (Array.isArray(value)) {
-    return value.map(sanitizeSharedConfigValue);
+    enterSharedConfigContainer(walk, value);
+    const items = value.map((item) => sanitizeSharedConfigValueBounded(item, walk));
+    leaveSharedConfigContainer(walk, value);
+    return items;
   }
   if (value === null || typeof value !== "object" || value instanceof Date) {
     return value;
   }
+  enterSharedConfigContainer(walk, value);
   const result: SharedConfigDocument = {};
   for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    // A mapping key can itself be an alias, so it is charged like a string
+    // leaf; the value under a dropped pollution key is still walked so the
+    // key cannot hide an unbudgeted alias chain.
+    chargeSharedConfigChars(walk, key.length);
+    const sanitized = sanitizeSharedConfigValueBounded(nested, walk);
     if (isPrototypePollutionKey(key)) continue;
-    result[key] = sanitizeSharedConfigValue(nested);
+    result[key] = sanitized;
   }
+  leaveSharedConfigContainer(walk, value);
   return result;
 }
 
@@ -167,7 +277,15 @@ export function parseSharedConfig({
   // leaves the parser holding an object whose prototype is the injected value,
   // which `isPlainObject` rejects — and coercing that to `{}` would throw away
   // every setting the file visibly states next to it.
-  const sanitized = sanitizeSharedConfigValue(parsed);
+  let sanitized: unknown;
+  try {
+    sanitized = sanitizeSharedConfigValue(parsed);
+  } catch (error) {
+    // An alias bomb or circular alias is refused by the sanitizer rather than
+    // the parser, but it is still the file that is at fault, so it carries the
+    // same path prefix as a syntax error.
+    throw new Error(`Failed to parse shared config${at}: ${formatError(error)}`, { cause: error });
+  }
   if (!isPlainObject(sanitized)) {
     if (invalidRootPolicy === "error") {
       throw new Error(`Failed to parse shared config${at}: expected a mapping at the root`);

--- a/src/utils/bounded-walk.test.ts
+++ b/src/utils/bounded-walk.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { createBoundedWalk } from "./bounded-walk.js";
+
+const limits = { maxValues: 3, maxStringChars: 10, maxDepth: 2 };
+
+describe("createBoundedWalk", () => {
+  it("throws once more values are charged than the budget allows", () => {
+    const walk = createBoundedWalk({ subject: "Document", limits });
+    walk.chargeValue();
+    walk.chargeValue();
+    walk.chargeValue();
+    expect(() => walk.chargeValue()).toThrow(
+      "Document expands to more than 3 values; refusing to process it (a chain of YAML aliases may be amplifying the document)",
+    );
+  });
+
+  it("charges string leaves and keys against the character budget", () => {
+    const walk = createBoundedWalk({ subject: "Document", limits });
+    walk.chargeValue(6);
+    walk.chargeChars(4);
+    expect(() => walk.chargeChars(1)).toThrow(
+      "Document's string values expand to more than 10 characters; refusing to process it",
+    );
+  });
+
+  it("throws once the descent nests deeper than the depth cap", () => {
+    const walk = createBoundedWalk({ subject: "Document", limits });
+    walk.enter({});
+    walk.enter({});
+    expect(() => walk.enter({})).toThrow(
+      "Document nests more than 2 levels deep; refusing to process it",
+    );
+  });
+
+  it("counts the root as the first level when it is given up front", () => {
+    const root = {};
+    const walk = createBoundedWalk({ subject: "Document", limits, root });
+    expect(walk.isAncestor(root)).toBe(true);
+    walk.enter({});
+    expect(() => walk.enter({})).toThrow(/nests more than 2 levels deep/);
+  });
+
+  it("tracks only the containers on the current descent path as ancestors", () => {
+    const walk = createBoundedWalk({ subject: "Document", limits });
+    const outer = {};
+    const inner = {};
+    walk.enter(outer);
+    walk.enter(inner);
+    expect(walk.isAncestor(outer)).toBe(true);
+    expect(walk.isAncestor(inner)).toBe(true);
+    walk.leave(inner);
+    expect(walk.isAncestor(inner)).toBe(false);
+    expect(walk.isAncestor(outer)).toBe(true);
+    // Leaving frees the level, so a sibling can be entered at the same depth.
+    expect(() => walk.enter({})).not.toThrow();
+  });
+});

--- a/src/utils/bounded-walk.ts
+++ b/src/utils/bounded-walk.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared bookkeeping for walks over a parsed YAML/JSON document that copy
+ * every reachable value, used by the frontmatter cleaner and the shared-config
+ * sanitizer.
+ *
+ * A YAML alias makes one parsed container reachable from many keys, and a
+ * walk that copies each reachable value writes every alias out independently
+ * (the writers dump with `noRefs`, so memoizing would only move the blowup
+ * into serialization). Left unbounded, a small "alias bomb" of nested anchors
+ * costs exponential time and memory, a long string aliased many times balloons
+ * the output while staying within a value count, a chain of aliases that each
+ * wrap the previous one overflows the call stack, and a self-referencing
+ * anchor recurses forever. The walk therefore charges every value against
+ * `maxValues`, every string leaf and mapping key against `maxStringChars`,
+ * caps nesting at `maxDepth`, and tracks the containers on the current
+ * descent path so a reference back to one of them is recognized as a cycle.
+ * Each bound trips with a clear error naming the document kind, instead of a
+ * hang or a crash.
+ */
+
+export type BoundedWalkLimits = {
+  /** Values the document may expand to once every alias is written out. */
+  maxValues: number;
+  /** Total characters of string leaves and mapping keys the document may expand to. */
+  maxStringChars: number;
+  /** Containers deep the document may nest. */
+  maxDepth: number;
+};
+
+export type BoundedWalk = {
+  /**
+   * Charge one visited value, plus the characters of a string leaf (or the
+   * serialized size of a leaf that is not a string), against the budgets.
+   */
+  chargeValue: (stringChars?: number) => void;
+  /** Charge string content that is not itself a value, such as a mapping key. */
+  chargeChars: (chars: number) => void;
+  /** Whether `container` is on the current descent path, i.e. entering it would close a cycle. */
+  isAncestor: (container: object) => boolean;
+  /** Enter one more container level, throwing if the depth cap is exceeded. */
+  enter: (container: object) => void;
+  /** Leave a container level entered via `enter`. */
+  leave: (container: object) => void;
+};
+
+const ALIAS_HINT = "(a chain of YAML aliases may be amplifying the document)";
+
+/**
+ * Create the bookkeeping for one walk. `subject` names the document kind in
+ * every error ("Frontmatter", "Shared config"); `root`, when given, is entered
+ * up front so the root object counts as the first nesting level, matching the
+ * +1 that `enter` applies to every container nested inside it.
+ */
+export function createBoundedWalk({
+  subject,
+  limits,
+  root,
+}: {
+  subject: string;
+  limits: BoundedWalkLimits;
+  root?: object;
+}): BoundedWalk {
+  const ancestors = new WeakSet<object>();
+  let valuesRemaining = limits.maxValues;
+  let stringCharsRemaining = limits.maxStringChars;
+  let depth = 0;
+
+  const chargeChars = (chars: number): void => {
+    stringCharsRemaining -= chars;
+    if (stringCharsRemaining < 0) {
+      throw new Error(
+        `${subject}'s string values expand to more than ${limits.maxStringChars} characters; refusing to process it ${ALIAS_HINT}`,
+      );
+    }
+  };
+
+  const chargeValue = (stringChars = 0): void => {
+    valuesRemaining -= 1;
+    if (valuesRemaining < 0) {
+      throw new Error(
+        `${subject} expands to more than ${limits.maxValues} values; refusing to process it ${ALIAS_HINT}`,
+      );
+    }
+    chargeChars(stringChars);
+  };
+
+  const enter = (container: object): void => {
+    depth += 1;
+    if (depth > limits.maxDepth) {
+      throw new Error(
+        `${subject} nests more than ${limits.maxDepth} levels deep; refusing to process it ${ALIAS_HINT}`,
+      );
+    }
+    ancestors.add(container);
+  };
+
+  const leave = (container: object): void => {
+    ancestors.delete(container);
+    depth -= 1;
+  };
+
+  if (root !== undefined) {
+    enter(root);
+  }
+
+  return {
+    chargeValue,
+    chargeChars,
+    isAncestor: (container) => ancestors.has(container),
+    enter,
+    leave,
+  };
+}

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,6 +1,7 @@
 import matter from "gray-matter";
 import { dump } from "js-yaml";
 
+import { type BoundedWalk, createBoundedWalk } from "./bounded-walk.js";
 import { stripControlCharacters } from "./control-characters.js";
 import { formatError } from "./error.js";
 import { toPosixPath } from "./file.js";
@@ -79,71 +80,12 @@ type DeepCleanOptions = {
   /** Applied to every string leaf; the default keeps strings as they are. */
   transformString?: (value: string) => string;
   /**
-   * Containers on the current descent path. A reference back to one of them
-   * (a YAML anchor that aliases its own ancestor) is a cycle and is dropped
-   * rather than walked until the stack overflows.
+   * The budgets, depth cap and descent path of this walk. A reference back
+   * to a container on the path (a YAML anchor that aliases its own ancestor)
+   * is a cycle and is dropped rather than walked until the stack overflows.
    */
-  ancestors: WeakSet<object>;
-  /** Values still allowed before the walk refuses the document. */
-  budget: { remaining: number; stringCharsRemaining: number };
-  /** Current container nesting depth, mutated as the walk descends and returns. */
-  depth: number;
+  walk: BoundedWalk;
 };
-
-/** Charge string content (a string leaf or an object key) against the character budget. */
-function chargeStringChars({ options, chars }: { options: DeepCleanOptions; chars: number }): void {
-  options.budget.stringCharsRemaining -= chars;
-  if (options.budget.stringCharsRemaining < 0) {
-    throw new Error(
-      `Frontmatter's string values expand to more than ${MAX_FRONTMATTER_STRING_CHARS} characters; refusing to process it (a chain of YAML aliases may be amplifying the document)`,
-    );
-  }
-}
-
-function consumeBudget({
-  options,
-  stringChars = 0,
-}: {
-  options: DeepCleanOptions;
-  stringChars?: number;
-}): void {
-  options.budget.remaining -= 1;
-  if (options.budget.remaining < 0) {
-    throw new Error(
-      `Frontmatter expands to more than ${MAX_FRONTMATTER_VALUES} values; refusing to process it (a chain of YAML aliases may be amplifying the document)`,
-    );
-  }
-  chargeStringChars({ options, chars: stringChars });
-}
-
-/** Enter one more container level, throwing if the depth cap is exceeded. */
-function enterContainer({
-  options,
-  container,
-}: {
-  options: DeepCleanOptions;
-  container: object;
-}): void {
-  options.depth += 1;
-  if (options.depth > MAX_FRONTMATTER_DEPTH) {
-    throw new Error(
-      `Frontmatter nests more than ${MAX_FRONTMATTER_DEPTH} levels deep; refusing to process it (a chain of YAML aliases may be amplifying the document)`,
-    );
-  }
-  options.ancestors.add(container);
-}
-
-/** Leave a container level entered via {@link enterContainer}. */
-function leaveContainer({
-  options,
-  container,
-}: {
-  options: DeepCleanOptions;
-  container: object;
-}): void {
-  options.ancestors.delete(container);
-  options.depth -= 1;
-}
 
 /**
  * Estimate the serialized character cost of a leaf that is not a string (a
@@ -173,7 +115,7 @@ function deepCleanValue(value: unknown, options: DeepCleanOptions): unknown {
   // Charge nullish leaves too: an aliased array of nulls would otherwise be
   // walked for free, and the walk is the work being bounded.
   const leafChars = typeof value === "string" ? value.length : estimateLeafChars(value);
-  consumeBudget({ options, stringChars: leafChars });
+  options.walk.chargeValue(leafChars);
 
   if (value === null || value === undefined) {
     return undefined;
@@ -184,10 +126,10 @@ function deepCleanValue(value: unknown, options: DeepCleanOptions): unknown {
   }
 
   if (Array.isArray(value)) {
-    if (options.ancestors.has(value)) {
+    if (options.walk.isAncestor(value)) {
       return undefined;
     }
-    enterContainer({ options, container: value });
+    options.walk.enter(value);
     const cleanedArray: unknown[] = [];
     for (const item of value) {
       const cleaned = deepCleanValue(item, options);
@@ -195,17 +137,17 @@ function deepCleanValue(value: unknown, options: DeepCleanOptions): unknown {
         cleanedArray.push(cleaned);
       }
     }
-    leaveContainer({ options, container: value });
+    options.walk.leave(value);
     return cleanedArray;
   }
 
   if (isPlainObject(value)) {
-    if (options.ancestors.has(value)) {
+    if (options.walk.isAncestor(value)) {
       return undefined;
     }
-    enterContainer({ options, container: value });
+    options.walk.enter(value);
     const result = cleanOwnEntries(value, options);
-    leaveContainer({ options, container: value });
+    options.walk.leave(value);
     return result;
   }
 
@@ -232,7 +174,7 @@ function cleanOwnEntries(
     // A YAML mapping key can itself be an alias, so its length has to be
     // charged against the character budget the same as a string leaf's; the
     // key is written into the output regardless of whether its value survives.
-    chargeStringChars({ options, chars: key.length });
+    options.walk.chargeChars(key.length);
     // Walk the value — and so charge its budget — even under a dropped
     // prototype-pollution key. Skipping the walk for `__proto__:` and its
     // siblings would let them hide an unbudgeted alias chain: free space to
@@ -250,21 +192,23 @@ function cleanOwnEntries(
 
 function deepCleanObject(
   obj: Record<string, unknown> | null | undefined,
-  options: Omit<DeepCleanOptions, "ancestors" | "budget" | "depth">,
+  options: Omit<DeepCleanOptions, "walk">,
 ): Record<string, unknown> {
   if (!obj || typeof obj !== "object") {
     return {};
   }
   return cleanOwnEntries(obj, {
     ...options,
-    ancestors: new WeakSet([obj]),
-    budget: {
-      remaining: MAX_FRONTMATTER_VALUES,
-      stringCharsRemaining: MAX_FRONTMATTER_STRING_CHARS,
-    },
-    // The root object is itself one level of nesting, matching the +1 that
-    // enterContainer applies to every container nested inside it.
-    depth: 1,
+    walk: createBoundedWalk({
+      subject: "Frontmatter",
+      limits: {
+        maxValues: MAX_FRONTMATTER_VALUES,
+        maxStringChars: MAX_FRONTMATTER_STRING_CHARS,
+        maxDepth: MAX_FRONTMATTER_DEPTH,
+      },
+      // The root object is itself one level of nesting.
+      root: obj,
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary

`sanitizeSharedConfigValue` in `src/features/shared/shared-config-gateway.ts` rebuilt every parsed value with a plain recursive walk that had no budget and no cycle guard. js-yaml resolves anchors and aliases into shared JS object references, so:

- a small "billion laughs" document of nested anchors made the walk exponential (CPU-exhaustion DoS), and
- a self-referencing anchor (`a: &a {self: *a}`) recursed until the process crashed with a stack overflow.

Both are reachable from a config file committed to a cloned repository (for example `.rovodev/config.yml`) when the victim runs `rulesync import`, and the sanitizer is shared by every tool whose native config is read through the gateway.

## Changes

- The sanitizer now walks with the same bounds the frontmatter cleaner gained in the fix for #2751: every value is charged against `MAX_SHARED_CONFIG_VALUES` (100,000), every string leaf and mapping key against `MAX_SHARED_CONFIG_STRING_CHARS` (4,000,000), nesting is capped at `MAX_SHARED_CONFIG_DEPTH` (64), and a reference back to an ancestor is refused outright with a clear error instead of walked until the stack overflows.
- The value under a dropped prototype-pollution key is still walked and charged, so `__proto__:` cannot hide an unbudgeted alias chain.
- `parseSharedConfig` prefixes these refusals with the file path (`Failed to parse shared config at <path>: ...`) the same way it does for syntax errors.
- Ordinary shared references that are not cycles are still expanded into independent copies, matching the existing writer behaviour (`dump` with `noRefs: true`).

Memoizing shared references was deliberately not used: the writers dump with `noRefs: true`, so it would only move the blowup from the sanitizer into serialization.

## Tests

New cases in `shared-config-gateway.test.ts` cover the alias bomb (with the path prefix), a self-referencing mapping and array, a long string aliased past the character budget, a document nested past the depth cap, a non-cyclic shared reference that must keep working, and an alias bomb hidden under `__proto__`.

`pnpm cicheck` passes.

Closes #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUHDgQV8g7bgV8TVuF1E7e