### PR TITLE
chore: release v16.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.26.0",
+  "version": "16.26.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.26.0";
+const getVersion = () => "16.26.1";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
Release PR for v16.26.1.

Bumps `getVersion()` in `src/cli/program.ts` and `package.json` to 16.26.1. Release notes are on the draft GitHub release.

Ships:
- `fix(qwencode)`: stop dropping `tools.eager` on import (#2668)
- `fix(reasonix)`: stop dropping the `[[plugins]]` `concurrency` and `auto_start` keys (#2599)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK