### PR TITLE
chore: release v16.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.24.0",
+  "version": "16.24.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.24.0";
+const getVersion = () => "16.24.1";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## Summary

Release v16.24.1 — a maintenance release covering dependency updates, a CI reliability fix, and a test hardening. There are no changes to rulesync's public API or generated output.

## Changes since v16.24.0

- **Dependencies**: `all-dependencies` group bumped with 168 updates (#2939) — notably `zod` 4.4.3 → 4.5.4, `fastmcp` 4.16.10 → 4.20.0, `es-toolkit` 1.51.0 → 1.52.0. `all-actions` group bumped with 3 SHA-pinned updates (#2928).
- **CI**: `Publish Assets` now generates the repomix XML variants under Node via `tsx` instead of Bun, and the script guards against being run under Bun (#2930, closes #2922). This removes the intermittent `Terminating worker thread` failure that forced repeated reruns of the release workflow.
- **Tests**: the `KiloSubagent.fromFile` invalid-type test asserts on structured Zod issue data instead of Zod's English error sentence (#2938).

## Version bump rationale

PATCH. Dependency updates plus CI and test changes; no public API change, no new feature, and no behavior change in generated files.

## Release checklist

- [x] `getVersion()` in `src/cli/program.ts` returns `16.24.1`
- [x] `package.json` version is `16.24.1`
- [x] `pnpm cicheck` passes locally
- [x] Draft GitHub release `v16.24.1` created with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrwSR9PWbPsPdZm5zibyDQ
