### PR TITLE
ci(dependabot): split npm major bumps into their own group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Majors get their own PR so a breaking bump is never buried inside a
+      # Semver-major bumps get their own PR so they are never buried inside a
       # 100-package batch and can be reviewed, reverted, or bisected alone.
+      # (0.x packages still classify 0.23 -> 0.24 as minor and stay above.)
       major-dependencies:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,20 @@ updates:
       default-days: 1
     open-pull-requests-limit: 2
     groups:
+      # Minor and patch bumps travel together so a routine week is one PR.
       all-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Majors get their own PR so a breaking bump is never buried inside a
+      # 100-package batch and can be reviewed, reverted, or bisected alone.
+      major-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
## Summary

Follow-up to the review of the 104-package dependency bump (#2989). This PR acts on the one item in #2991 that is a concrete configuration change and records the outcome of the others.

- **Split the Dependabot npm group by update type.** `all-dependencies` now only bundles `minor` and `patch` bumps; a new `major-dependencies` group collects majors. A breaking bump therefore arrives as its own PR instead of hidden inside a ~100-package batch, and can be reviewed, reverted, or bisected on its own. `open-pull-requests-limit: 2` already allows both PRs to be open at once.

## Items from #2991 that need no code change

- **MCP smoke coverage:** already exists. `src/e2e/e2e-mcp-server.spec.ts` spawns `rulesync mcp` over stdio with the MCP SDK client and exercises `rulesyncTool` (`put`/`get`/`delete` for permissions and hooks, `generate` run, and an error path), and it runs in the E2E matrix on all three CI platforms. The review finding that `fastmcp` bumps are untested by CI was inaccurate.
- **Cooldown window (`cooldown.default-days: 1` / `minimumReleaseAge: 1440`):** deliberately left unchanged. Raising it trades merge latency for observation time and is a policy call; the existing scanning-proxy registry and `allowBuilds` deny list stay as the mitigation.
- **`@openrouter/sdk` lifecycle scripts:** the `allowBuilds: false` entry in `pnpm-workspace.yaml` is untouched.
- **`@types/node` 26 vs `engines.node >=22`:** acknowledged, no change; holding typings back to the runtime floor would be a separate decision.

Closes #2991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
