### PR TITLE
chore: release v16.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rulesync",
-  "version": "16.29.0",
+  "version": "16.30.0",
   "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
   "keywords": [
     "ai",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -21,7 +21,7 @@ import { resolveGitignoreTargets } from "./commands/resolve-gitignore-targets.js
 import { updateCommand, UpdateCommandOptions } from "./commands/update.js";
 import { wrapCommand as _wrapCommand } from "./wrap-command.js";
 
-const getVersion = () => "16.29.0";
+const getVersion = () => "16.30.0";
 const FEATURES_HELP = `${ALL_FEATURES.join(",")}; ignore is deprecated, use permissions`;
 
 function wrapCommand(


### PR DESCRIPTION
## Summary

Release v16.30.0.

- Bump `getVersion()` in `src/cli/program.ts` to `16.30.0`.
- Bump `package.json` version to `16.30.0`.

## Release notes

See the draft release https://github.com/dyoshikawa/rulesync/releases/tag/v16.30.0 (created alongside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
