### PR TITLE
ci(publish-assets): generate repomix XML under Node instead of Bun

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -78,7 +78,11 @@ jobs:
         run: pnpm generate:schema
 
       - name: Generate repomix XML variants
-        run: bun scripts/generate-repomix-xml.ts
+        # Deliberately Node (tsx) and not Bun: repomix skips Tinypool#destroy()
+        # when it detects Bun, so each runCli() call leaks its worker pools and
+        # they race their idle timeout into a "Terminating worker thread" crash.
+        # See scripts/generate-repomix-xml.ts and #2922.
+        run: pnpm exec tsx scripts/generate-repomix-xml.ts
 
       - name: Bundle XML files into zip
         run: zip repomix-xml.zip repomix-output-*.xml

--- a/scripts/generate-repomix-xml.ts
+++ b/scripts/generate-repomix-xml.ts
@@ -3,6 +3,18 @@ import { join } from "node:path";
 
 import { runCli } from "repomix";
 
+// This script must run under Node (tsx), never under Bun. repomix detects Bun in
+// its cleanupWorkerPool() helper and skips Tinypool#destroy() there, so every
+// runCli() call below would leak the worker pools it created. Generating every
+// variant in one process then leaves those orphan pools to hit their idle
+// timeout mid-run, which rejects an in-flight task with tinypool's "Terminating
+// worker thread" error and kills the process. See #2922.
+if (process.versions.bun !== undefined) {
+  throw new Error(
+    "generate-repomix-xml.ts must run under Node (e.g. `pnpm exec tsx scripts/generate-repomix-xml.ts`), not Bun.",
+  );
+}
+
 type Variant = {
   name: string;
   include?: string[];


### PR DESCRIPTION
## Summary

The `Generate repomix XML variants` step of `Publish Assets` crashed with tinypool's `Terminating worker thread` error on 4 of 5 attempts for v16.22.0 and 1 of 2 for v16.21.0, blocking the tag push and asset upload.

## Root cause

`repomix` skips `Tinypool#destroy()` when it detects Bun:

```js
// node_modules/repomix/lib/shared/processConcurrency.js
const isBun = process.versions?.bun;
if (isBun) {
  logger.debug('Running in Bun environment, skipping Tinypool destroy method');
} else {
  await pool.destroy();
}
```

`scripts/generate-repomix-xml.ts` calls `runCli()` once per variant (~20 variants) in a single process, and each call spins up worker pools for file processing, security checks and metrics. Under Bun none of them are ever destroyed, so the orphan pools sit on their 5s `idleTimeout` and terminate workers while a later variant still has tasks in flight — tinypool then rejects that task with `Errors.ThreadTermination()` ("Terminating worker thread") and the process dies. That explains why the variant named in the crash differed on every attempt: it is a race, not a bad input.

## Fix

- Run the script with `tsx` (Node) in the workflow, like every other script in this repo, so `pool.destroy()` is awaited between variants. The neighbouring `Generate JSON Schemas` step already runs `pnpm generate:schema` (tsx) after `bun install`, so no extra setup is needed. Binaries are still built with Bun.
- Add a runtime guard in the script that fails fast with an explanatory message if it is ever run under Bun again.

## Verification

`pnpm exec tsx scripts/generate-repomix-xml.ts` generates all 22 variants in ~11s locally with exit code 0. `pnpm cicheck` passes.

Closes #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3NtR8ZpJbecS19RzPJ59m
