### PR TITLE
Prevent generated rule paths from escaping output roots

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -121,6 +121,8 @@ Example:
 }
 ```
 
+Output roots and generated rule paths are resolved before writing. A generated path must remain inside its selected output root; paths such as `../outside` are rejected with a configuration error.
+
 ## Per-Target Features
 
 The `targets` option accepts both an array and an object format. Use the

--- a/src/features/rules/rulesync-rule.test.ts
+++ b/src/features/rules/rulesync-rule.test.ts
@@ -6,6 +6,7 @@ import { RULESYNC_RULES_RELATIVE_DIR_PATH } from "../../constants/rulesync-paths
 import { setupTestDirectory } from "../../test-utils/test-directories.js";
 import { ensureDir, writeFileContent } from "../../utils/file.js";
 import { WarningCollectingLogger, withFallbackLoggerTarget } from "../../utils/logger.js";
+import { AgentsMdRule } from "./agentsmd-rule.js";
 import {
   AUTO_SUBPROJECT_PATH,
   RulesyncRule,
@@ -59,6 +60,40 @@ describe("RulesyncRule", () => {
       expect(rule.getFrontmatter()).toEqual(frontmatter);
       expect(rule.getBody()).toBe("This is a test rule body");
     });
+
+    it("should preserve a valid nested subproject path", () => {
+      const rule = new RulesyncRule({
+        outputRoot: testDir,
+        relativeDirPath: "rules",
+        relativeFilePath: "nested.md",
+        frontmatter: { agentsmd: { subprojectPath: "packages/api" } },
+        body: "Nested rule",
+      });
+
+      expect(rule.getFrontmatter().agentsmd?.subprojectPath).toBe("packages/api");
+
+      const generatedRule = AgentsMdRule.fromRulesyncRule({
+        outputRoot: testDir,
+        rulesyncRule: rule,
+      });
+      expect(generatedRule.getFilePath()).toBe(join(testDir, "packages/api", "AGENTS.md"));
+    });
+
+    it.each(["../outside", "packages/../../outside", "/tmp/outside"])(
+      "should reject a subproject path that escapes the output root: %s",
+      (subprojectPath) => {
+        expect(
+          () =>
+            new RulesyncRule({
+              outputRoot: testDir,
+              relativeDirPath: "rules",
+              relativeFilePath: "unsafe.md",
+              frontmatter: { agentsmd: { subprojectPath } },
+              body: "Unsafe rule",
+            }),
+        ).toThrow("generated rule path must stay inside the configured output root");
+      },
+    );
 
     it("should validate frontmatter by default", () => {
       const invalidFrontmatter = {

--- a/src/features/rules/rulesync-rule.ts
+++ b/src/features/rules/rulesync-rule.ts
@@ -14,7 +14,7 @@ import {
 } from "../../types/rulesync-file.js";
 import { RulesyncTargetsSchema } from "../../types/tool-targets.js";
 import { formatError } from "../../utils/error.js";
-import { readFileContent } from "../../utils/file.js";
+import { checkPathTraversal, readFileContent } from "../../utils/file.js";
 import { parseFrontmatter, stringifyFrontmatter } from "../../utils/frontmatter.js";
 import { getGlobsStaticPrefix } from "../../utils/glob-static-prefix.js";
 import { warnOnceWithFallback } from "../../utils/logger.js";
@@ -26,6 +26,33 @@ import { warnOnceWithFallback } from "../../utils/logger.js";
  * before any consumer reads the frontmatter.
  */
 export const AUTO_SUBPROJECT_PATH = "auto";
+
+/**
+ * A subproject path becomes part of a generated file path. Validate it before
+ * target-specific conversion so an authored `../` cannot escape an output root
+ * (or be silently ignored by a target that does not use nested rules).
+ */
+function assertSafeSubprojectPath({
+  subprojectPath,
+  outputRoot,
+  rulePath,
+}: {
+  subprojectPath: string;
+  outputRoot: string;
+  rulePath: string;
+}): void {
+  try {
+    checkPathTraversal({
+      relativePath: join(subprojectPath, "AGENTS.md"),
+      intendedRootDir: outputRoot,
+    });
+  } catch (error) {
+    throw new Error(
+      `Invalid agentsmd.subprojectPath in ${rulePath}: generated rule path must stay inside the configured output root (${outputRoot}).`,
+      { cause: error },
+    );
+  }
+}
 
 export const RulesyncRuleFrontmatterSchema = z.object({
   root: z.optional(z.boolean()),
@@ -223,10 +250,12 @@ export type RulesyncRuleFromFileParams = RulesyncFileFromFileParams & DeriveSubp
 function resolveSubprojectPath({
   frontmatter,
   deriveFromGlobs,
+  outputRoot,
   rulePath,
 }: {
   frontmatter: RulesyncRuleFrontmatter;
   deriveFromGlobs: boolean;
+  outputRoot: string;
   rulePath: string;
 }): string | undefined {
   const authored = frontmatter.agentsmd?.subprojectPath;
@@ -234,6 +263,7 @@ function resolveSubprojectPath({
     return undefined;
   }
   if (typeof authored === "string" && authored !== AUTO_SUBPROJECT_PATH) {
+    assertSafeSubprojectPath({ subprojectPath: authored, outputRoot, rulePath });
     return authored;
   }
   const requested = authored === AUTO_SUBPROJECT_PATH;
@@ -258,6 +288,9 @@ function resolveSubprojectPath({
       `Could not derive agentsmd.subprojectPath for ${rulePath} from globs ${JSON.stringify(globs)}: every glob must start with the same wildcard-free directory (e.g. "packages/api/**/*"). The rule is generated without a nested AGENTS.md; set agentsmd.subprojectPath explicitly to nest it.`,
     );
   }
+  if (derived !== undefined) {
+    assertSafeSubprojectPath({ subprojectPath: derived, outputRoot, rulePath });
+  }
   return derived;
 }
 
@@ -272,14 +305,21 @@ function resolveSubprojectPath({
 function withResolvedSubprojectPath({
   frontmatter,
   deriveFromGlobs,
+  outputRoot,
   rulePath,
 }: {
   frontmatter: RulesyncRuleFrontmatter;
   deriveFromGlobs: boolean;
+  outputRoot: string;
   rulePath: string;
 }): RulesyncRuleFrontmatter {
   const authored = frontmatter.agentsmd?.subprojectPath;
-  const resolved = resolveSubprojectPath({ frontmatter, deriveFromGlobs, rulePath });
+  const resolved = resolveSubprojectPath({
+    frontmatter,
+    deriveFromGlobs,
+    outputRoot,
+    rulePath,
+  });
   if (resolved === authored || (resolved === undefined && authored !== AUTO_SUBPROJECT_PATH)) {
     return frontmatter;
   }
@@ -346,6 +386,7 @@ export class RulesyncRule extends RulesyncFile {
     this.frontmatter = withResolvedSubprojectPath({
       frontmatter: parsedFrontmatter,
       deriveFromGlobs: deriveSubprojectPathFromGlobs,
+      outputRoot: rest.outputRoot ?? process.cwd(),
       rulePath: join(rest.relativeDirPath, rest.relativeFilePath),
     });
     this.body = body;


### PR DESCRIPTION
## Summary
- validate resolved `agentsmd.subprojectPath` output paths against the selected output root before generation
- reject escaping paths with a clear configuration error
- add focused valid-nested and traversal regression coverage
- document the output-root containment rule

## Validation
- `pnpm exec vitest run src/features/rules/rulesync-rule.test.ts --silent=true`
- `pnpm run fmt:check && pnpm run oxlint && pnpm run typecheck`

Validation observed for this change:
- `pnpm exec vitest run src/features/rules/rulesync-rule.test.ts --silent=true`
- `pnpm run fmt:check && pnpm run oxlint && pnpm run typecheck`
- `git status --short && git diff --stat && git diff --check`

<!-- repo-agent-case:4b925c58-5276-4184-89c5-529553f0aef9 -->