### PR TITLE
feat(factorydroid): carry five documented settings keys, refresh the research map

### DIFF
--- a/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
+++ b/.rulesync/skills/rulesync-feature-research/references/factorydroid.md
@@ -1,28 +1,63 @@
 # Factory Droid Map
 
+The `droid` CLI keeps everything under one `.factory/` tree at two authored
+scopes — the project `<repo>/.factory/` and the user `~/.factory/`. Factory's
+documentation moved in 2026: the old `/cli/configuration/*` and
+`/reference/hooks-reference` paths now 308-redirect to `/harness/*` and
+`/droid-cli/*`, so cite the canonical URLs below rather than the redirecting
+ones. Two upstream surfaces are worth keeping in view when reading the table:
+Factory documents **seven** settings levels (Org, Runtime, Folder, Project,
+User, Dynamic, BuiltIn) of which four are authored, and the Folder level is a
+per-subtree `.factory/` inside a monorepo carrying the full set of files —
+Rulesync writes one project root and one home root and has no per-subdirectory
+output root, so that level is out of reach by design rather than by oversight.
+
 ## Official Docs
 
-| Feature       | Official docs                                                     | Upstream surface                                                                                                |
-| ------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| index         | `https://docs.factory.ai/cli/getting-started/quickstart`          | Factory Droid CLI documentation                                                                                 |
-| `rules`       | `https://docs.factory.ai/cli/configuration/agents-md`             | `AGENTS.md`, nested AGENTS.md, personal `~/.factory/AGENTS.md`                                                  |
-| `ignore`      | No dedicated upstream ignore surface in map                       | No Rulesync-supported Factory Droid ignore target in map                                                        |
-| `mcp`         | `https://docs.factory.ai/cli/configuration/mcp`                   | `.factory/mcp.json`, `~/.factory/mcp.json`, stdio and HTTP servers                                              |
-| `commands`    | `https://docs.factory.ai/cli/configuration/custom-slash-commands` | `.factory/commands` and `~/.factory/commands`, `description`/`argument-hint` frontmatter only (no tool scoping) |
-| `subagents`   | `https://docs.factory.ai/cli/configuration/custom-droids`         | Custom droids in `.factory/droids` and `~/.factory/droids`                                                      |
-| `skills`      | `https://docs.factory.ai/cli/configuration/skills`                | `.factory/skills/<name>/SKILL.md`, `skill.mdx`, invocation controls                                             |
-| `hooks`       | `https://docs.factory.ai/reference/hooks-reference`               | `.factory/hooks.json` and `~/.factory/hooks.json`, hook events, matcher groups, command-type hooks only         |
-| `permissions` | `https://docs.factory.ai/cli/configuration/settings`              | `commandAllowlist`, `commandDenylist`, autonomy settings                                                        |
+| Feature       | Official docs                                                              | Upstream surface                                                                                                                                                                                                                                                                |
+| ------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| index         | `https://docs.factory.ai/droid-cli/quickstart`                             | Factory Droid CLI documentation                                                                                                                                                                                                                                                 |
+| `rules`       | `https://docs.factory.ai/harness/agents-md`                                | `AGENTS.md` at the repo root, nested `AGENTS.md`, personal `~/.factory/AGENTS.md`, and the separate `DESIGN.md` architecture document                                                                                                                                           |
+| `ignore`      | No dedicated upstream ignore surface in map                                | Factory documents no `.droidignore` / `.factoryignore` equivalent; no Rulesync-supported Factory Droid ignore target                                                                                                                                                            |
+| `mcp`         | `https://docs.factory.ai/harness/mcp`                                      | `.factory/mcp.json` (project) and `~/.factory/mcp.json` (user); stdio and HTTP servers                                                                                                                                                                                          |
+| `commands`    | `https://docs.factory.ai/harness/custom-slash-commands`                    | `.factory/commands/` and `~/.factory/commands/`; `description` and `argument-hint` frontmatter only — "Tool scoping is not available for custom commands"                                                                                                                       |
+| `subagents`   | `https://docs.factory.ai/harness/subagents`                                | Custom droids as `.factory/droids/<name>.md` and `~/.factory/droids/<name>.md`. (`/cli/configuration/custom-droids` and `/harness/custom-droids` both redirect here.)                                                                                                           |
+| `skills`      | `https://docs.factory.ai/harness/skills`                                   | `.factory/skills/<name>/SKILL.md` and `~/.factory/skills/<name>/SKILL.md`; `skill.mdx` supporting files; invocation controls; also discovered at the folder scope                                                                                                               |
+| `hooks`       | `https://docs.factory.ai/harness/hooks`                                    | `.factory/hooks.json` and `~/.factory/hooks.json` (legacy `settings.json` fallback); nine events — `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `Notification`, `PreCompact`; matcher groups; command-type hooks only |
+| `permissions` | `https://docs.factory.ai/droid-cli/settings`                               | `settings.json` at either scope: `commandAllowlist` / `commandDenylist` / `commandBlocklist`, autonomy, sandbox, network and MCP policy keys                                                                                                                                    |
+| `checks`      | `https://docs.factory.ai/software-factory/code-review-ci`                  | `.factory/skills/review-guidelines/SKILL.md` — review guidance delivered as a reserved skill directory rather than its own config file                                                                                                                                          |
+| org settings  | `https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control` | The seven settings levels and the org-delivered `settings.json` keys, including `builtInToolAutonomyOverrides`, `mcpAutonomyUrlOverrides`, `allowManagedHooksOnly`, `strictEnabledPlugins`, `strictKnownMarketplaces`                                                           |
+| output styles | `https://docs.factory.ai/droid-cli/output-styles`                          | `.factory/output-styles/<name>.md` and `~/.factory/output-styles/<name>.md`; `.md` only, no nesting; optional `name` / `description` frontmatter; selection persisted as the `outputStyle` setting; `Default` and `Concise` reserved — see below                                |
+| `plugins`     | `https://docs.factory.ai/harness/plugins`                                  | Plugin bundles carrying `.factory-plugin/plugin.json` and `.factory-plugin/marketplace.json`, consumed through the `extraKnownMarketplaces` / `enabledPlugins` settings keys — see below                                                                                        |
+
+Output styles are **not a Rulesync dimension and have no Factory Droid target**.
+The surface is a committed, frontmatter-carrying, system-prompt-shaping
+instruction channel in the same class as `AGENTS.md` and `DESIGN.md`, and
+`FactorydroidRule.getSettablePaths` emits nothing under `.factory/output-styles/`.
+Adding it would mean a directory-shaped `factorydroid.channel` value that carries
+a style name, at both project and global scope. Tracked in #2957; the row exists
+so a run does not read the missing row as a missing upstream surface.
+
+`plugins` is likewise **not a Rulesync dimension and has no Factory Droid
+target**. `src/types/tool-targets.ts` lists only `antigravity-plugin` and
+`claudecode-plugin`. The consumption half is different: `extraKnownMarketplaces`
+and `enabledPlugins` _are_ authorable, through the `factorydroid` permissions
+override — see `FACTORYDROID_OVERRIDE_KEYS`.
 
 ## Client Anchors
 
 Common adapter paths: `rulesync-source-map.md`.
 
