### PR TITLE
chore: release v16.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.28.0",
+  "version": "16.28.1",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.28.0";
+const getVersion = () => "16.28.1";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## Summary

Release v16.28.1.

- `ci(dependabot)`: split npm major bumps into their own group (#2992)
- `ci(draft-release)`: align the `actions/checkout` pin with the other workflows (#2993)
- `chore`: update Homebrew formula to v16.28.0 (#2998)

CI configuration only; no CLI or package content changes since v16.28.0. Release notes: draft release `v16.28.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
