### PR TITLE
chore(gitignore): ignore Vibe Code plugin-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,7 @@ rulesync.local.jsonc
 **/.takt/.cache/
 **/.takt/config.yaml
 **/.muse/worktrees/
+**/.vibe/plugin-data/
 **/.augment-guidelines
 **/.devin/workflows/
 **/.junie/memories/

--- a/src/cli/commands/gitignore-entries.test.ts
+++ b/src/cli/commands/gitignore-entries.test.ts
@@ -171,6 +171,10 @@ describe("registry derivation", () => {
       // Muse Code's `--subagent-worktree-isolation` worktrees, which the
       // runtime removes only when they are clean (issue #2727).
       "musecode::general::**/.muse/worktrees/",
+      // Vibe Code's plugin data root: knowledge documents and vendored
+      // `libraries/` dependencies that a project plugin under `.vibe/plugins/`
+      // materializes at session open (issue #2958).
+      "vibe::general::**/.vibe/plugin-data/",
       // Legacy/aggregate/ghost outputs not produced via getSettablePaths.
       "augmentcode::rules::**/.augment-guidelines",
       "devin::commands::**/.devin/workflows/",

--- a/src/cli/commands/gitignore-entries.ts
+++ b/src/cli/commands/gitignore-entries.ts
@@ -150,6 +150,18 @@ export const HAND_MAINTAINED_GITIGNORE_ENTRIES: ReadonlyArray<GitignoreEntryTag>
   // https://dev.meta.ai/docs/cookbook/subagent-fanout
   { target: "musecode", feature: "general", entry: "**/.muse/worktrees/" },
 
+  // Vibe Code's plugin data root: a plugin installed under the project's
+  // `.vibe/plugins/<name>/` gets its data root from
+  // `root.parent.parent / "plugin-data"` whenever no `data_root_base` override
+  // is supplied — and the session-open path, `PluginResolver.from_harness_files`,
+  // supplies none — so a project plugin materializes into
+  // `<project>/.vibe/plugin-data/<plugin>/`. It holds generated knowledge
+  // documents and vendored `libraries/` dependencies (node_modules, Python
+  // packages), all written by Vibe rather than by rulesync. Only that directory
+  // is ignored, not `.vibe/` as a whole, which carries committed project config.
+  // https://github.com/mistralai/mistral-vibe/blob/v2.25.0/vibe/core/plugins/_native.py
+  { target: "vibe", feature: "general", entry: "**/.vibe/plugin-data/" },
+
   // Augment Code's legacy single-file rules path: accepted on import but never
   // generated (so not in getSettablePaths), gitignored as a convenience.
   { target: "augmentcode", feature: "rules", entry: "**/.augment-guidelines" },


### PR DESCRIPTION
## Summary

Resolves gap 2 of #2958 — `.vibe/plugin-data/` is a repo-local by-product with no gitignore entry.

## Changes

A Vibe plugin installed under the project's `.vibe/plugins/<name>/` derives its data root as `root.parent.parent / "plugin-data"` whenever no `data_root_base` override is supplied ([`_native.py:1009`](https://github.com/mistralai/mistral-vibe/blob/v2.25.0/vibe/core/plugins/_native.py)), and `PluginResolver.from_harness_files` — the path Vibe runs on every session open ([`_plugins.py:176`](https://github.com/mistralai/mistral-vibe/blob/v2.25.0/vibe/app_server/_plugins.py)) — supplies none. So a project plugin materializes into `<project>/.vibe/plugin-data/<plugin>/`, holding generated knowledge documents (`knowledge/<name>/KNOWLEDGE.md`) and vendored `libraries/` dependencies (`node_modules`, Python packages).

Rulesync never writes that tree, so per `.claude/rules/feature-change-guidelines.md` it belongs in `HAND_MAINTAINED_GITIGNORE_ENTRIES` rather than being derived from `getSettablePaths` — the same treatment `**/.muse/worktrees/` got.

- `src/cli/commands/gitignore-entries.ts`: new `{ target: "vibe", feature: "general", entry: "**/.vibe/plugin-data/" }` entry, with a comment recording the derivation and the primary source.
- `src/cli/commands/gitignore-entries.test.ts`: the entry added to the `justified` allowlist that the "every hand-maintained tool entry is an explicitly justified exception" test enforces.
- `.gitignore`: regenerated with `pnpm dev gitignore`.

Only the `plugin-data` directory is ignored, not `.vibe/` as a whole — `.vibe/hooks.toml`, `.vibe/agents/` and the rest stay committed project config.

`pnpm cicheck` passes.

## Scope note

Refs #2958

The issue tracks two gaps. This PR resolves gap 2 only, which the issue itself lists as landable "independent of the plugin decision".

**Gap 1** — a `.vibe/plugins/<name>/` Agent Plugins package output root — is left open because it is a product decision: it would add a new packaging target with its own manifest writer and matrix row, and `KNOWLEDGE.md` has no canonical home at all today. As the issue notes, it is the same open question as #2666 (Antigravity `plugin.json`), #2502 (Kimi), #2729 (Devin) and #2960 (ZCode), so it is likely worth settling once across targets rather than adding another one-off. That call is for a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