-| Surface     | Anchor                                                                                                                          |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `rules`     | Project `AGENTS.md`, global `.factory/AGENTS.md`, and `.factory/rules` non-root path in `factorydroid-rule.ts`                  |
-| `mcp`       | `.factory/mcp.json`, stdio/HTTP server conversion, and project/global handling in `factorydroid-mcp.ts`                         |
-| `commands`  | Native command files under `.factory/commands` in `factorydroid-command.ts`                                                     |
-| `subagents` | Native custom droids under `.factory/droids` in `factorydroid-subagent.ts`                                                      |
-| `skills`    | Native skills under `.factory/skills` in `factorydroid-skill.ts`                                                                |
-| `hooks`     | `.factory/hooks.json` (legacy `settings.json` fallback), Factory hook events, and matcher conversion in `factorydroid-hooks.ts` |
+| Surface       | Anchor                                                                                                                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| paths         | `factorydroid-paths.ts` — the `.factory/` roots, `settings.json` / `settings.local.json`, and `FACTORYDROID_REVIEW_GUIDELINES_DIR_PATH`                                                              |
+| `rules`       | Project `AGENTS.md`, global `.factory/AGENTS.md`, the `.factory/rules` non-root path, and the `factorydroid.channel: design` route into `DESIGN.md` in `factorydroid-rule.ts`                        |
+| `mcp`         | `.factory/mcp.json`, stdio/HTTP server conversion, and project/global handling in `factorydroid-mcp.ts`                                                                                              |
+| `commands`    | Native command files under `.factory/commands` in `factorydroid-command.ts`                                                                                                                          |
+| `subagents`   | Native custom droids under `.factory/droids` in `factorydroid-subagent.ts`                                                                                                                           |
+| `skills`      | Native skills under `.factory/skills` in `factorydroid-skill.ts`                                                                                                                                     |
+| `hooks`       | `.factory/hooks.json` (legacy `settings.json` fallback), Factory hook events, and matcher conversion in `factorydroid-hooks.ts`                                                                      |
+| `permissions` | `.factory/settings.json` and the `settings.local.json` overlay in `factorydroid-permissions.ts`; the tool-specific keys that round-trip through the override live in `factorydroid-settings-keys.ts` |
+| `checks`      | `.factory/skills/review-guidelines/SKILL.md` in `factorydroid-check.ts`                                                                                                                              |
+| output styles | No target. `FactorydroidRule.getSettablePaths` returns only `root`, `nonRoot` and `design`                                                                                                           |
+| `plugins`     | No bundle target. The consumption keys `extraKnownMarketplaces` and `enabledPlugins` are carried in `FACTORYDROID_OVERRIDE_KEYS`                                                                     |

