### PR TITLE
chore: update Homebrew formula to v16.24.1

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.24.0"
+  version "16.24.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "7dbf1b0103dc78a9972074fc9b76770ffe6cc192f43952549b44c06760da0093"
+      sha256 "111a1b3f54ea3db5b695db1c7ab4f116a797ab6dee2b0b5444dcab387e7c33b6"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "a12129fcc871df7454d21814cba72c93d59cc163251e4b50118533e81c250f68"
+      sha256 "0a9c9377addd606f89186b88c44635bf45a7b1f166e464063ae4ad490c1316fd"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "aa0a56f7cca00e96224db0dd56ebe3433276544cf7164883cd6bb6a98d2f8030"
+      sha256 "dc5f02a218d03e155ce5be69a8fb59cd8e3a1e9bf76376321affc4a76c9df5aa"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "d9dd79b55ecf6eac137eb9e1915b9254b040847b054f825017149534e907d634"
+      sha256 "0f84487616151846bba32d8171e73f2c93f5badc5bec6449cb40d40982c91880"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.24.1 release.