### PR TITLE
docs: make the documentation site discoverable by search engines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # `lastUpdated` reads each page's last commit time from git history. A
+          # shallow clone has only one commit, so every page would report the
+          # same timestamp — both in the footer and in the sitemap's `lastmod`.
+          fetch-depth: 0
 
       - name: Setup mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Mentioned in Awesome Gemini CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/Piebald-AI/awesome-gemini-cli)
 <a href="https://flatt.tech/oss/gmo/trampoline" target="_blank"><img src="https://flatt.tech/assets/images/badges/gmo-oss.svg" height="24px"/></a>
 
-**[Documentation](https://dyoshikawa.github.io/rulesync/)** | **[npm](https://www.npmjs.com/package/rulesync)**
+**[Documentation](https://rulesync.dyoshikawa.com/)** | **[npm](https://www.npmjs.com/package/rulesync)**
 
 A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files. Features selective generation, comprehensive import/export capabilities, and supports major AI development tools with rules, commands, MCP, ignore files, subagents and skills.
 
@@ -44,7 +44,7 @@ not work.
 curl -fsSL https://github.com/dyoshikawa/rulesync/releases/latest/download/install.sh | bash
 ```
 
-See [Installation docs](https://dyoshikawa.github.io/rulesync/getting-started/installation) for manual install and platform-specific instructions.
+See [Installation docs](https://rulesync.dyoshikawa.com/getting-started/installation) for manual install and platform-specific instructions.
 
 ## Getting Started
 
@@ -76,11 +76,11 @@ adopting the `.rulesync/` source-of-truth workflow?
 rulesync convert --from cursor --to copilot,claudecode
 ```
 
-See [Quick Start guide](https://dyoshikawa.github.io/rulesync/getting-started/quick-start) for more details.
+See [Quick Start guide](https://rulesync.dyoshikawa.com/getting-started/quick-start) for more details.
 
 ## Supported Tools and Features
 
-The tables below show whether each tool supports a given feature (✅ = supported, blank = not supported). A ✅ means the feature is supported in at least one mode (project, global, or simulated) — for example, Codex CLI `commands` is global-only. For each tool's `--targets` value and full mode breakdown (project / global / simulated / MCP tool config), see the [Supported Tools reference](https://dyoshikawa.github.io/rulesync/reference/supported-tools).
+The tables below show whether each tool supports a given feature (✅ = supported, blank = not supported). A ✅ means the feature is supported in at least one mode (project, global, or simulated) — for example, Codex CLI `commands` is global-only. For each tool's `--targets` value and full mode breakdown (project / global / simulated / MCP tool config), see the [Supported Tools reference](https://rulesync.dyoshikawa.com/reference/supported-tools).
 
 ### AI Coding Tools
 
@@ -147,17 +147,17 @@ The tables below show whether each tool supports a given feature (✅ = supporte
 
 ### Target and deprecation notes
 
-- **Ignore feature** — The `ignore` feature is deprecated in favor of the more expressive `permissions` feature. Existing ignore configurations remain supported throughout Rulesync 14.x; removal, if any, will be decided separately and will not occur before a future major release. New `rulesync init` projects scaffold permissions without enabling or creating ignore files. See the [migration guide](https://dyoshikawa.github.io/rulesync/reference/file-formats#rulesync-aiignore-or-rulesyncignore-deprecated).
+- **Ignore feature** — The `ignore` feature is deprecated in favor of the more expressive `permissions` feature. Existing ignore configurations remain supported throughout Rulesync 14.x; removal, if any, will be decided separately and will not occur before a future major release. New `rulesync init` projects scaffold permissions without enabling or creating ignore files. See the [migration guide](https://rulesync.dyoshikawa.com/reference/file-formats#rulesync-aiignore-or-rulesyncignore-deprecated).
 - **Google Antigravity (`antigravity-ide` / `antigravity-cli`)** — Antigravity 2.0 splits into two products with separate global config trees: the desktop **`antigravity-ide`** and the **`antigravity-cli`** (`agy`). For project-scope rules, **both `antigravity-ide` and `antigravity-cli`** emit the root rule as a plain cross-tool **`AGENTS.md`** at the project root (the Gemini-lineage discovery order is `AGENTS.md`, `CONTEXT.md`, `GEMINI.md`; the IDE has read `AGENTS.md` since v1.20.3) and non-root rules under `.agents/rules/`.
-- **Plugin packaging (`claudecode-plugin` / `antigravity-plugin`)** — These project-only targets generate and import Rulesync-managed components inside an existing plugin directory selected with `--output-roots` (generate) or `--output-root` (import). They are excluded from `--targets "*"` to avoid writing package-level `skills/`, `rules/`, or `commands/` directories into ordinary projects. Rulesync preserves plugin manifests, marketplace metadata, scripts, and other non-component assets. See the [Plugin Packaging guide](https://dyoshikawa.github.io/rulesync/guide/plugin-packaging).
+- **Plugin packaging (`claudecode-plugin` / `antigravity-plugin`)** — These project-only targets generate and import Rulesync-managed components inside an existing plugin directory selected with `--output-roots` (generate) or `--output-root` (import). They are excluded from `--targets "*"` to avoid writing package-level `skills/`, `rules/`, or `commands/` directories into ordinary projects. Rulesync preserves plugin manifests, marketplace metadata, scripts, and other non-component assets. See the [Plugin Packaging guide](https://rulesync.dyoshikawa.com/guide/plugin-packaging).
 - **Kiro (`kiro`)** — Kiro's IDE and CLI use diverging config formats (IDE: Markdown subagents `.kiro/agents/*.md`; CLI: JSON agent-config subagents `.kiro/agents/*.json`), so `kiro` is split into **`kiro-cli`** and **`kiro-ide`**. The legacy `kiro` target remains as a **deprecated alias** with its current behavior unchanged. The two targets share every surface except **subagents** (Markdown vs JSON); both emit hooks as a single `.kiro/hooks/rulesync.json` (`{ "version": "v1", "hooks": [ ... ] }`) in project (`.kiro/hooks/`) and global (`~/.kiro/hooks/`) scope, the format Kiro CLI 3.0 [migrated to](https://kiro.dev/docs/cli/v3/hooks-migration/). Only the deprecated `kiro` alias still writes hooks into `.kiro/agents/default.json`, which the CLI no longer reads. Global skills (`~/.kiro/skills/`), global ignore (`~/.kiro/settings/kiroignore`), and global Kiro IDE subagents (`~/.kiro/agents/`) are supported too, as are global Kiro CLI commands (`~/.kiro/prompts/`) and subagents (`~/.kiro/agents/`). Kiro MCP generation preserves per-server `disabledTools`, and the deprecated `kiro` alias's hook caching maps `cacheTtl` to `cache_ttl_seconds`.
-- **Roo Code (`roo`)** — Roo Code is end of life: its final release was **v3.54.0 (2026-05-15)** and its repository is archived. New projects should target **`zoocode`** ([Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code)), the community continuation named by the Roo shutdown notice. The `roo` target stays supported because Zoo Code still reads the same `.roo/` project tree and `~/.roo` global tree, so existing output keeps working — it just no longer tracks anything Zoo Code added after the fork. Enable one of the two targets per project, not both. See [Supported tools > Deprecation notes](https://dyoshikawa.github.io/rulesync/reference/supported-tools#deprecation-notes).
+- **Roo Code (`roo`)** — Roo Code is end of life: its final release was **v3.54.0 (2026-05-15)** and its repository is archived. New projects should target **`zoocode`** ([Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code)), the community continuation named by the Roo shutdown notice. The `roo` target stays supported because Zoo Code still reads the same `.roo/` project tree and `~/.roo` global tree, so existing output keeps working — it just no longer tracks anything Zoo Code added after the fork. Enable one of the two targets per project, not both. See [Supported tools > Deprecation notes](https://rulesync.dyoshikawa.com/reference/supported-tools#deprecation-notes).
 
-Some features accept per-feature options. See [Configuration > Per-feature options](https://dyoshikawa.github.io/rulesync/guide/configuration#per-feature-options) for details.
+Some features accept per-feature options. See [Configuration > Per-feature options](https://rulesync.dyoshikawa.com/guide/configuration#per-feature-options) for details.
 
 ## Documentation
 
-For full documentation including configuration, CLI reference, file formats, programmatic API, and more, visit the **[documentation site](https://dyoshikawa.github.io/rulesync/)**.
+For full documentation including configuration, CLI reference, file formats, programmatic API, and more, visit the **[documentation site](https://rulesync.dyoshikawa.com/)**.
 
 ## License
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,8 +28,15 @@ export default defineConfig({
     }
 
     const pagePath = pageData.relativePath.replace(/(^|\/)index\.md$/, "$1").replace(/\.md$/, "");
+    // Encode per segment: `encodeURI` would leave `#` and `?` intact, turning
+    // part of a filename into a fragment or a query string.
+    const pageUrl = `${siteUrl}/${pagePath.split("/").map(encodeURIComponent).join("/")}`;
 
-    return [["link", { rel: "canonical", href: `${siteUrl}/${encodeURI(pagePath)}` }]];
+    return [
+      ["link", { rel: "canonical", href: pageUrl }],
+      // Social crawlers canonicalize on og:url rather than on rel=canonical.
+      ["meta", { property: "og:url", content: pageUrl }],
+    ];
   },
 
   head: [

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,25 +9,28 @@ export default defineConfig({
   base: "/",
   lastUpdated: true,
 
-  // Serve every page from a single extensionless URL. Without this, `/page` and
-  // `/page.html` both resolve and search engines split the ranking signals
-  // between them.
+  // Advertise every page under a single extensionless URL. GitHub Pages keeps
+  // serving both `/page` and `/page.html`; this only controls the form used by
+  // internal links and the sitemap, and the canonical link below is what tells
+  // search engines which of the two is authoritative.
   cleanUrls: true,
 
   sitemap: {
     hostname: `${siteUrl}/`,
   },
 
-  // VitePress has no built-in canonical link, so emit one per page.
-  transformHead: ({ pageData }) => [
-    [
-      "link",
-      {
-        rel: "canonical",
-        href: `${siteUrl}/${pageData.relativePath.replace(/(?:index)?\.md$/, "")}`,
-      },
-    ],
-  ],
+  // VitePress has no built-in canonical link, so emit one per page. The URL is
+  // derived from the source path, which holds as long as `rewrites` is unused.
+  transformHead: ({ pageData }) => {
+    // 404 is not a real URL, so it must not declare itself canonical.
+    if (pageData.relativePath === "404.md") {
+      return [];
+    }
+
+    const pagePath = pageData.relativePath.replace(/(^|\/)index\.md$/, "$1").replace(/\.md$/, "");
+
+    return [["link", { rel: "canonical", href: `${siteUrl}/${encodeURI(pagePath)}` }]];
+  },
 
   head: [
     ["link", { rel: "icon", href: "/logo.jpg" }],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,11 +1,33 @@
 import { defineConfig } from "vitepress";
 
+const siteUrl = "https://rulesync.dyoshikawa.com";
+
 export default defineConfig({
   title: "Rulesync",
   description:
     "A Node.js CLI tool that automatically generates configuration files for various AI development tools from unified AI rule files.",
   base: "/",
   lastUpdated: true,
+
+  // Serve every page from a single extensionless URL. Without this, `/page` and
+  // `/page.html` both resolve and search engines split the ranking signals
+  // between them.
+  cleanUrls: true,
+
+  sitemap: {
+    hostname: `${siteUrl}/`,
+  },
+
+  // VitePress has no built-in canonical link, so emit one per page.
+  transformHead: ({ pageData }) => [
+    [
+      "link",
+      {
+        rel: "canonical",
+        href: `${siteUrl}/${pageData.relativePath.replace(/(?:index)?\.md$/, "")}`,
+      },
+    ],
+  ],
 
   head: [
     ["link", { rel: "icon", href: "/logo.jpg" }],
@@ -23,7 +45,7 @@ export default defineConfig({
       "meta",
       {
         property: "og:image",
-        content: "https://rulesync.dyoshikawa.com/logo.jpg",
+        content: `${siteUrl}/logo.jpg`,
       },
     ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
@@ -40,7 +62,7 @@ export default defineConfig({
       "meta",
       {
         name: "twitter:image",
-        content: "https://rulesync.dyoshikawa.com/logo.jpg",
+        content: `${siteUrl}/logo.jpg`,
       },
     ],
   ],

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rulesync.dyoshikawa.com/sitemap.xml

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "development",
     "rules"
   ],
-  "homepage": "https://github.com/dyoshikawa/rulesync#readme",
+  "homepage": "https://rulesync.dyoshikawa.com",
   "bugs": {
     "url": "https://github.com/dyoshikawa/rulesync/issues"
   },


### PR DESCRIPTION
## Background

The documentation site at https://rulesync.dyoshikawa.com is live and crawlable (no `noindex`, HTTPS enforced, `dyoshikawa.github.io/rulesync` 301-redirects to it), but only a handful of its 21 pages show up in search results, and it never surfaces for natural-language queries about the project — GitHub, npm, and DeepWiki do instead.

Investigating the live site turned up several missing signals:

| Check | Before |
| --- | --- |
| `/sitemap.xml` | 404 |
| `/robots.txt` | 404 |
| `rel=canonical` | absent |
| `/getting-started/installation` vs `.html` | both 200, no canonical |
| README documentation links | pointed at the old `dyoshikawa.github.io` host |
| npm `homepage` | pointed at the GitHub README, not the docs site |

## Changes

- **Sitemap.** VitePress only generates `sitemap.xml` when `sitemap.hostname` is set. Without it, crawlers had to discover all 21 pages by following links. The build now emits a sitemap with every page.
- **robots.txt.** Added `docs/public/robots.txt` so the sitemap location is advertised. (A 404 already meant "allow all", so this was not blocking anything — it just had nowhere to point.)
- **Canonical URLs.** Enabled `cleanUrls` and added a `transformHead` hook emitting a per-page `rel=canonical`. Both `/page` and `/page.html` resolved with nothing declaring which is authoritative, splitting ranking signals across two URLs for identical content.
- **Canonical host in inbound links.** Repointed the 8 README documentation links and the `package.json` `homepage` at `rulesync.dyoshikawa.com`. The old host redirects correctly, but the two strongest inbound links — the README and the npm package page — were not naming the canonical host directly.
- Reused a single `siteUrl` constant for the `og:image` / `twitter:image` URLs that already hardcoded the same origin.

## Verification

`pnpm docs:build` output was inspected directly:

- `sitemap.xml` contains all 21 pages with extensionless URLs and `lastmod` timestamps
- `robots.txt` is served from the site root
- `index.html` → `rel=canonical` `https://rulesync.dyoshikawa.com/`
- `getting-started/installation.html` → `.../getting-started/installation`

`pnpm cicheck` passes (411 test files, 11115 tests).

## Follow-up (not in this PR)

The highest-impact remaining step is manual: register the property in Google Search Console, submit the sitemap, and request indexing. Nothing in the repository can do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mwHjdiPvdFiH4Zj2ikR5e