### PR TITLE
ci(draft-release): align actions/checkout pin with the other workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
       all-actions:
         patterns:
           - "*"
+    # actions/checkout is excluded from automatic bumps, so its SHA pins must
+    # be updated by hand and kept identical across every workflow file.
     ignore:
       - dependency-name: "actions/checkout"
     commit-message:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,7 +27,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` in `.github/workflows/draft-release.yml` to `8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1`, the same SHA every other workflow in the repository already uses. It was the only workflow left on `v5.0.1`.
- Add a comment next to the `actions/checkout` entry in the `ignore` list of `.github/dependabot.yml` so future readers know the pin is intentionally hand-maintained and must be kept identical across workflow files.

Verified against the GitHub API that `refs/tags/v6.0.1` in `actions/checkout` resolves to commit `8e8c483db84b4bee98b60c0593521ed34d9990e8`.

The `ignore` entry itself is kept as-is; whether to drop it and let Dependabot manage `actions/checkout` is a separate policy decision.

Closes #2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