--- a/src/constants/factorydroid-settings-keys.ts
+++ b/src/constants/factorydroid-settings-keys.ts
@@ -4,7 +4,7 @@
  * adapter so the settings reader in `src/utils/` can name the same list without
  * importing a feature.
  *
- * @see https://docs.factory.ai/cli/configuration/settings
+ * @see https://docs.factory.ai/droid-cli/settings
  */
 // Factory Droid-specific security keys that the `factorydroid` override authors
 // and that round-trip back into it on import. `commandBlocklist` is the
@@ -20,6 +20,17 @@ export const FACTORYDROID_OVERRIDE_KEYS = [
   "sandbox",
   "mcpPolicy",
   "mcpAutonomyOverrides",
+  // The URL-matched half of the same MCP autonomy pair: entries of
+  // `{ urlPattern, defaultLevel }` that set the default risk level for remote
+  // MCP servers. Carrying `mcpAutonomyOverrides` without it dropped one half of
+  // a documented pair on import.
+  // https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control
+  "mcpAutonomyUrlOverrides",
+  // Per-tool autonomy level required to run a built-in network tool without a
+  // confirmation prompt — the built-in-tool sibling of `subagentAutonomyLevel`
+  // and `mcpAutonomyOverrides`.
+  // https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control
+  "builtInToolAutonomyOverrides",
   "enableDroidShield",
   "sessionDefaultSettings",
   "maxAutonomyLevel",
@@ -28,14 +39,25 @@ export const FACTORYDROID_OVERRIDE_KEYS = [
   // Plugin bootstrap: Droid auto-registers these marketplaces and installs
   // these plugins on start — the upstream distribution path for the same
   // artifacts rulesync generates (commands, skills, droids, hooks, mcp).
-  // https://docs.factory.ai/cli/configuration/plugins
+  // https://docs.factory.ai/harness/plugins
   "extraKnownMarketplaces",
   "enabledPlugins",
-  // Global hooks kill-switch. https://docs.factory.ai/cli/configuration/settings
+  // The strict counterparts of the two keys above: with `strictEnabledPlugins`
+  // the `enabledPlugins` maps at this level and higher become the exhaustive
+  // plugin allowlist, and `strictKnownMarketplaces` makes a higher-level
+  // marketplace list the ceiling rather than a starting set.
+  // https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control
+  "strictEnabledPlugins",
+  "strictKnownMarketplaces",
+  // Global hooks kill-switch. https://docs.factory.ai/droid-cli/settings
   "hooksDisabled",
+  // Restricts hook loading to org-managed hooks and hooks from org-enabled
+  // plugins — the narrower sibling of `hooksDisabled`.
+  // https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control
+  "allowManagedHooksOnly",
   // Per-skill kill-switch: an array of skill names Droid must not load. Same
   // shape and settings file as `hooksDisabled`.
-  // https://docs.factory.ai/cli/configuration/settings
+  // https://docs.factory.ai/droid-cli/settings
   "disabledSkills",
   // Which models Droid may use and how a mission is allowed to run. Both are
   // organization-level controls with no canonical slot, so they round-trip

--- a/src/features/permissions/factorydroid-permissions.test.ts
+++ b/src/features/permissions/factorydroid-permissions.test.ts
@@ -685,6 +685,43 @@ describe("FactorydroidPermissions", () => {
       );
       expect(imported.factorydroid).toEqual(factorydroid);
     });
+    it("round-trips the five strict/URL/built-in siblings of keys already carried (issue #2957)", async () => {
+      const factorydroid = {
+        builtInToolAutonomyOverrides: { web_search: "high" },
+        mcpAutonomyUrlOverrides: [{ urlPattern: "https://*.internal/*", defaultLevel: "low" }],
+        allowManagedHooksOnly: true,
+        strictEnabledPlugins: true,
+        strictKnownMarketplaces: true,
+      };
+      const instance = await FactorydroidPermissions.fromRulesyncPermissions({
+        outputRoot: testDir,
+        rulesyncPermissions: new RulesyncPermissions({
+          relativeDirPath: RULESYNC_RELATIVE_DIR_PATH,
+          relativeFilePath: RULESYNC_PERMISSIONS_FILE_NAME,
+          fileContent: JSON.stringify({ permission: {}, factorydroid }),
+        }),
+      });
+
+      const settings = JSON.parse(instance.getFileContent());
+      expect(settings.builtInToolAutonomyOverrides).toEqual(
+        factorydroid.builtInToolAutonomyOverrides,
+      );
+      expect(settings.mcpAutonomyUrlOverrides).toEqual(factorydroid.mcpAutonomyUrlOverrides);
+      expect(settings.allowManagedHooksOnly).toBe(true);
+      expect(settings.strictEnabledPlugins).toBe(true);
+      expect(settings.strictKnownMarketplaces).toBe(true);
+
+      const imported = JSON.parse(
+        new FactorydroidPermissions({
+          relativeDirPath: ".factory",
+          relativeFilePath: "settings.json",
+          fileContent: instance.getFileContent(),
+        })
+          .toRulesyncPermissions()
+          .getFileContent(),
+      );
+      expect(imported.factorydroid).toEqual(factorydroid);
+    });
   });
 
   describe("fromFile", () => {


### PR DESCRIPTION
## Summary

Resolves gaps 2 and 3 of #2957 — the five missing `settings.json` keys, and the stale Factory Droid research reference map.

## Changes

### `src/constants/factorydroid-settings-keys.ts` — five documented keys added

`FACTORYDROID_OVERRIDE_KEYS` carried one half of three documented pairs, so the other half was silently dropped on import and unauthorable on generate:

| Added key | Documented as | Sibling already carried |
| --- | --- | --- |
| `mcpAutonomyUrlOverrides` | "Autonomy overrides matched by URL. Each entry has a `urlPattern` and a `defaultLevel`" | `mcpAutonomyOverrides` |
| `builtInToolAutonomyOverrides` | "Per-tool autonomy level required to run a built-in network tool without a confirmation prompt" | `subagentAutonomyLevel` |
| `allowManagedHooksOnly` | "When true, only org-managed hooks and hooks from org-enabled plugins are loaded" | `hooksDisabled` |
| `strictEnabledPlugins` | "When true, the `enabledPlugins` maps at this level and higher levels become the exhaustive plugin allowlist" | `enabledPlugins` |
| `strictKnownMarketplaces` | "Marketplace sources that are strictly enforced. A higher-level list is the ceiling" | `extraKnownMarketplaces` |

Every spelling was verified verbatim against the raw text of [`/enterprise/hierarchical-settings-and-org-control`](https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control); `mcpAutonomyUrlOverrides` and `allowManagedHooksOnly` are also on [`/droid-cli/settings`](https://docs.factory.ai/droid-cli/settings).

These are primarily org-delivered, but Factory's hierarchy uses the same schema at all four authored levels, so what matters is that a hand-written project or user `settings.json` round-trips instead of losing them — the same standing as #2765 gap 4 and #2209. `FactorydroidPermissionsOverrideSchema` is a `z.looseObject` and does not enumerate the existing autonomy/policy keys either, so no schema change is needed for consistency. `showHookOutput` was left out, per the issue: it is a display preference, not a security or autonomy control.

The file's own `@see` links were updated from the retired `/cli/configuration/*` paths to the canonical ones.

### `.rulesync/skills/rulesync-feature-research/references/factorydroid.md` — rewritten

The map was stale in four ways the issue names, all fixed:

- **Every URL was a retired path.** `/cli/configuration/*` and `/reference/hooks-reference` now 308-redirect; each was replaced with the target it resolves to (`/harness/agents-md`, `/harness/mcp`, `/harness/custom-slash-commands`, `/harness/subagents`, `/harness/skills`, `/harness/hooks`, `/droid-cli/settings`, `/droid-cli/quickstart`), and the header records the move so a future run does not re-derive it. Note `/harness/output-styles` is a 404 — the live page is `/droid-cli/output-styles`.
- **No `checks` row** even though the feature ships. Added: `.factory/skills/review-guidelines/SKILL.md` via [`/software-factory/code-review-ci`](https://docs.factory.ai/software-factory/code-review-ci), matching `FACTORYDROID_REVIEW_GUIDELINES_DIR_PATH`.
- **No row for output styles or the settings hierarchy.** Both added, each followed by a paragraph saying explicitly that it is unsupported and why, so the missing row is not misread as a missing upstream surface. A `plugins` row was added on the same principle, noting that the *consumption* half (`extraKnownMarketplaces` / `enabledPlugins`) is authorable while the bundle half is not.
- **The `rules` anchor predated the `DESIGN.md` channel.** It now names the `factorydroid.channel: design` route.

The nine hook events, the `.factory/` paths at both scopes, the commands frontmatter restriction and the skills layout were all re-verified against the live pages rather than carried over.

`pnpm cicheck` passes (`check:sync-skill-docs` confirms `.claude/skills/` is regenerated in step).

## Scope note

Refs #2957

**Gap 1 — the `.factory/output-styles/` rules channel — is left open.** It is a design decision rather than a mechanical follow-up: unlike `design`, which routes to one fixed file, an output-style channel is directory-shaped, so the `factorydroid.channel` frontmatter value would have to carry a style name, and the surface has a home-directory equivalent so it needs both scopes. That is a change to the shape of a canonical frontmatter key, and it is a maintainer's call. The map now carries a row for it so the surface stays visible.

**Gap 3's context note — the folder-level `.factory/` scope — is also left open**, as the issue itself frames it: rulesync has no per-subdirectory output root at all, which is a rulesync-wide architectural question rather than a factorydroid adapter bug. The map header now records it so a future run does not re-raise it as a gap.

### Side finding, not addressed here

Fourteen other files under `src/` and `docs/` still cite the retired `docs.factory.ai/cli/configuration/*` paths (they redirect, so nothing is broken). Sweeping them is a mechanical chore outside this issue's scope — it would also pull in `docs/reference/file-formats.md` and the regenerated `src/generated/docs-content.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
