### PR TITLE
chore: release v16.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.28.1",
+  "version": "16.29.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.28.1";
+const getVersion = () => "16.29.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## What's Changed

### New Features
- Grok CLI permissions: the canonical `agent` and `glob` categories now map onto Grok's `AgentMessage` and `Glob` tools (and back on import), with docs clarifying that `AgentMessage` gates messages sent to a running subagent rather than its launch by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3006
- Codex CLI hooks: the canonical `stopCancelled` event now maps onto Codex's `Interrupt` hook (rust-v0.150.0), forwarded as authored like `Stop` and `UserPromptSubmit` by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3007

### Bug Fixes
- Skills: Claude Code scheduled-task skills are skipped at project scope, where Claude Code does not read them, and the docs no longer claim `root: true` for them by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3003
- Kimi Code permissions: hand-written `[permission]` sibling keys are preserved when the file is regenerated by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3005

### Documentation
- AI Assistant MCP: cite the plugin registry keys behind the `.ai/mcp/mcp.json` path by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3004
- Takt: describe command quality gates as rule-gated since TAKT 0.62.0 (`command_gates: required` / `skip`) and gitignore the `takt make` run artifacts under `.takt/make/` by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3008

### Other Changes
- Update Homebrew formula to v16.28.1 by @dyoshikawa in https://github.com/dyoshikawa/rulesync/pull/3002

## Contributors
- @dyoshikawa

**Full Changelog**: https://github.com/dyoshikawa/rulesync/compare/v16.28.1...v16.29.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
