### PR TITLE
chore: update Homebrew formula to v16.30.0

### DIFF
--- a/Formula/rulesync.rb
+++ b/Formula/rulesync.rb
@@ -7,28 +7,28 @@
 class Rulesync < Formula
   desc "Unified AI rules management CLI that generates config files for AI dev tools"
   homepage "https://github.com/dyoshikawa/rulesync"
-  version "16.29.0"
+  version "16.30.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-arm64"
-      sha256 "daaf3680fcb272c3fe6cbc1f16fc562ea0e23acb5cbfc466ed2c06aa212e75e3"
+      sha256 "e6217b55c9da80226e20a6d46291a062630f86d58ba9091fa7795230d12368c6"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-darwin-x64"
-      sha256 "8df119a154a87100bcf59fb185d26893fd623539f5a688757b6da807c5648070"
+      sha256 "bcf1933c20f4f86357d593d13a983c3e2a09c12469d76fba04a7b971c00a1856"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-arm64"
-      sha256 "163da45b10ee6b9c214f7fbe7746473cefbc4d2cad8a5c72ab1a46f8c0325dc7"
+      sha256 "8c24467904543fcfbee36ba619400e5e6f6bab6731f66d286907eb95e85626d0"
     end
     on_intel do
       url "https://github.com/dyoshikawa/rulesync/releases/download/v#{version}/rulesync-linux-x64"
-      sha256 "3f7dc1c9f03dd124e27857c2d81ce9c525a7bcecb83f2a2ff24f9d1ca6b5296e"
+      sha256 "ba857fc7184d6849e5499276c2db3d58631a294e111cd664c480b8718de87d95"
     end
   end
 


### PR DESCRIPTION
Automated formula update for the v16.30.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yLN6CVqeZ8HCrjRb9o7mK
