### PR TITLE
docs(research): correct the AugmentCode reference map

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/augmentcode.md
+++ b/.rulesync/skills/rulesync-feature-research/references/augmentcode.md
@@ -1,26 +1,53 @@
 # AugmentCode Map
 
+Auggie CLI (`@augmentcode/auggie`) keeps everything under one `.augment/` tree at
+two scopes — the workspace `<repo>/.augment/` and the user `~/.augment/`. Four of
+the nine dimensions (`mcp`, `hooks`, `permissions`, and the plugin-consumption
+keys) share a single layered `settings.json` rather than having a file each, so
+generation merges into it instead of overwriting; check the per-surface rows
+before assuming a dimension owns its own file. Since 0.16.0 Auggie also
+discovers commands, subagents and skills from the cross-tool `.agents/` and
+`.claude/` roots — Rulesync reads those on import but always generates into
+`.augment/`.
+
 ## Official Docs
 
-| Feature       | Official docs                                                      | Upstream surface                                                                                            |
-| ------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| index         | `https://docs.augmentcode.com/`                                    | Augment documentation index                                                                                 |
-| `rules`       | `https://docs.augmentcode.com/cli/rules`                           | `.augment/rules`, `~/.augment/rules`, AGENTS.md and CLAUDE.md hierarchical rules                            |
-| `ignore`      | `https://docs.augmentcode.com/cli/setup-auggie/workspace-indexing` | `.augmentignore`, `.gitignore` interaction, workspace indexing filters                                      |
-| `mcp`         | No dedicated upstream MCP surface in map                           | MCP tool names appear in permissions                                                                        |
-| `commands`    | `https://docs.augmentcode.com/cli/custom-commands`                 | `.augment/commands/*.md` (workspace), `~/.augment/commands/*.md` (user); Markdown with optional frontmatter |
-| `subagents`   | No dedicated upstream subagents surface in map                     | No Rulesync-supported AugmentCode subagents target in map                                                   |
-| `skills`      | No dedicated upstream skills surface in map                        | No Rulesync-supported AugmentCode skills target in map                                                      |
-| `hooks`       | No dedicated upstream hooks surface in map                         | No Rulesync-supported AugmentCode hooks target in map                                                       |
-| `permissions` | `https://docs.augmentcode.com/cli/permissions`                     | `~/.augment/settings.json`, `toolPermissions`, `allow`/`deny`/`ask-user`, first-match-wins rules            |
+| Feature       | Official docs                                                      | Upstream surface                                                                                                                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| index         | `https://docs.augmentcode.com/`                                    | Augment documentation index                                                                                                                                                                                                                                             |
+| `rules`       | `https://docs.augmentcode.com/cli/rules`                           | `.augment/rules`, `~/.augment/rules`, AGENTS.md and CLAUDE.md hierarchical rules                                                                                                                                                                                        |
+| `ignore`      | `https://docs.augmentcode.com/cli/setup-auggie/workspace-indexing` | `.augmentignore`, `.gitignore` interaction, workspace indexing filters                                                                                                                                                                                                  |
+| `mcp`         | `https://docs.augmentcode.com/cli/integrations`                    | `mcpServers` inside `settings.json` (there is no `.augment/mcp.json`); the docs show only `~/.augment/settings.json`, plus the transient `--mcp-config` override and `auggie mcp add`. **`/cli/mcp` 404s — do not cite it.**                                            |
+| `commands`    | `https://docs.augmentcode.com/cli/custom-commands`                 | `.augment/commands/*.md` (workspace), `~/.augment/commands/*.md` (user); Markdown with optional frontmatter. Also resolved over `.claude/commands` and `.agents/commands` at both scopes                                                                                |
+| `subagents`   | `https://docs.augmentcode.com/cli/subagents`                       | `.augment/agents/*.md` (workspace) and `~/.augment/agents/*.md` (user); YAML frontmatter `name` (required), `description`, `color`, `model`, `tools`, `disabled_tools` — `disabled_tools` wins when both are set                                                        |
+| `skills`      | `https://docs.augmentcode.com/cli/skills`                          | agentskills.io `<name>/SKILL.md` bundles under `.augment/skills/`, `.claude/skills/`, `.agents/skills/` and their `~` equivalents; `name` (1–64 chars, lowercase/digits/hyphens) and `description` required; `~/.augment/skills/` has the highest precedence            |
+| `hooks`       | `https://docs.augmentcode.com/cli/hooks`                           | A `hooks` block in the layered `settings.json` (`/etc/augment/` or `%ProgramData%\Augment\`, `<workspace>/.augment/settings.local.json`, `<workspace>/.augment/settings.json`, `~/.augment/settings.json`); PascalCase events, `PreToolUse`/`PostToolUse` matcher-aware |
+| `permissions` | `https://docs.augmentcode.com/cli/permissions`                     | `toolPermissions` in `settings.json` at either scope; `allow`/`deny`/`ask-user`, first-match-wins rules                                                                                                                                                                 |
+| `checks`      | `https://docs.augmentcode.com/codereview/review-guidelines`        | `<repo-root>/.augment/code_review_guidelines.yaml` — project scope only; top-level `areas` (each with `description`, `globs`, `rules[{id, description, severity}]`) plus an optional `file_paths_to_ignore`; severity is `high` / `medium` / `low`                      |
+| `plugins`     | `https://docs.augmentcode.com/cli/plugins`                         | Plugin bundles (`.augment-plugin/plugin.json`, `.augment-plugin/marketplace.json`, `commands/`, `agents/`, `rules/`, `skills/`, `hooks/hooks.json`, `.mcp.json`; `.claude-plugin/` accepted for compatibility) and four consumption keys — see below                    |
+
+`plugins` is **not a Rulesync dimension and has no AugmentCode target** — it is
+listed so a run does not mistake the absence of a row for the absence of an
+upstream surface. Both halves are `unsupported`: the bundle side (tracked as the
+`augmentcode-plugin` proposal) and the consumption keys `recommendedMarketplaces`
+(project only), `enabledPlugins` (any tier, deep-merged), `autoUpdateMarketplaces`
+(user) and `dismissedMarketplaces` (`settings.local.json`, tool-managed), none of
+which Rulesync can author. See #2959.
 
 ## Client Anchors
 
 Common adapter paths: `rulesync-source-map.md`.
 
-| Surface       | Anchor                                                                                                                                        |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rules`       | `.augment/rules` non-root conversion and frontmatter stripping in `augmentcode-rule.ts`                                                       |
-| `commands`    | `.augment/commands/*.md` (project) and `~/.augment/commands/*.md` (global) emitted in `augmentcode-command.ts`                                |
-| `ignore`      | `.augmentignore` passthrough and gitignore-compatible comments in `augmentcode-ignore.ts`                                                     |
-| `permissions` | `.augment/settings.json`, `toolPermissions`, tool-name aliases, regex/glob fallback, and fail-closed ordering in `augmentcode-permissions.ts` |
+| Surface       | Anchor                                                                                                                                                                                                                                         |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| paths         | `augmentcode-paths.ts` — the `.augment/` roots, the `.agents/` import-only discovery roots, `settings.json` / `settings.local.json`, and `code_review_guidelines.yaml`                                                                         |
+| `rules`       | `.augment/rules` non-root conversion and frontmatter stripping in `augmentcode-rule.ts`; the retired root `.augment-guidelines` in `augmentcode-legacy-rule.ts`                                                                                |
+| `ignore`      | `.augmentignore` passthrough and gitignore-compatible comments in `augmentcode-ignore.ts`                                                                                                                                                      |
+| `mcp`         | `augmentcode-mcp.ts` merges the `mcpServers` block into `settings.json` at either scope and never deletes the file; project import overlays the gitignored `settings.local.json`                                                               |
+| `commands`    | `.augment/commands/*.md` (project) and `~/.augment/commands/*.md` (global) emitted in `augmentcode-command.ts`; `.agents/commands/` is read on import only                                                                                     |
+| `subagents`   | `.augment/agents/*.md` at both scopes in `augmentcode-subagent.ts`; `.agents/` is an import-only discovery root                                                                                                                                |
+| `skills`      | `.augment/skills/<name>/SKILL.md` at both scopes in `augmentcode-skill.ts`; `.agents/skills/` is an import-only discovery root                                                                                                                 |
+| `hooks`       | `augmentcode-hooks.ts` merges the `hooks` block into `settings.json`; seven canonical events map onto the PascalCase set — see `AUGMENTCODE_HOOK_EVENTS` in `types/hooks.ts` (`PromptSubmit` ← `beforeSubmitPrompt`, added upstream in 0.27.0) |
+| `permissions` | `.augment/settings.json`, `toolPermissions`, tool-name aliases, regex/glob fallback, and fail-closed ordering in `augmentcode-permissions.ts`                                                                                                  |
+| `checks`      | `.augment/code_review_guidelines.yaml` in `augmentcode-check.ts`; canonical `critical` folds one-way into Augment's `high`, and an unannotated check defaults to `medium`                                                                      |
+| `plugins`     | No target. `src/types/tool-targets.ts` lists only `antigravity-plugin` and `claudecode-plugin`; Auggie reads `.claude-plugin/` too, so the existing `claudecode-plugin` output is already partly consumable                                    |


### PR DESCRIPTION
## Summary

Resolves gap 3 of #2959 — the stale AugmentCode research reference map.

`.rulesync/skills/rulesync-feature-research/references/augmentcode.md` recorded `mcp`, `subagents`, `skills` and `hooks` as *"No dedicated upstream `<feature>` surface in map"* / *"No Rulesync-supported AugmentCode `<feature>` target in map"*. All four have live upstream documentation and shipped adapters (`augmentcode-mcp.ts`, `augmentcode-subagent.ts`, `augmentcode-skill.ts`, `augmentcode-hooks.ts`), and the research skill's Collect step treats those exact sentinel phrases as "upstream has nothing here" — so the stale rows were actively steering future research runs away from four implemented dimensions. The map also had no rows at all for `checks` or `plugins`.

## Changes

Rewrote the map from the primary sources, each re-fetched for this PR:

- **`mcp`** → [`/cli/integrations`](https://docs.augmentcode.com/cli/integrations). `/cli/mcp` genuinely 404s, so the row now names the live page and says explicitly not to cite the dead one. Records that MCP servers live in a `mcpServers` block inside `settings.json` — there is no `.augment/mcp.json` — plus the transient `--mcp-config` override.
- **`subagents`** → [`/cli/subagents`](https://docs.augmentcode.com/cli/subagents): `.augment/agents/*.md` at both scopes, with the frontmatter contract (`name` required; `disabled_tools` beats `tools`).
- **`skills`** → [`/cli/skills`](https://docs.augmentcode.com/cli/skills): agentskills.io `<name>/SKILL.md` bundles, the three discovery roots at each scope, the name constraints, and the precedence order.
- **`hooks`** → [`/cli/hooks`](https://docs.augmentcode.com/cli/hooks): the `hooks` block in the layered `settings.json`, the five-tier precedence list, and matcher-awareness.
- **`checks`** (new row) → [`/codereview/review-guidelines`](https://docs.augmentcode.com/codereview/review-guidelines): `<repo-root>/.augment/code_review_guidelines.yaml`, the `areas` / `file_paths_to_ignore` structure, and the `high`/`medium`/`low` severity scale.
- **`plugins`** (new row) → [`/cli/plugins`](https://docs.augmentcode.com/cli/plugins): the bundle layout and manifests, marked `unsupported` with both halves named (the `augmentcode-plugin` bundle side and the four consumption keys), so a future run does not misread the missing row as a missing upstream surface.

Client Anchors gained matching rows for `mcp`, `subagents`, `skills`, `hooks`, `checks` and `plugins`, and the header paragraph now states the one thing that most often trips a run: four dimensions share a single layered `settings.json` rather than owning a file each.

`pnpm cicheck` passes (`check:sync-skill-docs` confirms `.claude/skills/` is regenerated in step).

## Scope note

Refs #2959

The issue tracks three gaps. This PR resolves gap 3 only. Gaps 1 and 2 stay open because both are product decisions rather than mechanical follow-ups:

- **Gap 1** — a full `augmentcode-plugin` target. As the issue itself notes, this is the same open decision as #2502 (Kimi), #2729 (Devin) and #2960 (ZCode); a shared Agent Plugins manifest writer would settle all of them at once rather than adding a fourth one-off.
- **Gap 2** — authoring `recommendedMarketplaces` / `enabledPlugins`. These are plugin-*consumption* keys, so which feature dimension should own them (the issue suggests a tool-scoped `augmentcode` permissions override, following #2931's Devin `sandbox` shape) is a design call, and landing it means changing `.augment/settings.json` ownership in `shared-config-gateway.ts` plus the preservation regression test at `augmentcode-permissions.test.ts:1290`.

Hence `Refs` rather than `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
