### PR TITLE
test(subagents): assert structured Zod issue data instead of version-specific wording

### DIFF
--- a/src/features/subagents/kilo-subagent.test.ts
+++ b/src/features/subagents/kilo-subagent.test.ts
@@ -309,11 +309,16 @@ temperature: "hot"
 Body content`,
     );
 
-    await expect(
-      KiloSubagent.fromFile({
-        relativeFilePath: "invalid-type.md",
-      }),
-    ).rejects.toThrow("Invalid input: expected number, received string");
+    const resultPromise = KiloSubagent.fromFile({
+      relativeFilePath: "invalid-type.md",
+    });
+
+    // Zod's human-readable wording for `invalid_type` differs between versions, so
+    // assert on the structured issue data that formatError serializes instead.
+    await expect(resultPromise).rejects.toThrow("Invalid frontmatter in");
+    await expect(resultPromise).rejects.toThrow('"code":"invalid_type"');
+    await expect(resultPromise).rejects.toThrow('"expected":"number"');
+    await expect(resultPromise).rejects.toThrow('"path":["temperature"]');
   });
 
   it("should preserve custom mode value when explicitly set", async () => {


### PR DESCRIPTION
## Summary

`src/features/subagents/kilo-subagent.test.ts` asserted on Zod's English sentence for the `invalid_type` issue:

```
Invalid input: expected number, received string
```

Zod 4.5.x changed that issue shape — the `received` field is gone and the default message is now just `Invalid input` — so the assertion fails purely on a dependency bump, even though `KiloSubagent.fromFile` still rejects the invalid frontmatter exactly as before.

This is the only test failure in #2929 (`chore(deps): bump the all-dependencies group with 113 updates`), which bumps `zod` from 4.4.3 to 4.5.4.

## Change

Assert on the structured issue data that `formatError` serializes, rather than on the localized sentence:

```ts
await expect(resultPromise).rejects.toThrow("Invalid frontmatter in");
await expect(resultPromise).rejects.toThrow('"code":"invalid_type"');
await expect(resultPromise).rejects.toThrow('"expected":"number"');
await expect(resultPromise).rejects.toThrow('"path":["temperature"]');
```

These substrings are present in both Zod 4.4.3 and 4.5.4 output, and they pin more of the failure than the previous single assertion did (the offending field path is now checked explicitly). No production code changes, and the test still fails if validation stops rejecting the input.

## Verification

- `pnpm cicheck` passes on the current `zod@4.4.3`.
- The assertions match the exact serialized issue reported by CI on #2929 under `zod@4.5.4`:
  `[{"expected":"number","code":"invalid_type","path":["temperature"],"message":"Invalid input"}]`

Related: #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrwSR9PWbPsPdZm5zibyDQ
