### PR TITLE
chore: release v16.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.27.0",
+  "version": "16.28.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.27.0";
+const getVersion = () => "16.28.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## Summary

Release v16.28.0.

- `feat(deepagents)`: follow `DEEPAGENTS_HOME` as the global profile root (#2996)
- `fix(sources)`: refetch when the skill selection widens past the lockfile (#2994)
- Dependency updates (#2988, #2989) and the project-local `merge-contributor-pr` skill (#2987)

Release notes: draft release `v16.28.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
