### PR TITLE
chore(release): v16.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.22.1",
+  "version": "16.23.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.22.1";
+const getVersion = () => "16.23.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## What's Changed

### New Features

- **The `devin` override can now author Devin's `sandbox` block** by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2931
  - `rulesync.jsonc`'s tool-scoped `devin` permissions override previously accepted only the raw allow/ask/deny arrays, so Devin's `sandbox` settings (network mode, excluded commands, and the rest of the block) had no authoring path and could only be hand-edited in the generated file (refs #2729).
- **The `reasonix` override can now author `[permissions] allow_dynamic_bash`** by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/2932
  - Reasonix added the `allow_dynamic_bash` opt-in upstream in v1.19.0, which lets an Allow fallback cover nested or indirect Bash. It is now settable as `reasonix.allowDynamicBash`, is lifted back out on `rulesync import`, and is left untouched when the key is absent from the override (refs #2599).

### Other Changes

- **Trust-affecting sandbox settings are announced when they are written.** Generating a Devin or Reasonix permissions file now emits a single warning per file naming every setting that widens what the tool trusts (Devin's `sandbox` openings, Reasonix's `bash`, `network`, `allow_write` and `workspace_root`, and `allow_dynamic_bash`), plus any restriction the overlay would drop from a list already in the file (Reasonix's `forbid_read`). A permissions file is shareable and `rulesync fetch` can copy one into a project, so these are written but never silently.
- The warning machinery the Devin adapter grew now lives in `src/features/permissions/sandbox-trust.ts` and is shared by both adapters, so the two cannot drift apart.
- `docs/reference/file-formats.md` documents both override keys and every value the warnings name.
- Homebrew formula updated to v16.22.1 in https://github.com/dyoshikawa/rulesync/pull/2927

## Contributors

- @dyoshikawa

## Full Changelog

https://github.com/dyoshikawa/rulesync/compare/v16.22.1...v16.23.0
