### PR TITLE
chore: update Homebrew formula to v16.28.1

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.28.0"
+  version "16.28.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "df1d23686e25272a0d9b78354465dfa81608e30fb5a6ba1e653d2078c0dc8c39"
+      sha256 "df81f3f9565a45122b07b06eeeb68110d00f56714176074e94a6339d722afbce"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "90ba7232106a253af7fedf080173d61ae186d41def8e5c0ba72d0ed8fe4fe917"
+      sha256 "915aed6f8f13c98ff19d8c2604f250bf57047f1d025facd0802844c16a65a941"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "bb1183015ee1f3d437c578ed8a20fe1c58df8f13c8f1a32171ecab6d7dd9e21e"
+      sha256 "ad2eb96ee39a9ddd90924fc9290ca60817dad997731794434934f8c9e05fe15c"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "e01aeeebd065e5c35df52b9a9e992ddf6cb20019fe0f3f761687807d56b7b3a1"
+      sha256 "8b4a26f604ffd14e8575efe376d909e77bd04d21446d054172041070cf206a8f"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
