### PR TITLE
docs(aiassistant): cite the plugin registry keys for the .ai/mcp/mcp.json path

### DIFF
--- a/src/constants/aiassistant-paths.ts
+++ b/src/constants/aiassistant-paths.ts
@@ -13,7 +13,13 @@ export const AIASSISTANT_IGNORE_FILE_NAME = ".aiignore";
 // same as the agentsskills target. https://agentskills.io/specification
 export const AIASSISTANT_SKILLS_DIR_PATH = AGENTSMD_SKILLS_DIR_PATH;
 // JetBrains AI Assistant project-level MCP configuration is read from
-// `.ai/mcp/mcp.json`. https://www.jetbrains.com/help/ai-assistant/mcp.html
+// `.ai/mcp/mcp.json`. The help page (https://www.jetbrains.com/help/ai-assistant/mcp.html)
+// documents the file shape but not its location; the path is the plugin's
+// own default, declared in `ml-llm/lib/ml-llm.jar!/META-INF/plugin.xml` of
+// the JetBrains AI Assistant plugin (https://plugins.jetbrains.com/plugin/22282)
+// as the registry keys `llm.mcp.client.project.mcp.json.path` and
+// `llm.mcp.client.global.mcp.json.path`, both defaulting to
+// `.ai/mcp/mcp.json` (verified in builds 262.10315.x and 263.4732.x).
 export const AIASSISTANT_MCP_DIR = ".ai";
 export const AIASSISTANT_MCP_SUB_DIR = "mcp";
 export const AIASSISTANT_MCP_DIR_PATH = join(AIASSISTANT_MCP_DIR, AIASSISTANT_MCP_SUB_DIR);

--- a/src/features/mcp/aiassistant-mcp.ts
+++ b/src/features/mcp/aiassistant-mcp.ts
@@ -33,6 +33,10 @@ export class AiassistantMcp extends ToolMcp {
     // `.ai/mcp/mcp.json` and global (user-level) config from
     // `~/.ai/mcp/mcp.json`. The relative path is identical for both scopes;
     // the base directory changes (cwd for project, home dir for global).
+    // Both paths are the plugin's registry-key defaults
+    // (`llm.mcp.client.project.mcp.json.path`, resolved against the project
+    // directory, and `llm.mcp.client.global.mcp.json.path`, resolved against
+    // the user home); see the note in `src/constants/aiassistant-paths.ts`.
     return {
       relativeDirPath: AIASSISTANT_MCP_DIR_PATH,
       relativeFilePath: AIASSISTANT_MCP_FILE_NAME,

--- a/src/features/mcp/mcp-processor.ts
+++ b/src/features/mcp/mcp-processor.ts
@@ -110,7 +110,8 @@ export const toolMcpFactories = new Map<McpProcessorToolTarget, ToolMcpFactory>(
       // `.ai/mcp/mcp.json` and global (user-level) config from
       // `~/.ai/mcp/mcp.json`. The relative path is identical for both scopes;
       // the base directory changes (cwd for project, home dir for global).
-      // https://www.jetbrains.com/help/ai-assistant/mcp.html
+      // Both are the plugin's registry-key defaults; see the note in
+      // `src/constants/aiassistant-paths.ts`.
       class: AiassistantMcp,
       meta: {
         supportsProject: true,


### PR DESCRIPTION
## Summary

Closes #2600

The code comments for the JetBrains AI Assistant MCP path cited https://www.jetbrains.com/help/ai-assistant/mcp.html, which documents the `mcpServers` file shape but never names the on-disk location. The path is settled by the plugin artifact itself: `ml-llm/lib/ml-llm.jar!/META-INF/plugin.xml` of the [JetBrains AI Assistant plugin](https://plugins.jetbrains.com/plugin/22282) declares the registry keys `llm.mcp.client.project.mcp.json.path` (resolved against the project directory) and `llm.mcp.client.global.mcp.json.path` (resolved against the user home), both defaulting to `.ai/mcp/mcp.json`. Re-verified independently in build 263.4732.31 (2026-09-11) while preparing this PR, matching the earlier 262.10315.174 / 263.3889.92 findings recorded on the issue.

## Changes

- `src/constants/aiassistant-paths.ts`: replace the unsupporting help-page citation with the registry-key evidence.
- `src/features/mcp/aiassistant-mcp.ts`, `src/features/mcp/mcp-processor.ts`: point at that note instead of the help page.

Comment-only change; no generated output, docs, or tests change. The `mcp ✅ 🌏` row for `aiassistant` stays as is.

## Not done here

The issue also records a `.aiassistant/commands/**/*.md` custom chat-command surface in the same plugin. It is gated behind the registry key `llm.chat.input.language.user.commands.enabled`, whose default is `false`, and is undocumented, so generating into it would produce files a default IDE ignores. Left unimplemented; worth revisiting if the gate flips or the feature is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
